### PR TITLE
[api] Don't tear down log connection on stack-trace decode failure

### DIFF
--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -68,10 +68,13 @@ class _LogLineProcessor:
         except EsphomeError as exc:
             self._decode_enabled = False
             self.backtrace_state = False
+            # _run_idedata raises EsphomeError with no message; fall back
+            # to a generic explanation when str(exc) is empty.
+            detail = str(exc) or "build artifacts not found locally"
             _LOGGER.warning(
-                "Crash trace decoding unavailable (%s). Run "
-                "'esphome compile' for this device to enable PC decoding.",
-                exc,
+                "Crash trace decoding unavailable: %s. "
+                "Run 'esphome compile' for this device to enable PC decoding.",
+                detail,
             )
 
 

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -18,7 +18,7 @@ with warnings.catch_warnings():
 import contextlib
 
 from esphome.const import CONF_KEY, CONF_PORT, __version__
-from esphome.core import CORE
+from esphome.core import CORE, EsphomeError
 from esphome.platformio_api import process_stacktrace
 
 from . import CONF_ENCRYPTION
@@ -30,6 +30,32 @@ if TYPE_CHECKING:
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _process_stacktrace_line(
+    config: dict[str, Any],
+    raw_line: str,
+    backtrace_state: bool,
+    platform_process_stacktrace: Any | None,
+) -> bool:
+    """Run the stack-trace decoder for a single log line.
+
+    on_log runs inside an asyncio protocol callback; if an exception
+    escapes, the loop tears the transport down with "Fatal error:
+    protocol.data_received() call failed." and ReconnectLogic
+    immediately reconnects, the device replays the same crash trace,
+    and we loop forever. Stack-trace decoding requires a populated
+    build dir for the device, which may not exist (e.g. flashed from
+    another machine); log and continue instead of killing the
+    connection.
+    """
+    try:
+        if platform_process_stacktrace:
+            return platform_process_stacktrace(config, raw_line, backtrace_state)
+        return process_stacktrace(config, raw_line, backtrace_state=backtrace_state)
+    except EsphomeError as exc:
+        _LOGGER.debug("Stack-trace decoding failed: %s", exc)
+        return False
 
 
 async def async_run_logs(
@@ -84,14 +110,9 @@ async def async_run_logs(
         for parsed_msg in parse_log_message(text, timestamp):
             print(parsed_msg.replace("\033", "\\033") if dashboard else parsed_msg)
         for raw_line in text.splitlines():
-            if platform_process_stacktrace:
-                backtrace_state = platform_process_stacktrace(
-                    config, raw_line, backtrace_state
-                )
-            else:
-                backtrace_state = process_stacktrace(
-                    config, raw_line, backtrace_state=backtrace_state
-                )
+            backtrace_state = _process_stacktrace_line(
+                config, raw_line, backtrace_state, platform_process_stacktrace
+            )
 
     # Safe to fall back to plaintext here only for this diagnostics use
     # case: the stream is one-way from device to client, and this code

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -32,30 +32,47 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-def _process_stacktrace_line(
-    config: dict[str, Any],
-    raw_line: str,
-    backtrace_state: bool,
-    platform_process_stacktrace: Any | None,
-) -> bool:
-    """Run the stack-trace decoder for a single log line.
+class _LogLineProcessor:
+    """Feeds incoming log lines to the stack-trace decoder.
 
-    on_log runs inside an asyncio protocol callback; if an exception
-    escapes, the loop tears the transport down with "Fatal error:
-    protocol.data_received() call failed." and ReconnectLogic
-    immediately reconnects, the device replays the same crash trace,
-    and we loop forever. Stack-trace decoding requires a populated
-    build dir for the device, which may not exist (e.g. flashed from
-    another machine); log and continue instead of killing the
-    connection.
+    Two responsibilities beyond just calling the decoder:
+    1. Catch EsphomeError. on_log runs inside an asyncio protocol
+       callback; if an exception escapes, the loop tears the transport
+       down with "Fatal error: protocol.data_received() call failed."
+       and ReconnectLogic immediately reconnects, the device replays
+       the same crash trace, and we loop forever.
+    2. Disable decoding after the first failure. _decode_pc shells out
+       to PlatformIO via _run_idedata, which is expensive; a single
+       crash dump can contain many PC/BT lines and we don't want to
+       retry the failing subprocess for each one.
     """
-    try:
-        if platform_process_stacktrace:
-            return platform_process_stacktrace(config, raw_line, backtrace_state)
-        return process_stacktrace(config, raw_line, backtrace_state=backtrace_state)
-    except EsphomeError as exc:
-        _LOGGER.debug("Stack-trace decoding failed: %s", exc)
-        return False
+
+    def __init__(self, config: dict[str, Any], platform_handler: Any | None) -> None:
+        self._config = config
+        self._platform_handler = platform_handler
+        self._decode_enabled = True
+        self.backtrace_state = False
+
+    def process_line(self, raw_line: str) -> None:
+        if not self._decode_enabled:
+            return
+        try:
+            if self._platform_handler is not None:
+                self.backtrace_state = self._platform_handler(
+                    self._config, raw_line, self.backtrace_state
+                )
+            else:
+                self.backtrace_state = process_stacktrace(
+                    self._config, raw_line, backtrace_state=self.backtrace_state
+                )
+        except EsphomeError as exc:
+            self._decode_enabled = False
+            self.backtrace_state = False
+            _LOGGER.warning(
+                "Crash trace decoding unavailable (%s). Run "
+                "'esphome compile' for this device to enable PC decoding.",
+                exc,
+            )
 
 
 async def async_run_logs(
@@ -87,7 +104,6 @@ async def async_run_logs(
         addresses=addresses,  # Pass all addresses for automatic retry
     )
     dashboard = CORE.dashboard
-    backtrace_state = False
 
     # Try platform-specific stacktrace handler first, fall back to generic
     platform_process_stacktrace = None
@@ -97,9 +113,10 @@ async def async_run_logs(
     except (AttributeError, ImportError):
         pass
 
+    processor = _LogLineProcessor(config, platform_process_stacktrace)
+
     def on_log(msg: SubscribeLogsResponse) -> None:
         """Handle a new log message."""
-        nonlocal backtrace_state
         time_ = datetime.now()
         message: bytes = msg.message
         text = message.decode("utf8", "backslashreplace")
@@ -110,9 +127,7 @@ async def async_run_logs(
         for parsed_msg in parse_log_message(text, timestamp):
             print(parsed_msg.replace("\033", "\\033") if dashboard else parsed_msg)
         for raw_line in text.splitlines():
-            backtrace_state = _process_stacktrace_line(
-                config, raw_line, backtrace_state, platform_process_stacktrace
-            )
+            processor.process_line(raw_line)
 
     # Safe to fall back to plaintext here only for this diagnostics use
     # case: the stream is one-way from device to client, and this code

--- a/tests/unit_tests/components/api/test_client.py
+++ b/tests/unit_tests/components/api/test_client.py
@@ -1,0 +1,80 @@
+"""Tests for esphome.components.api.client."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from esphome.components.api import client as api_client
+from esphome.core import EsphomeError
+
+
+def test_process_stacktrace_line_swallows_esphome_error() -> None:
+    """A failing stack-trace decode must not propagate.
+
+    on_log runs inside an asyncio protocol callback; if EsphomeError
+    escapes, the loop reports "Fatal error: protocol.data_received()
+    call failed.", tears the connection down, and ReconnectLogic loops
+    forever as the device replays the same crash trace on every
+    reconnect.
+    """
+    config = {"esphome": {"name": "test"}}
+
+    with patch.object(
+        api_client, "process_stacktrace", side_effect=EsphomeError("no idedata")
+    ) as mock_process:
+        result = api_client._process_stacktrace_line(
+            config, "PC: 0x4010496e", True, None
+        )
+
+    assert mock_process.called
+    assert result is False
+
+
+def test_process_stacktrace_line_swallows_platform_handler_error() -> None:
+    """The same protection must apply to the platform-specific handler."""
+    config = {"esphome": {"name": "test"}}
+
+    def platform_handler(_config, _line, _state):
+        raise EsphomeError("no idedata")
+
+    result = api_client._process_stacktrace_line(
+        config, "PC: 0x4010496e", True, platform_handler
+    )
+
+    assert result is False
+
+
+def test_process_stacktrace_line_returns_handler_result() -> None:
+    """When decoding succeeds, the handler's result is returned unchanged."""
+    config = {"esphome": {"name": "test"}}
+
+    with patch.object(
+        api_client, "process_stacktrace", return_value=True
+    ) as mock_process:
+        result = api_client._process_stacktrace_line(
+            config, "PC: 0x4010496e", False, None
+        )
+
+    mock_process.assert_called_once_with(
+        config, "PC: 0x4010496e", backtrace_state=False
+    )
+    assert result is True
+
+
+def test_process_stacktrace_line_uses_platform_handler_when_provided() -> None:
+    """The platform handler is preferred over the generic one."""
+    config = {"esphome": {"name": "test"}}
+    calls: list[tuple[object, str, bool]] = []
+
+    def platform_handler(cfg, line, state):
+        calls.append((cfg, line, state))
+        return True
+
+    with patch.object(api_client, "process_stacktrace") as mock_generic:
+        result = api_client._process_stacktrace_line(
+            config, "BT0: 0x4010496e", False, platform_handler
+        )
+
+    assert calls == [(config, "BT0: 0x4010496e", False)]
+    assert mock_generic.called is False
+    assert result is True

--- a/tests/unit_tests/components/api/test_client.py
+++ b/tests/unit_tests/components/api/test_client.py
@@ -42,6 +42,21 @@ def test_decoder_swallows_platform_handler_error() -> None:
     assert processor.backtrace_state is False
 
 
+def test_decoder_warning_uses_fallback_for_empty_error(caplog) -> None:
+    """_run_idedata raises EsphomeError with no message; the warning
+    must show a useful explanation rather than empty parens.
+    """
+    config = {"esphome": {"name": "test"}}
+    processor = api_client._LogLineProcessor(config, None)
+
+    with patch.object(api_client, "process_stacktrace", side_effect=EsphomeError()):
+        processor.process_line("PC: 0x4010496e")
+
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert any("build artifacts not found locally" in m for m in warnings)
+    assert not any("()" in m for m in warnings)
+
+
 def test_decoder_short_circuits_after_failure() -> None:
     """After one failure, subsequent lines must not retry the decoder.
 

--- a/tests/unit_tests/components/api/test_client.py
+++ b/tests/unit_tests/components/api/test_client.py
@@ -8,7 +8,7 @@ from esphome.components.api import client as api_client
 from esphome.core import EsphomeError
 
 
-def test_process_stacktrace_line_swallows_esphome_error() -> None:
+def test_decoder_swallows_esphome_error() -> None:
     """A failing stack-trace decode must not propagate.
 
     on_log runs inside an asyncio protocol callback; if EsphomeError
@@ -18,50 +18,68 @@ def test_process_stacktrace_line_swallows_esphome_error() -> None:
     reconnect.
     """
     config = {"esphome": {"name": "test"}}
+    processor = api_client._LogLineProcessor(config, None)
 
     with patch.object(
         api_client, "process_stacktrace", side_effect=EsphomeError("no idedata")
     ) as mock_process:
-        result = api_client._process_stacktrace_line(
-            config, "PC: 0x4010496e", True, None
-        )
+        processor.process_line("PC: 0x4010496e")
 
     assert mock_process.called
-    assert result is False
+    assert processor.backtrace_state is False
 
 
-def test_process_stacktrace_line_swallows_platform_handler_error() -> None:
+def test_decoder_swallows_platform_handler_error() -> None:
     """The same protection must apply to the platform-specific handler."""
     config = {"esphome": {"name": "test"}}
 
     def platform_handler(_config, _line, _state):
         raise EsphomeError("no idedata")
 
-    result = api_client._process_stacktrace_line(
-        config, "PC: 0x4010496e", True, platform_handler
-    )
+    processor = api_client._LogLineProcessor(config, platform_handler)
+    processor.process_line("PC: 0x4010496e")
 
-    assert result is False
+    assert processor.backtrace_state is False
 
 
-def test_process_stacktrace_line_returns_handler_result() -> None:
-    """When decoding succeeds, the handler's result is returned unchanged."""
+def test_decoder_short_circuits_after_failure() -> None:
+    """After one failure, subsequent lines must not retry the decoder.
+
+    _decode_pc shells out to PlatformIO; a crash dump can contain many
+    PC/BT lines and retrying the failing subprocess for each one would
+    stall log streaming.
+    """
     config = {"esphome": {"name": "test"}}
+    processor = api_client._LogLineProcessor(config, None)
 
     with patch.object(
-        api_client, "process_stacktrace", return_value=True
+        api_client, "process_stacktrace", side_effect=EsphomeError("no idedata")
     ) as mock_process:
-        result = api_client._process_stacktrace_line(
-            config, "PC: 0x4010496e", False, None
-        )
+        processor.process_line("PC: 0x4010496e")
+        processor.process_line("BT0: 0x4010496e")
+        processor.process_line("BT1: 0x401049aa")
 
-    mock_process.assert_called_once_with(
-        config, "PC: 0x4010496e", backtrace_state=False
-    )
-    assert result is True
+    assert mock_process.call_count == 1
 
 
-def test_process_stacktrace_line_uses_platform_handler_when_provided() -> None:
+def test_decoder_threads_backtrace_state() -> None:
+    """When decoding succeeds, backtrace_state is threaded across calls."""
+    config = {"esphome": {"name": "test"}}
+    processor = api_client._LogLineProcessor(config, None)
+
+    with patch.object(
+        api_client, "process_stacktrace", side_effect=[True, False]
+    ) as mock_process:
+        processor.process_line(">>>stack>>>")
+        assert processor.backtrace_state is True
+        processor.process_line("<<<stack<<<")
+        assert processor.backtrace_state is False
+
+    assert mock_process.call_args_list[0].kwargs == {"backtrace_state": False}
+    assert mock_process.call_args_list[1].kwargs == {"backtrace_state": True}
+
+
+def test_decoder_uses_platform_handler_when_provided() -> None:
     """The platform handler is preferred over the generic one."""
     config = {"esphome": {"name": "test"}}
     calls: list[tuple[object, str, bool]] = []
@@ -70,11 +88,11 @@ def test_process_stacktrace_line_uses_platform_handler_when_provided() -> None:
         calls.append((cfg, line, state))
         return True
 
+    processor = api_client._LogLineProcessor(config, platform_handler)
+
     with patch.object(api_client, "process_stacktrace") as mock_generic:
-        result = api_client._process_stacktrace_line(
-            config, "BT0: 0x4010496e", False, platform_handler
-        )
+        processor.process_line("BT0: 0x4010496e")
 
     assert calls == [(config, "BT0: 0x4010496e", False)]
     assert mock_generic.called is False
-    assert result is True
+    assert processor.backtrace_state is True


### PR DESCRIPTION
# What does this implement/fix?

Fixes a reconnect loop in `esphome logs` when the device has just rebooted from a crash and the local PlatformIO build dir for the project hasn't been populated (e.g. the YAML was OTA-flashed from another machine, or the user is just tailing logs from a fresh checkout).

The crash-trace decoder in `process_stacktrace` calls `_decode_pc` -> `get_idedata` -> `_run_idedata`, which raises `EsphomeError` when PlatformIO can't produce idedata. `on_log` in `esphome/components/api/client.py` runs inside an asyncio protocol callback, so the unhandled exception causes the loop to tear the transport down with:

```
Fatal error: protocol.data_received() call failed.
```

`aioesphomeapi.ReconnectLogic` immediately reconnects, the device replays the same crash trace on connect, and we loop at roughly one reconnect/second forever. Symptom (truncated):

```
INFO Successfully connected to <device>
[E][esp8266:171]: *** CRASH DETECTED ON PREVIOUS BOOT ***
[E][esp8266:191]:   PC: 0x4010496E
ERROR Could not match idedata, please report this error
ERROR Fatal error: protocol.data_received() call failed.
INFO Processing unexpected disconnect from ESPHome API for <device>
WARNING Disconnected from API
INFO Successfully resolved <device>
INFO Successfully connected to <device>
[E][esp8266:171]: *** CRASH DETECTED ON PREVIOUS BOOT ***
... (loops forever)
```

Workaround until this fix lands: run `esphome compile <name>.yaml` once on the same machine; afterwards the build dir + idedata exist and the decode path succeeds.

The fix moves the per-line stack-trace handling from the inline `on_log` closure into a `_LogLineProcessor` helper that:

1. Catches `EsphomeError` so it never escapes the asyncio protocol callback.
2. Disables decoding after the first failure. `_decode_pc` shells out to PlatformIO via `_run_idedata`, which is expensive; a single crash dump can contain many PC/BT lines and we don't want to retry the failing subprocess on every one. A single user-facing warning is emitted instead.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change required; reproduce by running `esphome logs <yaml>`
# against a device that just crashed, with no local build dir for the
# project (e.g. cloned to a fresh machine, or freshly checked out).
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).