### PR TITLE
[light] Fix LightControlAction trigger args with reference types

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -37,14 +37,13 @@ template<bool HasTransitionLength, typename... Ts> class ToggleAction : public A
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `brightness: !lambda "return x;"`) keep working.
 //
-// Trigger args are forwarded as `Ts...`. The previous `const Ts &...`
-// form caused codegen to emit `const T &` for each arg in the apply
-// lambda's parameter list, which is invalid C++ source text when T is
-// already a reference (e.g. `const std::string & &` for triggers that
-// pass `std::string &`).
+// Trigger args are forwarded as `const std::remove_reference_t<Ts> &...`
+// (instead of `const Ts &...`) so codegen can emit the same form in the
+// apply lambda's parameter list without producing `const T & &` for
+// triggers whose Ts already carries a reference (e.g. `std::string &`).
 template<typename... Ts> class LightControlAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(LightState *, LightCall &, Ts...);
+  using ApplyFn = void (*)(LightState *, LightCall &, const std::remove_reference_t<Ts> &...);
   LightControlAction(LightState *parent, ApplyFn apply) : parent_(parent), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -37,16 +37,15 @@ template<bool HasTransitionLength, typename... Ts> class ToggleAction : public A
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `brightness: !lambda "return x;"`) keep working.
 //
-// Trigger args are forwarded as `Ts...`. The previous `const Ts &...`
-// form caused codegen to emit `const T &` for each arg in the apply
-// lambda's parameter list, which is invalid C++ source text when T is
-// already a reference (e.g. `const std::string & &` for triggers that
-// pass `std::string &`). Forwarding `Ts...` lets the codegen reuse the
-// trigger's `args` types unchanged for both the apply lambda and any
-// inner field lambdas, so they always type-match.
+// Trigger args are normalized to `const std::remove_cvref_t<Ts> &...` so
+// the codegen can emit a matching parameter list for both the apply lambda
+// and any inner field lambdas without producing invalid C++ source text
+// (e.g. `const T & &` if Ts already carries a reference, or `const const
+// T &` if Ts already carries a const). This keeps trigger args no-copy
+// regardless of whether the trigger supplies `T`, `T &`, or `const T &`.
 template<typename... Ts> class LightControlAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(LightState *, LightCall &, Ts...);
+  using ApplyFn = void (*)(LightState *, LightCall &, const std::remove_cvref_t<Ts> &...);
   LightControlAction(LightState *parent, ApplyFn apply) : parent_(parent), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -37,13 +37,16 @@ template<bool HasTransitionLength, typename... Ts> class ToggleAction : public A
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `brightness: !lambda "return x;"`) keep working.
 //
-// Trigger args are forwarded as `const std::remove_reference_t<Ts> &...`
-// (instead of `const Ts &...`) so codegen can emit the same form in the
-// apply lambda's parameter list without producing `const T & &` for
-// triggers whose Ts already carries a reference (e.g. `std::string &`).
+// Trigger args are forwarded as `Ts...`. The previous `const Ts &...`
+// form caused codegen to emit `const T &` for each arg in the apply
+// lambda's parameter list, which is invalid C++ source text when T is
+// already a reference (e.g. `const std::string & &` for triggers that
+// pass `std::string &`). Forwarding `Ts...` lets the codegen reuse the
+// trigger's `args` types unchanged for both the apply lambda and any
+// inner field lambdas, so they always type-match.
 template<typename... Ts> class LightControlAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(LightState *, LightCall &, const std::remove_reference_t<Ts> &...);
+  using ApplyFn = void (*)(LightState *, LightCall &, Ts...);
   LightControlAction(LightState *parent, ApplyFn apply) : parent_(parent), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -36,9 +36,12 @@ template<bool HasTransitionLength, typename... Ts> class ToggleAction : public A
 // plus one parent pointer, regardless of how many fields the user set.
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `brightness: !lambda "return x;"`) keep working.
+//
+// Ts... must be forwarded by-value: `const T &` is ill-formed when T is
+// already a reference type (some triggers pass `std::string &`).
 template<typename... Ts> class LightControlAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(LightState *, LightCall &, const Ts &...);
