### PR TITLE
[helpers] Document write_file's external consumer contract (esphome-device-builder)

### DIFF
--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -465,6 +465,12 @@ def _write_file(
 
 
 def write_file(path: Path, text: str | bytes, private: bool = False) -> None:
+    """Atomically write text or bytes to path. Wraps OSError as EsphomeError.
+
+    Used by esphome-device-builder for in-place YAML rewrites; the
+    atomicity (sibling tempfile + shutil.move) and EsphomeError
+    wrapping are part of the public contract.
+    """
     try:
         _write_file(path, text, private=private)
     except OSError as err:


### PR DESCRIPTION
# What does this implement/fix?

Adds a docstring to `helpers.write_file` calling out its external-consumer contract. No behaviour change — this is documenting an interface that already works correctly.

The `esphome-device-builder` dashboard backend (the new WebSocket API server that's an opt-in preview toggle in the official ESPHome Home Assistant addon) leans on `write_file` for in-place rewrites of user-edited YAML — rename, friendly-name edit, clone, add-component. It needs three properties this implementation already provides:

1. **Atomic write** via the staging-tempfile-in-destination-directory + `shutil.move` shape, so a crash mid-write doesn't leave the user with a corrupt config.
2. **Same-directory tempfile** so the rename stays within one filesystem — important under the HA addon shape where `/config` is mounted from the host and `/tmp` from the container; if the staging temp lived on `/tmp` the cross-FS `shutil.move` would silently degrade to copy+delete and the atomic guarantee would be lost.
3. **`EsphomeError` wrapping** of the underlying `OSError` so callers can `except EsphomeError` once at their boundary.

Documenting these so future refactors of `write_file` preserve the contract instead of silently breaking atomicity / wrapping for the dashboard. Same shape upstream uses to mark the `friendly_name_slugify` move (esphome/esphome#16206) and the `dashboard_import` import path the dashboard depends on — keeps the cross-repo dependency surface visible.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A — docstring-only change driven by the device-builder's friendly-name editor work (esphome/device-builder#390) which surfaced the cross-repo dependency.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (this is a Python docstring, not a user-facing config field).

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

N/A — Python-side docstring, not a firmware-side change.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# N/A — Python-side docstring change. The function ``write_file``
# is internal to esphome's tooling layer and isn't user-configurable
# via YAML.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

