### PR TITLE
[climate][ektf2232] Remove deprecations scheduled for 2026.5.0

### DIFF
--- a/esphome/components/climate/climate_traits.h
+++ b/esphome/components/climate/climate_traits.h
@@ -81,63 +81,6 @@ class ClimateTraits {
   bool has_feature_flags(uint32_t feature_flags) const { return this->feature_flags_ & feature_flags; }
   void set_feature_flags(uint32_t feature_flags) { this->feature_flags_ = feature_flags; }
 
-  ESPDEPRECATED("This method is deprecated, use get_feature_flags() instead", "2025.11.0")
-  bool get_supports_current_temperature() const {
-    return this->has_feature_flags(CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-  }
-  ESPDEPRECATED("This method is deprecated, use add_feature_flags() instead", "2025.11.0")
-  void set_supports_current_temperature(bool supports_current_temperature) {
-    if (supports_current_temperature) {
-      this->add_feature_flags(CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-    } else {
-      this->clear_feature_flags(CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-    }
-  }
-  ESPDEPRECATED("This method is deprecated, use get_feature_flags() instead", "2025.11.0")
-  bool get_supports_current_humidity() const { return this->has_feature_flags(CLIMATE_SUPPORTS_CURRENT_HUMIDITY); }
-  ESPDEPRECATED("This method is deprecated, use add_feature_flags() instead", "2025.11.0")
-  void set_supports_current_humidity(bool supports_current_humidity) {
-    if (supports_current_humidity) {
-      this->add_feature_flags(CLIMATE_SUPPORTS_CURRENT_HUMIDITY);
-    } else {
-      this->clear_feature_flags(CLIMATE_SUPPORTS_CURRENT_HUMIDITY);
-    }
-  }
-  ESPDEPRECATED("This method is deprecated, use get_feature_flags() instead", "2025.11.0")
-  bool get_supports_two_point_target_temperature() const {
-    return this->has_feature_flags(CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
-  }
-  ESPDEPRECATED("This method is deprecated, use add_feature_flags() instead", "2025.11.0")
-  void set_supports_two_point_target_temperature(bool supports_two_point_target_temperature) {
-    if (supports_two_point_target_temperature)
-    // Use CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE to mimic previous behavior
-    {
-      this->add_feature_flags(CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
-    } else {
-      this->clear_feature_flags(CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
-    }
-  }
-  ESPDEPRECATED("This method is deprecated, use get_feature_flags() instead", "2025.11.0")
-  bool get_supports_target_humidity() const { return this->has_feature_flags(CLIMATE_SUPPORTS_TARGET_HUMIDITY); }
-  ESPDEPRECATED("This method is deprecated, use add_feature_flags() instead", "2025.11.0")
-  void set_supports_target_humidity(bool supports_target_humidity) {
-    if (supports_target_humidity) {
-      this->add_feature_flags(CLIMATE_SUPPORTS_TARGET_HUMIDITY);
-    } else {
-      this->clear_feature_flags(CLIMATE_SUPPORTS_TARGET_HUMIDITY);
-    }
-  }
-  ESPDEPRECATED("This method is deprecated, use get_feature_flags() instead", "2025.11.0")
-  bool get_supports_action() const { return this->has_feature_flags(CLIMATE_SUPPORTS_ACTION); }
-  ESPDEPRECATED("This method is deprecated, use add_feature_flags() instead", "2025.11.0")
-  void set_supports_action(bool supports_action) {
-    if (supports_action) {
-      this->add_feature_flags(CLIMATE_SUPPORTS_ACTION);
-    } else {
-      this->clear_feature_flags(CLIMATE_SUPPORTS_ACTION);
-    }
-  }
-
   void set_supported_modes(ClimateModeMask modes) { this->supported_modes_ = modes; }
   void add_supported_mode(ClimateMode mode) { this->supported_modes_.insert(mode); }
   bool supports_mode(ClimateMode mode) const { return this->supported_modes_.count(mode); }

--- a/esphome/components/ektf2232/touchscreen/__init__.py
+++ b/esphome/components/ektf2232/touchscreen/__init__.py
@@ -15,7 +15,6 @@ EKTF2232Touchscreen = ektf2232_ns.class_(
 )
 
 CONF_EKTF2232_ID = "ektf2232_id"
-CONF_RTS_PIN = "rts_pin"  # To be removed before 2026.4.0
 
 CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
     cv.Schema(
@@ -25,9 +24,6 @@ CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
                 pins.internal_gpio_input_pin_schema
             ),
             cv.Required(CONF_RESET_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_RTS_PIN): cv.invalid(
-                f"{CONF_RTS_PIN} has been renamed to {CONF_RESET_PIN}"
-            ),
         }
     ).extend(i2c.i2c_device_schema(0x15))
 )


### PR DESCRIPTION
# What does this implement/fix?

Removes two sets of deprecated APIs whose 6-month deprecation window has elapsed (current dev version is 2026.5.0-dev):

1. **`[climate]`** — drops 10 `ClimateTraits` accessors that were marked `ESPDEPRECATED(..., "2025.11.0")`:
   - `get/set_supports_current_temperature`
   - `get/set_supports_current_humidity`
   - `get/set_supports_two_point_target_temperature`
   - `get/set_supports_target_humidity`
   - `get/set_supports_action`

   These were superseded by the `get_feature_flags()` / `add_feature_flags()` / `has_feature_flags()` API. Internal callers were already migrated; no in-tree component uses these methods. External components should migrate as follows:

   ```cpp
   // Before
   traits.set_supports_current_temperature(true);
   if (traits.get_supports_action()) { ... }

   // After
   traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
   if (traits.has_feature_flags(climate::CLIMATE_SUPPORTS_ACTION)) { ... }
   ```

   Note: `get/set_supports_two_point_target_temperature` mapped to `CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE` (not `CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE`) — preserve that when migrating.

2. **`[ektf2232]`** — removes the `rts_pin` → `reset_pin` rename `cv.invalid` migration helper. The source comment marked it for removal "before 2026.4.0", which has now passed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a — scheduled deprecation cleanup

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a — these were already documented as deprecated; no user-facing YAML surface change for the climate accessors. The ektf2232 `rts_pin` rename was already a hard error via `cv.invalid`; users still on `rts_pin` will now see a generic schema-rejection error instead of the renamed-to message.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Compile-time-only changes — header method removal and Python schema entry removal. Existing climate/ektf2232 component tests cover all targets.)

## Example entry for `config.yaml`:

```yaml
# No new configuration. Removes the migration shim for `ektf2232.rts_pin`
# (already invalid since the rename) and the deprecated C++ trait accessors.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).