### PR TITLE
[valve] Fix ControlAction trigger args with reference types

### DIFF
--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -251,11 +251,15 @@ async def valve_control_to_code(config, action_id, template_arg, args):
         else:
             body_lines.append(f"call.{setter}({cg.safe_exp(value)});")
 
-    # Match ControlAction::ApplyFn signature: trigger args forwarded
-    # by-value as Ts...
+    # Match ControlAction::ApplyFn signature: `const std::remove_reference_t<T> &`
+    # for each trigger arg so non-reference Ts stay no-copy (`const T &`) and
+    # reference Ts collapse correctly without producing `const T & &`.
     apply_args = [
         (ValveCall.operator("ref"), "call"),
-        *args,
+        *(
+            (cg.RawExpression(f"const std::remove_reference_t<{cg.safe_exp(t)}> &"), n)
+            for t, n in args
+        ),
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -240,23 +240,29 @@ async def valve_control_to_code(config, action_id, template_arg, args):
         (CONF_POSITION, "set_position", cg.float_),
     )
 
+    # Normalize trigger args to `const std::remove_cvref_t<T> &` so the
+    # apply lambda and any inner field lambdas (generated below via
+    # `process_lambda`) share one parameter spelling that's well-formed for
+    # any T (value, ref, or const-ref). Matches ControlAction::ApplyFn.
+    normalized_args = [
+        (cg.RawExpression(f"const std::remove_cvref_t<{cg.safe_exp(t)}> &"), n)
+        for t, n in args
+    ]
+
     fwd_args = ", ".join(name for _, name in args)
     body_lines: list[str] = []
     for conf_key, setter, type_ in FIELDS:
         if (value := config.get(conf_key)) is None:
             continue
         if isinstance(value, Lambda):
-            inner = await cg.process_lambda(value, args, return_type=type_)
+            inner = await cg.process_lambda(value, normalized_args, return_type=type_)
             body_lines.append(f"call.{setter}(({inner})({fwd_args}));")
         else:
             body_lines.append(f"call.{setter}({cg.safe_exp(value)});")
 
