### PR TITLE
[substitutions] Fix sibling references inside dict-valued substitutions

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -278,7 +278,18 @@ def _push_context(
         """Resolve a variable, recursively resolving any dependencies it references."""
         value = unresolved_vars.pop(key, Missing)
         if value is Missing:
-            return Missing
+            # Either already resolved (in resolved_vars) or currently being
+            # resolved (self-reference from inside a dict-valued substitution).
+            # Returning what we have lets sibling references inside a dict
+            # value, e.g. ``${device.manufacturer}`` inside ``device.name``,
+            # see literal sibling values during their own resolution.
+            return resolved_vars.get(key, Missing)
+        if isinstance(value, dict):
+            # Dict-valued substitutions form a namespace; eagerly publish the
+            # original mapping so its members can reference each other while
+            # the dict's own substitution pass is still running. The entry is
+            # replaced with the fully-substituted dict once recursion returns.
+            resolved_vars[key] = value
         try:
             value = substitute(value, [], resolver_context, True)
         except UndefinedError as err:

--- a/tests/unit_tests/fixtures/substitutions/18-dict_self_reference.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/18-dict_self_reference.approved.yaml
@@ -1,0 +1,16 @@
+substitutions:
+  device:
+    manufacturer: espressif
+    model: esp32
+    mac_suffix: ffffff
+    name: espressif-esp32-ffffff
+  network:
+    host: example.com
+    port: 8080
+    url: http://example.com:8080/api
+esphome:
+  name: espressif-esp32-ffffff
+test_list:
+  - espressif-esp32-ffffff
+  - http://example.com:8080/api
+  - espressif/esp32

--- a/tests/unit_tests/fixtures/substitutions/18-dict_self_reference.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/18-dict_self_reference.input.yaml
@@ -1,0 +1,18 @@
+substitutions:
+  device:
+    manufacturer: "espressif"
+    model: "esp32"
+    mac_suffix: "ffffff"
+    name: ${device.manufacturer}-${device.model}-${device.mac_suffix}
+  network:
+    host: "example.com"
+    port: 8080
+    url: "http://${network.host}:${network.port}/api"
+
+esphome:
+  name: ${device.name}
+
+test_list:
+  - ${device.name}
+  - ${network.url}
+  - "${device.manufacturer}/${device.model}"


### PR DESCRIPTION
# What does this implement/fix?

Restores the ability for a dict-valued substitution variable to reference its own siblings. The substitutions refactor in 2026.4.0 (#14918, #15031, #12213) replaced the in-place tree walk with a pre-resolution pass over each top-level substitution. For dict-valued entries the pre-resolution pops the variable from `unresolved_vars` before recursing into the dict's contents, so a sibling reference such as `${device.manufacturer}` inside `device.name` raises `Could not resolve substitution variable 'device': 'device' is undefined` and the rest of the config sees the unsubstituted string.

The fix:

- Eagerly publish dict-valued substitutions to `resolved_vars` before recursing so siblings see literal values during their own resolution.
- Have the lazy resolver fall back to `resolved_vars.get(key, Missing)` for a key that has already been popped, so a self-reference returns the partially-resolved dict instead of `Missing`.
- Overwrite the eager entry with the fully-substituted dict once recursion returns.

A regression fixture (`18-dict_self_reference`) covers the issue's exact pattern plus a second dict (`network`) that uses the same construct, exercising both sibling resolution and downstream `${device.name}` access.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16254

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
substitutions:
  device:
    manufacturer: "espressif"
    model: "esp32"
    mac_suffix: "ffffff"
    name: ${device.manufacturer}-${device.model}-${device.mac_suffix}

esphome:
  name: ${device.name}

esp8266:
  board: esp01_1m
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).