### PR TITLE
[packages] Add resolve_packages single-call seam

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -611,3 +611,48 @@ def merge_packages(config: dict) -> dict:
     config = reduce(lambda new, old: merge_config(old, new), merge_list, config)
     del config[CONF_PACKAGES]
     return config
+
+
+def resolve_packages(
+    config: dict[str, Any],
+    *,
+    command_line_substitutions: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Load and merge ``packages:`` in one call; return the flattened config.
+
+    Convenience wrapper around :func:`do_packages_pass` followed by
+    :func:`merge_packages`. External tools that want the package-
+    merged dict (without going through full schema validation via
+    :func:`esphome.config.read_config`) get one stable seam to call
+    instead of having to chain the two functions and stay in sync
+    with the pipeline order.
+
+    Note: the full :func:`esphome.config.validate_config` pipeline
+    runs :func:`esphome.components.substitutions.do_substitution_pass`
+    BETWEEN :func:`do_packages_pass` and :func:`merge_packages`.
+    This wrapper deliberately skips the substitution pass — it's
+    only "load and merge", not "load, substitute, merge". Callers
+    that care about ``${var}`` resolution inside package content
+    should invoke ``do_substitution_pass`` themselves between
+    calls, or go through the full ``validate_config``.
+
+    Used by:
+
+    - ``esphome/device-builder`` — the new WebSocket dashboard
+      backend reads device metadata (api / wifi / target-platform
+      flags) off the merged config so packages contribute the same
+      blocks the compiler sees, not just whatever sits at the top
+      of the user's YAML. See
+      https://github.com/esphome/device-builder/issues/288 for the
+      bug this fixes.
+
+    Returns *config* unchanged when ``packages:`` isn't present, so
+    callers can apply this unconditionally without having to peek
+    at the config first.
+    """
+    if CONF_PACKAGES not in config:
+        return config
+    config = do_packages_pass(
+        config, command_line_substitutions=command_line_substitutions
+    )
+    return merge_packages(config)

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -628,13 +628,27 @@ def resolve_packages(
     with the pipeline order.
 
     Note: the full :func:`esphome.config.validate_config` pipeline
-    runs :func:`esphome.components.substitutions.do_substitution_pass`
-    BETWEEN :func:`do_packages_pass` and :func:`merge_packages`.
-    This wrapper deliberately skips the substitution pass — it's
-    only "load and merge", not "load, substitute, merge". Callers
-    that care about ``${var}`` resolution inside package content
-    should invoke ``do_substitution_pass`` themselves between
-    calls, or go through the full ``validate_config``.
+    runs two extra passes around the merge that this wrapper
+    deliberately skips:
+
+    1. :func:`esphome.components.substitutions.do_substitution_pass`
+       runs BETWEEN :func:`do_packages_pass` and
+       :func:`merge_packages`, so ``${var}`` placeholders inside
+       package content are NOT resolved here. Callers that need
+       substitution should invoke ``do_substitution_pass``
+       themselves between calls, or go through the full
+       ``validate_config``.
+    2. :func:`esphome.config.resolve_extend_remove` runs AFTER
+       :func:`merge_packages`, so top-level ``!remove`` / ``!extend``
+       markers are NOT applied here. A package-contributed block
+       paired with a top-level ``key: !remove`` will still appear
+       in the returned dict (the marker just sits next to it).
+
+    The wrapper exists for the "what blocks did packages
+    contribute?" question — metadata callers that just need to
+    see merged top-level keys. It is NOT a stand-in for
+    :func:`esphome.config.validate_config` and the two passes
+    above are the reasons why.
 
     Used by:
 

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -1697,3 +1697,47 @@ def test_resolve_packages_forwards_command_line_substitutions() -> None:
     spy.assert_called_once()
     _, kwargs = spy.call_args
     assert kwargs.get("command_line_substitutions") == {"foo": "bar"}
+
+
+def test_resolve_packages_does_not_run_substitutions() -> None:
+    """``${var}`` placeholders inside package content stay literal.
+
+    The full ``validate_config`` pipeline runs ``do_substitution_pass``
+    BETWEEN ``do_packages_pass`` and ``merge_packages``; this wrapper
+    skips it on purpose. Pin that contract so a future refactor can't
+    silently start resolving substitutions and break callers that
+    deliberately compose the passes themselves.
+    """
+    config = {
+        CONF_ESPHOME: {CONF_NAME: "main"},
+        CONF_SUBSTITUTIONS: {"ssid_value": "resolved_ssid"},
+        CONF_PACKAGES: {
+            "shared": {CONF_WIFI: {CONF_SSID: "${ssid_value}"}},
+        },
+    }
+    result = resolve_packages(config)
+    # Without ``do_substitution_pass`` the placeholder is preserved.
+    assert result[CONF_WIFI][CONF_SSID] == "${ssid_value}"
+
+
+def test_resolve_packages_does_not_apply_extend_remove() -> None:
+    """Top-level ``!remove`` / ``!extend`` markers stay in the merged dict.
+
+    The full ``validate_config`` pipeline runs ``resolve_extend_remove``
+    AFTER ``merge_packages``; this wrapper skips it on purpose. Pin
+    that contract: a package-contributed block paired with a top-level
+    ``!remove`` is left as-is for callers to handle (or for them to
+    call ``resolve_extend_remove`` themselves).
+    """
+    config = {
+        CONF_ESPHOME: {CONF_NAME: "main"},
+        CONF_WIFI: Remove(),
+        CONF_PACKAGES: {
+            "shared": {CONF_WIFI: {CONF_SSID: "from_package"}},
+        },
+    }
+    result = resolve_packages(config)
+    # ``merge_packages`` keeps the top-level ``!remove`` (it wins
+    # over the package value during merge), and the marker is not
+    # resolved by this wrapper.
+    assert isinstance(result[CONF_WIFI], Remove)

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -14,6 +14,7 @@ from esphome.components.packages import (
     do_packages_pass,
     is_package_definition,
     merge_packages,
+    resolve_packages,
 )
 from esphome.components.substitutions import ContextVars, do_substitution_pass
 import esphome.config as config_module
@@ -1621,3 +1622,78 @@ def test_remote_package_vars_resolved_against_sibling_package_substitutions(
     actual = packages_pass(config)
 
     assert actual[CONF_SENSOR][0]["pin"] == "GPIO5"
+
+
+# ---------------------------------------------------------------------------
+# resolve_packages — single-call wrapper around do_packages_pass + merge_packages
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_packages_returns_config_unchanged_without_packages() -> None:
+    """No ``packages:`` key → no-op, same dict back."""
+    config = {CONF_ESPHOME: {CONF_NAME: "test"}, CONF_WIFI: {CONF_SSID: "x"}}
+    result = resolve_packages(config)
+    assert result is config
+    assert CONF_PACKAGES not in result
+
+
+def test_resolve_packages_loads_and_merges_in_one_call() -> None:
+    """End-to-end: a config with one local-dict package gets its blocks flattened."""
+    config = {
+        CONF_ESPHOME: {CONF_NAME: "main"},
+        CONF_PACKAGES: {
+            "shared": {
+                CONF_WIFI: {CONF_SSID: "from_package"},
+                CONF_SENSOR: [
+                    {CONF_PLATFORM: "template", CONF_NAME: "from_package_sensor"},
+                ],
+            }
+        },
+    }
+    result = resolve_packages(config)
+    # ``packages:`` is gone — it was consumed by the merge.
+    assert CONF_PACKAGES not in result
+    # Blocks contributed by the package are now top-level.
+    assert result[CONF_WIFI][CONF_SSID] == "from_package"
+    assert result[CONF_SENSOR][0][CONF_NAME] == "from_package_sensor"
+    # The main config's own keys survive untouched.
+    assert result[CONF_ESPHOME][CONF_NAME] == "main"
+
+
+def test_resolve_packages_preserves_main_config_overrides() -> None:
+    """Main-config values win over package values for the same key.
+
+    Pinning the precedence ESPHome's compiler uses so any future
+    refactor of the wrapper doesn't accidentally flip the order.
+    """
+    config = {
+        CONF_ESPHOME: {CONF_NAME: "main"},
+        CONF_WIFI: {CONF_SSID: "main_wins"},
+        CONF_PACKAGES: {
+            "shared": {CONF_WIFI: {CONF_SSID: "package_loses"}},
+        },
+    }
+    result = resolve_packages(config)
+    assert result[CONF_WIFI][CONF_SSID] == "main_wins"
+
+
+def test_resolve_packages_forwards_command_line_substitutions() -> None:
+    """``command_line_substitutions`` reaches the underlying ``do_packages_pass``.
+
+    The wrapper exists so external tools have one stable seam; if
+    that seam silently dropped a kwarg the underlying call accepts,
+    callers would see surprising behaviour. This pins the
+    pass-through.
+    """
+    config = {
+        CONF_ESPHOME: {CONF_NAME: "main"},
+        CONF_PACKAGES: {"shared": {CONF_WIFI: {CONF_SSID: "from_package"}}},
+    }
+    with patch(
+        "esphome.components.packages.do_packages_pass",
+        wraps=do_packages_pass,
+    ) as spy:
+        resolve_packages(config, command_line_substitutions={"foo": "bar"})
+    spy.assert_called_once()
+    _, kwargs = spy.call_args
+    assert kwargs.get("command_line_substitutions") == {"foo": "bar"}


### PR DESCRIPTION
# What does this implement/fix?

Adds `resolve_packages(config, *, command_line_substitutions=None)` to `esphome.components.packages`. Convenience wrapper around `do_packages_pass(config)` followed by `merge_packages(config)` — the same two-step ESPHome's own pipeline runs at [`esphome/config.py:1010-1039`](https://github.com/esphome/esphome/blob/dev/esphome/config.py#L1010-L1039). External tools that want the package-merged config dict (without going through full schema validation via `read_config`) get one stable public entry point to call instead of having to chain the two functions and stay in sync with the pipeline order.

```python
from esphome.components.packages import resolve_packages

config = yaml_util.load_yaml(path)
config = resolve_packages(config)
# `api:` / `wifi:` / `esp32:` blocks contributed by `packages:` are now top-level.
```

Returns the config unchanged when `packages:` isn't present, so callers can apply this unconditionally without having to peek first.

## Motivation

The new `esphome/device-builder` dashboard backend (a WebSocket rewrite that will replace the legacy Tornado dashboard) inspects device YAML to drive its `api_encrypted` / `target_platform` / `loaded_integrations` flags — these light the lock indicator on the device card and gate the web-flasher option inside the install-method dialog. It needs to see what the compiler sees: `api:` / `wifi:` / `esp32:` blocks contributed by `packages:` have to register at the top level. `yaml_util.load_yaml` alone leaves them nested under the `packages:` tree.

Today device-builder has to import both `do_packages_pass` and `merge_packages` separately, call them in the right order, and stay in sync with the pipeline shape. With `resolve_packages` it'll switch to a single stable seam (with a `try: from … import resolve_packages; except ImportError: …` shim against the dep floor for one release cycle, then drop the shim).

Bug repro and the device-builder-side workaround:

- https://github.com/esphome/device-builder/issues/288 — BLE-beacon configs sharing a common `api:` / `wifi:` / `ota:` package showed `api_encrypted=False`, empty `target_platform`, empty `loaded_integrations`.
- https://github.com/esphome/device-builder/pull/295 — temporary fallback in the dashboard that chains `do_packages_pass + merge_packages` directly. Will switch to `resolve_packages` once this lands and the dashboard's esphome-dep floor moves.

## Final state

- One commit: `[packages] Add resolve_packages single-call seam`.
- 113 net lines added (function + tests).
- Touches `esphome/components/packages/__init__.py` and `tests/component_tests/packages/test_packages.py` only.
- `ruff` / `flake8` / `pyupgrade` / `pylint` / `ci-custom` all clean (locally).
- 73 existing package tests still pass; 4 new resolve_packages tests added.

## Test coverage

`tests/component_tests/packages/test_packages.py`:

- `test_resolve_packages_returns_config_unchanged_without_packages` — no `packages:` key → no-op, same dict back, callers can apply unconditionally without peeking.
- `test_resolve_packages_loads_and_merges_in_one_call` — end-to-end: a config with a local-dict package gets its blocks flattened to top-level, `packages:` itself is consumed.
- `test_resolve_packages_preserves_main_config_overrides` — pins precedence (main config wins over package values for the same key) so a future refactor of the wrapper can't flip the order silently.
- `test_resolve_packages_forwards_command_line_substitutions` — kwarg pass-through to `do_packages_pass` is part of the public contract.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- referenced from https://github.com/esphome/device-builder/pull/295

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (Python-side helper for external tooling; no user-facing config changes).

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Pure-Python wrapper around two existing functions; no firmware-side impact.)

## Example entry for `config.yaml`:

N/A — `resolve_packages` is an internal-tooling Python helper, not a user-facing config knob.

## Checklist:

- [x] The code change is tested and works locally (`pytest tests/component_tests/packages/` is green; new tests added).
- [x] Tests have been added to verify that the new code works (`tests/component_tests/packages/test_packages.py` — 4 new test cases).

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).