### PR TITLE
[audio] Bump esp-audio-libs to v3.0.0

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -334,7 +334,7 @@ async def to_code(config):
 
     add_idf_component(
         name="esphome/esp-audio-libs",
-        ref="2.0.4",
+        ref="3.0.0",
     )
 
     data = _get_data()

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -2,7 +2,7 @@ dependencies:
   bblanchon/arduinojson:
     version: "7.4.2"
   esphome/esp-audio-libs:
-    version: 2.0.4
+    version: 3.0.0
   esphome/esp-micro-speech-features:
     version: 1.2.3
   esphome/micro-decoder:


### PR DESCRIPTION
# What does this implement/fix?

Bumps the esp-audio-libs library v3.0.0 ([GitHub](https://github.com/esphome-libs/esp-audio-libs) and [Espressif Registry](https://components.espressif.com/components/esphome/esp-audio-libs/versions/3.0.0/readme)).

Since the ``AudioDecoder`` class no longer uses any codec decoders from this library (FLAC #15372  ,MP3 #16236, WAV #16251), I removed them to reduce compilation time/effort. Now the librarr implements two things: audio resampler and optimized audio gain methods. I will make a follow up PR to use the optimized audio gain methods to speed up the ``i2s_audio`` and ``mixer`` speaker components. The audio resampler is still currently being built all the time, but I am tracking this issue in https://github.com/esphome-libs/esp-audio-libs/issues/39. This is still a dramatic reduction in compilation effort because of the dropped decoder libraries, so this PR is worthwhile while I work on making the resampler optional.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
