### PR TITLE
[fan] Fix TurnOnAction trigger args with reference types

### DIFF
--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -358,26 +358,29 @@ async def fan_turn_on_to_code(config, action_id, template_arg, args):
         (CONF_DIRECTION, "set_direction", FanDirection),
     )
 
+    # Normalize trigger args to `const std::remove_cvref_t<T> &` so the
+    # apply lambda and any inner field lambdas (generated below via
+    # `process_lambda`) share one parameter spelling that's well-formed for
+    # any T (value, ref, or const-ref). Matches TurnOnAction::ApplyFn.
+    normalized_args = [
+        (cg.RawExpression(f"const std::remove_cvref_t<{cg.safe_exp(t)}> &"), n)
+        for t, n in args
+    ]
+
     fwd_args = ", ".join(name for _, name in args)
     body_lines: list[str] = []
     for conf_key, setter, type_ in FIELDS:
         if (value := config.get(conf_key)) is None:
             continue
         if isinstance(value, Lambda):
-            inner = await cg.process_lambda(value, args, return_type=type_)
+            inner = await cg.process_lambda(value, normalized_args, return_type=type_)
             body_lines.append(f"call.{setter}(({inner})({fwd_args}));")
         else:
             body_lines.append(f"call.{setter}({cg.safe_exp(value)});")
 
