### PR TITLE
[test] DO NOT MERGE — verify device-builder CI from #16214

### DIFF
--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,4 +1,4 @@
-"""Constants used by esphome."""
+"""Constants used by ESPHome."""
 
 from enum import Enum
 


### PR DESCRIPTION
# What does this implement/fix?

**DO NOT MERGE.** Re-opens the chained verification PR for #16214 (the original #16215 was closed). Same purpose: trigger the new `Test downstream esphome/device-builder` job from #16214 against this PR's Python code so we can confirm the install + pytest path works end-to-end before merging the parent.

This PR makes a one-character docstring tweak in `esphome/const.py` (lowercase "esphome" → "ESPHome") solely to trip the `should_run_device_builder()` gate in #16214. Once the chained CI run shows the downstream job executing and going green (or surfacing real downstream breakage), this PR can be closed.

Base is `ci-device-builder-downstream` so the diff against #16214's branch is just the trigger change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Verifies #16214

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# N/A — CI verification PR
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).