### PR TITLE
[schema] Surface OnlyWith / OnlyWithout default + gate components in schema generator

### DIFF
--- a/script/build_language_schema.py
+++ b/script/build_language_schema.py
@@ -1065,7 +1065,40 @@ def convert_keys(converted, schema, path):
             else:
                 converted["key_type"] = str(k)
 
-        if hasattr(k, "default") and str(k.default) != "...":
+        # ``cv.OnlyWith`` / ``cv.OnlyWithout`` expose ``default`` as
+        # a property that returns ``vol.UNDEFINED`` when the gating
+        # component isn't loaded — and at schema-generation time
+        # ``CORE.loaded_integrations`` is always empty, so the
+        # property never resolves. The unconditional default lives
+        # on ``_default``; expose it under a *new* per-class field
+        # (``default_with`` for ``OnlyWith``, ``default_without`` for
+        # ``OnlyWithout``) that bundles the value with the gating
+        # component(s). Pure addition to the bundle — old consumers
+        # that read only ``default`` see these fields as
+        # default-less (same as today, no regression where they used
+        # to fall back to a hard-coded UI default); new consumers
+        # opt-in to the gated fields and apply the default
+        # *conditionally* on which integrations the user has
+        # loaded. Without the gate info, an ethernet-only config on
+        # ``cv.OnlyWith(K, "wifi", default=True)`` would otherwise
+        # render ``True`` even though ESPHome itself wouldn't apply
+        # the default for that config.
+        if isinstance(k, (cv.OnlyWith, cv.OnlyWithout)):
+            default_value = k._default()
+            if default_value is not None:
+                components = (
+                    list(k._component)
+                    if isinstance(k._component, list)
+                    else [k._component]
+                )
+                gate_field = (
+                    "default_with" if isinstance(k, cv.OnlyWith) else "default_without"
+                )
+                result[gate_field] = {
+                    "value": str(default_value),
+                    "components": components,
+                }
+        elif hasattr(k, "default") and str(k.default) != "...":
             default_value = k.default()
             if default_value is not None:
                 result["default"] = str(default_value)


### PR DESCRIPTION
# What does this implement/fix?

`cv.OnlyWith` / `cv.OnlyWithout` expose `default` as a `@property` that returns `vol.UNDEFINED` whenever the gating component isn't loaded. At schema-generation time `CORE.loaded_integrations` is always empty (the script doesn't run a real config-load pass), so the property never resolves — and the unconditional default the user passed to the validator silently disappears from the published schema bundle.

That means a field declared as

```python
cv.OnlyWith(CONF_SOFTWARE_COEXISTENCE, "wifi", default=True): bool,
```

ships in `schema.esphome.io`'s bundle with no `default` field at all, even though the running firmware applies `True` whenever `wifi:` is configured.

Read `_default()` directly for `OnlyWith` / `OnlyWithout` and ship the default value + gating component(s) under new per-class fields:

- `default_with: {value, components}` — `OnlyWith`'s "all listed components must be loaded" gate
- `default_without: {value, components}` — `OnlyWithout`'s "component must NOT be loaded" gate

## Backwards compatibility

**Pure addition to the bundle.** The unconditional `default` field is intentionally left unset for these validators, so old consumers that read only `default` see no change in shape (same as today, no regression). New consumers (device-builder dashboard's catalog generator, vscode language server, etc.) opt in to `default_with` / `default_without` and apply the default *conditionally* on which integrations the user has loaded. Without the gate info, an ethernet-only config on a field declared as `cv.OnlyWith(K, "wifi", default=True)` would otherwise render `True` even though ESPHome itself wouldn't apply the default — that's the regression we're avoiding by NOT populating `default`.

## Verification

Ran `python script/build_language_schema.py --output-path /tmp/test` against the current ESPHome tree. Every existing call site now exposes the gated default in the bundle:

| Component | Field | Field shape | Value | Gate |
|---|---|---|---|---|
| `esp32_ble_tracker` | `software_coexistence` | `default_with` | `True` | `["wifi"]` |
| `esp32_ble_beacon` | `tx_power` | `default_without` | `3dBm` | `["esp32_hosted"]` |
| `zigbee` | `wipe_on_boot` | `default_with` | `False` | `["nrf52"]` |
| `zigbee` | `power_source` | `default_with` | `DC_SOURCE` | `["nrf52"]` |
| `zigbee` | `sleepy` | `default_with` | `False` | `["nrf52"]` |

Sample bundle entry:

```json
"software_coexistence": {
  "key": "Optional",
  "default_with": {"value": "True", "components": ["wifi"]}
}
```

The validator's runtime contract (when the gate fires the default applies, when it doesn't the key is omitted) is already covered by the existing `test_only_with_*` suite in `tests/unit_tests/test_config_validation.py`. The change here is in a tooling path (schema-bundle generation) that has no unit-test surface today; the published bundle is the natural verification.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A — surfaced from device-builder dashboard catalog work; no GitHub issue filed.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — no user-facing config change.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Schema-generator change; no firmware build path touched.)

## Example entry for `config.yaml`:

```yaml
# Existing call site that triggered this — schema bundle now
# publishes default_with: {value: True, components: [wifi]}
# for software_coexistence.
esp32_ble_tracker:
  scan_parameters:
    active: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