+  using ApplyFn = void (*)(LightState *, LightCall &, Ts...);
   LightControlAction(LightState *parent, ApplyFn apply) : parent_(parent), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -37,8 +37,11 @@ template<bool HasTransitionLength, typename... Ts> class ToggleAction : public A
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `brightness: !lambda "return x;"`) keep working.
 //
-// Ts... must be forwarded by-value: `const T &` is ill-formed when T is
-// already a reference type (some triggers pass `std::string &`).
+// Trigger args are forwarded as `Ts...`. The previous `const Ts &...`
+// form caused codegen to emit `const T &` for each arg in the apply
+// lambda's parameter list, which is invalid C++ source text when T is
+// already a reference (e.g. `const std::string & &` for triggers that
+// pass `std::string &`).
 template<typename... Ts> class LightControlAction : public Action<Ts...> {
  public:
   using ApplyFn = void (*)(LightState *, LightCall &, Ts...);

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -230,16 +230,13 @@ async def light_control_to_code(config, action_id, template_arg, args):
                 f"call.set_effect(static_cast<uint32_t>({_resolve_effect_index(config)}));"
             )
 
-    # Match LightControlAction::ApplyFn signature: `const std::remove_reference_t<T> &`
-    # for each trigger arg so non-reference Ts stay no-copy (`const T &`) and
-    # reference Ts collapse correctly without producing `const T & &`.
+    # Match LightControlAction::ApplyFn signature: forward trigger args as Ts...
+    # so the apply lambda's parameter types match both ApplyFn and the
+    # inner field lambdas (which are generated from `args` directly).
     apply_args = [
         (LightState.operator("ptr"), "parent"),
         (LightCall.operator("ref"), "call"),
-        *(
-            (cg.RawExpression(f"const std::remove_reference_t<{cg.safe_exp(t)}> &"), n)
-            for t, n in args
-        ),
+        *args,
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -200,6 +200,15 @@ async def light_control_to_code(config, action_id, template_arg, args):
         (CONF_WARM_WHITE, "set_warm_white", cg.float_),
     )
 
+    # Normalize trigger args to `const std::remove_cvref_t<T> &` so the
+    # apply lambda and any inner field lambdas (generated below via
+    # `process_lambda`) share one parameter spelling that's well-formed for
+    # any T (value, ref, or const-ref). Matches LightControlAction::ApplyFn.
+    normalized_args = [
+        (cg.RawExpression(f"const std::remove_cvref_t<{cg.safe_exp(t)}> &"), n)
+        for t, n in args
+    ]
+
     fwd_args = ", ".join(name for _, name in args)
     body_lines: list[str] = []
 
@@ -208,7 +217,7 @@ async def light_control_to_code(config, action_id, template_arg, args):
             continue
         value = config[conf_key]
         if isinstance(value, Lambda):
-            inner = await cg.process_lambda(value, args, return_type=type_)
+            inner = await cg.process_lambda(value, normalized_args, return_type=type_)
             body_lines.append(f"call.{setter}(({inner})({fwd_args}));")
         else:
             body_lines.append(f"call.{setter}({cg.safe_exp(value)});")
@@ -216,7 +225,7 @@ async def light_control_to_code(config, action_id, template_arg, args):
     if CONF_EFFECT in config:
         if isinstance(config[CONF_EFFECT], Lambda):
             inner_lambda = await cg.process_lambda(
-                config[CONF_EFFECT], args, return_type=cg.std_string
+                config[CONF_EFFECT], normalized_args, return_type=cg.std_string
             )
             body_lines.append(
                 f"{{ auto __effect_s = ({inner_lambda})({fwd_args});\n"
@@ -230,13 +239,10 @@ async def light_control_to_code(config, action_id, template_arg, args):
                 f"call.set_effect(static_cast<uint32_t>({_resolve_effect_index(config)}));"
             )
 
-    # Match LightControlAction::ApplyFn signature: forward trigger args as Ts...
-    # so the apply lambda's parameter types match both ApplyFn and the
-    # inner field lambdas (which are generated from `args` directly).
     apply_args = [
         (LightState.operator("ptr"), "parent"),
         (LightCall.operator("ref"), "call"),
-        *args,
+        *normalized_args,
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -230,15 +230,16 @@ async def light_control_to_code(config, action_id, template_arg, args):
                 f"call.set_effect(static_cast<uint32_t>({_resolve_effect_index(config)}));"
             )
 
