### PR TITLE
[tests] Fix flaky host_mode_climate_basic_state

### DIFF
--- a/tests/integration/fixtures/host_mode_climate_basic_state.yaml
+++ b/tests/integration/fixtures/host_mode_climate_basic_state.yaml
@@ -28,6 +28,10 @@ climate:
       min_temperature: 15.0
       max_temperature: 32.0
       temperature_step: 0.1
+    # Don't restore previous state from flash — this fixture shares the
+    # `host-climate-test` build dir with host_mode_climate_control.yaml, so a
+    # prior run of that test could leave the thermostat in HEAT/COOL.
+    on_boot_restore_from: default_preset
     default_preset: home
     preset:
       - name: "away"


### PR DESCRIPTION
# What does this implement/fix?

Fixes a flaky integration test. The fixture for `host_mode_climate_basic_state` shares its build dir name (`host-climate-test`) with `host_mode_climate_control`, so the host-mode preferences file persists between them. When the control test runs first and leaves the thermostat in HEAT, MEMORY-based restore on the next basic_state boot picks up HEAT and the initial-state assertion fails (`assert ClimateMode.HEAT == ClimateMode.OFF`).

Setting `on_boot_restore_from: default_preset` on the basic_state fixture forces a deterministic initial state regardless of prior runs. The `home` preset doesn't set a mode, so mode stays at the default (OFF).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Host mode integration test only.)

## Example entry for `config.yaml`:

```yaml
# tests/integration/fixtures/host_mode_climate_basic_state.yaml — added line:
climate:
  - platform: thermostat
    on_boot_restore_from: default_preset
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).