### PR TITLE
sen5x: Add actions for restart and measurement modes (normal, RHT-only)

### DIFF
--- a/esphome/components/sen5x/automation.h
+++ b/esphome/components/sen5x/automation.h
@@ -7,6 +7,7 @@
 namespace esphome {
 namespace sen5x {
 
+  
 template<typename... Ts> class StartFanAction : public Action<Ts...> {
  public:
   explicit StartFanAction(SEN5XComponent *sen5x) : sen5x_(sen5x) {}
@@ -17,5 +18,39 @@ template<typename... Ts> class StartFanAction : public Action<Ts...> {
   SEN5XComponent *sen5x_;
 };
 
+  
+template<typename... Ts> class StartReset : public Action<Ts...> {
+ public:
+  explicit StartReset(SEN5XComponent *sen5x) : sen5x_(sen5x) {}
+
+  void play(Ts... x) override { this->sen5x_->start_reset(); }
+
+ protected:
+  SEN5XComponent *sen5x_;
+};
+
+  
+template<typename... Ts> class StartMeasurementsRHTOnly : public Action<Ts...> {
+ public:
+  explicit StartMeasurementsRHTOnly(SEN5XComponent *sen5x) : sen5x_(sen5x) {}
+
+  void play(Ts... x) override { this->sen5x_->start_measurements_rht_only(); }
+
+ protected:
+  SEN5XComponent *sen5x_;
+};
+
+
+template<typename... Ts> class StartMeasurements : public Action<Ts...> {
+ public:
+  explicit StartMeasurements(SEN5XComponent *sen5x) : sen5x_(sen5x) {}
+
+  void play(Ts... x) override { this->sen5x_->start_measurements(); }
+
+ protected:
+  SEN5XComponent *sen5x_;
+};
+
+  
 }  // namespace sen5x
 }  // namespace esphome

--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -25,6 +25,7 @@ static const uint16_t SEN5X_CMD_STOP_MEASUREMENTS = 0x3f86;
 static const uint16_t SEN5X_CMD_TEMPERATURE_COMPENSATION = 0x60B2;
 static const uint16_t SEN5X_CMD_VOC_ALGORITHM_STATE = 0x6181;
 static const uint16_t SEN5X_CMD_VOC_ALGORITHM_TUNING = 0x60D0;
+static const uint16_t SEN5X_CMD_RESTART = 0xD304;
 
 static const int8_t SEN5X_INDEX_SCALE_FACTOR = 10;                            // used for VOC and NOx index values
 static const int8_t SEN5X_MIN_INDEX_VALUE = 1 * SEN5X_INDEX_SCALE_FACTOR;     // must be adjusted by the scale factor
@@ -412,6 +413,17 @@ bool SEN5XComponent::write_temperature_compensation_(const TemperatureCompensati
   return true;
 }
 
+bool SEN5XComponent::start_reset() {
+  if (!write_command(SEN5X_CMD_RESTART)) {
+    this->status_set_warning();
+    ESP_LOGE(TAG, "error restart sensor", this->last_error_);
+    return false;
+  } else {
+    ESP_LOGD(TAG, "restart sensor started");
+  }
+  return true;
+}
+
 bool SEN5XComponent::start_fan_cleaning() {
   if (!write_command(SEN5X_CMD_START_CLEANING_FAN)) {
     this->status_set_warning();
@@ -419,6 +431,28 @@ bool SEN5XComponent::start_fan_cleaning() {
     return false;
   } else {
     ESP_LOGD(TAG, "Fan auto clean started");
+  }
+  return true;
+}
+
+bool SEN5XComponent::start_measurements_rht_only() {
+  if (!write_command(SEN5X_CMD_START_MEASUREMENTS_RHT_ONLY)) {
+    this->status_set_warning();
+    ESP_LOGE(TAG, "write error start mesurement mode rht only (%d)", this->last_error_);
+    return false;
+  } else {
+    ESP_LOGD(TAG, "Started Measurement Mode RHT Only");
+  }
+  return true;
+}
+
+bool SEN5XComponent::start_measurements() {
+  if (!write_command(SEN5X_CMD_START_MEASUREMENTS)) {
+    this->status_set_warning();
+    ESP_LOGE(TAG, "write error start mesurement mode normal (%d)", this->last_error_);
+    return false;
+  } else {
+    ESP_LOGD(TAG, "Started Measurement Mode Normal");
   }
   return true;
 }

--- a/esphome/components/sen5x/sen5x.h
+++ b/esphome/components/sen5x/sen5x.h
@@ -96,6 +96,10 @@ class SEN5XComponent : public PollingComponent, public sensirion_common::Sensiri
     temp_comp.time_constant = time_constant;
     this->temperature_compensation_ = temp_comp;
   }
+
+  bool start_reset();
+  bool start_measurements_rht_only();
+  bool start_measurements();
   bool start_fan_cleaning();
 
  protected:

--- a/esphome/components/sen5x/sensor.py
+++ b/esphome/components/sen5x/sensor.py
@@ -57,6 +57,9 @@ CONF_AUTO_CLEANING_INTERVAL = "auto_cleaning_interval"
 
 # Actions
 StartFanAction = sen5x_ns.class_("StartFanAction", automation.Action)
+StartReset = sen5x_ns.class_("StartReset", automation.Action)
+StartMeasurements = sen5x_ns.class_("StartMeasurements", automation.Action)
+StartMeasurementsRHTOnly = sen5x_ns.class_("StartMeasurementsRHTOnly", automation.Action)
 
 ACCELERATION_MODES = {
     "low": RhtAccelerationMode.LOW_ACCELERATION,
@@ -270,6 +273,40 @@ SEN5X_ACTION_SCHEMA = maybe_simple_id(
     SEN5X_ACTION_SCHEMA,
     synchronous=True,
 )
+
+async def sen54_fan_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+@automation.register_action(
+    "sen5x.start_restart",
+    StartReset,
+    SEN5X_ACTION_SCHEMA,
+    synchronous=True,
+)
+
+async def sen54_fan_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+@automation.register_action(
+    "sen5x.start_measurements",
+    StartMeasurements,
+    SEN5X_ACTION_SCHEMA,
+    synchronous=True,
+)
+
+async def sen54_fan_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+@automation.register_action(
+    "sen5x.start_measurements_rht_only",
+    StartMeasurementsRHTOnly,
+    SEN5X_ACTION_SCHEMA,
+    synchronous=True,
+)
+
 async def sen54_fan_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)


### PR DESCRIPTION
senx5: Add Actions for Restart, Measurement-RHTOnly and Measurement-Normal

# What does this implement/fix?

Adds new actions to the sen5x component:

- restart
- start_measurements (normal mode)
- start_measurements_rht_only (RHT-only mode)

This allows switching measurement modes at runtime via automations.

Use case:
During nighttime, the fan can be disabled by switching to RHT-only mode,
reducing noise and power consumption while still measuring temperature and humidity.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
switch:
  - platform: template # Sen55 restart
    name: "${location} Sen55 Restart"
    turn_on_action:
      - sen5x.start_restart: sen55

  - platform: template # Sen55 normal Mode
    name: "${location} Sen55 Normal Mode"
    turn_on_action:
      - sen5x.start_measurements: sen55

  - platform: template # Sen55 RHT only mode
    name: "${location} Sen55 RHT Only Mode"
    turn_on_action:
      - sen5x.start_measurements_rht_only: sen55

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
