### PR TITLE
[http_request] Add regression test for light action inside on_response

### DIFF
--- a/tests/components/http_request/http_request.yaml
+++ b/tests/components/http_request/http_request.yaml
@@ -50,11 +50,32 @@ esphome:
                   format: "After delay, body still: %s"
                   args:
                     - body.c_str()
+              # Regression test for esphome/esphome#16224: a LightControlAction
+              # nested inside on_response with capture_response: true puts
+              # `std::string &` into the trigger's Ts..., which exposed a codegen
+              # bug where the apply lambda's parameter list did not match the
+              # ApplyFn signature.
+              - light.turn_on:
+                  id: test_regression_light
+                  brightness: 100%
+                  effect: "None"
 
 http_request:
   useragent: esphome/tagreader
   timeout: 10s
   verify_ssl: ${verify_ssl}
+
+output:
+  - platform: template
+    id: test_regression_output
+    type: float
+    write_action:
+      - logger.log: "set"
+
+light:
+  - platform: monochromatic
+    id: test_regression_light
+    output: test_regression_output
 
 script:
   - id: does_not_compile


### PR DESCRIPTION
# What does this implement/fix?

Adds a regression test that exercises `light.turn_on` nested inside `http_request.on_response` with `capture_response: true` — the trigger's `Ts...` then contains `std::string &`, which previously broke `LightControlAction` codegen.

`tests/components/light/common.yaml` already covers `number.on_value` (passing `float`), but no test covered a non-const-reference type in `Ts...` until now. Reverting #16220 against this test reproduces the original failure from #16224:

```
error: cannot declare reference to 'const std::string&', which is not
a typedef or a template type argument
```

With #16220 applied (current `dev`), the test compiles cleanly on all 7 http_request test platforms (host, esp32-ard, esp32-idf, esp32-idf custom-ca, esp8266-ard, esp8266-ard nossl, rp2040-ard).

The light is wired through a `template` float output so the fixture has no platform-specific pin requirements.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16224

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Reproducer from issue #16224 — compiles on dev with #16220 applied.
http_request:
  useragent: esphome

esphome:
  on_boot:
    then:
      - http_request.get:
          url: https://example.com/
          capture_response: true
          on_response:
            then:
              - light.turn_on:
                  id: my_light
                  brightness: 100%
                  effect: "None"

output:
  - platform: template
    id: my_output
    type: float
    write_action:
      - logger.log: "set"

light:
  - platform: monochromatic
    id: my_light
    output: my_output
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).