-    # Match TurnOnAction::ApplyFn signature: `const std::remove_reference_t<T> &`
-    # for each trigger arg so non-reference Ts stay no-copy (`const T &`) and
-    # reference Ts collapse correctly without producing `const T & &`.
     apply_args = [
         (FanCall.operator("ref"), "call"),
-        *(
-            (cg.RawExpression(f"const std::remove_reference_t<{cg.safe_exp(t)}> &"), n)
-            for t, n in args
-        ),
+        *normalized_args,
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -369,11 +369,15 @@ async def fan_turn_on_to_code(config, action_id, template_arg, args):
         else:
             body_lines.append(f"call.{setter}({cg.safe_exp(value)});")
 
-    # Match TurnOnAction::ApplyFn signature: trigger args forwarded
-    # by-value as Ts...
+    # Match TurnOnAction::ApplyFn signature: `const std::remove_reference_t<T> &`
+    # for each trigger arg so non-reference Ts stay no-copy (`const T &`) and
+    # reference Ts collapse correctly without producing `const T & &`.
     apply_args = [
         (FanCall.operator("ref"), "call"),
-        *args,
+        *(
+            (cg.RawExpression(f"const std::remove_reference_t<{cg.safe_exp(t)}> &"), n)
+            for t, n in args
+        ),
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -369,10 +369,11 @@ async def fan_turn_on_to_code(config, action_id, template_arg, args):
         else:
             body_lines.append(f"call.{setter}({cg.safe_exp(value)});")
 
-    # Match TurnOnAction::ApplyFn signature: const Ts &... for trigger args.
+    # Match TurnOnAction::ApplyFn signature: trigger args forwarded
+    # by-value as Ts...
     apply_args = [
         (FanCall.operator("ref"), "call"),
-        *((t.operator("const").operator("ref"), n) for t, n in args),
+        *args,
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/fan/automation.h
+++ b/esphome/components/fan/automation.h
@@ -13,11 +13,13 @@ namespace fan {
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `speed: !lambda "return x;"`) keep working.
 //
-// Ts... must be forwarded by-value: `const T &` is ill-formed when T is
-// already a reference type (some triggers pass `std::string &`).
+// Trigger args are forwarded as `const std::remove_reference_t<Ts> &...`
+// (instead of `const Ts &...`) so codegen can emit the same form in the
+// apply lambda's parameter list without producing `const T & &` for
+// triggers whose Ts already carries a reference (e.g. `std::string &`).
 template<typename... Ts> class TurnOnAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(FanCall &, Ts...);
+  using ApplyFn = void (*)(FanCall &, const std::remove_reference_t<Ts> &...);
   TurnOnAction(Fan *state, ApplyFn apply) : state_(state), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/esphome/components/fan/automation.h
+++ b/esphome/components/fan/automation.h
@@ -13,13 +13,15 @@ namespace fan {
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `speed: !lambda "return x;"`) keep working.
 //
-// Trigger args are forwarded as `const std::remove_reference_t<Ts> &...`
-// (instead of `const Ts &...`) so codegen can emit the same form in the
-// apply lambda's parameter list without producing `const T & &` for
-// triggers whose Ts already carries a reference (e.g. `std::string &`).
+// Trigger args are normalized to `const std::remove_cvref_t<Ts> &...` so
+// the codegen can emit a matching parameter list for both the apply lambda
+// and any inner field lambdas without producing invalid C++ source text
+// (e.g. `const T & &` if Ts already carries a reference, or `const const
+// T &` if Ts already carries a const). This keeps trigger args no-copy
+// regardless of whether the trigger supplies `T`, `T &`, or `const T &`.
 template<typename... Ts> class TurnOnAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(FanCall &, const std::remove_reference_t<Ts> &...);
+  using ApplyFn = void (*)(FanCall &, const std::remove_cvref_t<Ts> &...);
   TurnOnAction(Fan *state, ApplyFn apply) : state_(state), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/esphome/components/fan/automation.h
+++ b/esphome/components/fan/automation.h
@@ -12,9 +12,12 @@ namespace fan {
 // plus one parent pointer, regardless of how many fields the user set.
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `speed: !lambda "return x;"`) keep working.
+//
+// Ts... must be forwarded by-value: `const T &` is ill-formed when T is
+// already a reference type (some triggers pass `std::string &`).
 template<typename... Ts> class TurnOnAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(FanCall &, const Ts &...);
+  using ApplyFn = void (*)(FanCall &, Ts...);
   TurnOnAction(Fan *state, ApplyFn apply) : state_(state), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/tests/components/fan/common.yaml
+++ b/tests/components/fan/common.yaml
@@ -9,6 +9,14 @@ fan:
     has_oscillating: true
     has_direction: true
     speed_count: 3
+    # Exercise fan.turn_on inside a trigger whose Ts pack is non-empty
+    # (StringRef from on_preset_set) so the apply-lambda + inner-lambda
+    # codegen runs through the cvref-normalized path.
+    on_preset_set:
+      then:
+        - fan.turn_on:
+            id: test_fan
+            speed: !lambda "return x.empty() ? 1 : 3;"
 
 # Test lambdas using get_preset_mode() which returns StringRef
 # These examples match the migration guide in the PR description
@@ -89,8 +97,11 @@ button:
           id: test_fan
           speed: !lambda 'return 1;'
 
-# Exercise fan.turn_on inside a trigger with non-empty Ts (number on_value
-# passes float).
+# Exercise fan.turn_on inside triggers with non-empty Ts:
+#  - number.on_value: Ts = float (Python value type; previously raised
+#    AttributeError on .operator("const"))
+#  - fan.on_preset_set: Ts = StringRef (already a value-type wrapper around
+#    a const char * + size; tests the cvref-normalized inner-lambda path)
 number:
   - platform: template
     id: fan_speed_number

--- a/tests/components/fan/common.yaml
+++ b/tests/components/fan/common.yaml
@@ -88,3 +88,18 @@ button:
       - fan.turn_on:
           id: test_fan
           speed: !lambda 'return 1;'
+
+# Exercise fan.turn_on inside a trigger with non-empty Ts (number on_value
+# passes float).
+number:
+  - platform: template
+    id: fan_speed_number
+    optimistic: true
+    min_value: 1
+    max_value: 3
+    step: 1
+    on_value:
+      then:
+        - fan.turn_on:
+            id: test_fan
+            speed: !lambda "return (int) x;"


### PR DESCRIPTION
# What does this implement/fix?

Same regression as esphome/esphome#16219, but for `fan.turn_on`.

The Python codegen previously called `.operator("const").operator("ref")` on each trigger arg type, which raised `AttributeError` on plain Python types (`float`, `bool`) and produced invalid `const T & &` source text on reference types.

Both `TurnOnAction::ApplyFn` and the codegen now use `const std::remove_cvref_t<T> &` for each trigger arg. The same normalized form is used for the apply lambda *and* the inner field lambdas, so they always type-match. Trigger args stay no-copy regardless of whether the trigger supplies `T`, `T &`, or `const T &`.

**Note:** the memory-impact bot will report a small growth — that's the new `number: template` regression test fixture in `tests/components/fan/common.yaml`, not the fix itself.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/16219

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Previously failed to compile, now works
number:
  - platform: template
    id: fan_speed
    optimistic: true
    min_value: 1
    max_value: 3
    step: 1
    on_value:
      then:
        - fan.turn_on:
            id: my_fan
            speed: !lambda "return (int) x;"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
