### PR TITLE
[ha-addon] Add opt-in toggle for the new ESPHome Device Builder

### DIFF
--- a/docker/ha-addon-rootfs/etc/cont-init.d/40-device-builder.sh
+++ b/docker/ha-addon-rootfs/etc/cont-init.d/40-device-builder.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Installs the latest prerelease of esphome-device-builder when the
+# `use_new_device_builder` config option is enabled.
+# This is a temporary install-on-boot step until esphome-device-builder
+# becomes a direct dependency of esphome.
+# ==============================================================================
+
+if ! bashio::config.true 'use_new_device_builder'; then
+  exit 0
+fi
+
+bashio::log.info "Installing latest prerelease of esphome-device-builder..."
+if command -v uv > /dev/null; then
+  uv pip install --system --no-cache-dir --prerelease=allow --upgrade \
+    esphome-device-builder ||
+    bashio::exit.nok "Failed installing esphome-device-builder."
+else
+  pip install --no-cache-dir --pre --upgrade esphome-device-builder ||
+    bashio::exit.nok "Failed installing esphome-device-builder."
+fi
+bashio::log.info "Installed esphome-device-builder."

--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
@@ -49,5 +49,12 @@ if bashio::fs.directory_exists '/config/esphome/.esphome'; then
     rm -rf /config/esphome/.esphome
 fi
 
+if bashio::config.true 'use_new_device_builder'; then
+    bashio::log.info "Starting ESPHome Device Builder..."
+    exec esphome-device-builder /config/esphome \
+        --ha-addon \
+        --ingress-port "$(bashio::addon.ingress_port)"
+fi
+
 bashio::log.info "Starting ESPHome dashboard..."
 exec esphome dashboard /config/esphome --socket /var/run/esphome.sock --ha-addon

--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -4,6 +4,14 @@
 # Community Hass.io Add-ons: ESPHome
 # Configures NGINX for use with ESPHome
 # ==============================================================================
+
+# When the new device builder is enabled it serves HA ingress directly,
+# so nginx is not used at all -- skip configuration.
+if bashio::config.true 'use_new_device_builder'; then
+    bashio::log.info "Skipping NGINX setup: new device builder serves ingress directly."
+    bashio::exit.ok
+fi
+
 mkdir -p /var/log/nginx
 
 # Generate Ingress configuration

--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -5,6 +5,14 @@
 # Runs the NGINX proxy
 # ==============================================================================
 
+# The new device builder handles HA ingress itself, so nginx is bypassed.
+# Block the longrun forever so s6 keeps the dependency satisfied and does
+# not respawn it.
+if bashio::config.true 'use_new_device_builder'; then
+    bashio::log.info "NGINX bypassed: new device builder serves ingress directly."
+    exec sleep infinity
+fi
+
 bashio::log.info "Waiting for ESPHome dashboard to come up..."
 
 while [[ ! -S /var/run/esphome.sock ]]; do


### PR DESCRIPTION
# What does this implement/fix?

Adds an opt-in `use_new_device_builder` toggle to the dev Home Assistant add-on. When enabled, the addon installs the latest prerelease of `esphome-device-builder` on container start, bypasses nginx entirely, and runs the new builder so it serves HA ingress directly via its native `--ha-addon` mode. When the toggle is off (default), the addon behaves exactly as before — classic `esphome dashboard` behind nginx with the unix socket.

The schema change for the toggle itself lives in the [home-assistant-addon repo](https://github.com/esphome/home-assistant-addon); this PR contains only the rootfs changes shipped in the addon image. To start, the toggle is exposed only in the dev addon — beta and stable will follow later.

How the toggle wires up at runtime:

- `cont-init.d/40-device-builder.sh` runs `uv pip install --system --prerelease=allow --upgrade esphome-device-builder` (with a pip fallback) when the toggle is on. This is install-on-boot for now; once `esphome-device-builder` becomes a direct dependency, this script can be removed.
- `init-nginx` (oneshot) short-circuits with `bashio::exit.ok` so nginx configs aren't templated.
- `nginx` (longrun) execs `sleep infinity` so s6 keeps the dependency satisfied without ever starting nginx and without respawn churn. Shutdown signal handling is unchanged — SIGTERM exits as code 256 / signal 15, which the existing finish script treats as a clean halt.
- `esphome` runs `esphome-device-builder /config/esphome --ha-addon --ingress-port <supervisor-allocated port>`. The builder's `--ha-addon` mode binds the supervisor's ingress port directly. `discovery` is unchanged — it polls `127.0.0.1:<ingress_port>` which is now the builder rather than nginx.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# N/A — this PR only changes the HA add-on rootfs.
\`\`\`

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).