### PR TITLE
[script] Make pre-commit and helpers work on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     hooks:
       - id: pylint
         name: pylint
-        entry: python3 script/run-in-env.py pylint
+        entry: python script/run-in-env.py pylint
         language: system
         types: [python]
         files: ^esphome/.+\.py$
@@ -68,5 +68,5 @@ repos:
         additional_dependencies: []
       - id: ci-custom
         name: ci-custom
-        entry: python3 script/run-in-env.py script/ci-custom.py
+        entry: python script/run-in-env.py script/ci-custom.py
         language: system

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -250,7 +250,7 @@ def lint_ext_check(fname):
     ]
 )
 def lint_executable_bit(fname: Path) -> str | None:
-    ex = EXECUTABLE_BIT[str(fname)]
+    ex = EXECUTABLE_BIT[fname.as_posix()]
     if ex != 100644:
         return (
             f"File has invalid executable bit {ex}. If running from a windows machine please "

--- a/script/run-in-env.py
+++ b/script/run-in-env.py
@@ -44,7 +44,14 @@ def find_and_activate_virtualenv():
 def run_command():
     # Execute the remaining arguments in the new environment
     if len(sys.argv) > 1:
-        result = subprocess.run(sys.argv[1:], check=False, close_fds=False)
+        args = sys.argv[1:]
+        # Windows CreateProcess doesn't follow shebangs, so prepend the
+        # current interpreter when the entry is a .py script. Using
+        # sys.executable also pins the nested call to the same Python that
+        # ran us — no ambiguous PATH lookup for "python".
+        if args[0].endswith(".py"):
+            args = [sys.executable, *args]
+        result = subprocess.run(args, check=False, close_fds=False)
         sys.exit(result.returncode)
     else:
         print(


### PR DESCRIPTION
# What does this implement/fix?

Three small portability fixes so contributors on Windows can run `pre-commit` and the in-tree dev scripts.

- **`.pre-commit-config.yaml`** — drop the `python3` hardcode in the `pylint` and `ci-custom` hook entries. Windows ships only `python.exe`; the `python3.exe` name is intercepted by Microsoft's App Execution Alias stub which prints `Python was not found ...` and exits 9009. `python` works on Windows + macOS + modern Linux (where `python-is-python3` is the default), so the hooks become invocable.
- **`script/run-in-env.py`** — when the forwarded entry is a `.py` file, prepend `sys.executable` so Windows actually launches it. `CreateProcess` on Windows doesn't follow `#!/usr/bin/env` shebangs, so passing a `.py` filename directly to `subprocess` raises `WinError 193` (*"not a valid Win32 application"*). Using `sys.executable` also pins the nested call to the same interpreter that ran us, eliminating PATH ambiguity for the `python` lookup.
- **`script/ci-custom.py`** — look up `EXECUTABLE_BIT` by `fname.as_posix()` instead of `str(fname)`. `git ls-files` emits POSIX paths, but `Path` on Windows stringifies with backslashes, causing a `KeyError` on every file.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a — tooling-only change, no user-facing surface.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

n/a — does not affect device builds. Verified locally on Windows 11 by running `pre-commit run` from an activated venv: all hooks now execute (previously `pylint`, `ci-custom` failed at the `python3` invocation, and `ci-custom` further failed on `WinError 193` and the `EXECUTABLE_BIT` `KeyError`).

## Example entry for `config.yaml`:

n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).