### PR TITLE
[nextion] TFT upload no longer fails when the display sends a split `0x08` ack

### DIFF
--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -108,8 +108,8 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
           }
         }
         if (recv_string.size() < 5) {
-          ESP_LOGE(TAG, "Truncated 0x08 response: got %zu bytes within %" PRIu32 "ms",
-                  recv_string.size(), NEXTION_UPLOAD_ACK_TIMEOUT_MS);
+          ESP_LOGE(TAG, "Truncated 0x08 response: got %zu bytes within %" PRIu32 "ms", recv_string.size(),
+                   NEXTION_UPLOAD_ACK_TIMEOUT_MS);
           allocator.deallocate(buffer, 4096);
           buffer = nullptr;
           return -1;

--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -88,6 +88,33 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
       this->write_array(buffer, buffer_size);
       App.feed_wdt();
       this->recv_ret_string_(recv_string, NEXTION_UPLOAD_ACK_TIMEOUT_MS, true);
+
+      // Some Nextion firmware variants (notably bootloader/recovery mode on panels
+      // with no installed TFT) emit the 5-byte 0x08+position fast-mode ack with a
+      // multi-second gap between the leading 0x08 byte and the 4 trailing position
+      // bytes. recv_ret_string_ returns after the first byte; manually drain the
+      // trailing bytes from the UART before continuing.
+      if (!recv_string.empty() && recv_string[0] == 0x08 && recv_string.size() < 5) {
+        const uint32_t deadline = millis() + NEXTION_UPLOAD_ACK_TIMEOUT_MS;
+        while (recv_string.size() < 5 && millis() < deadline) {
+          if (this->available()) {
+            uint8_t b = 0;
+            if (this->read_byte(&b)) {
+              recv_string.push_back(static_cast<char>(b));
+            }
+          } else {
+            delay(5);  // NOLINT
+            App.feed_wdt();
+          }
+        }
+        if (recv_string.size() < 5) {
+          ESP_LOGE(TAG, "Truncated 0x08 response: got %zu bytes within %" PRIu32 "ms",
+                  recv_string.size(), NEXTION_UPLOAD_ACK_TIMEOUT_MS);
+          allocator.deallocate(buffer, 4096);
+          buffer = nullptr;
+          return -1;
+        }
+      }
       this->content_length_ -= read_len;
       const float upload_percentage = 100.0f * (this->tft_size_ - this->content_length_) / this->tft_size_;
       ESP_LOGD(TAG, "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 ")", upload_percentage, this->content_length_,

--- a/esphome/components/nextion/nextion_upload_esp32.cpp
+++ b/esphome/components/nextion/nextion_upload_esp32.cpp
@@ -104,6 +104,33 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
       this->write_array(buffer, buffer_size);
       App.feed_wdt();
       this->recv_ret_string_(recv_string, NEXTION_UPLOAD_ACK_TIMEOUT_MS, true);
+
+      // Some Nextion firmware variants (notably bootloader/recovery mode on panels
+      // with no installed TFT) emit the 5-byte 0x08+position fast-mode ack with a
+      // multi-second gap between the leading 0x08 byte and the 4 trailing position
+      // bytes. recv_ret_string_ returns after the first byte; manually drain the
+      // trailing bytes from the UART before continuing.
+      if (!recv_string.empty() && recv_string[0] == 0x08 && recv_string.size() < 5) {
+        const uint32_t deadline = millis() + NEXTION_UPLOAD_ACK_TIMEOUT_MS;
+        while (recv_string.size() < 5 && millis() < deadline) {
+          if (this->available()) {
+            uint8_t b = 0;
+            if (this->read_byte(&b)) {
+              recv_string.push_back(static_cast<char>(b));
+            }
+          } else {
+            vTaskDelay(pdMS_TO_TICKS(5));  // NOLINT
+            App.feed_wdt();
+          }
+        }
+        if (recv_string.size() < 5) {
+          ESP_LOGE(TAG, "Truncated 0x08 response: got %zu bytes within %" PRIu32 "ms",
+                  recv_string.size(), NEXTION_UPLOAD_ACK_TIMEOUT_MS);
+          allocator.deallocate(buffer, 4096);
+          buffer = nullptr;
+          return -1;
+        }
+      }
       this->content_length_ -= read_len;
       const float upload_percentage = 100.0f * (this->tft_size_ - this->content_length_) / this->tft_size_;
 #ifdef USE_PSRAM

--- a/esphome/components/nextion/nextion_upload_esp32.cpp
+++ b/esphome/components/nextion/nextion_upload_esp32.cpp
@@ -124,8 +124,8 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
           }
         }
         if (recv_string.size() < 5) {
-          ESP_LOGE(TAG, "Truncated 0x08 response: got %zu bytes within %" PRIu32 "ms",
-                  recv_string.size(), NEXTION_UPLOAD_ACK_TIMEOUT_MS);
+          ESP_LOGE(TAG, "Truncated 0x08 response: got %zu bytes within %" PRIu32 "ms", recv_string.size(),
+                   NEXTION_UPLOAD_ACK_TIMEOUT_MS);
           allocator.deallocate(buffer, 4096);
           buffer = nullptr;
           return -1;


### PR DESCRIPTION
# What does this implement/fix?

Fixes TFT upload failures that occur immediately after the first 4096-byte chunk on Nextion panels that emit the v1.2 fast-mode `0x08 + position` ack with a multi-second gap between the leading `0x08` byte and the 4 trailing position bytes.

Applied to both the ESP-IDF (`nextion_upload_esp32.cpp`) and Arduino (`nextion_upload_arduino.cpp`) upload paths, since both share the same `recv_ret_string_` early-return behavior and the same protocol handling.

### Symptom

After the first chunk uploads successfully (`Upload: 0.03%`), the upload aborts with:

```log
Read failed: 0/4096 bytes
TFT upload error
Upload failed
```
The retries fire instantly (`got 0/4096 bytes after 0ms`) because the read loop is reading from an HTTP response that is already exhausted.

### Root cause

The fast-mode protocol's `0x08 + position` packet is sent without a `FF FF FF` terminator. `recv_ret_string_` returns as soon as the leading `0x08` byte arrives, leaving the 4 position bytes still pending. The existing handler requires `recv_string.size() == 5` to parse the position, so the truncated response falls through to the `0x05` path. The inner read loop then tries to read more bytes from the already-exhausted ranged HTTP request and fails.

The split is reproducible on panels in bootloader/recovery mode (no installed TFT). UART tracing or any other added latency between `recv_ret_string_` and the next read happens to mask the issue, which is why earlier reports were intermittent.

A diagnostic log confirmed the response is split with up to ~5 seconds between the `0x08` byte and the trailing 4 position bytes, well beyond any reasonable recv-loop early-termination heuristic.

### Fix

When `recv_ret_string_` returns with `0x08` as the first byte and fewer than 5 bytes total, actively poll the UART for up to `NEXTION_UPLOAD_ACK_TIMEOUT_MS` to drain the trailing position bytes before passing the response to the existing handler.

The fix is targeted: the active-wait only runs in this specific failure path (once per upload, on the fast-mode handshake response). The happy path is untouched.

### Reproduction

1. Flash an ESPHome firmware with Nextion TFT upload configured
2. Power on the panel with no TFT installed (or with a corrupted TFT) - You can cut-off display power in the middle of a TFT transfer to get into that state (where you see `System data ERROR!` on the screen)
3. Trigger TFT upload
4. Without this fix: upload aborts at 0.03% with "Read failed: 0/4096 bytes"
5. With this fix: upload proceeds normally to completion

### Verification

Tested on Sonoff NSPanel (NX4832F035, FW v115) on `esp32dev` board with ESP-IDF framework, ESPHome 2026.5.0-dev. Upload completed end-to-end with no TFT pre-installed.

The Arduino path was patched based on the same protocol reasoning (the bug is in the shared protocol handling, not platform-specific), but I did not have ESP8266 hardware to test that path directly. Independent verification on Arduino welcome.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
