### PR TITLE
[ota] Partition table update: Fix log messages

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -117,8 +117,8 @@ void ESPHomeOTAComponent::dump_config() {
                 "  Partition table:\n"
                 "    %-12s %-4s %-8s %-10s %-10s",
                 "Name", "Type", "Subtype", "Address", "Size");
-  esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_ANY, ESP_PARTITION_SUBTYPE_ANY, NULL);
-  while (it != NULL) {
+  esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_ANY, ESP_PARTITION_SUBTYPE_ANY, nullptr);
+  while (it != nullptr) {
     const esp_partition_t *partition = esp_partition_get(it);
     ESP_LOGCONFIG(TAG, "    %-12s 0x%-2X 0x%-6X 0x%-8" PRIX32 " 0x%-8" PRIX32, partition->label, partition->type,
                   partition->subtype, partition->address, partition->size);

--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -20,8 +20,7 @@ OTAResponseTypes IDFOTABackend::begin(size_t image_size, ota::OTAType ota_type) 
 #ifdef USE_OTA_PARTITIONS
   this->ota_type_ = ota_type;
   if (this->ota_type_ == ota::OTA_TYPE_UPDATE_PARTITION_TABLE) {
-    // Reject any size other than ESP_PARTITION_TABLE_MAX_LEN: under- leaves stale bytes from the
-    // previous table; over- can't fit the reserved region.
+    // Reject any size other than ESP_PARTITION_TABLE_MAX_LEN
     if (image_size != ESP_PARTITION_TABLE_MAX_LEN) {
       ESP_LOGE(TAG, "Wrong partition table size: expected %u bytes, got %zu", ESP_PARTITION_TABLE_MAX_LEN, image_size);
       return OTA_RESPONSE_ERROR_PARTITION_TABLE_VERIFY;

--- a/esphome/components/ota/ota_partitions_esp_idf.cpp
+++ b/esphome/components/ota/ota_partitions_esp_idf.cpp
@@ -135,10 +135,20 @@ OTAResponseTypes IDFOTABackend::validate_new_partition_table_(uint32_t running_a
     // Rejecting here is non-destructive (no flash op has run yet); the user can safely retry with
     // a different .bin. Log enough info that they can pick the right method without guessing.
     ESP_LOGE(TAG,
-             "The new partition table must contain an app partition with the same address as any of the app\n"
-             "  partitions (type 0x0) in the current partition table and size at least %u bytes (0x%X).\n"
-             "  Upload a different partition table. No flash content was modified.",
+             "The new partition table must contain a compatible app partition with:\n"
+             "  size: at least %u bytes (0x%X)\n"
+             "  address: one of",
              running_app_size, running_app_size);
+    esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, NULL);
+    while (it != NULL) {
+      const esp_partition_t *partition = esp_partition_get(it);
+      if (partition->size >= running_app_size) {
+        ESP_LOGE(TAG, "    0x%" PRIX32, partition->address);
+      }
+      it = esp_partition_next(it);
+    }
+    esp_partition_iterator_release(it);
+    ESP_LOGE(TAG, "Upload a different partition table. No flash content was modified.");
     return OTA_RESPONSE_ERROR_PARTITION_TABLE_VERIFY;
   }
   if (app_partitions_found < 2) {
@@ -155,7 +165,7 @@ OTAResponseTypes IDFOTABackend::validate_new_partition_table_(uint32_t running_a
   }
   if (otadata_overlap) {
     // Unlikely, the otadata partition is before the start of the first app partition in most cases
-    ESP_LOGE(TAG, "New otadata partition overlaps with the running app at address: 0x%X, size: %u bytes",
+    ESP_LOGE(TAG, "New otadata partition overlaps with the running app which has address: 0x%X, size: %u bytes",
              running_app_offset, running_app_size);
     return OTA_RESPONSE_ERROR_PARTITION_TABLE_VERIFY;
   }
@@ -196,7 +206,7 @@ OTAResponseTypes IDFOTABackend::update_partition_table() {
   // can leave the device unbootable until it is recovered with a serial flash.
   ESP_LOGE(TAG, "Starting partition table update.\n"
                 "  DO NOT REMOVE POWER until the device reboots successfully.\n"
-                "  Loss of power during this operation may render the device \n"
+                "  Loss of power during this operation may render the device\n"
                 "  unable to boot until it is recovered via a serial flash.");
 
   // One guard over the whole critical section in case an IDF call takes longer than expected on

--- a/esphome/components/ota/ota_partitions_esp_idf.cpp
+++ b/esphome/components/ota/ota_partitions_esp_idf.cpp
@@ -155,8 +155,7 @@ OTAResponseTypes IDFOTABackend::validate_new_partition_table_(uint32_t running_a
   }
   if (otadata_overlap) {
     // Unlikely, the otadata partition is before the start of the first app partition in most cases
-    ESP_LOGE(TAG,
-             "New otadata partition overlaps with the running app at address: 0x%X, size: %u bytes",
+    ESP_LOGE(TAG, "New otadata partition overlaps with the running app at address: 0x%X, size: %u bytes",
              running_app_offset, running_app_size);
     return OTA_RESPONSE_ERROR_PARTITION_TABLE_VERIFY;
   }

--- a/esphome/components/ota/ota_partitions_esp_idf.cpp
+++ b/esphome/components/ota/ota_partitions_esp_idf.cpp
@@ -11,6 +11,7 @@
 #include <esp_ota_ops.h>
 #include <nvs_flash.h>
 
+#include <cinttypes>
 #include <cstring>
 
 namespace esphome::ota {
@@ -136,9 +137,9 @@ OTAResponseTypes IDFOTABackend::validate_new_partition_table_(uint32_t running_a
     // a different .bin. Log enough info that they can pick the right method without guessing.
     ESP_LOGE(TAG,
              "The new partition table must contain a compatible app partition with:\n"
-             "  size: at least %u bytes (0x%X)\n"
+             "  size: at least %" PRIu32 " bytes (0x%" PRIX32 ")\n"
              "  address: one of",
-             running_app_size, running_app_size);
+             (uint32_t) running_app_size, (uint32_t) running_app_size);
     esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, NULL);
     while (it != NULL) {
       const esp_partition_t *partition = esp_partition_get(it);
@@ -165,8 +166,10 @@ OTAResponseTypes IDFOTABackend::validate_new_partition_table_(uint32_t running_a
   }
   if (otadata_overlap) {
     // Unlikely, the otadata partition is before the start of the first app partition in most cases
-    ESP_LOGE(TAG, "New otadata partition overlaps with the running app which has address: 0x%X, size: %u bytes",
-             running_app_offset, running_app_size);
+    ESP_LOGE(TAG,
+             "New otadata partition overlaps with the running app at address: 0x%" PRIX32 ", running app size: %" PRIu32
+             " bytes",
+             running_app_offset, (uint32_t) running_app_size);
     return OTA_RESPONSE_ERROR_PARTITION_TABLE_VERIFY;
   }
 
@@ -222,7 +225,7 @@ OTAResponseTypes IDFOTABackend::update_partition_table() {
     // which leaves esp_ota_get_running_partition() returning nullptr.
     const esp_partition_t *running_app_part = find_app_partition_at(running_app_offset, running_app_size);
     if (running_app_part == nullptr) {
-      ESP_LOGE(TAG, "Cannot resolve running app partition at address 0x%X", running_app_offset);
+      ESP_LOGE(TAG, "Cannot resolve running app partition at address 0x%" PRIX32, running_app_offset);
       return OTA_RESPONSE_ERROR_PARTITION_TABLE_UPDATE;
     }
     ESP_LOGD(TAG, "Copying running app from 0x%X to 0x%X (size: 0x%X)", running_app_part->address,

--- a/esphome/components/ota/ota_partitions_esp_idf.cpp
+++ b/esphome/components/ota/ota_partitions_esp_idf.cpp
@@ -140,8 +140,7 @@ OTAResponseTypes IDFOTABackend::validate_new_partition_table_(uint32_t running_a
              "  size: at least %" PRIu32 " bytes (0x%" PRIX32 ")\n"
              "  address: one of",
              (uint32_t) running_app_size, (uint32_t) running_app_size);
-    esp_partition_iterator_t it =
-        esp_partition_find(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, nullptr);
+    esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, nullptr);
     while (it != nullptr) {
       const esp_partition_t *partition = esp_partition_get(it);
       if (partition->size >= running_app_size) {

--- a/esphome/components/ota/ota_partitions_esp_idf.cpp
+++ b/esphome/components/ota/ota_partitions_esp_idf.cpp
@@ -135,10 +135,10 @@ OTAResponseTypes IDFOTABackend::validate_new_partition_table_(uint32_t running_a
     // Rejecting here is non-destructive (no flash op has run yet); the user can safely retry with
     // a different .bin. Log enough info that they can pick the right method without guessing.
     ESP_LOGE(TAG,
-             "Running app at 0x%X (%u bytes used) does not fit any compatible slot in the new "
-             "partition table. Pick a migration method whose size limit is at least %u bytes and "
-             "retry; no flash content was modified.",
-             running_app_offset, running_app_size, running_app_size);
+             "The new partition table must contain an app partition with the same address as any of the app\n"
+             "  partitions (type 0x0) in the current partition table and size at least %u bytes (0x%X).\n"
+             "  Upload a different partition table. No flash content was modified.",
+             running_app_size, running_app_size);
     return OTA_RESPONSE_ERROR_PARTITION_TABLE_VERIFY;
   }
   if (app_partitions_found < 2) {
@@ -154,10 +154,9 @@ OTAResponseTypes IDFOTABackend::validate_new_partition_table_(uint32_t running_a
     return OTA_RESPONSE_ERROR_PARTITION_TABLE_VERIFY;
   }
   if (otadata_overlap) {
+    // Unlikely, the otadata partition is before the start of the first app partition in most cases
     ESP_LOGE(TAG,
-             "New otadata partition overlaps with the running app at 0x%X (size %u). The chosen "
-             "partition table is not compatible with this device's current flash layout; pick a "
-             "different migration method.",
+             "New otadata partition overlaps with the running app at address: 0x%X, size: %u bytes",
              running_app_offset, running_app_size);
     return OTA_RESPONSE_ERROR_PARTITION_TABLE_VERIFY;
   }
@@ -198,8 +197,8 @@ OTAResponseTypes IDFOTABackend::update_partition_table() {
   // can leave the device unbootable until it is recovered with a serial flash.
   ESP_LOGE(TAG, "Starting partition table update.\n"
                 "  DO NOT REMOVE POWER until the device reboots successfully.\n"
-                "  Loss of power during this operation may render the device unable to boot until\n"
-                "  it is recovered via a serial flash.");
+                "  Loss of power during this operation may render the device \n"
+                "  unable to boot until it is recovered via a serial flash.");
 
   // One guard over the whole critical section in case an IDF call takes longer than expected on
   // some chip variant.
@@ -214,7 +213,7 @@ OTAResponseTypes IDFOTABackend::update_partition_table() {
     // which leaves esp_ota_get_running_partition() returning nullptr.
     const esp_partition_t *running_app_part = find_app_partition_at(running_app_offset, running_app_size);
     if (running_app_part == nullptr) {
-      ESP_LOGE(TAG, "Cannot resolve running app partition at offset 0x%X", running_app_offset);
+      ESP_LOGE(TAG, "Cannot resolve running app partition at address 0x%X", running_app_offset);
       return OTA_RESPONSE_ERROR_PARTITION_TABLE_UPDATE;
     }
     ESP_LOGD(TAG, "Copying running app from 0x%X to 0x%X (size: 0x%X)", running_app_part->address,

--- a/esphome/components/ota/ota_partitions_esp_idf.cpp
+++ b/esphome/components/ota/ota_partitions_esp_idf.cpp
@@ -140,8 +140,9 @@ OTAResponseTypes IDFOTABackend::validate_new_partition_table_(uint32_t running_a
              "  size: at least %" PRIu32 " bytes (0x%" PRIX32 ")\n"
              "  address: one of",
              (uint32_t) running_app_size, (uint32_t) running_app_size);
-    esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, NULL);
-    while (it != NULL) {
+    esp_partition_iterator_t it =
+        esp_partition_find(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, nullptr);
+    while (it != nullptr) {
       const esp_partition_t *partition = esp_partition_get(it);
       if (partition->size >= running_app_size) {
         ESP_LOGE(TAG, "    0x%" PRIX32, partition->address);

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -139,9 +139,9 @@ _ERROR_MESSAGES: dict[int, str] = {
     ),
     RESPONSE_ERROR_PARTITION_TABLE_UPDATE: (
         "An error occurred while updating the partition table. The device is now "
-        "in a degraded state (NVS handles are invalid; many components will fail) "
-        "and may not be able to boot. Check the logs, reboot the device, and "
-        "retry the update. If the device fails to boot, recover it via a serial flash."
+        "in a degraded state and may not be able to boot. Open the logs and retry "
+        "the partition table update without rebooting the device. If the device "
+        "fails to boot, recover it via a serial flash."
     ),
     RESPONSE_ERROR_UNKNOWN: "Unknown error from ESP",
 }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Follow-up on https://github.com/esphome/esphome/pull/15780

- Don't tell users to reboot if the device may be unbootable
- Remove wrong comment about stale bytes from the previous partition table
- Use the word 'address' instead of 'offset' in log messages to be consistent with dump_config
- Remove language specific to the Tasmota migration guide ("migration method") and clarify the actual requirement
- On the "no compatible app partition" failure, enumerate the candidate addresses from the current partition table so the user knows exactly what the new table has to match
- Align the line lengths of log messages
- Use `PRIX32` / `PRIu32` consistently for `uint32_t` / `size_t` values in the touched log lines

The log messages now look like this:
```
[E][ota.idf:138]: The new partition table must contain a compatible app partition with:
[E][ota.idf:138]:   size: at least 831488 bytes (0xCB000)
[E][ota.idf:138]:   address: one of
[E][ota.idf:147]:     0x10000
[E][ota.idf:147]:     0x1D0000
[E][ota.idf:152]: Upload a different partition table. No flash content was modified.

[E][ota.idf:168]: New otadata partition overlaps with the running app at address: 0x10000, running app size: 831488 bytes

[E][ota.idf:200]: Starting partition table update.
[E][ota.idf:200]:   DO NOT REMOVE POWER until the device reboots successfully.
[E][ota.idf:200]:   Loss of power during this operation may render the device
[E][ota.idf:200]:   unable to boot until it is recovered via a serial flash.
```


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).