### PR TITLE
[esp8266] Lower WDT_FEED_INTERVAL_MS to 100 ms

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -233,11 +233,10 @@ class Application {
   /// loops and scheduler items still feed after every op, so any op exceeding
   /// this threshold triggers a real feed naturally.
   /// Safety margins vs. platform watchdog timeouts:
-  ///   - ESP32 task WDT (user-configurable):  ~5x  <-- auto-scaled below
-  ///   - ESP8266 soft WDT (~1.6 s):           ~5x  <-- floor case; any future change
-  ///                                                   must keep comfortable margin here
-  ///   - ESP8266 HW WDT (~6 s):               ~20x
-  ///   - BK72xx HW WDT (10 s):                ~5x  <-- platform override below
+  ///   - ESP32 task WDT (user-configurable):  ~5x   <-- auto-scaled below
+  ///   - ESP8266 soft WDT (~1.6 s):           ~16x  <-- 100 ms feed (see USE_ESP8266 below)
+  ///   - ESP8266 HW WDT (~6 s):               ~60x
+  ///   - BK72xx HW WDT (10 s):                ~5x   <-- platform override below
 #ifdef USE_BK72XX
   // BDK busy-waits 200us per WDT reload (sctrl_dpll_delay200us). LibreTiny
   // sets HW WDT to 10s; 2000ms keeps ~5x margin. See wdt_ctrl WCMD_RELOAD_PERIOD:
@@ -257,6 +256,15 @@ class Application {
   static_assert(CONFIG_ESP_TASK_WDT_TIMEOUT_S >= 5,
                 "CONFIG_ESP_TASK_WDT_TIMEOUT_S must be at least 5s for a safe WDT feed interval");
   static constexpr uint32_t WDT_FEED_INTERVAL_MS = (CONFIG_ESP_TASK_WDT_TIMEOUT_S * 1000U) / 5U;
+#elif defined(USE_ESP8266)
+  // ESP8266 needs a tighter feed cadence than the other targets: the soft WDT
+  // is ~1.6 s and the HW WDT ~6 s, but a single long iteration (mDNS reply,
+  // wifi scan, OTA verify, lwIP TCP retransmit storm) can push the loop past
+  // a few hundred ms without giving the SDK a chance to feed. 100 ms keeps a
+  // ~16x margin to the soft WDT and ~60x to the HW WDT while still avoiding
+  // the per-iteration arch_feed_wdt() cost (this is the rate limit; component
+  // loops and scheduler items still feed after every op).
+  static constexpr uint32_t WDT_FEED_INTERVAL_MS = 100;
 #else
   static constexpr uint32_t WDT_FEED_INTERVAL_MS = 300;
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Restores a tighter WDT feed cadence on ESP8266. The shared default of `WDT_FEED_INTERVAL_MS = 300` (introduced in #15846 alongside the move to a rate-limited `arch_feed_wdt()`) is reasonable on ESP32 / BK72xx / RTL where the WDT budgets are large, but it leaves uncomfortably little headroom on ESP8266:

| WDT          | Timeout  | Old margin (300 ms) | New margin (100 ms) |
|--------------|----------|---------------------|---------------------|
| Soft WDT     | ~1.6 s   | ~5x                 | ~16x                |
| HW WDT       | ~6 s     | ~20x                | ~60x                |

A single long iteration on ESP8266 (mDNS reply burst, wifi scan, OTA verify, lwIP TCP retransmit storm, web_server SSE flush) can easily push the loop past a few hundred ms. With a 300 ms feed window the loop can occasionally land in the small-but-real region where the soft WDT fires before the next outer feed; reports of `Hardware WDT - Level1Int (exccause=4)` crashes on ESP8266 line up with this margin being too tight under the new (post #15792 / #15846 / #15662) main-loop cadence.

The change is a one-line knob: ESP8266 gets its own branch in the existing platform `#if`/`#elif` ladder. Component loops and scheduler items still feed after every op, so this is purely the rate-limit on the outer per-tick feed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change required.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).