-    # Match ControlAction::ApplyFn signature: forward trigger args as Ts...
-    # so the apply lambda's parameter types match both ApplyFn and the
-    # inner field lambdas (which are generated from `args` directly).
     apply_args = [
         (ValveCall.operator("ref"), "call"),
-        *args,
+        *normalized_args,
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -251,15 +251,12 @@ async def valve_control_to_code(config, action_id, template_arg, args):
         else:
             body_lines.append(f"call.{setter}({cg.safe_exp(value)});")
 
-    # Match ControlAction::ApplyFn signature: `const std::remove_reference_t<T> &`
-    # for each trigger arg so non-reference Ts stay no-copy (`const T &`) and
-    # reference Ts collapse correctly without producing `const T & &`.
+    # Match ControlAction::ApplyFn signature: forward trigger args as Ts...
+    # so the apply lambda's parameter types match both ApplyFn and the
+    # inner field lambdas (which are generated from `args` directly).
     apply_args = [
         (ValveCall.operator("ref"), "call"),
-        *(
-            (cg.RawExpression(f"const std::remove_reference_t<{cg.safe_exp(t)}> &"), n)
-            for t, n in args
-        ),
+        *args,
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -251,10 +251,11 @@ async def valve_control_to_code(config, action_id, template_arg, args):
         else:
             body_lines.append(f"call.{setter}({cg.safe_exp(value)});")
 
-    # Match ControlAction::ApplyFn signature: const Ts &... for trigger args.
+    # Match ControlAction::ApplyFn signature: trigger args forwarded
+    # by-value as Ts...
     apply_args = [
         (ValveCall.operator("ref"), "call"),
-        *((t.operator("const").operator("ref"), n) for t, n in args),
+        *args,
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/valve/automation.h
+++ b/esphome/components/valve/automation.h
@@ -52,9 +52,12 @@ template<typename... Ts> class ToggleAction : public Action<Ts...> {
 // plus one parent pointer, regardless of how many fields the user set.
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `position: !lambda "return x;"`) keep working.
+//
+// Ts... must be forwarded by-value: `const T &` is ill-formed when T is
+// already a reference type (some triggers pass `std::string &`).
 template<typename... Ts> class ControlAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(ValveCall &, const Ts &...);
+  using ApplyFn = void (*)(ValveCall &, Ts...);
   ControlAction(Valve *valve, ApplyFn apply) : valve_(valve), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/esphome/components/valve/automation.h
+++ b/esphome/components/valve/automation.h
@@ -53,16 +53,15 @@ template<typename... Ts> class ToggleAction : public Action<Ts...> {
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `position: !lambda "return x;"`) keep working.
 //
-// Trigger args are forwarded as `Ts...`. The previous `const Ts &...`
-// form caused codegen to emit `const T &` for each arg in the apply
-// lambda's parameter list, which is invalid C++ source text when T is
-// already a reference (e.g. `const std::string & &` for triggers that
-// pass `std::string &`). Forwarding `Ts...` lets the codegen reuse the
-// trigger's `args` types unchanged for both the apply lambda and any
-// inner field lambdas, so they always type-match.
+// Trigger args are normalized to `const std::remove_cvref_t<Ts> &...` so
+// the codegen can emit a matching parameter list for both the apply lambda
+// and any inner field lambdas without producing invalid C++ source text
+// (e.g. `const T & &` if Ts already carries a reference, or `const const
+// T &` if Ts already carries a const). This keeps trigger args no-copy
+// regardless of whether the trigger supplies `T`, `T &`, or `const T &`.
 template<typename... Ts> class ControlAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(ValveCall &, Ts...);
+  using ApplyFn = void (*)(ValveCall &, const std::remove_cvref_t<Ts> &...);
   ControlAction(Valve *valve, ApplyFn apply) : valve_(valve), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/esphome/components/valve/automation.h
+++ b/esphome/components/valve/automation.h
@@ -53,11 +53,13 @@ template<typename... Ts> class ToggleAction : public Action<Ts...> {
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `position: !lambda "return x;"`) keep working.
 //
-// Ts... must be forwarded by-value: `const T &` is ill-formed when T is
-// already a reference type (some triggers pass `std::string &`).
+// Trigger args are forwarded as `const std::remove_reference_t<Ts> &...`
+// (instead of `const Ts &...`) so codegen can emit the same form in the
+// apply lambda's parameter list without producing `const T & &` for
+// triggers whose Ts already carries a reference (e.g. `std::string &`).
 template<typename... Ts> class ControlAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(ValveCall &, Ts...);
+  using ApplyFn = void (*)(ValveCall &, const std::remove_reference_t<Ts> &...);
   ControlAction(Valve *valve, ApplyFn apply) : valve_(valve), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/esphome/components/valve/automation.h
+++ b/esphome/components/valve/automation.h
@@ -53,13 +53,16 @@ template<typename... Ts> class ToggleAction : public Action<Ts...> {
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `position: !lambda "return x;"`) keep working.
 //
-// Trigger args are forwarded as `const std::remove_reference_t<Ts> &...`
-// (instead of `const Ts &...`) so codegen can emit the same form in the
-// apply lambda's parameter list without producing `const T & &` for
-// triggers whose Ts already carries a reference (e.g. `std::string &`).
+// Trigger args are forwarded as `Ts...`. The previous `const Ts &...`
+// form caused codegen to emit `const T &` for each arg in the apply
+// lambda's parameter list, which is invalid C++ source text when T is
+// already a reference (e.g. `const std::string & &` for triggers that
+// pass `std::string &`). Forwarding `Ts...` lets the codegen reuse the
+// trigger's `args` types unchanged for both the apply lambda and any
+// inner field lambdas, so they always type-match.
 template<typename... Ts> class ControlAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(ValveCall &, const std::remove_reference_t<Ts> &...);
+  using ApplyFn = void (*)(ValveCall &, Ts...);
   ControlAction(Valve *valve, ApplyFn apply) : valve_(valve), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -356,6 +356,19 @@ number:
     min_value: 0
     max_value: 100
     step: 1
+  # Exercise valve.control inside a trigger with non-empty Ts (number on_value
+  # passes float).
+  - platform: template
+    id: template_valve_position_number
+    optimistic: true
+    min_value: 0
+    max_value: 100
+    step: 1
+    on_value:
+      then:
+        - valve.control:
+            id: template_valve
+            position: !lambda "return x / 100.0f;"
 
 select:
   - platform: template


### PR DESCRIPTION
# What does this implement/fix?

Same regression as esphome/esphome#16219, but for `valve.control`.

The Python codegen previously called `.operator("const").operator("ref")` on each trigger arg type, which raised `AttributeError` on plain Python types (`float`, `bool`) and produced invalid `const T & &` source text on reference types.

Both `ControlAction::ApplyFn` and the codegen now use `const std::remove_cvref_t<T> &` for each trigger arg. The same normalized form is used for the apply lambda *and* the inner field lambdas, so they always type-match. Trigger args stay no-copy regardless of whether the trigger supplies `T`, `T &`, or `const T &`.

**Note:** the memory-impact bot will report a small growth — that's the new `number: template` entry added to `tests/components/template/common-base.yaml` for the regression test, not the fix itself.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/16219

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Previously failed to compile, now works
number:
  - platform: template
    id: valve_position
    optimistic: true
    min_value: 0
    max_value: 100
    step: 1
    on_value:
      then:
        - valve.control:
            id: my_valve
            position: !lambda "return x / 100.0f;"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