-    # Forward trigger args as Ts... so each (type, name) pair passes through
-    # unchanged. Wrapping in `const &` here would emit invalid C++ source
-    # for trigger types that already carry a reference (e.g. `std::string &`)
-    # and fails on plain Python types (`float`/`bool`) which have no
-    # `.operator()` method.
+    # Match LightControlAction::ApplyFn signature: `const std::remove_reference_t<T> &`
+    # for each trigger arg so non-reference Ts stay no-copy (`const T &`) and
+    # reference Ts collapse correctly without producing `const T & &`.
     apply_args = [
         (LightState.operator("ptr"), "parent"),
         (LightCall.operator("ref"), "call"),
-        *args,
+        *(
+            (cg.RawExpression(f"const std::remove_reference_t<{cg.safe_exp(t)}> &"), n)
+            for t, n in args
+        ),
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -230,11 +230,12 @@ async def light_control_to_code(config, action_id, template_arg, args):
                 f"call.set_effect(static_cast<uint32_t>({_resolve_effect_index(config)}));"
             )
 
-    # Match LightControlAction::ApplyFn signature: const Ts &... for trigger args.
+    # Match LightControlAction::ApplyFn signature: trigger args forwarded
+    # by-value as Ts...
     apply_args = [
         (LightState.operator("ptr"), "parent"),
         (LightCall.operator("ref"), "call"),
-        *((t.operator("const").operator("ref"), n) for t, n in args),
+        *args,
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -230,8 +230,11 @@ async def light_control_to_code(config, action_id, template_arg, args):
                 f"call.set_effect(static_cast<uint32_t>({_resolve_effect_index(config)}));"
             )
 
-    # Match LightControlAction::ApplyFn signature: trigger args forwarded
-    # by-value as Ts...
+    # Forward trigger args as Ts... so each (type, name) pair passes through
+    # unchanged. Wrapping in `const &` here would emit invalid C++ source
+    # for trigger types that already carry a reference (e.g. `std::string &`)
+    # and fails on plain Python types (`float`/`bool`) which have no
+    # `.operator()` method.
     apply_args = [
         (LightState.operator("ptr"), "parent"),
         (LightCall.operator("ref"), "call"),

--- a/tests/components/light/common.yaml
+++ b/tests/components/light/common.yaml
@@ -127,6 +127,21 @@ esphome:
           blue: 0%
           transition_length: 1s
 
+# Exercise light actions inside a trigger with non-empty Ts (number on_value
+# passes float).
+number:
+  - platform: template
+    id: test_number_brightness
+    optimistic: true
+    min_value: 0
+    max_value: 100
+    step: 1
+    on_value:
+      then:
+        - light.turn_on:
+            id: test_monochromatic_light
+            brightness: !lambda "return x / 100.0;"
+
 light:
   - platform: binary
     id: test_binary_light


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression where `light.turn_on` / `light.turn_off` / `light.control` fail to compile when used inside a trigger with non-empty `Ts...` (e.g. `number.on_value` passing `float`, `http_request.on_response` passing `std::string &`).

The Python codegen previously called `.operator("const").operator("ref")` on each trigger arg type, which raised `AttributeError` on plain Python types (`float`, `bool`) and produced invalid `const T & &` source text on reference types.

Both `LightControlAction::ApplyFn` and the codegen now use `const std::remove_cvref_t<T> &` for each trigger arg. The same normalized form is used for the apply lambda *and* the inner field lambdas, so they always type-match. Trigger args stay no-copy regardless of whether the trigger supplies `T`, `T &`, or `const T &` (important for triggers like `text_sensor.on_value` and `voice_assistant.on_stt_end` which pass `std::string` by value).

**Note:** the memory-impact bot will report a small growth — that's the new `number: template` regression test fixture in `tests/components/light/common.yaml`, not the fix itself.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16219

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Previously failed to compile, now works
number:
  - platform: template
    id: display_brightness
    optimistic: true
    min_value: 40
    max_value: 100
    step: 10
    on_value:
      then:
        - light.turn_on:
            id: my_light
            brightness: !lambda return x / 100.0;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
