### PR TITLE
[bundle] Include secrets.yaml when `!secret` keys are quoted

### DIFF
--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -98,11 +98,13 @@ _KNOWN_FILE_EXTENSIONS = frozenset(
 )
 
 
-# Matches !secret references in YAML text.  This is intentionally a simple
-# regex scan rather than a YAML parse — it may match inside comments or
-# multi-line strings, which is the conservative direction (include more
-# secrets rather than fewer).
-_SECRET_RE = re.compile(r"!secret\s+(\S+)")
+# Matches !secret references in YAML text. The key may be single- or
+# double-quoted; YAML strips those quotes during parsing so the resolved
+# key in secrets.yaml does not contain them. This is intentionally a
+# simple regex scan rather than a YAML parse — it may match inside
+# comments or multi-line strings, which is the conservative direction
+# (include more secrets rather than fewer).
+_SECRET_RE = re.compile(r"""!secret\s+(?:'([^'\n]*)'|"([^"\n]*)"|(\S+))""")
 
 
 def _find_used_secret_keys(yaml_files: list[Path]) -> set[str]:
@@ -114,7 +116,10 @@ def _find_used_secret_keys(yaml_files: list[Path]) -> set[str]:
         except (OSError, UnicodeDecodeError):
             continue
         for match in _SECRET_RE.finditer(text):
-            keys.add(match.group(1))
+            single, double, bare = match.groups()
+            keys.add(
+                single if single is not None else double if double is not None else bare
+            )
     return keys
 
 

--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -98,13 +98,13 @@ _KNOWN_FILE_EXTENSIONS = frozenset(
 )
 
 
-# Matches !secret references in YAML text. The key may be single- or
-# double-quoted; YAML strips those quotes during parsing so the resolved
-# key in secrets.yaml does not contain them. This is intentionally a
-# simple regex scan rather than a YAML parse — it may match inside
-# comments or multi-line strings, which is the conservative direction
-# (include more secrets rather than fewer).
-_SECRET_RE = re.compile(r"""!secret\s+(?:'([^'\n]*)'|"([^"\n]*)"|(\S+))""")
+# Matches !secret references in YAML text.  An optional surrounding
+# quote pair around the key is allowed and ignored: YAML treats
+# ``!secret 'foo'`` and ``!secret foo`` as the same key.  This is
+# intentionally a simple regex scan rather than a YAML parse — it may
+# match inside comments or multi-line strings, which is the conservative
+# direction (include more secrets rather than fewer).
+_SECRET_RE = re.compile(r"""!secret\s+['"]?([^\s'"]+)""")
 
 
 def _find_used_secret_keys(yaml_files: list[Path]) -> set[str]:
@@ -116,10 +116,7 @@ def _find_used_secret_keys(yaml_files: list[Path]) -> set[str]:
         except (OSError, UnicodeDecodeError):
             continue
         for match in _SECRET_RE.finditer(text):
-            single, double, bare = match.groups()
-            keys.add(
-                single if single is not None else double if double is not None else bare
-            )
+            keys.add(match.group(1))
     return keys
 
 

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -170,6 +170,23 @@ def test_find_used_secret_keys_deduplicates(tmp_path: Path) -> None:
     assert keys == {"key1"}
 
 
+def test_find_used_secret_keys_quoted(tmp_path: Path) -> None:
+    """Quoted !secret keys should resolve to the same key as unquoted form.
+
+    YAML strips surrounding quotes during parsing, so the secrets.yaml
+    lookup uses the unquoted key. The bundle scan must do the same.
+    """
+    yaml1 = tmp_path / "a.yaml"
+    yaml1.write_text(
+        "single: !secret 'wifi_ssid'\n"
+        'double: !secret "wifi_pw"\n'
+        "bare: !secret api_key\n"
+    )
+
+    keys = _find_used_secret_keys([yaml1])
+    assert keys == {"wifi_ssid", "wifi_pw", "api_key"}
+
+
 # ---------------------------------------------------------------------------
 # _add_bytes_to_tar
 # ---------------------------------------------------------------------------
@@ -1215,6 +1232,35 @@ def test_create_bundle_filters_secrets(tmp_path: Path) -> None:
     assert "wifi_pw" in secrets_data
     assert "unused" not in secrets_data
     assert "should_not_appear" not in secrets_data
+
+
+def test_create_bundle_filters_secrets_quoted(tmp_path: Path) -> None:
+    """Bundling must include secrets.yaml when !secret keys are quoted.
+
+    Regression test for issue 16259: quoted !secret references previously
+    captured the quotes as part of the key, so no key matched secrets.yaml
+    entries and the secrets file was dropped from the bundle entirely.
+    """
+    config_dir = _setup_config_dir(tmp_path)
+
+    secrets = config_dir / "secrets.yaml"
+    secrets.write_text("ota_password: hunter2\nunused: should_not_appear\n")
+
+    config_yaml = "ota:\n  password: !secret 'ota_password'\n"
+    (config_dir / "test.yaml").write_text(config_yaml)
+
+    creator = ConfigBundleCreator({})
+    result = creator.create_bundle()
+
+    assert result.manifest[ManifestKey.HAS_SECRETS] is True
+
+    buf = io.BytesIO(result.data)
+    with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+        secrets_data = tar.extractfile("secrets.yaml").read().decode()
+
+    assert "ota_password" in secrets_data
+    assert "hunter2" in secrets_data
+    assert "unused" not in secrets_data
 
 
 def test_create_bundle_no_secrets(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug in `esphome bundle` where `secrets.yaml` is silently dropped from the generated archive whenever a `!secret` reference is quoted, e.g. `password: !secret 'ota_password'`.

The bundle's secret-key scan in `esphome/bundle.py` used the regex `r"!secret\s+(\S+)"`. Because `\S+` is greedy over non-whitespace, it captured the surrounding quotes as part of the key. The captured key `'ota_password'` (with quotes) never matched the actual entry `ota_password` in `secrets.yaml`, so `_build_filtered_secrets` returned an empty dict and the secrets file was omitted from the bundle. Both single- and double-quoted forms were affected.

YAML treats `!secret 'foo'` and `!secret foo` as the same key, so the bundle scan must too. The fix tightens the regex to allow an optional opening quote and then capture key characters using a class that excludes whitespace and quotes: `r"""!secret\s+['"]?([^\s'"]+)"""`. A trailing quote, if present, falls outside the capture because the character class already terminates the key. No post-processing of the captured group is needed.

A regression test exercises bare, single-quoted, and double-quoted forms in `_find_used_secret_keys`, and an end-to-end test verifies that `secrets.yaml` is included in the bundle (with `has_secrets=True`) when a single-quoted `!secret` reference is used. All 88 existing tests in `tests/unit_tests/test_bundle.py` continue to pass.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16259

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Pure Python change to the bundling tool; no firmware/platform exercised.)

## Example entry for `config.yaml`:

```yaml
# secrets.yaml
ota_password: hunter2

# device.yaml — both forms now correctly cause secrets.yaml to be bundled
ota:
  - platform: esphome
    password: !secret 'ota_password'   # quoted (previously broken)
    # password: !secret ota_password   # unquoted (already worked)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).