### PR TITLE
[core] Adds acquire and release methods to the ring buffer class

### DIFF
--- a/esphome/core/ring_buffer.cpp
+++ b/esphome/core/ring_buffer.cpp
@@ -37,6 +37,14 @@ std::unique_ptr<RingBuffer> RingBuffer::create(size_t len, MemoryPreference pref
   return rb;
 }
 
+void *RingBuffer::receive_acquire(size_t &length, size_t max_length, TickType_t ticks_to_wait) {
+  length = 0;
+  void *buffer_data = xRingbufferReceiveUpTo(this->handle_, &length, ticks_to_wait, max_length);
+  return buffer_data;
+}
+
+void RingBuffer::receive_release(void *item) { vRingbufferReturnItem(this->handle_, item); }
+
 size_t RingBuffer::read(void *data, size_t len, TickType_t ticks_to_wait) {
   size_t bytes_read = 0;
 

--- a/esphome/core/ring_buffer.h
+++ b/esphome/core/ring_buffer.h
@@ -28,6 +28,28 @@ class RingBuffer {
   size_t read(void *data, size_t len, TickType_t ticks_to_wait = 0);
 
   /**
+   * @brief Acquires a pointer into the ring buffer's internal storage without copying.
+   *
+   * The returned pointer is valid until receive_release() is called. Only one item
+   * may be checked out at a time.
+   *
+   * @param[out] length Set to the number of bytes actually acquired (may be less than max_length at wrap boundary)
+   * @param max_length Maximum number of bytes to acquire
+   * @param ticks_to_wait Maximum number of FreeRTOS ticks to wait (default: 0)
+   * @return Pointer into the ring buffer's internal storage, or nullptr if no data is available
+   */
+  void *receive_acquire(size_t &length, size_t max_length, TickType_t ticks_to_wait = 0);
+
+  /**
+   * @brief Releases a previously acquired ring buffer item.
+   *
+   * Must be called exactly once for each successful receive_acquire().
+   *
+   * @param item Pointer returned by receive_acquire()
+   */
+  void receive_release(void *item);
+
+  /**
    * @brief Writes to the ring buffer, overwriting oldest data if necessary.
    *
    * The provided data is written to the ring buffer. If not enough space is available,


### PR DESCRIPTION
# What does this implement/fix?

This enables accessing data directly in the ring buffer without copying into a secondary transfer buffer. This will help optimize the `mixer` and `i2s_audio` speakers by eliminating an extra allocation and an extra copy.

I will follow up with another PR to add a new audio transfer buffer source class that uses the data in the ring buffer directly

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
