### PR TITLE
[logger] give a chance to print crash

### DIFF
--- a/esphome/components/logger/logger_zephyr.cpp
+++ b/esphome/components/logger/logger_zephyr.cpp
@@ -80,8 +80,8 @@ void Logger::pre_setup() {
       this->uart_dev_ = uart_dev;
 #if defined(USE_LOGGER_WAIT_FOR_CDC) && defined(USE_LOGGER_UART_SELECTION_USB_CDC)
       uint32_t dtr = 0;
-      uint32_t count = (10 * 100);  // wait 10 sec for USB CDC to have early logs
-      while (dtr == 0 && count-- != 0) {
+      int count = (10 * 100);  // wait 10 sec for USB CDC to have early logs
+      while (dtr == 0 && count-- > 0) {
         uart_line_ctrl_get(this->uart_dev_, UART_LINE_CTRL_DTR, &dtr);
         delay(10);
         arch_feed_wdt();
@@ -160,6 +160,11 @@ void Logger::dump_crash_() {
 #if defined(CONFIG_THREAD_NAME)
     ESP_LOGE(TAG, "Thread: %s", crash_buf.thread);
 #endif
+    int count = (2 * 100);  // wait 2 sec to give a chance to print crash
+    while (count-- > 0) {
+      delay(10);
+      arch_feed_wdt();
+    }
   }
 }
 

--- a/esphome/components/logger/logger_zephyr.cpp
+++ b/esphome/components/logger/logger_zephyr.cpp
@@ -80,7 +80,7 @@ void Logger::pre_setup() {
       this->uart_dev_ = uart_dev;
 #if defined(USE_LOGGER_WAIT_FOR_CDC) && defined(USE_LOGGER_UART_SELECTION_USB_CDC)
       uint32_t dtr = 0;
-      int count = (10 * 100);  // wait 10 sec for USB CDC to have early logs
+      int32_t count = (10 * 100);  // wait 10 sec for USB CDC to have early logs
       while (dtr == 0 && count-- > 0) {
         uart_line_ctrl_get(this->uart_dev_, UART_LINE_CTRL_DTR, &dtr);
         delay(10);
@@ -160,7 +160,7 @@ void Logger::dump_crash_() {
 #if defined(CONFIG_THREAD_NAME)
     ESP_LOGE(TAG, "Thread: %s", crash_buf.thread);
 #endif
-    int count = (2 * 100);  // wait 2 sec to give a chance to print crash
+    int32_t count = (2 * 100);  // wait 2 sec to give a chance to print crash
     while (count-- > 0) {
       delay(10);
       arch_feed_wdt();


### PR DESCRIPTION
# What does this implement/fix?

wait 2 sec to make sure that crash is printed. Otherwise device might reset again without printing anything.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
