### PR TITLE
[audio] Bump microFLAC to v0.2.0

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -386,7 +386,7 @@ async def to_code(config):
     # Adds a define and IDF component for legacy `audio_decoder.cpp`.
     if data.flac_support:
         cg.add_define("USE_AUDIO_FLAC_SUPPORT")
-        add_idf_component(name="esphome/micro-flac", ref="0.1.1")
+        add_idf_component(name="esphome/micro-flac", ref="0.2.0")
         _emit_memory_pair(
             data.flac.buffer_memory,
             "CONFIG_MICRO_FLAC_PREFER_PSRAM",

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -8,7 +8,7 @@ dependencies:
   esphome/micro-decoder:
     version: 0.2.0
   esphome/micro-flac:
-    version: 0.1.1
+    version: 0.2.0
   esphome/micro-mp3:
     version: 0.2.0
   esphome/micro-opus:


### PR DESCRIPTION
# What does this implement/fix?

Bumps the microFLAC library to v0.2.0 ([GitHub](https://github.com/esphome-libs/micro-flac) and [Espressif Registry](https://components.espressif.com/components/esphome/micro-flac/versions/0.2.0/readme)).

Decoding is approximately 15% faster on an ESP32-S3! It can decode stereo 48 kHz 16 bits per sample audio over 30 times faster than real-time (with CRC checks enabled). I was able to speed this up quite a bit more by reducing register pressure in the hot functions to avoid storing/retrieving temporary info on the stack.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Note this also speeds up ``audio_file``, ``audio_http``, and ``sendspin`` decoding, not just `speaker` media player!

```yaml
# Example config.yaml

media_player:
  - platform: speaker
    name: None
    id: speaker_media_player
    announcement_pipeline:
      speaker: SPEAKER_ID
      format: FLAC
      sample_rate: 48000
      num_channels: 2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
