### PR TITLE
[cover] Fix ControlAction / CoverPublishAction trigger args with reference types

### DIFF
--- a/esphome/components/cover/__init__.py
+++ b/esphome/components/cover/__init__.py
@@ -328,17 +328,28 @@ async def build_apply_lambda_action(
     Used by both `cover.control` and `cover.template.publish` (and shared
     with the template/cover platform). Constants are emitted as flash
     immediates; user lambdas are invoked inline so trigger args still flow.
-    The trigger arg types are wrapped as `const T &` to match the
-    `void (*)(..., const Ts &...)` ApplyFn signature.
+    Trigger arg types are normalized to `const std::remove_cvref_t<T> &`
+    to match the ApplyFn signature for any T (value, ref, or const-ref).
     """
     paren = await cg.get_variable(config[CONF_ID])
+    # Normalize trigger args to `const std::remove_cvref_t<T> &` so the
+    # apply lambda and any inner field lambdas (generated below via
+    # `process_lambda`) share one parameter spelling that's well-formed for
+    # any T.
+    normalized_args = [
+        (cg.RawExpression(f"const std::remove_cvref_t<{cg.safe_exp(t)}> &"), n)
+        for t, n in args
+    ]
+
     fwd_args = ", ".join(name for _, name in args)
     body_lines: list[str] = []
     for field in fields:
         if (value := config.get(field.conf_key)) is None:
             continue
         if isinstance(value, Lambda):
-            inner = await cg.process_lambda(value, args, return_type=field.type_)
+            inner = await cg.process_lambda(
+                value, normalized_args, return_type=field.type_
+            )
             value_expr = f"({inner})({fwd_args})"
         else:
             value_expr = str(cg.safe_exp(value))
@@ -346,7 +357,7 @@ async def build_apply_lambda_action(
 
     apply_args = [
         *prefix_args,
-        *((t.operator("const").operator("ref"), n) for t, n in args),
+        *normalized_args,
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/cover/automation.h
+++ b/esphome/components/cover/automation.h
@@ -51,10 +51,17 @@ template<typename... Ts> class ToggleAction : public Action<Ts...> {
 // plus one parent pointer, regardless of how many fields the user set.
 // Trigger args are forwarded to the apply function so user lambdas
 // (e.g. `position: !lambda "return x;"`) keep working.
+//
+// Trigger args are normalized to `const std::remove_cvref_t<Ts> &...` so
+// the codegen can emit a matching parameter list for both the apply lambda
+// and any inner field lambdas without producing invalid C++ source text
+// (e.g. `const T & &` if Ts already carries a reference, or `const const
+// T &` if Ts already carries a const). This keeps trigger args no-copy
+// regardless of whether the trigger supplies `T`, `T &`, or `const T &`.
 
 template<typename... Ts> class ControlAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(CoverCall &, const Ts &...);
+  using ApplyFn = void (*)(CoverCall &, const std::remove_cvref_t<Ts> &...);
   ControlAction(Cover *cover, ApplyFn apply) : cover_(cover), apply_(apply) {}
 
   void play(const Ts &...x) override {
@@ -70,7 +77,7 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
 
 template<typename... Ts> class CoverPublishAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(Cover *, const Ts &...);
+  using ApplyFn = void (*)(Cover *, const std::remove_cvref_t<Ts> &...);
   CoverPublishAction(Cover *cover, ApplyFn apply) : cover_(cover), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -369,6 +369,19 @@ number:
         - valve.control:
             id: template_valve
             position: !lambda "return x / 100.0f;"
+  # Same regression test for cover.control: forces the apply-lambda
+  # codegen to handle a non-empty trigger Ts (float).
+  - platform: template
+    id: template_cover_position_number
+    optimistic: true
+    min_value: 0
+    max_value: 100
+    step: 1
+    on_value:
+      then:
+        - cover.control:
+            id: template_cover_with_triggers
+            position: !lambda "return x / 100.0f;"
 
 select:
   - platform: template


### PR DESCRIPTION
# What does this implement/fix?

Same regression as esphome/esphome#16219, but for `cover.control` and `cover.template.publish`. Both were introduced by #16046 (which folded the cover action fields into a stateless lambda) and inherited the same buggy codegen pattern that #16220–#16223 fix for light/climate/fan/valve.

The shared `build_apply_lambda_action` helper called `.operator("const").operator("ref")` on each trigger arg type, which raised `AttributeError` on plain Python types (`float`, `bool`) and produced invalid `const T & &` source text on reference-typed `Ts`. The inner field lambdas (`process_lambda`) were also generated from raw `args`, so calls from the apply lambda would not type-check when `Ts` contained a non-const reference.

Both `ApplyFn` signatures (`ControlAction`, `CoverPublishAction`) and the codegen now use `const std::remove_cvref_t<T> &` for each trigger arg. The same normalized form is used for the apply lambda *and* the inner field lambdas, so they always type-match. Trigger args stay no-copy regardless of whether the trigger supplies `T`, `T &`, or `const T &`.

**Note:** the memory-impact bot will report a small growth — that's the new `template_cover_position_number` test fixture in `tests/components/template/common-base.yaml`, not the fix itself.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/16219
- follow-up to https://github.com/esphome/esphome/pull/16046

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Previously failed to compile, now works
number:
  - platform: template
    id: cover_position
    optimistic: true
    min_value: 0
    max_value: 100
    step: 1
    on_value:
      then:
        - cover.control:
            id: my_cover
            position: !lambda "return x / 100.0f;"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).