### PR TITLE
[bmp581] Fix negative temperature calculation

### DIFF
--- a/esphome/components/bmp581_base/bmp581_base.cpp
+++ b/esphome/components/bmp581_base/bmp581_base.cpp
@@ -429,9 +429,9 @@ bool BMP581Component::read_temperature_(float &temperature) {
   }
 
   // temperature MSB is in data[2], LSB is in data[1], XLSB in data[0]
-  int32_t raw_temp = ((uint32_t)data[2] << 16) | ((uint32_t)data[1] << 8) | (uint32_t)data[0];
+  int32_t raw_temp = ((uint32_t) data[2] << 16) | ((uint32_t) data[1] << 8) | (uint32_t) data[0];
   if (raw_temp & 0x00800000) {
-    raw_temp |= 0xFF000000; // Sign extension
+    raw_temp |= 0xFF000000;  // Sign extension
   }
   temperature = (float) (raw_temp / 65536.0);  // convert measurement to degrees Celsius (page 22 of datasheet)
 
@@ -461,9 +461,9 @@ bool BMP581Component::read_temperature_and_pressure_(float &temperature, float &
   }
 
   // temperature MSB is in data[2], LSB is in data[1], XLSB in data[0]
-  int32_t raw_temp = ((uint32_t)data[2] << 16) | ((uint32_t)data[1] << 8) | (uint32_t)data[0];
+  int32_t raw_temp = ((uint32_t) data[2] << 16) | ((uint32_t) data[1] << 8) | (uint32_t) data[0];
   if (raw_temp & 0x00800000) {
-    raw_temp |= 0xFF000000; // Sign extension
+    raw_temp |= 0xFF000000;  // Sign extension
   }
   temperature = (float) (raw_temp / 65536.0);  // convert measurement to degrees Celsius (page 22 of datasheet)
 

--- a/esphome/components/bmp581_base/bmp581_base.cpp
+++ b/esphome/components/bmp581_base/bmp581_base.cpp
@@ -429,7 +429,10 @@ bool BMP581Component::read_temperature_(float &temperature) {
   }
 
   // temperature MSB is in data[2], LSB is in data[1], XLSB in data[0]
-  int32_t raw_temp = static_cast<int32_t>(encode_uint32(data[2], data[1], data[0], 0)) >> 8;
+  int32_t raw_temp = ((uint32_t)data[2] << 16) | ((uint32_t)data[1] << 8) | (uint32_t)data[0];
+  if (raw_temp & 0x00800000) {
+    raw_temp |= 0xFF000000; // Sign extension
+  }
   temperature = (float) (raw_temp / 65536.0);  // convert measurement to degrees Celsius (page 22 of datasheet)
 
   return true;
@@ -458,7 +461,10 @@ bool BMP581Component::read_temperature_and_pressure_(float &temperature, float &
   }
 
   // temperature MSB is in data[2], LSB is in data[1], XLSB in data[0]
-  int32_t raw_temp = static_cast<int32_t>(encode_uint32(data[2], data[1], data[0], 0)) >> 8;
+  int32_t raw_temp = ((uint32_t)data[2] << 16) | ((uint32_t)data[1] << 8) | (uint32_t)data[0];
+  if (raw_temp & 0x00800000) {
+    raw_temp |= 0xFF000000; // Sign extension
+  }
   temperature = (float) (raw_temp / 65536.0);  // convert measurement to degrees Celsius (page 22 of datasheet)
 
   // pressure MSB is in data[5], LSB is in data[4], XLSB in data[3]


### PR DESCRIPTION
# What does this implement/fix?

When the temperature drops below 0 °C, the BMP581 sensor reports completely incorrect positive values (e.g. 256 °C).

The temperature data from the sensor is a 24-bit signed integer. However, the current component code reads these 3 bytes into a 32-bit integer without proper sign extension. When the temperature is negative, the highest bit of the 24-bit chunk is 1, but the top 8 bits of the 32-bit variable remain 0. This results in a massive positive integer.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:
No config changes required

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
