### PR TITLE
[modbus_controller] Merged branch 'modbus-switch-register_count' to use 'modbus::helpers::'

### DIFF
--- a/esphome/components/modbus_controller/switch/__init__.py
+++ b/esphome/components/modbus_controller/switch/__init__.py
@@ -16,6 +16,7 @@ from ..const import (
     CONF_BITMASK,
     CONF_FORCE_NEW_RANGE,
     CONF_MODBUS_CONTROLLER_ID,
+    CONF_REGISTER_COUNT,
     CONF_REGISTER_TYPE,
     CONF_SKIP_UPDATES,
     CONF_USE_WRITE_MULTIPLE,
@@ -48,6 +49,9 @@ CONFIG_SCHEMA = cv.All(
 
 async def to_code(config):
     byte_offset, _ = modbus_calc_properties(config)
+    reg_count = config.get(CONF_REGISTER_COUNT)
+    if reg_count is None:
+        reg_count = 1
     var = cg.new_Pvariable(
         config[CONF_ID],
         config[CONF_REGISTER_TYPE],
@@ -56,6 +60,7 @@ async def to_code(config):
         config[CONF_BITMASK],
         config[CONF_SKIP_UPDATES],
         config[CONF_FORCE_NEW_RANGE],
+        reg_count,
     )
     await cg.register_component(var, config)
     await switch.register_switch(var, config)

--- a/esphome/components/modbus_controller/switch/__init__.py
+++ b/esphome/components/modbus_controller/switch/__init__.py
@@ -41,6 +41,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_REGISTER_TYPE): cv.enum(MODBUS_REGISTER_TYPE),
             cv.Optional(CONF_USE_WRITE_MULTIPLE, default=False): cv.boolean,
             cv.Optional(CONF_WRITE_LAMBDA): cv.returning_lambda,
+            cv.Optional(CONF_REGISTER_COUNT, default=1): cv.positive_int,
         }
     ),
     validate_modbus_register,

--- a/esphome/components/modbus_controller/switch/modbus_switch.cpp
+++ b/esphome/components/modbus_controller/switch/modbus_switch.cpp
@@ -33,7 +33,12 @@ void ModbusSwitch::parse_and_publish(const std::vector<uint8_t> &data) {
     case ModbusRegisterType::DISCRETE_INPUT:
     case ModbusRegisterType::COIL:
       // offset for coil is the actual number of the coil not the byte offset
-      value = modbus::helpers::coil_from_vector(this->offset, data);
+      if (this->use_write_multiple_ && this->register_count > 1) {
+        // for multy registers switch, consider last 2 bytes only as offset
+        value = modbus::helpers::get_data<uint16_t>(data, this->register_count * 2 - 2) & this->bitmask;
+      } else {
+        value = modbus::helpers::get_data<uint16_t>(data, this->offset) & this->bitmask;
+      }
       break;
     default:
       value = modbus::helpers::get_data<uint16_t>(data, this->offset) & this->bitmask;
@@ -99,9 +104,10 @@ void ModbusSwitch::write_state(bool state) {
     } else {
       // since offset is in bytes and a register is 16 bits we get the start by adding offset/2
       if (this->use_write_multiple_) {
-        std::vector<uint16_t> bool_states(1, state ? (0xFFFF & this->bitmask) : 0);
-        cmd = ModbusCommandItem::create_write_multiple_command(this->parent_, this->start_address + this->offset / 2, 1,
-                                                               bool_states);
+        std::vector<uint16_t> bool_states(this->register_count, 0u);
+        bool_states[this->register_count - 1] = state ? (0xFFFF & this->bitmask) : 0u;
+        cmd = ModbusCommandItem::create_write_multiple_command(this->parent_, this->start_address + this->offset / 2,
+                                                               this->register_count, bool_states);
       } else {
         cmd = ModbusCommandItem::create_write_single_command(this->parent_, this->start_address + this->offset / 2,
                                                              state ? 0xFFFF & this->bitmask : 0u);

--- a/esphome/components/modbus_controller/switch/modbus_switch.h
+++ b/esphome/components/modbus_controller/switch/modbus_switch.h
@@ -12,14 +12,14 @@ namespace modbus_controller {
 class ModbusSwitch : public Component, public switch_::Switch, public SensorItem {
  public:
   ModbusSwitch(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint32_t bitmask,
-               uint16_t skip_updates, bool force_new_range) {
+               uint16_t skip_updates, bool force_new_range, int register_count) {
     this->register_type = register_type;
     this->start_address = start_address;
     this->offset = offset;
     this->bitmask = bitmask;
     this->sensor_value_type = SensorValueType::BIT;
     this->skip_updates = skip_updates;
-    this->register_count = 1;
+    this->register_count = register_count;
     if (register_type == ModbusRegisterType::HOLDING || register_type == ModbusRegisterType::COIL) {
       this->start_address += offset;
       this->offset = 0;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Some modbus slave devices expects more different register count for switches (see JKBMS).
Added "register_count" to modbus_switch
Previous PR was https://github.com/esphome/esphome/pull/9329

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes (https://github.com/esphome/issues/issues/7205#issuecomment-3786339471)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: jkbms-modbus
  friendly_name: jkbms-modbus
  comment: "Monitor a JK-BMS (JK-PB series) via Modbus"
  platformio_options:
    upload_speed: 115200

esp32:
  board: m5stack-atom
  framework:
    type: arduino

api:

ota:
  - platform: esphome

wifi:
  networks:
    - ssid: !secret wifi_ssid
      password: !secret wifi_password
      priority: 10
    - ssid: !secret wifi_ssid_2
      password: !secret wifi_password_2
      priority: 8

  manual_ip:
    static_ip: 192.168.4.100
    gateway: !secret gateway
    subnet: !secret subnet
    dns1: !secret dns1
    dns2: !secret dns2

  domain: .firtz.box
  reboot_timeout: 15min
  passive_scan: true

  ap:
    ssid: "${name}"
    password: !secret ap_password

uart:
  id: mod_uart
  rx_pin: GPIO22
  tx_pin: GPIO19
  baud_rate: 115200
  stop_bits: 1
  parity: NONE
  data_bits: 8
  rx_buffer_size: 1024

modbus:
  id: modbus1
  uart_id: mod_uart

modbus_controller:
  - id: bms0
    address: 0x1
    modbus_id: modbus1
    setup_priority: -10
    update_interval: 30s
    command_throttle: 75ms

switch:
  - platform: modbus_controller
    modbus_controller_id: bms0
    name: "Discharge switch"
    id: jkbms_discharging_switch
    register_count: 2
    address: 0x1074
    register_type: holding
    use_write_multiple: true
    bitmask: 1
    icon: "mdi:toggle-switch"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
