### PR TITLE
[core] Skip external component update on `esphome clean`

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2301,8 +2301,9 @@ def run_esphome(argv):
     CORE.config_path = conf_path
     CORE.dashboard = args.dashboard
 
-    # For logs command, skip updating external components
-    skip_external = args.command == "logs"
+    # Commands that don't need fresh external components: logs just connects
+    # to the device, and clean is about to delete the build directory.
+    skip_external = args.command in ("logs", "clean")
     config = read_config(
         dict(args.substitution) if args.substitution else {},
         skip_external_update=skip_external,

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -5038,6 +5038,32 @@ def test_run_esphome_non_bundle_skips_extraction(tmp_path: Path) -> None:
     assert result == 2
 
 
+@pytest.mark.parametrize(
+    ("command", "expected_skip"),
+    [
+        ("logs", True),
+        ("clean", True),
+        ("compile", False),
+        ("config", False),
+        ("run", False),
+        ("clean-mqtt", False),
+    ],
+)
+def test_run_esphome_skip_external_update_per_command(
+    tmp_path: Path, command: str, expected_skip: bool
+) -> None:
+    """read_config is invoked with skip_external_update=True only for commands
+    that don't need fresh external components (logs, clean)."""
+    yaml_file = tmp_path / "device.yaml"
+    yaml_file.write_text("esphome:\n  name: test\n")
+
+    with patch("esphome.__main__.read_config", return_value=None) as mock_read:
+        run_esphome(["esphome", command, str(yaml_file)])
+
+    mock_read.assert_called_once()
+    assert mock_read.call_args.kwargs["skip_external_update"] is expected_skip
+
+
 def test_get_configured_xtal_freq_reads_sdkconfig(tmp_path: Path) -> None:
     """Test reading XTAL_FREQ from sdkconfig."""
     CORE.name = "test-device"


### PR DESCRIPTION
# What does this implement/fix?

`esphome clean` is about to delete the build directory, but currently it still triggers an external-component refresh (git clone/pull, etc.) before doing so. That work is wasted — same logic that already short-circuits the refresh for `esphome logs` (which only connects to the device) applies here.

This noticed during device-builder development where `esphome clean` was visibly slower than expected; the time was being spent updating external components that were about to be irrelevant.

The fix is the minimal scope change to the `skip_external` flag passed to `read_config`:

```python
skip_external = args.command in ("logs", "clean")
```

Note: `clean-mqtt` is intentionally not included — it publishes wipe messages to topics derived from the (potentially externally-supplied) config and benefits from up-to-date external components.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change. Behavior change is on the CLI:
#   esphome clean device.yaml
# no longer pulls/refreshes external_components before deleting the build dir.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).