### PR TITLE
[audio] Bump microOpus to v0.4.1

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -402,7 +402,7 @@ async def to_code(config):
         )
     if data.opus_support:
         cg.add_define("USE_AUDIO_OPUS_SUPPORT")
-        add_idf_component(name="esphome/micro-opus", ref="0.4.0")
+        add_idf_component(name="esphome/micro-opus", ref="0.4.1")
         if data.opus.floating_point is not None:
             add_idf_sdkconfig_option(
                 "CONFIG_OPUS_FLOATING_POINT", data.opus.floating_point

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -12,7 +12,7 @@ dependencies:
   esphome/micro-mp3:
     version: 0.2.0
   esphome/micro-opus:
-    version: 0.4.0
+    version: 0.4.1
   espressif/esp-dsp:
     version: "1.7.1"
   espressif/esp-tflite-micro:


### PR DESCRIPTION
# What does this implement/fix?
 
microOpus was causing native IDF support #14678 due to a false positive compilation error. Bumps the library to v0.4.1 ([GitHub](https://github.com/esphome-libs/micro-opus) and [Espressif Registry](https://components.espressif.com/components/esphome/micro-opus/versions/0.4.1/readme)) that makes the error a warning instead so builds can succeed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
