### PR TITLE
[clang-tidy] Concatenate nested namespaces (1/7: components a-c)

### DIFF
--- a/esphome/components/a01nyub/a01nyub.cpp
+++ b/esphome/components/a01nyub/a01nyub.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace a01nyub {
+namespace esphome::a01nyub {
 
 static const char *const TAG = "a01nyub.sensor";
 
@@ -42,5 +41,4 @@ void A01nyubComponent::check_buffer_() {
 
 void A01nyubComponent::dump_config() { LOG_SENSOR("", "A01nyub Sensor", this); }
 
-}  // namespace a01nyub
-}  // namespace esphome
+}  // namespace esphome::a01nyub

--- a/esphome/components/a01nyub/a01nyub.h
+++ b/esphome/components/a01nyub/a01nyub.h
@@ -6,8 +6,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace a01nyub {
+namespace esphome::a01nyub {
 
 class A01nyubComponent : public sensor::Sensor, public Component, public uart::UARTDevice {
  public:
@@ -23,5 +22,4 @@ class A01nyubComponent : public sensor::Sensor, public Component, public uart::U
   std::vector<uint8_t> buffer_;
 };
 
-}  // namespace a01nyub
-}  // namespace esphome
+}  // namespace esphome::a01nyub

--- a/esphome/components/a02yyuw/a02yyuw.cpp
+++ b/esphome/components/a02yyuw/a02yyuw.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace a02yyuw {
+namespace esphome::a02yyuw {
 
 static const char *const TAG = "a02yyuw.sensor";
 
@@ -41,5 +40,4 @@ void A02yyuwComponent::check_buffer_() {
 
 void A02yyuwComponent::dump_config() { LOG_SENSOR("", "A02yyuw Sensor", this); }
 
-}  // namespace a02yyuw
-}  // namespace esphome
+}  // namespace esphome::a02yyuw

--- a/esphome/components/a02yyuw/a02yyuw.h
+++ b/esphome/components/a02yyuw/a02yyuw.h
@@ -6,8 +6,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace a02yyuw {
+namespace esphome::a02yyuw {
 
 class A02yyuwComponent : public sensor::Sensor, public Component, public uart::UARTDevice {
  public:
@@ -23,5 +22,4 @@ class A02yyuwComponent : public sensor::Sensor, public Component, public uart::U
   std::vector<uint8_t> buffer_;
 };
 
-}  // namespace a02yyuw
-}  // namespace esphome
+}  // namespace esphome::a02yyuw

--- a/esphome/components/a4988/a4988.cpp
+++ b/esphome/components/a4988/a4988.cpp
@@ -1,8 +1,7 @@
 #include "a4988.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace a4988 {
+namespace esphome::a4988 {
 
 static const char *const TAG = "a4988.stepper";
 
@@ -51,5 +50,4 @@ void A4988::loop() {
   this->step_pin_->digital_write(false);
 }
 
-}  // namespace a4988
-}  // namespace esphome
+}  // namespace esphome::a4988

--- a/esphome/components/a4988/a4988.h
+++ b/esphome/components/a4988/a4988.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/stepper/stepper.h"
 
-namespace esphome {
-namespace a4988 {
+namespace esphome::a4988 {
 
 class A4988 : public stepper::Stepper, public Component {
  public:
@@ -25,5 +24,4 @@ class A4988 : public stepper::Stepper, public Component {
   HighFrequencyLoopRequester high_freq_;
 };
 
-}  // namespace a4988
-}  // namespace esphome
+}  // namespace esphome::a4988

--- a/esphome/components/adalight/adalight_light_effect.cpp
+++ b/esphome/components/adalight/adalight_light_effect.cpp
@@ -1,8 +1,7 @@
 #include "adalight_light_effect.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace adalight {
+namespace esphome::adalight {
 
 static const char *const TAG = "adalight_light_effect";
 
@@ -138,5 +137,4 @@ AdalightLightEffect::Frame AdalightLightEffect::parse_frame_(light::AddressableL
   return CONSUMED;
 }
 
-}  // namespace adalight
-}  // namespace esphome
+}  // namespace esphome::adalight

--- a/esphome/components/adalight/adalight_light_effect.h
+++ b/esphome/components/adalight/adalight_light_effect.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace adalight {
+namespace esphome::adalight {
 
 class AdalightLightEffect : public light::AddressableLightEffect, public uart::UARTDevice {
  public:
@@ -35,5 +34,4 @@ class AdalightLightEffect : public light::AddressableLightEffect, public uart::U
   std::vector<uint8_t> frame_;
 };
 
-}  // namespace adalight
-}  // namespace esphome
+}  // namespace esphome::adalight

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -17,8 +17,7 @@
 #include <zephyr/drivers/adc.h>
 #endif
 
-namespace esphome {
-namespace adc {
+namespace esphome::adc {
 
 #ifdef USE_ESP32
 // clang-format off
@@ -162,5 +161,4 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
 #endif
 };
 
-}  // namespace adc
-}  // namespace esphome
+}  // namespace esphome::adc

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -1,8 +1,7 @@
 #include "adc_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace adc {
+namespace esphome::adc {
 
 static const char *const TAG = "adc.common";
 
@@ -79,5 +78,4 @@ void ADCSensor::set_sample_count(uint8_t sample_count) {
 
 void ADCSensor::set_sampling_mode(SamplingMode sampling_mode) { this->sampling_mode_ = sampling_mode; }
 
-}  // namespace adc
-}  // namespace esphome
+}  // namespace esphome::adc

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace adc {
+namespace esphome::adc {
 
 static const char *const TAG = "adc.esp32";
 
@@ -364,7 +363,6 @@ float ADCSensor::sample_autorange_() {
   return final_result;
 }
 
-}  // namespace adc
-}  // namespace esphome
+}  // namespace esphome::adc
 
 #endif  // USE_ESP32

--- a/esphome/components/adc128s102/adc128s102.cpp
+++ b/esphome/components/adc128s102/adc128s102.cpp
@@ -1,8 +1,7 @@
 #include "adc128s102.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace adc128s102 {
+namespace esphome::adc128s102 {
 
 static const char *const TAG = "adc128s102";
 
@@ -28,5 +27,4 @@ uint16_t ADC128S102::read_data(uint8_t channel) {
   return digital_value;
 }
 
-}  // namespace adc128s102
-}  // namespace esphome
+}  // namespace esphome::adc128s102

--- a/esphome/components/adc128s102/adc128s102.h
+++ b/esphome/components/adc128s102/adc128s102.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace adc128s102 {
+namespace esphome::adc128s102 {
 
 class ADC128S102 : public Component,
                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
@@ -19,5 +18,4 @@ class ADC128S102 : public Component,
   uint16_t read_data(uint8_t channel);
 };
 
-}  // namespace adc128s102
-}  // namespace esphome
+}  // namespace esphome::adc128s102

--- a/esphome/components/adc128s102/sensor/adc128s102_sensor.cpp
+++ b/esphome/components/adc128s102/sensor/adc128s102_sensor.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace adc128s102 {
+namespace esphome::adc128s102 {
 
 static const char *const TAG = "adc128s102.sensor";
 
@@ -18,5 +17,4 @@ void ADC128S102Sensor::dump_config() {
 float ADC128S102Sensor::sample() { return this->parent_->read_data(this->channel_); }
 void ADC128S102Sensor::update() { this->publish_state(this->sample()); }
 
-}  // namespace adc128s102
-}  // namespace esphome
+}  // namespace esphome::adc128s102

--- a/esphome/components/adc128s102/sensor/adc128s102_sensor.h
+++ b/esphome/components/adc128s102/sensor/adc128s102_sensor.h
@@ -7,8 +7,7 @@
 
 #include "../adc128s102.h"
 
-namespace esphome {
-namespace adc128s102 {
+namespace esphome::adc128s102 {
 
 class ADC128S102Sensor : public PollingComponent,
                          public Parented<ADC128S102>,
@@ -24,5 +23,4 @@ class ADC128S102Sensor : public PollingComponent,
  protected:
   uint8_t channel_;
 };
-}  // namespace adc128s102
-}  // namespace esphome
+}  // namespace esphome::adc128s102

--- a/esphome/components/addressable_light/addressable_light_display.cpp
+++ b/esphome/components/addressable_light/addressable_light_display.cpp
@@ -1,8 +1,7 @@
 #include "addressable_light_display.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace addressable_light {
+namespace esphome::addressable_light {
 
 static const char *const TAG = "addressable_light.display";
 
@@ -66,5 +65,4 @@ void HOT AddressableLightDisplay::draw_absolute_pixel_internal(int x, int y, Col
     this->addressable_light_buffer_[y * this->get_width_internal() + x] = color;
   }
 }
-}  // namespace addressable_light
-}  // namespace esphome
+}  // namespace esphome::addressable_light

--- a/esphome/components/addressable_light/addressable_light_display.h
+++ b/esphome/components/addressable_light/addressable_light_display.h
@@ -7,8 +7,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace addressable_light {
+namespace esphome::addressable_light {
 
 class AddressableLightDisplay : public display::DisplayBuffer {
  public:
@@ -61,5 +60,4 @@ class AddressableLightDisplay : public display::DisplayBuffer {
   optional<uint32_t> last_effect_index_;
   optional<std::function<int(int, int)>> pixel_mapper_f_;
 };
-}  // namespace addressable_light
-}  // namespace esphome
+}  // namespace esphome::addressable_light

--- a/esphome/components/ade7880/ade7880.cpp
+++ b/esphome/components/ade7880/ade7880.cpp
@@ -13,8 +13,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace ade7880 {
+namespace esphome::ade7880 {
 
 static const char *const TAG = "ade7880";
 
@@ -313,5 +312,4 @@ void ADE7880::reset_device_() {
   this->store_.reset_pending = true;
 }
 
-}  // namespace ade7880
-}  // namespace esphome
+}  // namespace esphome::ade7880

--- a/esphome/components/ade7880/ade7880.h
+++ b/esphome/components/ade7880/ade7880.h
@@ -16,8 +16,7 @@
 
 #include "ade7880_registers.h"
 
-namespace esphome {
-namespace ade7880 {
+namespace esphome::ade7880 {
 
 struct NeutralChannel {
   void set_current(sensor::Sensor *sens) { this->current = sens; }
@@ -125,5 +124,4 @@ class ADE7880 : public i2c::I2CDevice, public PollingComponent {
   void write_u32_register16_(uint16_t a_register, uint32_t value);
 };
 
-}  // namespace ade7880
-}  // namespace esphome
+}  // namespace esphome::ade7880

--- a/esphome/components/ade7880/ade7880_i2c.cpp
+++ b/esphome/components/ade7880/ade7880_i2c.cpp
@@ -9,8 +9,7 @@
 
 #include "ade7880.h"
 
-namespace esphome {
-namespace ade7880 {
+namespace esphome::ade7880 {
 
 // adapted from https://stackoverflow.com/a/55912127/1886371
 template<size_t Bits, typename T> inline T sign_extend(const T &v) noexcept {
@@ -97,5 +96,4 @@ void ADE7880::write_u32_register16_(uint16_t a_register, uint32_t value) {
   this->write_register16(a_register, reinterpret_cast<uint8_t *>(&out), sizeof(out));
 }
 
-}  // namespace ade7880
-}  // namespace esphome
+}  // namespace esphome::ade7880

--- a/esphome/components/ade7880/ade7880_registers.h
+++ b/esphome/components/ade7880/ade7880_registers.h
@@ -4,8 +4,7 @@
 
 // Source: https://www.analog.com/media/en/technical-documentation/application-notes/AN-1127.pdf
 
-namespace esphome {
-namespace ade7880 {
+namespace esphome::ade7880 {
 
 // DSP Data Memory RAM registers
 constexpr uint16_t AIGAIN = 0x4380;
@@ -242,5 +241,4 @@ constexpr uint8_t DSPWP_SET_RO = (1 << 7);
 // DSPWP_SEL Register Bits
 constexpr uint8_t DSPWP_SEL_SET = 0xAD;
 
-}  // namespace ade7880
-}  // namespace esphome
+}  // namespace esphome::ade7880

--- a/esphome/components/ade7953_base/ade7953_base.cpp
+++ b/esphome/components/ade7953_base/ade7953_base.cpp
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace ade7953_base {
+namespace esphome::ade7953_base {
 
 static const char *const TAG = "ade7953";
 
@@ -160,5 +159,4 @@ void ADE7953::update() {
   ADE_PUBLISH(frequency, 223750.0f, 1 + val_16);
 }
 
-}  // namespace ade7953_base
-}  // namespace esphome
+}  // namespace esphome::ade7953_base

--- a/esphome/components/ade7953_base/ade7953_base.h
+++ b/esphome/components/ade7953_base/ade7953_base.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace ade7953_base {
+namespace esphome::ade7953_base {
 
 static constexpr uint8_t PGA_V_8 =
     0x007;  // PGA_V,  (R/W) Default: 0x00, Unsigned, Voltage channel gain configuration (Bits[2:0])
@@ -131,5 +130,4 @@ class ADE7953 : public PollingComponent, public sensor::Sensor {
   virtual bool ade_read_32(uint16_t reg, uint32_t *value) = 0;
 };
 
-}  // namespace ade7953_base
-}  // namespace esphome
+}  // namespace esphome::ade7953_base

--- a/esphome/components/ade7953_i2c/ade7953_i2c.cpp
+++ b/esphome/components/ade7953_i2c/ade7953_i2c.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ade7953_i2c {
+namespace esphome::ade7953_i2c {
 
 static const char *const TAG = "ade7953";
 
@@ -76,5 +75,4 @@ bool AdE7953I2c::ade_read_32(uint16_t reg, uint32_t *value) {
   return false;
 }
 
-}  // namespace ade7953_i2c
-}  // namespace esphome
+}  // namespace esphome::ade7953_i2c

--- a/esphome/components/ade7953_i2c/ade7953_i2c.h
+++ b/esphome/components/ade7953_i2c/ade7953_i2c.h
@@ -8,8 +8,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace ade7953_i2c {
+namespace esphome::ade7953_i2c {
 
 class AdE7953I2c : public ade7953_base::ADE7953, public i2c::I2CDevice {
  public:
@@ -24,5 +23,4 @@ class AdE7953I2c : public ade7953_base::ADE7953, public i2c::I2CDevice {
   bool ade_read_32(uint16_t reg, uint32_t *value) override;
 };
 
-}  // namespace ade7953_i2c
-}  // namespace esphome
+}  // namespace esphome::ade7953_i2c

--- a/esphome/components/ade7953_spi/ade7953_spi.cpp
+++ b/esphome/components/ade7953_spi/ade7953_spi.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ade7953_spi {
+namespace esphome::ade7953_spi {
 
 static const char *const TAG = "ade7953";
 
@@ -83,5 +82,4 @@ bool AdE7953Spi::ade_read_32(uint16_t reg, uint32_t *value) {
   return false;
 }
 
-}  // namespace ade7953_spi
-}  // namespace esphome
+}  // namespace esphome::ade7953_spi

--- a/esphome/components/ade7953_spi/ade7953_spi.h
+++ b/esphome/components/ade7953_spi/ade7953_spi.h
@@ -8,8 +8,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace ade7953_spi {
+namespace esphome::ade7953_spi {
 
 class AdE7953Spi : public ade7953_base::ADE7953,
                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
@@ -28,5 +27,4 @@ class AdE7953Spi : public ade7953_base::ADE7953,
   bool ade_read_32(uint16_t reg, uint32_t *value) override;
 };
 
-}  // namespace ade7953_spi
-}  // namespace esphome
+}  // namespace esphome::ade7953_spi

--- a/esphome/components/ads1115/ads1115.cpp
+++ b/esphome/components/ads1115/ads1115.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ads1115 {
+namespace esphome::ads1115 {
 
 static const char *const TAG = "ads1115";
 static const uint8_t ADS1115_REGISTER_CONVERSION = 0x00;
@@ -208,5 +207,4 @@ float ADS1115Component::request_measurement(ADS1115Multiplexer multiplexer, ADS1
   return millivolts / 1e3f;
 }
 
-}  // namespace ads1115
-}  // namespace esphome
+}  // namespace esphome::ads1115

--- a/esphome/components/ads1115/ads1115.h
+++ b/esphome/components/ads1115/ads1115.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace ads1115 {
+namespace esphome::ads1115 {
 
 enum ADS1115Multiplexer {
   ADS1115_MULTIPLEXER_P0_N1 = 0b000,
@@ -60,5 +59,4 @@ class ADS1115Component : public Component, public i2c::I2CDevice {
   bool continuous_mode_;
 };
 
-}  // namespace ads1115
-}  // namespace esphome
+}  // namespace esphome::ads1115

--- a/esphome/components/ads1115/sensor/ads1115_sensor.cpp
+++ b/esphome/components/ads1115/sensor/ads1115_sensor.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ads1115 {
+namespace esphome::ads1115 {
 
 static const char *const TAG = "ads1115.sensor";
 
@@ -29,5 +28,4 @@ void ADS1115Sensor::dump_config() {
                 this->multiplexer_, this->gain_, this->resolution_, this->samplerate_);
 }
 
-}  // namespace ads1115
-}  // namespace esphome
+}  // namespace esphome::ads1115

--- a/esphome/components/ads1115/sensor/ads1115_sensor.h
+++ b/esphome/components/ads1115/sensor/ads1115_sensor.h
@@ -8,8 +8,7 @@
 
 #include "../ads1115.h"
 
-namespace esphome {
-namespace ads1115 {
+namespace esphome::ads1115 {
 
 /// Internal holder class that is in instance of Sensor so that the hub can create individual sensors.
 class ADS1115Sensor : public sensor::Sensor,
@@ -33,5 +32,4 @@ class ADS1115Sensor : public sensor::Sensor,
   ADS1115Samplerate samplerate_;
 };
 
-}  // namespace ads1115
-}  // namespace esphome
+}  // namespace esphome::ads1115

--- a/esphome/components/ads1118/ads1118.cpp
+++ b/esphome/components/ads1118/ads1118.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ads1118 {
+namespace esphome::ads1118 {
 
 static const char *const TAG = "ads1118";
 static const uint8_t ADS1118_DATA_RATE_860_SPS = 0b111;
@@ -122,5 +121,4 @@ float ADS1118::request_measurement(ADS1118Multiplexer multiplexer, ADS1118Gain g
   }
 }
 
-}  // namespace ads1118
-}  // namespace esphome
+}  // namespace esphome::ads1118

--- a/esphome/components/ads1118/ads1118.h
+++ b/esphome/components/ads1118/ads1118.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace ads1118 {
+namespace esphome::ads1118 {
 
 enum ADS1118Multiplexer {
   ADS1118_MULTIPLEXER_P0_N1 = 0b000,
@@ -41,5 +40,4 @@ class ADS1118 : public Component,
   uint16_t config_{0};
 };
 
-}  // namespace ads1118
-}  // namespace esphome
+}  // namespace esphome::ads1118

--- a/esphome/components/ads1118/sensor/ads1118_sensor.cpp
+++ b/esphome/components/ads1118/sensor/ads1118_sensor.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ads1118 {
+namespace esphome::ads1118 {
 
 static const char *const TAG = "ads1118.sensor";
 
@@ -27,5 +26,4 @@ void ADS1118Sensor::update() {
   }
 }
 
-}  // namespace ads1118
-}  // namespace esphome
+}  // namespace esphome::ads1118

--- a/esphome/components/ads1118/sensor/ads1118_sensor.h
+++ b/esphome/components/ads1118/sensor/ads1118_sensor.h
@@ -8,8 +8,7 @@
 
 #include "../ads1118.h"
 
-namespace esphome {
-namespace ads1118 {
+namespace esphome::ads1118 {
 
 class ADS1118Sensor : public PollingComponent,
                       public sensor::Sensor,
@@ -32,5 +31,4 @@ class ADS1118Sensor : public PollingComponent,
   bool temperature_mode_;
 };
 
-}  // namespace ads1118
-}  // namespace esphome
+}  // namespace esphome::ads1118

--- a/esphome/components/ags10/ags10.cpp
+++ b/esphome/components/ags10/ags10.cpp
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace ags10 {
+namespace esphome::ags10 {
 static const char *const TAG = "ags10";
 
 // Data acquisition.
@@ -192,5 +191,4 @@ template<size_t N> optional<std::array<uint8_t, N>> AGS10Component::read_and_che
 
   return data;
 }
-}  // namespace ags10
-}  // namespace esphome
+}  // namespace esphome::ags10

--- a/esphome/components/ags10/ags10.h
+++ b/esphome/components/ags10/ags10.h
@@ -5,8 +5,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace ags10 {
+namespace esphome::ags10 {
 
 class AGS10Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -136,5 +135,4 @@ template<typename... Ts> class AGS10SetZeroPointAction : public Action<Ts...>, p
     }
   }
 };
-}  // namespace ags10
-}  // namespace esphome
+}  // namespace esphome::ags10

--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -17,8 +17,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace aht10 {
+namespace esphome::aht10 {
 
 static const char *const TAG = "aht10";
 static const uint8_t AHT10_INITIALIZE_CMD[] = {0xE1, 0x08, 0x00};
@@ -160,5 +159,4 @@ void AHT10Component::dump_config() {
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
 
-}  // namespace aht10
-}  // namespace esphome
+}  // namespace esphome::aht10

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -6,8 +6,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace aht10 {
+namespace esphome::aht10 {
 
 enum AHT10Variant { AHT10, AHT20 };
 
@@ -31,5 +30,4 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
   uint32_t start_time_{};
 };
 
-}  // namespace aht10
-}  // namespace esphome
+}  // namespace esphome::aht10

--- a/esphome/components/aic3204/aic3204.cpp
+++ b/esphome/components/aic3204/aic3204.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace aic3204 {
+namespace esphome::aic3204 {
 
 static const char *const TAG = "aic3204";
 
@@ -167,5 +166,4 @@ bool AIC3204::write_volume_() {
   return true;
 }
 
-}  // namespace aic3204
-}  // namespace esphome
+}  // namespace esphome::aic3204

--- a/esphome/components/aic3204/aic3204.h
+++ b/esphome/components/aic3204/aic3204.h
@@ -6,8 +6,7 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace aic3204 {
+namespace esphome::aic3204 {
 
 // TLV320AIC3204 Register Addresses
 // Page 0
@@ -83,5 +82,4 @@ class AIC3204 : public audio_dac::AudioDac, public Component, public i2c::I2CDev
   float volume_{0};
 };
 
-}  // namespace aic3204
-}  // namespace esphome
+}  // namespace esphome::aic3204

--- a/esphome/components/aic3204/automation.h
+++ b/esphome/components/aic3204/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "aic3204.h"
 
-namespace esphome {
-namespace aic3204 {
+namespace esphome::aic3204 {
 
 template<typename... Ts> class SetAutoMuteAction : public Action<Ts...> {
  public:
@@ -19,5 +18,4 @@ template<typename... Ts> class SetAutoMuteAction : public Action<Ts...> {
   AIC3204 *aic3204_;
 };
 
-}  // namespace aic3204
-}  // namespace esphome
+}  // namespace esphome::aic3204

--- a/esphome/components/airthings_ble/airthings_listener.cpp
+++ b/esphome/components/airthings_ble/airthings_listener.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace airthings_ble {
+namespace esphome::airthings_ble {
 
 static const char *const TAG = "airthings_ble";
 
@@ -29,7 +28,6 @@ bool AirthingsListener::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
   return false;
 }
 
-}  // namespace airthings_ble
-}  // namespace esphome
+}  // namespace esphome::airthings_ble
 
 #endif

--- a/esphome/components/airthings_ble/airthings_listener.h
+++ b/esphome/components/airthings_ble/airthings_listener.h
@@ -5,15 +5,13 @@
 #include "esphome/core/component.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
-namespace esphome {
-namespace airthings_ble {
+namespace esphome::airthings_ble {
 
 class AirthingsListener : public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 };
 
-}  // namespace airthings_ble
-}  // namespace esphome
+}  // namespace esphome::airthings_ble
 
 #endif

--- a/esphome/components/airthings_wave_base/airthings_wave_base.cpp
+++ b/esphome/components/airthings_wave_base/airthings_wave_base.cpp
@@ -6,8 +6,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace airthings_wave_base {
+namespace esphome::airthings_wave_base {
 
 static const char *const TAG = "airthings_wave_base";
 
@@ -211,7 +210,6 @@ void AirthingsWaveBase::set_response_timeout_() {
   });
 }
 
-}  // namespace airthings_wave_base
-}  // namespace esphome
+}  // namespace esphome::airthings_wave_base
 
 #endif  // USE_ESP32

--- a/esphome/components/airthings_wave_base/airthings_wave_base.h
+++ b/esphome/components/airthings_wave_base/airthings_wave_base.h
@@ -14,8 +14,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace airthings_wave_base {
+namespace esphome::airthings_wave_base {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -84,7 +83,6 @@ class AirthingsWaveBase : public PollingComponent, public ble_client::BLEClientN
   };
 };
 
-}  // namespace airthings_wave_base
-}  // namespace esphome
+}  // namespace esphome::airthings_wave_base
 
 #endif  // USE_ESP32

--- a/esphome/components/airthings_wave_mini/airthings_wave_mini.cpp
+++ b/esphome/components/airthings_wave_mini/airthings_wave_mini.cpp
@@ -2,8 +2,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace airthings_wave_mini {
+namespace esphome::airthings_wave_mini {
 
 static const char *const TAG = "airthings_wave_mini";
 
@@ -49,7 +48,6 @@ AirthingsWaveMini::AirthingsWaveMini() {
       espbt::ESPBTUUID::from_raw(ACCESS_CONTROL_POINT_CHARACTERISTIC_UUID);
 }
 
-}  // namespace airthings_wave_mini
-}  // namespace esphome
+}  // namespace esphome::airthings_wave_mini
 
 #endif  // USE_ESP32

--- a/esphome/components/airthings_wave_mini/airthings_wave_mini.h
+++ b/esphome/components/airthings_wave_mini/airthings_wave_mini.h
@@ -4,8 +4,7 @@
 
 #include "esphome/components/airthings_wave_base/airthings_wave_base.h"
 
-namespace esphome {
-namespace airthings_wave_mini {
+namespace esphome::airthings_wave_mini {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -34,7 +33,6 @@ class AirthingsWaveMini : public airthings_wave_base::AirthingsWaveBase {
   };
 };
 
-}  // namespace airthings_wave_mini
-}  // namespace esphome
+}  // namespace esphome::airthings_wave_mini
 
 #endif  // USE_ESP32

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
@@ -2,8 +2,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace airthings_wave_plus {
+namespace esphome::airthings_wave_plus {
 
 static const char *const TAG = "airthings_wave_plus";
 
@@ -98,7 +97,6 @@ void AirthingsWavePlus::setup() {
       espbt::ESPBTUUID::from_raw(access_control_point_characteristic_uuid);
 }
 
-}  // namespace airthings_wave_plus
-}  // namespace esphome
+}  // namespace esphome::airthings_wave_plus
 
 #endif  // USE_ESP32

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.h
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.h
@@ -4,8 +4,7 @@
 
 #include "esphome/components/airthings_wave_base/airthings_wave_base.h"
 
-namespace esphome {
-namespace airthings_wave_plus {
+namespace esphome::airthings_wave_plus {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -58,7 +57,6 @@ class AirthingsWavePlus : public airthings_wave_base::AirthingsWaveBase {
   };
 };
 
-}  // namespace airthings_wave_plus
-}  // namespace esphome
+}  // namespace esphome::airthings_wave_plus
 
 #endif  // USE_ESP32

--- a/esphome/components/alpha3/alpha3.cpp
+++ b/esphome/components/alpha3/alpha3.cpp
@@ -5,8 +5,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace alpha3 {
+namespace esphome::alpha3 {
 
 static const char *const TAG = "alpha3";
 
@@ -185,7 +184,6 @@ void Alpha3::update() {
     delay(25);  // need to wait between requests
   }
 }
-}  // namespace alpha3
-}  // namespace esphome
+}  // namespace esphome::alpha3
 
 #endif

--- a/esphome/components/alpha3/alpha3.h
+++ b/esphome/components/alpha3/alpha3.h
@@ -9,8 +9,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace alpha3 {
+namespace esphome::alpha3 {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -64,7 +63,6 @@ class Alpha3 : public esphome::ble_client::BLEClientNode, public PollingComponen
   void send_request_(uint8_t *request, size_t len);
   bool is_current_response_type_(const uint8_t *response_type);
 };
-}  // namespace alpha3
-}  // namespace esphome
+}  // namespace esphome::alpha3
 
 #endif

--- a/esphome/components/am2315c/am2315c.cpp
+++ b/esphome/components/am2315c/am2315c.cpp
@@ -24,8 +24,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace am2315c {
+namespace esphome::am2315c {
 
 static const char *const TAG = "am2315c";
 
@@ -176,5 +175,4 @@ void AM2315C::dump_config() {
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
 
-}  // namespace am2315c
-}  // namespace esphome
+}  // namespace esphome::am2315c

--- a/esphome/components/am2315c/am2315c.h
+++ b/esphome/components/am2315c/am2315c.h
@@ -25,8 +25,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace am2315c {
+namespace esphome::am2315c {
 
 class AM2315C : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -45,5 +44,4 @@ class AM2315C : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *humidity_sensor_{nullptr};
 };
 
-}  // namespace am2315c
-}  // namespace esphome
+}  // namespace esphome::am2315c

--- a/esphome/components/am2320/am2320.cpp
+++ b/esphome/components/am2320/am2320.cpp
@@ -8,8 +8,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace am2320 {
+namespace esphome::am2320 {
 
 static const char *const TAG = "am2320";
 
@@ -86,5 +85,4 @@ bool AM2320Component::read_data_(uint8_t *data) {
   return true;
 }
 
-}  // namespace am2320
-}  // namespace esphome
+}  // namespace esphome::am2320

--- a/esphome/components/am2320/am2320.h
+++ b/esphome/components/am2320/am2320.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace am2320 {
+namespace esphome::am2320 {
 
 class AM2320Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -24,5 +23,4 @@ class AM2320Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *humidity_sensor_{nullptr};
 };
 
-}  // namespace am2320
-}  // namespace esphome
+}  // namespace esphome::am2320

--- a/esphome/components/am43/am43_base.cpp
+++ b/esphome/components/am43/am43_base.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include <cstring>
 
-namespace esphome {
-namespace am43 {
+namespace esphome::am43 {
 
 const uint8_t START_PACKET[5] = {0x00, 0xff, 0x00, 0x00, 0x9a};
 
@@ -134,5 +133,4 @@ void Am43Decoder::decode(const uint8_t *data, uint16_t length) {
   }
 };
 
-}  // namespace am43
-}  // namespace esphome
+}  // namespace esphome::am43

--- a/esphome/components/am43/am43_base.h
+++ b/esphome/components/am43/am43_base.h
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace am43 {
+namespace esphome::am43 {
 
 static const uint16_t AM43_SERVICE_UUID = 0xFE50;
 static const uint16_t AM43_CHARACTERISTIC_UUID = 0xFE51;
@@ -74,5 +73,4 @@ class Am43Decoder {
   bool has_pin_response_;
 };
 
-}  // namespace am43
-}  // namespace esphome
+}  // namespace esphome::am43

--- a/esphome/components/am43/cover/am43_cover.cpp
+++ b/esphome/components/am43/cover/am43_cover.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace am43 {
+namespace esphome::am43 {
 
 static const char *const TAG = "am43_cover";
 
@@ -154,7 +153,6 @@ void Am43Component::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
   }
 }
 
-}  // namespace am43
-}  // namespace esphome
+}  // namespace esphome::am43
 
 #endif

--- a/esphome/components/am43/cover/am43_cover.h
+++ b/esphome/components/am43/cover/am43_cover.h
@@ -10,8 +10,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace am43 {
+namespace esphome::am43 {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -38,7 +37,6 @@ class Am43Component : public cover::Cover, public esphome::ble_client::BLEClient
   float position_;
 };
 
-}  // namespace am43
-}  // namespace esphome
+}  // namespace esphome::am43
 
 #endif

--- a/esphome/components/am43/sensor/am43_sensor.cpp
+++ b/esphome/components/am43/sensor/am43_sensor.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace am43 {
+namespace esphome::am43 {
 
 static const char *const TAG = "am43";
 
@@ -111,7 +110,6 @@ void Am43::update() {
   }
 }
 
-}  // namespace am43
-}  // namespace esphome
+}  // namespace esphome::am43
 
 #endif

--- a/esphome/components/am43/sensor/am43_sensor.h
+++ b/esphome/components/am43/sensor/am43_sensor.h
@@ -10,8 +10,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace am43 {
+namespace esphome::am43 {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -38,7 +37,6 @@ class Am43 : public esphome::ble_client::BLEClientNode, public PollingComponent 
   uint32_t last_battery_update_;
 };
 
-}  // namespace am43
-}  // namespace esphome
+}  // namespace esphome::am43
 
 #endif

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
@@ -1,8 +1,7 @@
 #include "analog_threshold_binary_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace analog_threshold {
+namespace esphome::analog_threshold {
 
 static const char *const TAG = "analog_threshold.binary_sensor";
 
@@ -43,5 +42,4 @@ void AnalogThresholdBinarySensor::dump_config() {
                 this->upper_threshold_.value(), this->lower_threshold_.value());
 }
 
-}  // namespace analog_threshold
-}  // namespace esphome
+}  // namespace esphome::analog_threshold

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
@@ -5,8 +5,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace analog_threshold {
+namespace esphome::analog_threshold {
 
 class AnalogThresholdBinarySensor : public Component, public binary_sensor::BinarySensor {
  public:
@@ -24,5 +23,4 @@ class AnalogThresholdBinarySensor : public Component, public binary_sensor::Bina
   bool raw_state_{false};  // Pre-filter state for hysteresis logic
 };
 
-}  // namespace analog_threshold
-}  // namespace esphome
+}  // namespace esphome::analog_threshold

--- a/esphome/components/animation/animation.cpp
+++ b/esphome/components/animation/animation.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace animation {
+namespace esphome::animation {
 
 Animation::Animation(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count,
                      image::ImageType type, image::Transparency transparent)
@@ -71,5 +70,4 @@ void Animation::update_data_start_() {
   this->data_start_ = this->animation_data_start_ + image_size * this->current_frame_;
 }
 
-}  // namespace animation
-}  // namespace esphome
+}  // namespace esphome::animation

--- a/esphome/components/animation/animation.h
+++ b/esphome/components/animation/animation.h
@@ -3,8 +3,7 @@
 
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace animation {
+namespace esphome::animation {
 
 class Animation : public image::Image {
  public:
@@ -64,5 +63,4 @@ template<typename... Ts> class AnimationSetFrameAction : public Action<Ts...> {
   Animation *parent_;
 };
 
-}  // namespace animation
-}  // namespace esphome
+}  // namespace esphome::animation

--- a/esphome/components/anova/anova.cpp
+++ b/esphome/components/anova/anova.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace anova {
+namespace esphome::anova {
 
 static const char *const TAG = "anova";
 
@@ -160,7 +159,6 @@ void Anova::update() {
   }
 }
 
-}  // namespace anova
-}  // namespace esphome
+}  // namespace esphome::anova
 
 #endif

--- a/esphome/components/anova/anova.h
+++ b/esphome/components/anova/anova.h
@@ -10,8 +10,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace anova {
+namespace esphome::anova {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -45,7 +44,6 @@ class Anova : public climate::Climate, public esphome::ble_client::BLEClientNode
   bool fahrenheit_;
 };
 
-}  // namespace anova
-}  // namespace esphome
+}  // namespace esphome::anova
 
 #endif

--- a/esphome/components/anova/anova_base.cpp
+++ b/esphome/components/anova/anova_base.cpp
@@ -4,8 +4,7 @@
 
 #include "esphome/core/alloc_helpers.h"
 
-namespace esphome {
-namespace anova {
+namespace esphome::anova {
 
 float ftoc(float f) { return (f - 32.0) * (5.0f / 9.0f); }
 
@@ -132,5 +131,4 @@ void AnovaCodec::decode(const uint8_t *data, uint16_t length) {
   }
 }
 
-}  // namespace anova
-}  // namespace esphome
+}  // namespace esphome::anova

--- a/esphome/components/anova/anova_base.h
+++ b/esphome/components/anova/anova_base.h
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace anova {
+namespace esphome::anova {
 
 enum CurrentQuery {
   NONE,
@@ -75,5 +74,4 @@ class AnovaCodec {
   CurrentQuery current_query_;
 };
 
-}  // namespace anova
-}  // namespace esphome
+}  // namespace esphome::anova

--- a/esphome/components/apds9306/apds9306.cpp
+++ b/esphome/components/apds9306/apds9306.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace apds9306 {
+namespace esphome::apds9306 {
 
 static const char *const TAG = "apds9306";
 
@@ -147,5 +146,4 @@ void APDS9306::update() {
   this->publish_state(lux);
 }
 
-}  // namespace apds9306
-}  // namespace esphome
+}  // namespace esphome::apds9306

--- a/esphome/components/apds9306/apds9306.h
+++ b/esphome/components/apds9306/apds9306.h
@@ -7,8 +7,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace apds9306 {
+namespace esphome::apds9306 {
 
 enum MeasurementBitWidth : uint8_t {
   MEASUREMENT_BIT_WIDTH_20 = 0,
@@ -62,5 +61,4 @@ class APDS9306 : public sensor::Sensor, public PollingComponent, public i2c::I2C
   AmbientLightGain gain_;
 };
 
-}  // namespace apds9306
-}  // namespace esphome
+}  // namespace esphome::apds9306

--- a/esphome/components/apds9960/apds9960.cpp
+++ b/esphome/components/apds9960/apds9960.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace apds9960 {
+namespace esphome::apds9960 {
 
 static const char *const TAG = "apds9960";
 
@@ -402,5 +401,4 @@ bool APDS9960::is_gesture_enabled_() const {
 #endif
 }
 
-}  // namespace apds9960
-}  // namespace esphome
+}  // namespace esphome::apds9960

--- a/esphome/components/apds9960/apds9960.h
+++ b/esphome/components/apds9960/apds9960.h
@@ -10,8 +10,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #endif
 
-namespace esphome {
-namespace apds9960 {
+namespace esphome::apds9960 {
 
 class APDS9960 : public PollingComponent, public i2c::I2CDevice {
 #ifdef USE_SENSOR
@@ -71,5 +70,4 @@ class APDS9960 : public PollingComponent, public i2c::I2CDevice {
   uint32_t gesture_start_{0};
 };
 
-}  // namespace apds9960
-}  // namespace esphome
+}  // namespace esphome::apds9960

--- a/esphome/components/as3935/as3935.cpp
+++ b/esphome/components/as3935/as3935.cpp
@@ -1,8 +1,7 @@
 #include "as3935.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace as3935 {
+namespace esphome::as3935 {
 
 static const char *const TAG = "as3935";
 
@@ -320,5 +319,4 @@ uint8_t AS3935Component::read_register_(uint8_t reg, uint8_t mask) {
   return value;
 }
 
-}  // namespace as3935
-}  // namespace esphome
+}  // namespace esphome::as3935

--- a/esphome/components/as3935/as3935.h
+++ b/esphome/components/as3935/as3935.h
@@ -10,8 +10,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #endif
 
-namespace esphome {
-namespace as3935 {
+namespace esphome::as3935 {
 
 static const uint8_t DIRECT_COMMAND = 0x96;
 static const uint8_t ANTFREQ = 3;
@@ -127,5 +126,4 @@ class AS3935Component : public Component {
   bool calibration_;
 };
 
-}  // namespace as3935
-}  // namespace esphome
+}  // namespace esphome::as3935

--- a/esphome/components/as3935_i2c/as3935_i2c.cpp
+++ b/esphome/components/as3935_i2c/as3935_i2c.cpp
@@ -1,8 +1,7 @@
 #include "as3935_i2c.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace as3935_i2c {
+namespace esphome::as3935_i2c {
 
 static const char *const TAG = "as3935_i2c";
 
@@ -40,5 +39,4 @@ void I2CAS3935Component::dump_config() {
   LOG_I2C_DEVICE(this);
 }
 
-}  // namespace as3935_i2c
-}  // namespace esphome
+}  // namespace esphome::as3935_i2c

--- a/esphome/components/as3935_i2c/as3935_i2c.h
+++ b/esphome/components/as3935_i2c/as3935_i2c.h
@@ -3,8 +3,7 @@
 #include "esphome/components/as3935/as3935.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace as3935_i2c {
+namespace esphome::as3935_i2c {
 
 class I2CAS3935Component : public as3935::AS3935Component, public i2c::I2CDevice {
  public:
@@ -15,5 +14,4 @@ class I2CAS3935Component : public as3935::AS3935Component, public i2c::I2CDevice
   uint8_t read_register(uint8_t reg) override;
 };
 
-}  // namespace as3935_i2c
-}  // namespace esphome
+}  // namespace esphome::as3935_i2c

--- a/esphome/components/as3935_spi/as3935_spi.cpp
+++ b/esphome/components/as3935_spi/as3935_spi.cpp
@@ -1,8 +1,7 @@
 #include "as3935_spi.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace as3935_spi {
+namespace esphome::as3935_spi {
 
 static const char *const TAG = "as3935_spi";
 
@@ -42,5 +41,4 @@ uint8_t SPIAS3935Component::read_register(uint8_t reg) {
   return value;
 }
 
-}  // namespace as3935_spi
-}  // namespace esphome
+}  // namespace esphome::as3935_spi

--- a/esphome/components/as3935_spi/as3935_spi.h
+++ b/esphome/components/as3935_spi/as3935_spi.h
@@ -4,8 +4,7 @@
 #include "esphome/components/as3935/as3935.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace as3935_spi {
+namespace esphome::as3935_spi {
 
 enum AS3935RegisterMasks { SPI_READ_M = 0x40 };
 
@@ -21,5 +20,4 @@ class SPIAS3935Component : public as3935::AS3935Component,
   uint8_t read_register(uint8_t reg) override;
 };
 
-}  // namespace as3935_spi
-}  // namespace esphome
+}  // namespace esphome::as3935_spi

--- a/esphome/components/as5600/as5600.cpp
+++ b/esphome/components/as5600/as5600.cpp
@@ -1,8 +1,7 @@
 #include "as5600.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace as5600 {
+namespace esphome::as5600 {
 
 static const char *const TAG = "as5600";
 
@@ -134,5 +133,4 @@ optional<uint16_t> AS5600Component::read_raw_position() {
   return pos;
 }
 
-}  // namespace as5600
-}  // namespace esphome
+}  // namespace esphome::as5600

--- a/esphome/components/as5600/as5600.h
+++ b/esphome/components/as5600/as5600.h
@@ -6,8 +6,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace as5600 {
+namespace esphome::as5600 {
 
 static const uint16_t POSITION_COUNT = 4096;
 static const float RAW_TO_DEGREES = 360.0 / POSITION_COUNT;
@@ -100,5 +99,4 @@ class AS5600Component : public Component, public i2c::I2CDevice {
   float range_scale_{1.0};
 };
 
-}  // namespace as5600
-}  // namespace esphome
+}  // namespace esphome::as5600

--- a/esphome/components/as5600/sensor/as5600_sensor.cpp
+++ b/esphome/components/as5600/sensor/as5600_sensor.cpp
@@ -1,8 +1,7 @@
 #include "as5600_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace as5600 {
+namespace esphome::as5600 {
 
 static const char *const TAG = "as5600.sensor";
 
@@ -75,5 +74,4 @@ void AS5600Sensor::update() {
   this->status_clear_warning();
 }
 
-}  // namespace as5600
-}  // namespace esphome
+}  // namespace esphome::as5600

--- a/esphome/components/as5600/sensor/as5600_sensor.h
+++ b/esphome/components/as5600/sensor/as5600_sensor.h
@@ -7,8 +7,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/as5600/as5600.h"
 
-namespace esphome {
-namespace as5600 {
+namespace esphome::as5600 {
 
 class AS5600Sensor : public PollingComponent, public Parented<AS5600Component>, public sensor::Sensor {
  public:
@@ -32,5 +31,4 @@ class AS5600Sensor : public PollingComponent, public Parented<AS5600Component>, 
   OutRangeMode out_of_range_mode_{OUT_RANGE_MODE_MIN_MAX};
 };
 
-}  // namespace as5600
-}  // namespace esphome
+}  // namespace esphome::as5600

--- a/esphome/components/as7341/as7341.cpp
+++ b/esphome/components/as7341/as7341.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace as7341 {
+namespace esphome::as7341 {
 
 static const char *const TAG = "as7341";
 
@@ -266,5 +265,4 @@ bool AS7341Component::clear_register_bit(uint8_t address, uint8_t bit_position) 
 
 uint16_t AS7341Component::swap_bytes(uint16_t data) { return (data >> 8) | (data << 8); }
 
-}  // namespace as7341
-}  // namespace esphome
+}  // namespace esphome::as7341

--- a/esphome/components/as7341/as7341.h
+++ b/esphome/components/as7341/as7341.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace as7341 {
+namespace esphome::as7341 {
 
 static const uint8_t AS7341_CHIP_ID = 0x09;
 
@@ -139,5 +138,4 @@ class AS7341Component : public PollingComponent, public i2c::I2CDevice {
   uint16_t channel_readings_[12];
 };
 
-}  // namespace as7341
-}  // namespace esphome
+}  // namespace esphome::as7341

--- a/esphome/components/at581x/at581x.cpp
+++ b/esphome/components/at581x/at581x.cpp
@@ -49,8 +49,7 @@ const uint8_t TRIGGER_KEEP_TIME_ADDR = 0x42;  // 4 bytes, so up to 0x45
 const uint8_t TIME41_VALUE = 1;
 const uint8_t SELF_CHECK_TIME_ADDR = 0x38;  // 2 bytes, up to 0x39
 
-namespace esphome {
-namespace at581x {
+namespace esphome::at581x {
 
 static const char *const TAG = "at581x";
 
@@ -199,5 +198,4 @@ void AT581XComponent::set_rf_mode(bool enable) {
   }
 }
 
-}  // namespace at581x
-}  // namespace esphome
+}  // namespace esphome::at581x

--- a/esphome/components/at581x/at581x.h
+++ b/esphome/components/at581x/at581x.h
@@ -10,8 +10,7 @@
 #endif
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace at581x {
+namespace esphome::at581x {
 
 class AT581XComponent : public Component, public i2c::I2CDevice {
  public:
@@ -58,5 +57,4 @@ class AT581XComponent : public Component, public i2c::I2CDevice {
   int power_;                /*!< In µA */
 };
 
-}  // namespace at581x
-}  // namespace esphome
+}  // namespace esphome::at581x

--- a/esphome/components/at581x/automation.h
+++ b/esphome/components/at581x/automation.h
@@ -5,8 +5,7 @@
 
 #include "at581x.h"
 
-namespace esphome {
-namespace at581x {
+namespace esphome::at581x {
 
 template<typename... Ts> class AT581XResetAction : public Action<Ts...>, public Parented<AT581XComponent> {
  public:
@@ -67,5 +66,4 @@ template<typename... Ts> class AT581XSettingsAction : public Action<Ts...>, publ
     }
   }
 };
-}  // namespace at581x
-}  // namespace esphome
+}  // namespace esphome::at581x

--- a/esphome/components/at581x/switch/rf_switch.cpp
+++ b/esphome/components/at581x/switch/rf_switch.cpp
@@ -1,12 +1,10 @@
 #include "rf_switch.h"
 
-namespace esphome {
-namespace at581x {
+namespace esphome::at581x {
 
 void RFSwitch::write_state(bool state) {
   this->publish_state(state);
   this->parent_->set_rf_mode(state);
 }
 
-}  // namespace at581x
-}  // namespace esphome
+}  // namespace esphome::at581x

--- a/esphome/components/at581x/switch/rf_switch.h
+++ b/esphome/components/at581x/switch/rf_switch.h
@@ -3,13 +3,11 @@
 #include "esphome/components/switch/switch.h"
 #include "../at581x.h"
 
-namespace esphome {
-namespace at581x {
+namespace esphome::at581x {
 
 class RFSwitch : public switch_::Switch, public Parented<AT581XComponent> {
  protected:
   void write_state(bool state) override;
 };
 
-}  // namespace at581x
-}  // namespace esphome
+}  // namespace esphome::at581x

--- a/esphome/components/atc_mithermometer/atc_mithermometer.cpp
+++ b/esphome/components/atc_mithermometer/atc_mithermometer.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace atc_mithermometer {
+namespace esphome::atc_mithermometer {
 
 static const char *const TAG = "atc_mithermometer";
 
@@ -133,7 +132,6 @@ bool ATCMiThermometer::report_results_(const optional<ParseResult> &result, cons
   return true;
 }
 
-}  // namespace atc_mithermometer
-}  // namespace esphome
+}  // namespace esphome::atc_mithermometer
 
 #endif

--- a/esphome/components/atc_mithermometer/atc_mithermometer.h
+++ b/esphome/components/atc_mithermometer/atc_mithermometer.h
@@ -8,8 +8,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace atc_mithermometer {
+namespace esphome::atc_mithermometer {
 
 struct ParseResult {
   optional<float> temperature;
@@ -44,7 +43,6 @@ class ATCMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevice
   bool report_results_(const optional<ParseResult> &result, const char *address);
 };
 
-}  // namespace atc_mithermometer
-}  // namespace esphome
+}  // namespace esphome::atc_mithermometer
 
 #endif

--- a/esphome/components/atm90e26/atm90e26.cpp
+++ b/esphome/components/atm90e26/atm90e26.cpp
@@ -2,8 +2,7 @@
 #include "atm90e26_reg.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace atm90e26 {
+namespace esphome::atm90e26 {
 
 static const char *const TAG = "atm90e26";
 
@@ -229,5 +228,4 @@ float ATM90E26Component::get_frequency_() {
   return freq / 100.0f;
 }
 
-}  // namespace atm90e26
-}  // namespace esphome
+}  // namespace esphome::atm90e26

--- a/esphome/components/atm90e26/atm90e26.h
+++ b/esphome/components/atm90e26/atm90e26.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace atm90e26 {
+namespace esphome::atm90e26 {
 
 class ATM90E26Component : public PollingComponent,
                           public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH,
@@ -67,5 +66,4 @@ class ATM90E26Component : public PollingComponent,
   uint32_t pl_const_{1429876};
 };
 
-}  // namespace atm90e26
-}  // namespace esphome
+}  // namespace esphome::atm90e26

--- a/esphome/components/atm90e26/atm90e26_reg.h
+++ b/esphome/components/atm90e26/atm90e26_reg.h
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace esphome {
-namespace atm90e26 {
+namespace esphome::atm90e26 {
 
 /* Status and Special Register */
 static const uint8_t ATM90E26_REGISTER_SOFTRESET = 0x00;  // Software Reset
@@ -66,5 +65,4 @@ static const uint8_t ATM90E26_REGISTER_POWERF2 = 0x6D;  // N Line Power Factor
 static const uint8_t ATM90E26_REGISTER_PANGLE2 = 0x6E;  // Phase Angle between Voltage and N Line Current
 static const uint8_t ATM90E26_REGISTER_SMEAN2 = 0x6F;   // N Line Mean Apparent Power
 
-}  // namespace atm90e26
-}  // namespace esphome
+}  // namespace esphome::atm90e26

--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -5,8 +5,7 @@
 #include <numbers>
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace atm90e32 {
+namespace esphome::atm90e32 {
 
 static const char *const TAG = "atm90e32";
 
@@ -1313,5 +1312,4 @@ bool ATM90E32Component::validate_spi_read_(uint16_t expected, const char *contex
   return true;
 }
 
-}  // namespace atm90e32
-}  // namespace esphome
+}  // namespace esphome::atm90e32

--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -11,8 +11,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace atm90e32 {
+namespace esphome::atm90e32 {
 
 class ATM90E32Component : public PollingComponent,
                           public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH,
@@ -275,5 +274,4 @@ class ATM90E32Component : public PollingComponent,
   bool gain_calibration_mismatch_[3]{false, false, false};
 };
 
-}  // namespace atm90e32
-}  // namespace esphome
+}  // namespace esphome::atm90e32

--- a/esphome/components/atm90e32/atm90e32_reg.h
+++ b/esphome/components/atm90e32/atm90e32_reg.h
@@ -2,8 +2,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace atm90e32 {
+namespace esphome::atm90e32 {
 
 /* STATUS REGISTERS */
 static const uint16_t ATM90E32_REGISTER_METEREN = 0x00;        // Metering Enable
@@ -268,5 +267,4 @@ static const uint16_t ATM90E32_REGISTER_UANGLEA = 0xFD;  // A Voltage Phase Angl
 static const uint16_t ATM90E32_REGISTER_UANGLEB = 0xFE;  // B Voltage Phase Angle
 static const uint16_t ATM90E32_REGISTER_UANGLEC = 0xFF;  // C Voltage Phase Angle
 
-}  // namespace atm90e32
-}  // namespace esphome
+}  // namespace esphome::atm90e32

--- a/esphome/components/atm90e32/button/atm90e32_button.cpp
+++ b/esphome/components/atm90e32/button/atm90e32_button.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace atm90e32 {
+namespace esphome::atm90e32 {
 
 static const char *const TAG = "atm90e32.button";
 
@@ -75,5 +74,4 @@ void ATM90E32ClearPowerOffsetCalibrationButton::press_action() {
   this->parent_->clear_power_offset_calibrations();
 }
 
-}  // namespace atm90e32
-}  // namespace esphome
+}  // namespace esphome::atm90e32

--- a/esphome/components/atm90e32/button/atm90e32_button.h
+++ b/esphome/components/atm90e32/button/atm90e32_button.h
@@ -4,8 +4,7 @@
 #include "esphome/components/atm90e32/atm90e32.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace atm90e32 {
+namespace esphome::atm90e32 {
 
 class ATM90E32GainCalibrationButton : public button::Button, public Parented<ATM90E32Component> {
  public:
@@ -55,5 +54,4 @@ class ATM90E32ClearPowerOffsetCalibrationButton : public button::Button, public 
   void press_action() override;
 };
 
-}  // namespace atm90e32
-}  // namespace esphome
+}  // namespace esphome::atm90e32

--- a/esphome/components/atm90e32/number/atm90e32_number.h
+++ b/esphome/components/atm90e32/number/atm90e32_number.h
@@ -4,13 +4,11 @@
 #include "esphome/components/atm90e32/atm90e32.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace atm90e32 {
+namespace esphome::atm90e32 {
 
 class ATM90E32Number : public number::Number, public Parented<ATM90E32Component> {
  public:
   void control(float value) override { this->publish_state(value); }
 };
 
-}  // namespace atm90e32
-}  // namespace esphome
+}  // namespace esphome::atm90e32

--- a/esphome/components/audio/audio.cpp
+++ b/esphome/components/audio/audio.cpp
@@ -4,8 +4,7 @@
 
 #include <cstring>
 
-namespace esphome {
-namespace audio {
+namespace esphome::audio {
 
 // Euclidean's algorithm for finding the greatest common divisor
 static uint32_t gcd(uint32_t a, uint32_t b) {
@@ -129,5 +128,4 @@ void scale_audio_samples(const int16_t *audio_samples, int16_t *output_buffer, i
   }
 }
 
-}  // namespace audio
-}  // namespace esphome
+}  // namespace esphome::audio

--- a/esphome/components/audio/audio.h
+++ b/esphome/components/audio/audio.h
@@ -5,8 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace esphome {
-namespace audio {
+namespace esphome::audio {
 
 class AudioStreamInfo {
   /* Class to respresent important parameters of the audio stream that also provides helper function to convert between
@@ -195,5 +194,4 @@ inline void pack_q31_as_audio_sample(int32_t sample, uint8_t *data, size_t bytes
   }
 }
 
-}  // namespace audio
-}  // namespace esphome
+}  // namespace esphome::audio

--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace audio {
+namespace esphome::audio {
 
 static const char *const TAG = "audio.decoder";
 
@@ -428,7 +427,6 @@ FileDecoderState AudioDecoder::decode_wav_() {
 }
 #endif
 
-}  // namespace audio
-}  // namespace esphome
+}  // namespace esphome::audio
 
 #endif

--- a/esphome/components/audio/audio_decoder.h
+++ b/esphome/components/audio/audio_decoder.h
@@ -35,8 +35,7 @@
 #include <micro_wav/wav_decoder.h>
 #endif
 
-namespace esphome {
-namespace audio {
+namespace esphome::audio {
 
 enum class AudioDecoderState : uint8_t {
   DECODING = 0,  // More data is available to decode
@@ -155,7 +154,6 @@ class AudioDecoder {
 
   bool pause_output_{false};
 };
-}  // namespace audio
-}  // namespace esphome
+}  // namespace esphome::audio
 
 #endif

--- a/esphome/components/audio/audio_reader.cpp
+++ b/esphome/components/audio/audio_reader.cpp
@@ -11,8 +11,7 @@
 #include "esp_crt_bundle.h"
 #endif
 
-namespace esphome {
-namespace audio {
+namespace esphome::audio {
 
 static const uint32_t READ_WRITE_TIMEOUT_MS = 20;
 
@@ -289,7 +288,6 @@ void AudioReader::cleanup_connection_() {
   }
 }
 
-}  // namespace audio
-}  // namespace esphome
+}  // namespace esphome::audio
 
 #endif

--- a/esphome/components/audio/audio_reader.h
+++ b/esphome/components/audio/audio_reader.h
@@ -11,8 +11,7 @@
 
 #include <esp_http_client.h>
 
-namespace esphome {
-namespace audio {
+namespace esphome::audio {
 
 enum class AudioReaderState : uint8_t {
   READING = 0,  // More data is available to read
@@ -74,7 +73,6 @@ class AudioReader {
   AudioFileType audio_file_type_{AudioFileType::NONE};
   const uint8_t *file_current_{nullptr};
 };
-}  // namespace audio
-}  // namespace esphome
+}  // namespace esphome::audio
 
 #endif

--- a/esphome/components/audio/audio_resampler.cpp
+++ b/esphome/components/audio/audio_resampler.cpp
@@ -6,8 +6,7 @@
 
 #include <cstring>
 
-namespace esphome {
-namespace audio {
+namespace esphome::audio {
 
 static const uint32_t READ_WRITE_TIMEOUT_MS = 20;
 
@@ -157,7 +156,6 @@ AudioResamplerState AudioResampler::resample(bool stop_gracefully, int32_t *ms_d
   return AudioResamplerState::RESAMPLING;
 }
 
-}  // namespace audio
-}  // namespace esphome
+}  // namespace esphome::audio
 
 #endif

--- a/esphome/components/audio/audio_resampler.h
+++ b/esphome/components/audio/audio_resampler.h
@@ -17,8 +17,7 @@
 
 #include <resampler.h>  // esp-audio-libs
 
-namespace esphome {
-namespace audio {
+namespace esphome::audio {
 
 enum class AudioResamplerState : uint8_t {
   RESAMPLING,  // More data is available to resample
@@ -96,7 +95,6 @@ class AudioResampler {
   std::unique_ptr<esp_audio_libs::resampler::Resampler> resampler_;
 };
 
-}  // namespace audio
-}  // namespace esphome
+}  // namespace esphome::audio
 
 #endif

--- a/esphome/components/audio/audio_transfer_buffer.cpp
+++ b/esphome/components/audio/audio_transfer_buffer.cpp
@@ -6,8 +6,7 @@
 
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace audio {
+namespace esphome::audio {
 
 AudioTransferBuffer::~AudioTransferBuffer() { this->deallocate_buffer_(); };
 
@@ -208,7 +207,6 @@ void ConstAudioSourceBuffer::consume(size_t bytes) {
   this->data_start_ += bytes;
 }
 
-}  // namespace audio
-}  // namespace esphome
+}  // namespace esphome::audio
 
 #endif

--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -12,8 +12,7 @@
 
 #include <freertos/FreeRTOS.h>
 
-namespace esphome {
-namespace audio {
+namespace esphome::audio {
 
 /// @brief Abstract interface for writing decoded audio data to a sink.
 class AudioSinkCallback {
@@ -213,7 +212,6 @@ class ConstAudioSourceBuffer : public AudioReadableBuffer {
   size_t length_{0};
 };
 
-}  // namespace audio
-}  // namespace esphome
+}  // namespace esphome::audio
 
 #endif

--- a/esphome/components/audio_adc/audio_adc.h
+++ b/esphome/components/audio_adc/audio_adc.h
@@ -3,8 +3,7 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace audio_adc {
+namespace esphome::audio_adc {
 
 class AudioAdc {
  public:
@@ -13,5 +12,4 @@ class AudioAdc {
   virtual float mic_gain() = 0;
 };
 
-}  // namespace audio_adc
-}  // namespace esphome
+}  // namespace esphome::audio_adc

--- a/esphome/components/audio_adc/automation.h
+++ b/esphome/components/audio_adc/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "audio_adc.h"
 
-namespace esphome {
-namespace audio_adc {
+namespace esphome::audio_adc {
 
 template<typename... Ts> class SetMicGainAction : public Action<Ts...> {
  public:
@@ -19,5 +18,4 @@ template<typename... Ts> class SetMicGainAction : public Action<Ts...> {
   AudioAdc *audio_adc_;
 };
 
-}  // namespace audio_adc
-}  // namespace esphome
+}  // namespace esphome::audio_adc

--- a/esphome/components/audio_dac/audio_dac.h
+++ b/esphome/components/audio_dac/audio_dac.h
@@ -3,8 +3,7 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace audio_dac {
+namespace esphome::audio_dac {
 
 class AudioDac {
  public:
@@ -19,5 +18,4 @@ class AudioDac {
   bool is_muted_{false};
 };
 
-}  // namespace audio_dac
-}  // namespace esphome
+}  // namespace esphome::audio_dac

--- a/esphome/components/audio_dac/automation.h
+++ b/esphome/components/audio_dac/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "audio_dac.h"
 
-namespace esphome {
-namespace audio_dac {
+namespace esphome::audio_dac {
 
 template<typename... Ts> class MuteOffAction : public Action<Ts...> {
  public:
@@ -39,5 +38,4 @@ template<typename... Ts> class SetVolumeAction : public Action<Ts...> {
   AudioDac *audio_dac_;
 };
 
-}  // namespace audio_dac
-}  // namespace esphome
+}  // namespace esphome::audio_dac

--- a/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
+++ b/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace axs15231 {
+namespace esphome::axs15231 {
 
 static const char *const TAG = "ax15231.touchscreen";
 
@@ -64,5 +63,4 @@ void AXS15231Touchscreen::dump_config() {
                 this->x_raw_max_, this->y_raw_max_);
 }
 
-}  // namespace axs15231
-}  // namespace esphome
+}  // namespace esphome::axs15231

--- a/esphome/components/axs15231/touchscreen/axs15231_touchscreen.h
+++ b/esphome/components/axs15231/touchscreen/axs15231_touchscreen.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace axs15231 {
+namespace esphome::axs15231 {
 
 class AXS15231Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice {
  public:
@@ -23,5 +22,4 @@ class AXS15231Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevi
   GPIOPin *reset_pin_{};
 };
 
-}  // namespace axs15231
-}  // namespace esphome
+}  // namespace esphome::axs15231

--- a/esphome/components/b_parasite/b_parasite.cpp
+++ b/esphome/components/b_parasite/b_parasite.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace b_parasite {
+namespace esphome::b_parasite {
 
 static const char *const TAG = "b_parasite";
 
@@ -113,7 +112,6 @@ bool BParasite::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return true;
 }
 
-}  // namespace b_parasite
-}  // namespace esphome
+}  // namespace esphome::b_parasite
 
 #endif  // USE_ESP32

--- a/esphome/components/b_parasite/b_parasite.h
+++ b/esphome/components/b_parasite/b_parasite.h
@@ -6,8 +6,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace b_parasite {
+namespace esphome::b_parasite {
 
 class BParasite : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -35,7 +34,6 @@ class BParasite : public Component, public esp32_ble_tracker::ESPBTDeviceListene
   sensor::Sensor *illuminance_{nullptr};
 };
 
-}  // namespace b_parasite
-}  // namespace esphome
+}  // namespace esphome::b_parasite
 
 #endif  // USE_ESP32

--- a/esphome/components/ballu/ballu.cpp
+++ b/esphome/components/ballu/ballu.cpp
@@ -1,8 +1,7 @@
 #include "ballu.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ballu {
+namespace esphome::ballu {
 
 static const char *const TAG = "ballu.climate";
 
@@ -235,5 +234,4 @@ bool BalluClimate::on_receive(remote_base::RemoteReceiveData data) {
   return true;
 }
 
-}  // namespace ballu
-}  // namespace esphome
+}  // namespace esphome::ballu

--- a/esphome/components/ballu/ballu.h
+++ b/esphome/components/ballu/ballu.h
@@ -2,8 +2,7 @@
 
 #include "esphome/components/climate_ir/climate_ir.h"
 
-namespace esphome {
-namespace ballu {
+namespace esphome::ballu {
 
 // Support for Ballu air conditioners with YKR-K/002E remote
 
@@ -27,5 +26,4 @@ class BalluClimate : public climate_ir::ClimateIR {
   bool on_receive(remote_base::RemoteReceiveData data) override;
 };
 
-}  // namespace ballu
-}  // namespace esphome
+}  // namespace esphome::ballu

--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -1,8 +1,7 @@
 #include "bang_bang_climate.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace bang_bang {
+namespace esphome::bang_bang {
 
 static const char *const TAG = "bang_bang.climate";
 
@@ -231,5 +230,4 @@ BangBangClimateTargetTempConfig::BangBangClimateTargetTempConfig(float default_t
                                                                  float default_temperature_high)
     : default_temperature_low(default_temperature_low), default_temperature_high(default_temperature_high) {}
 
-}  // namespace bang_bang
-}  // namespace esphome
+}  // namespace esphome::bang_bang

--- a/esphome/components/bang_bang/bang_bang_climate.h
+++ b/esphome/components/bang_bang/bang_bang_climate.h
@@ -5,8 +5,7 @@
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace bang_bang {
+namespace esphome::bang_bang {
 
 struct BangBangClimateTargetTempConfig {
  public:
@@ -84,5 +83,4 @@ class BangBangClimate : public climate::Climate, public Component {
   BangBangClimateTargetTempConfig away_config_{};
 };
 
-}  // namespace bang_bang
-}  // namespace esphome
+}  // namespace esphome::bang_bang

--- a/esphome/components/bedjet/bedjet_child.h
+++ b/esphome/components/bedjet/bedjet_child.h
@@ -3,8 +3,7 @@
 #include "bedjet_codec.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 // Forward declare BedJetHub
 class BedJetHub;
@@ -19,5 +18,4 @@ class BedJetClient : public Parented<BedJetHub> {
   virtual std::string describe() = 0;
 };
 
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet

--- a/esphome/components/bedjet/bedjet_codec.cpp
+++ b/esphome/components/bedjet/bedjet_codec.cpp
@@ -3,8 +3,7 @@
 #include <cstdio>
 #include <cstring>
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 /// Converts a BedJet temp step into degrees Fahrenheit.
 float bedjet_temp_to_f(const uint8_t temp) {
@@ -177,5 +176,4 @@ float bedjet_temp_to_c(uint8_t temp) {
   return temp / 2.0f;
 }
 
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet

--- a/esphome/components/bedjet/bedjet_codec.h
+++ b/esphome/components/bedjet/bedjet_codec.h
@@ -5,8 +5,7 @@
 
 #include "bedjet_const.h"
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 struct BedjetPacket {
   uint8_t data_length;
@@ -190,5 +189,4 @@ class BedjetCodec {
 /// Converts a BedJet temp step into degrees Celsius.
 float bedjet_temp_to_c(uint8_t temp);
 
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet

--- a/esphome/components/bedjet/bedjet_const.h
+++ b/esphome/components/bedjet/bedjet_const.h
@@ -2,8 +2,7 @@
 
 #include <set>
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 static const char *const TAG = "bedjet";
 
@@ -101,5 +100,4 @@ static const uint8_t BEDJET_FAN_SPEED_COUNT = 20;
 
 static constexpr const char *const BEDJET_FAN_STEP_NAMES[BEDJET_FAN_SPEED_COUNT] = BEDJET_FAN_STEP_NAMES_;
 
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet

--- a/esphome/components/bedjet/bedjet_hub.cpp
+++ b/esphome/components/bedjet/bedjet_hub.cpp
@@ -6,8 +6,7 @@
 #include "esphome/core/application.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 static const LogString *bedjet_button_to_string(BedjetButton button) {
   switch (button) {
@@ -551,7 +550,6 @@ void BedJetHub::register_child(BedJetClient *obj) {
   obj->set_parent(this);
 }
 
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet
 
 #endif

--- a/esphome/components/bedjet/bedjet_hub.h
+++ b/esphome/components/bedjet/bedjet_hub.h
@@ -18,8 +18,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -172,7 +171,6 @@ class BedJetHub : public esphome::ble_client::BLEClientNode, public PollingCompo
   uint8_t write_notify_config_descriptor_(bool enable);
 };
 
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet
 
 #endif

--- a/esphome/components/bedjet/climate/bedjet_climate.cpp
+++ b/esphome/components/bedjet/climate/bedjet_climate.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 using namespace esphome::climate;
 
@@ -359,7 +358,6 @@ void BedJetClimate::update() {
   ESP_LOGD(TAG, "[%s] update_status result=%s", this->get_name().c_str(), result ? "true" : "false");
 }
 
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet
 
 #endif

--- a/esphome/components/bedjet/climate/bedjet_climate.h
+++ b/esphome/components/bedjet/climate/bedjet_climate.h
@@ -10,8 +10,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 class BedJetClimate : public climate::Climate, public BedJetClient, public PollingComponent {
  public:
@@ -72,7 +71,6 @@ class BedJetClimate : public climate::Climate, public BedJetClient, public Polli
   }
 };
 
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet
 
 #endif

--- a/esphome/components/bedjet/fan/bedjet_fan.cpp
+++ b/esphome/components/bedjet/fan/bedjet_fan.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 using namespace esphome::fan;
 
@@ -109,7 +108,6 @@ void BedJetFan::reset_state_() {
   this->state = false;
   this->publish_state();
 }
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet
 
 #endif

--- a/esphome/components/bedjet/fan/bedjet_fan.h
+++ b/esphome/components/bedjet/fan/bedjet_fan.h
@@ -10,8 +10,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 class BedJetFan : public fan::Fan, public BedJetClient, public PollingComponent {
  public:
@@ -34,7 +33,6 @@ class BedJetFan : public fan::Fan, public BedJetClient, public PollingComponent 
   bool update_status_();
 };
 
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet
 
 #endif

--- a/esphome/components/bedjet/sensor/bedjet_sensor.cpp
+++ b/esphome/components/bedjet/sensor/bedjet_sensor.cpp
@@ -1,8 +1,7 @@
 #include "bedjet_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 std::string BedjetSensor::describe() { return "BedJet Sensor"; }
 
@@ -30,5 +29,4 @@ void BedjetSensor::on_status(const BedjetStatusPacket *data) {
   }
 }
 
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet

--- a/esphome/components/bedjet/sensor/bedjet_sensor.h
+++ b/esphome/components/bedjet/sensor/bedjet_sensor.h
@@ -5,8 +5,7 @@
 #include "esphome/components/bedjet/bedjet_child.h"
 #include "esphome/components/bedjet/bedjet_codec.h"
 
-namespace esphome {
-namespace bedjet {
+namespace esphome::bedjet {
 
 class BedjetSensor : public BedJetClient, public Component {
  public:
@@ -28,5 +27,4 @@ class BedjetSensor : public BedJetClient, public Component {
   sensor::Sensor *ambient_temperature_sensor_{nullptr};
 };
 
-}  // namespace bedjet
-}  // namespace esphome
+}  // namespace esphome::bedjet

--- a/esphome/components/bh1900nux/bh1900nux.cpp
+++ b/esphome/components/bh1900nux/bh1900nux.cpp
@@ -1,8 +1,7 @@
 #include "esphome/core/log.h"
 #include "bh1900nux.h"
 
-namespace esphome {
-namespace bh1900nux {
+namespace esphome::bh1900nux {
 
 static const char *const TAG = "bh1900nux.sensor";
 
@@ -50,5 +49,4 @@ void BH1900NUXSensor::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace bh1900nux
-}  // namespace esphome
+}  // namespace esphome::bh1900nux

--- a/esphome/components/bh1900nux/bh1900nux.h
+++ b/esphome/components/bh1900nux/bh1900nux.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace bh1900nux {
+namespace esphome::bh1900nux {
 
 class BH1900NUXSensor : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
  public:
@@ -14,5 +13,4 @@ class BH1900NUXSensor : public sensor::Sensor, public PollingComponent, public i
   void dump_config() override;
 };
 
-}  // namespace bh1900nux
-}  // namespace esphome
+}  // namespace esphome::bh1900nux

--- a/esphome/components/binary/fan/binary_fan.cpp
+++ b/esphome/components/binary/fan/binary_fan.cpp
@@ -1,8 +1,7 @@
 #include "binary_fan.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace binary {
+namespace esphome::binary {
 
 static const char *const TAG = "binary.fan";
 
@@ -39,5 +38,4 @@ void BinaryFan::write_state_() {
     this->direction_->set_state(this->direction == fan::FanDirection::REVERSE);
 }
 
-}  // namespace binary
-}  // namespace esphome
+}  // namespace esphome::binary

--- a/esphome/components/binary/fan/binary_fan.h
+++ b/esphome/components/binary/fan/binary_fan.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/binary_output.h"
 #include "esphome/components/fan/fan.h"
 
-namespace esphome {
-namespace binary {
+namespace esphome::binary {
 
 class BinaryFan : public Component, public fan::Fan {
  public:
@@ -27,5 +26,4 @@ class BinaryFan : public Component, public fan::Fan {
   output::BinaryOutput *direction_{nullptr};
 };
 
-}  // namespace binary
-}  // namespace esphome
+}  // namespace esphome::binary

--- a/esphome/components/binary/light/binary_light_output.h
+++ b/esphome/components/binary/light/binary_light_output.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/binary_output.h"
 #include "esphome/components/light/light_output.h"
 
-namespace esphome {
-namespace binary {
+namespace esphome::binary {
 
 class BinaryLightOutput : public light::LightOutput {
  public:
@@ -29,5 +28,4 @@ class BinaryLightOutput : public light::LightOutput {
   output::BinaryOutput *output_;
 };
 
-}  // namespace binary
-}  // namespace esphome
+}  // namespace esphome::binary

--- a/esphome/components/binary_sensor_map/binary_sensor_map.cpp
+++ b/esphome/components/binary_sensor_map/binary_sensor_map.cpp
@@ -1,8 +1,7 @@
 #include "binary_sensor_map.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace binary_sensor_map {
+namespace esphome::binary_sensor_map {
 
 static const char *const TAG = "binary_sensor_map";
 
@@ -138,5 +137,4 @@ void BinarySensorMap::add_channel(binary_sensor::BinarySensor *sensor, float pro
   };
   this->channels_.push_back(sensor_channel);
 }
-}  // namespace binary_sensor_map
-}  // namespace esphome
+}  // namespace esphome::binary_sensor_map

--- a/esphome/components/binary_sensor_map/binary_sensor_map.h
+++ b/esphome/components/binary_sensor_map/binary_sensor_map.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace binary_sensor_map {
+namespace esphome::binary_sensor_map {
 
 enum BinarySensorMapType {
   BINARY_SENSOR_MAP_TYPE_GROUP,
@@ -96,5 +95,4 @@ class BinarySensorMap : public sensor::Sensor, public Component {
   float bayesian_predicate_(bool sensor_state, float prior, float prob_given_true, float prob_given_false);
 };
 
-}  // namespace binary_sensor_map
-}  // namespace esphome
+}  // namespace esphome::binary_sensor_map

--- a/esphome/components/bl0906/bl0906.cpp
+++ b/esphome/components/bl0906/bl0906.cpp
@@ -3,8 +3,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace bl0906 {
+namespace esphome::bl0906 {
 
 static const char *const TAG = "bl0906";
 
@@ -262,5 +261,4 @@ void BL0906::dump_config() {
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
 }
 
-}  // namespace bl0906
-}  // namespace esphome
+}  // namespace esphome::bl0906

--- a/esphome/components/bl0906/bl0906.h
+++ b/esphome/components/bl0906/bl0906.h
@@ -9,8 +9,7 @@
 // https://www.belling.com.cn/media/file_object/bel_product/BL0906/datasheet/BL0906_V1.02_cn.pdf
 // https://www.belling.com.cn/media/file_object/bel_product/BL0906/guide/BL0906%20APP%20Note_V1.02.pdf
 
-namespace esphome {
-namespace bl0906 {
+namespace esphome::bl0906 {
 
 // Stage values for the read state machine. After STAGE_CHANNEL_6 the state machine
 // jumps to the two sentinel stages below, then to STAGE_IDLE which marks the cycle
@@ -109,5 +108,4 @@ template<typename... Ts> class ResetEnergyAction : public Action<Ts...>, public 
   void play(const Ts &...x) override { this->parent_->enqueue_action_(&BL0906::reset_energy_); }
 };
 
-}  // namespace bl0906
-}  // namespace esphome
+}  // namespace esphome::bl0906

--- a/esphome/components/bl0906/constants.h
+++ b/esphome/components/bl0906/constants.h
@@ -1,8 +1,7 @@
 #pragma once
 #include <cstdint>
 
-namespace esphome {
-namespace bl0906 {
+namespace esphome::bl0906 {
 
 // Total power conversion
 static const float BL0906_WATT = 16 * 1.097 * 1.097 * (20000 + 20000 + 20000 + 20000 + 20000) /
@@ -118,5 +117,4 @@ const uint8_t BL0906_INIT[2][6] = {
     // Enable User Operation Write
     {BL0906_WRITE_COMMAND, BL0906_USR_WRPROT, 0x55, 0x55, 0x00, 0xB7}};
 
-}  // namespace bl0906
-}  // namespace esphome
+}  // namespace esphome::bl0906

--- a/esphome/components/bl0939/bl0939.cpp
+++ b/esphome/components/bl0939/bl0939.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace bl0939 {
+namespace esphome::bl0939 {
 
 static const char *const TAG = "bl0939";
 
@@ -142,5 +141,4 @@ uint32_t BL0939::to_uint32_t(ube24_t input) { return input.h << 16 | input.m << 
 
 int32_t BL0939::to_int32_t(sbe24_t input) { return input.h << 16 | input.m << 8 | input.l; }
 
-}  // namespace bl0939
-}  // namespace esphome
+}  // namespace esphome::bl0939

--- a/esphome/components/bl0939/bl0939.h
+++ b/esphome/components/bl0939/bl0939.h
@@ -4,8 +4,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace bl0939 {
+namespace esphome::bl0939 {
 
 // https://datasheet.lcsc.com/lcsc/2108071830_BL-Shanghai-Belling-BL0939_C2841044.pdf
 // (unfortunately chinese, but the formulas can be easily understood)
@@ -103,5 +102,4 @@ class BL0939 : public PollingComponent, public uart::UARTDevice {
 
   void received_package_(const DataPacket *data) const;
 };
-}  // namespace bl0939
-}  // namespace esphome
+}  // namespace esphome::bl0939

--- a/esphome/components/bl0940/bl0940.cpp
+++ b/esphome/components/bl0940/bl0940.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace bl0940 {
+namespace esphome::bl0940 {
 
 static const char *const TAG = "bl0940";
 
@@ -274,5 +273,4 @@ void BL0940::dump_config() {  // NOLINT(readability-function-cognitive-complexit
   LOG_SENSOR("", "External temperature", this->external_temperature_sensor_);
 }
 
-}  // namespace bl0940
-}  // namespace esphome
+}  // namespace esphome::bl0940

--- a/esphome/components/bl0940/bl0940.h
+++ b/esphome/components/bl0940/bl0940.h
@@ -12,8 +12,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace bl0940 {
+namespace esphome::bl0940 {
 
 // Caveat: All these values are big endian (low - middle - high)
 struct DataPacket {
@@ -148,5 +147,4 @@ class BL0940 : public PollingComponent, public uart::UARTDevice {
   void recalibrate_();
 };
 
-}  // namespace bl0940
-}  // namespace esphome
+}  // namespace esphome::bl0940

--- a/esphome/components/bl0940/button/calibration_reset_button.cpp
+++ b/esphome/components/bl0940/button/calibration_reset_button.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace bl0940 {
+namespace esphome::bl0940 {
 
 static const char *const TAG = "bl0940.button.calibration_reset";
 
@@ -16,5 +15,4 @@ void CalibrationResetButton::press_action() {
   this->parent_->reset_calibration();
 }
 
-}  // namespace bl0940
-}  // namespace esphome
+}  // namespace esphome::bl0940

--- a/esphome/components/bl0940/button/calibration_reset_button.h
+++ b/esphome/components/bl0940/button/calibration_reset_button.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace bl0940 {
+namespace esphome::bl0940 {
 
 class BL0940;  // Forward declaration of BL0940 class
 
@@ -15,5 +14,4 @@ class CalibrationResetButton : public button::Button, public Component, public P
   void press_action() override;
 };
 
-}  // namespace bl0940
-}  // namespace esphome
+}  // namespace esphome::bl0940

--- a/esphome/components/bl0940/number/calibration_number.cpp
+++ b/esphome/components/bl0940/number/calibration_number.cpp
@@ -1,8 +1,7 @@
 #include "calibration_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace bl0940 {
+namespace esphome::bl0940 {
 
 static const char *const TAG = "bl0940.number";
 
@@ -25,5 +24,4 @@ void CalibrationNumber::control(float value) {
 
 void CalibrationNumber::dump_config() { LOG_NUMBER("", "Calibration Number", this); }
 
-}  // namespace bl0940
-}  // namespace esphome
+}  // namespace esphome::bl0940

--- a/esphome/components/bl0940/number/calibration_number.h
+++ b/esphome/components/bl0940/number/calibration_number.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace bl0940 {
+namespace esphome::bl0940 {
 
 class CalibrationNumber : public number::Number, public Component {
  public:
@@ -22,5 +21,4 @@ class CalibrationNumber : public number::Number, public Component {
   ESPPreferenceObject pref_;
 };
 
-}  // namespace bl0940
-}  // namespace esphome
+}  // namespace esphome::bl0940

--- a/esphome/components/bl0942/bl0942.cpp
+++ b/esphome/components/bl0942/bl0942.cpp
@@ -4,8 +4,7 @@
 
 // Datasheet: https://www.belling.com.cn/media/file_object/bel_product/BL0942/datasheet/BL0942_V1.06_en.pdf
 
-namespace esphome {
-namespace bl0942 {
+namespace esphome::bl0942 {
 
 static const char *const TAG = "bl0942";
 
@@ -210,5 +209,4 @@ void BL0942::dump_config() {  // NOLINT(readability-function-cognitive-complexit
   LOG_SENSOR("", "Frequency", this->frequency_sensor_);
 }
 
-}  // namespace bl0942
-}  // namespace esphome
+}  // namespace esphome::bl0942

--- a/esphome/components/bl0942/bl0942.h
+++ b/esphome/components/bl0942/bl0942.h
@@ -5,8 +5,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace bl0942 {
+namespace esphome::bl0942 {
 
 // The BL0942 IC is "calibration-free", which means that it doesn't care
 // at all about calibration, and that's left to software. It measures a
@@ -147,5 +146,4 @@ class BL0942 : public PollingComponent, public uart::UARTDevice {
   void write_reg_(uint8_t reg, uint32_t val);
   void received_package_(DataPacket *data);
 };
-}  // namespace bl0942
-}  // namespace esphome
+}  // namespace esphome::bl0942

--- a/esphome/components/ble_presence/ble_presence_device.cpp
+++ b/esphome/components/ble_presence/ble_presence_device.cpp
@@ -3,14 +3,12 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_presence {
+namespace esphome::ble_presence {
 
 static const char *const TAG = "ble_presence";
 
 void BLEPresenceDevice::dump_config() { LOG_BINARY_SENSOR("", "BLE Presence", this); }
 
-}  // namespace ble_presence
-}  // namespace esphome
+}  // namespace esphome::ble_presence
 
 #endif

--- a/esphome/components/ble_presence/ble_presence_device.h
+++ b/esphome/components/ble_presence/ble_presence_device.h
@@ -6,8 +6,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_presence {
+namespace esphome::ble_presence {
 
 class BLEPresenceDevice : public binary_sensor::BinarySensorInitiallyOff,
                           public esp32_ble_tracker::ESPBTDeviceListener,
@@ -137,7 +136,6 @@ class BLEPresenceDevice : public binary_sensor::BinarySensorInitiallyOff,
   uint32_t timeout_{};
 };
 
-}  // namespace ble_presence
-}  // namespace esphome
+}  // namespace esphome::ble_presence
 
 #endif

--- a/esphome/components/ble_rssi/ble_rssi_sensor.cpp
+++ b/esphome/components/ble_rssi/ble_rssi_sensor.cpp
@@ -3,14 +3,12 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_rssi {
+namespace esphome::ble_rssi {
 
 static const char *const TAG = "ble_rssi";
 
 void BLERSSISensor::dump_config() { LOG_SENSOR("", "BLE RSSI Sensor", this); }
 
-}  // namespace ble_rssi
-}  // namespace esphome
+}  // namespace esphome::ble_rssi
 
 #endif

--- a/esphome/components/ble_rssi/ble_rssi_sensor.h
+++ b/esphome/components/ble_rssi/ble_rssi_sensor.h
@@ -6,8 +6,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_rssi {
+namespace esphome::ble_rssi {
 
 class BLERSSISensor : public sensor::Sensor, public esp32_ble_tracker::ESPBTDeviceListener, public Component {
  public:
@@ -120,7 +119,6 @@ class BLERSSISensor : public sensor::Sensor, public esp32_ble_tracker::ESPBTDevi
   bool check_ibeacon_minor_;
 };
 
-}  // namespace ble_rssi
-}  // namespace esphome
+}  // namespace esphome::ble_rssi
 
 #endif

--- a/esphome/components/ble_scanner/ble_scanner.cpp
+++ b/esphome/components/ble_scanner/ble_scanner.cpp
@@ -3,14 +3,12 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_scanner {
+namespace esphome::ble_scanner {
 
 static const char *const TAG = "ble_scanner";
 
 void BLEScanner::dump_config() { LOG_TEXT_SENSOR("", "BLE Scanner", this); }
 
-}  // namespace ble_scanner
-}  // namespace esphome
+}  // namespace esphome::ble_scanner
 
 #endif

--- a/esphome/components/ble_scanner/ble_scanner.h
+++ b/esphome/components/ble_scanner/ble_scanner.h
@@ -10,8 +10,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_scanner {
+namespace esphome::ble_scanner {
 
 class BLEScanner : public text_sensor::TextSensor, public esp32_ble_tracker::ESPBTDeviceListener, public Component {
  public:
@@ -43,7 +42,6 @@ class BLEScanner : public text_sensor::TextSensor, public esp32_ble_tracker::ESP
   void dump_config() override;
 };
 
-}  // namespace ble_scanner
-}  // namespace esphome
+}  // namespace esphome::ble_scanner
 
 #endif

--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -9,8 +9,7 @@
 
 #define BME280_ERROR_WRONG_CHIP_ID "Wrong chip ID or no response"
 
-namespace esphome {
-namespace bme280_base {
+namespace esphome::bme280_base {
 
 static const char *const TAG = "bme280.sensor";
 
@@ -355,5 +354,4 @@ uint16_t BME280Component::read_u16_le_(uint8_t a_register) {
 }
 int16_t BME280Component::read_s16_le_(uint8_t a_register) { return this->read_u16_le_(a_register); }
 
-}  // namespace bme280_base
-}  // namespace esphome
+}  // namespace esphome::bme280_base

--- a/esphome/components/bme280_base/bme280_base.h
+++ b/esphome/components/bme280_base/bme280_base.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace bme280_base {
+namespace esphome::bme280_base {
 
 /// Internal struct storing the calibration values of an BME280.
 struct BME280CalibrationData {
@@ -109,5 +108,4 @@ class BME280Component : public PollingComponent {
   } error_code_{NONE};
 };
 
-}  // namespace bme280_base
-}  // namespace esphome
+}  // namespace esphome::bme280_base

--- a/esphome/components/bme280_i2c/bme280_i2c.cpp
+++ b/esphome/components/bme280_i2c/bme280_i2c.cpp
@@ -5,8 +5,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "../bme280_base/bme280_base.h"
 
-namespace esphome {
-namespace bme280_i2c {
+namespace esphome::bme280_i2c {
 
 bool BME280I2CComponent::read_byte(uint8_t a_register, uint8_t *data) {
   return I2CDevice::read_byte(a_register, data);
@@ -26,5 +25,4 @@ void BME280I2CComponent::dump_config() {
   BME280Component::dump_config();
 }
 
-}  // namespace bme280_i2c
-}  // namespace esphome
+}  // namespace esphome::bme280_i2c

--- a/esphome/components/bme280_i2c/bme280_i2c.h
+++ b/esphome/components/bme280_i2c/bme280_i2c.h
@@ -3,8 +3,7 @@
 #include "esphome/components/bme280_base/bme280_base.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace bme280_i2c {
+namespace esphome::bme280_i2c {
 
 static const char *const TAG = "bme280_i2c.sensor";
 
@@ -16,5 +15,4 @@ class BME280I2CComponent : public esphome::bme280_base::BME280Component, public 
   void dump_config() override;
 };
 
-}  // namespace bme280_i2c
-}  // namespace esphome
+}  // namespace esphome::bme280_i2c

--- a/esphome/components/bme280_spi/bme280_spi.cpp
+++ b/esphome/components/bme280_spi/bme280_spi.cpp
@@ -4,8 +4,7 @@
 #include "bme280_spi.h"
 #include <esphome/components/bme280_base/bme280_base.h>
 
-namespace esphome {
-namespace bme280_spi {
+namespace esphome::bme280_spi {
 
 uint8_t set_bit(uint8_t num, int position) {
   int mask = 1 << position;
@@ -61,5 +60,4 @@ bool BME280SPIComponent::read_byte_16(uint8_t a_register, uint16_t *data) {
   return true;
 }
 
-}  // namespace bme280_spi
-}  // namespace esphome
+}  // namespace esphome::bme280_spi

--- a/esphome/components/bme280_spi/bme280_spi.h
+++ b/esphome/components/bme280_spi/bme280_spi.h
@@ -3,8 +3,7 @@
 #include "esphome/components/bme280_base/bme280_base.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace bme280_spi {
+namespace esphome::bme280_spi {
 
 class BME280SPIComponent : public esphome::bme280_base::BME280Component,
                            public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
@@ -16,5 +15,4 @@ class BME280SPIComponent : public esphome::bme280_base::BME280Component,
   bool read_byte_16(uint8_t a_register, uint16_t *data) override;
 };
 
-}  // namespace bme280_spi
-}  // namespace esphome
+}  // namespace esphome::bme280_spi

--- a/esphome/components/bme680/bme680.cpp
+++ b/esphome/components/bme680/bme680.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace bme680 {
+namespace esphome::bme680 {
 
 static const char *const TAG = "bme680.sensor";
 
@@ -508,5 +507,4 @@ void BME680Component::set_heater(uint16_t heater_temperature, uint16_t heater_du
   this->heater_duration_ = heater_duration;
 }
 
-}  // namespace bme680
-}  // namespace esphome
+}  // namespace esphome::bme680

--- a/esphome/components/bme680/bme680.h
+++ b/esphome/components/bme680/bme680.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace bme680 {
+namespace esphome::bme680 {
 
 /// Enum listing all IIR Filter options for the BME680.
 enum BME680IIRFilter {
@@ -134,5 +133,4 @@ class BME680Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *gas_resistance_sensor_{nullptr};
 };
 
-}  // namespace bme680
-}  // namespace esphome
+}  // namespace esphome::bme680

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include <string>
 
-namespace esphome {
-namespace bme680_bsec {
+namespace esphome::bme680_bsec {
 #ifdef USE_BSEC
 static const char *const TAG = "bme680_bsec.sensor";
 
@@ -565,5 +564,4 @@ void BME680BSECComponent::save_state_(uint8_t accuracy) {
   ESP_LOGI(TAG, "Saved state");
 }
 #endif
-}  // namespace bme680_bsec
-}  // namespace esphome
+}  // namespace esphome::bme680_bsec

--- a/esphome/components/bme680_bsec/bme680_bsec.h
+++ b/esphome/components/bme680_bsec/bme680_bsec.h
@@ -13,8 +13,7 @@
 #include <bsec.h>
 #endif
 
-namespace esphome {
-namespace bme680_bsec {
+namespace esphome::bme680_bsec {
 #ifdef USE_BSEC
 
 enum IAQMode {
@@ -133,5 +132,4 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   sensor::Sensor *breath_voc_equivalent_sensor_{nullptr};
 };
 #endif
-}  // namespace bme680_bsec
-}  // namespace esphome
+}  // namespace esphome::bme680_bsec

--- a/esphome/components/bmi160/bmi160.cpp
+++ b/esphome/components/bmi160/bmi160.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace bmi160 {
+namespace esphome::bmi160 {
 
 static const char *const TAG = "bmi160";
 static constexpr uint32_t GYRO_WAKEUP_TIMEOUT_MS = 100;
@@ -265,5 +264,4 @@ void BMI160Component::update() {
   this->status_clear_warning();
 }
 
-}  // namespace bmi160
-}  // namespace esphome
+}  // namespace esphome::bmi160

--- a/esphome/components/bmi160/bmi160.h
+++ b/esphome/components/bmi160/bmi160.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace bmi160 {
+namespace esphome::bmi160 {
 
 class BMI160Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -38,5 +37,4 @@ class BMI160Component : public PollingComponent, public i2c::I2CDevice {
   i2c::ErrorCode read_le_int16_(uint8_t reg, int16_t *value, uint8_t len);
 };
 
-}  // namespace bmi160
-}  // namespace esphome
+}  // namespace esphome::bmi160

--- a/esphome/components/bmp085/bmp085.cpp
+++ b/esphome/components/bmp085/bmp085.cpp
@@ -1,8 +1,7 @@
 #include "bmp085.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace bmp085 {
+namespace esphome::bmp085 {
 
 static const char *const TAG = "bmp085.sensor";
 
@@ -132,5 +131,4 @@ bool BMP085Component::set_mode_(uint8_t mode) {
   return this->write_byte(BMP085_REGISTER_CONTROL, mode);
 }
 
-}  // namespace bmp085
-}  // namespace esphome
+}  // namespace esphome::bmp085

--- a/esphome/components/bmp085/bmp085.h
+++ b/esphome/components/bmp085/bmp085.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace bmp085 {
+namespace esphome::bmp085 {
 
 class BMP085Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -39,5 +38,4 @@ class BMP085Component : public PollingComponent, public i2c::I2CDevice {
   CalibrationData calibration_;
 };
 
-}  // namespace bmp085
-}  // namespace esphome
+}  // namespace esphome::bmp085

--- a/esphome/components/bmp280_base/bmp280_base.cpp
+++ b/esphome/components/bmp280_base/bmp280_base.cpp
@@ -4,8 +4,7 @@
 
 #define BMP280_ERROR_WRONG_CHIP_ID "Wrong chip ID or no response"
 
-namespace esphome {
-namespace bmp280_base {
+namespace esphome::bmp280_base {
 
 static const char *const TAG = "bmp280.sensor";
 
@@ -268,5 +267,4 @@ uint16_t BMP280Component::read_u16_le_(uint8_t a_register) {
 }
 int16_t BMP280Component::read_s16_le_(uint8_t a_register) { return this->read_u16_le_(a_register); }
 
-}  // namespace bmp280_base
-}  // namespace esphome
+}  // namespace esphome::bmp280_base

--- a/esphome/components/bmp280_base/bmp280_base.h
+++ b/esphome/components/bmp280_base/bmp280_base.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace bmp280_base {
+namespace esphome::bmp280_base {
 
 /// Internal struct storing the calibration values of an BMP280.
 struct BMP280CalibrationData {
@@ -93,5 +92,4 @@ class BMP280Component : public PollingComponent {
   } error_code_{NONE};
 };
 
-}  // namespace bmp280_base
-}  // namespace esphome
+}  // namespace esphome::bmp280_base

--- a/esphome/components/bmp280_i2c/bmp280_i2c.cpp
+++ b/esphome/components/bmp280_i2c/bmp280_i2c.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace bmp280_i2c {
+namespace esphome::bmp280_i2c {
 
 void BMP280I2CComponent::dump_config() {
   LOG_I2C_DEVICE(this);
   BMP280Component::dump_config();
 }
 
-}  // namespace bmp280_i2c
-}  // namespace esphome
+}  // namespace esphome::bmp280_i2c

--- a/esphome/components/bmp280_i2c/bmp280_i2c.h
+++ b/esphome/components/bmp280_i2c/bmp280_i2c.h
@@ -3,8 +3,7 @@
 #include "esphome/components/bmp280_base/bmp280_base.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace bmp280_i2c {
+namespace esphome::bmp280_i2c {
 
 static const char *const TAG = "bmp280_i2c.sensor";
 
@@ -20,5 +19,4 @@ class BMP280I2CComponent : public esphome::bmp280_base::BMP280Component, public 
   void dump_config() override;
 };
 
-}  // namespace bmp280_i2c
-}  // namespace esphome
+}  // namespace esphome::bmp280_i2c

--- a/esphome/components/bmp280_spi/bmp280_spi.cpp
+++ b/esphome/components/bmp280_spi/bmp280_spi.cpp
@@ -4,8 +4,7 @@
 #include "bmp280_spi.h"
 #include <esphome/components/bmp280_base/bmp280_base.h>
 
-namespace esphome {
-namespace bmp280_spi {
+namespace esphome::bmp280_spi {
 
 uint8_t set_bit(uint8_t num, uint8_t position) {
   uint8_t mask = 1 << position;
@@ -61,5 +60,4 @@ bool BMP280SPIComponent::bmp_read_byte_16(uint8_t a_register, uint16_t *data) {
   return true;
 }
 
-}  // namespace bmp280_spi
-}  // namespace esphome
+}  // namespace esphome::bmp280_spi

--- a/esphome/components/bmp280_spi/bmp280_spi.h
+++ b/esphome/components/bmp280_spi/bmp280_spi.h
@@ -3,8 +3,7 @@
 #include "esphome/components/bmp280_base/bmp280_base.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace bmp280_spi {
+namespace esphome::bmp280_spi {
 
 class BMP280SPIComponent : public esphome::bmp280_base::BMP280Component,
                            public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
@@ -16,5 +15,4 @@ class BMP280SPIComponent : public esphome::bmp280_base::BMP280Component,
   bool bmp_read_byte_16(uint8_t a_register, uint16_t *data) override;
 };
 
-}  // namespace bmp280_spi
-}  // namespace esphome
+}  // namespace esphome::bmp280_spi

--- a/esphome/components/bmp3xx_base/bmp3xx_base.cpp
+++ b/esphome/components/bmp3xx_base/bmp3xx_base.cpp
@@ -11,8 +11,7 @@
 #include "esphome/core/progmem.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace bmp3xx_base {
+namespace esphome::bmp3xx_base {
 
 static const char *const TAG = "bmp3xx.sensor";
 
@@ -356,5 +355,4 @@ float BMP3XXComponent::bmp388_compensate_pressure_(float uncomp_press, float t_l
   return partial_out1 + partial_out2 + partial_data4;
 }
 
-}  // namespace bmp3xx_base
-}  // namespace esphome
+}  // namespace esphome::bmp3xx_base

--- a/esphome/components/bmp3xx_base/bmp3xx_base.h
+++ b/esphome/components/bmp3xx_base/bmp3xx_base.h
@@ -10,8 +10,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace bmp3xx_base {
+namespace esphome::bmp3xx_base {
 
 static const uint8_t BMP388_ID = 0x50;   // The BMP388 device ID
 static const uint8_t BMP390_ID = 0x60;   // The BMP390 device ID
@@ -237,5 +236,4 @@ class BMP3XXComponent : public PollingComponent {
   virtual bool write_bytes(uint8_t a_register, uint8_t *data, size_t len) = 0;
 };
 
-}  // namespace bmp3xx_base
-}  // namespace esphome
+}  // namespace esphome::bmp3xx_base

--- a/esphome/components/bmp3xx_i2c/bmp3xx_i2c.cpp
+++ b/esphome/components/bmp3xx_i2c/bmp3xx_i2c.cpp
@@ -2,8 +2,7 @@
 #include "bmp3xx_i2c.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace bmp3xx_i2c {
+namespace esphome::bmp3xx_i2c {
 
 static const char *const TAG = "bmp3xx_i2c.sensor";
 
@@ -25,5 +24,4 @@ void BMP3XXI2CComponent::dump_config() {
   BMP3XXComponent::dump_config();
 }
 
-}  // namespace bmp3xx_i2c
-}  // namespace esphome
+}  // namespace esphome::bmp3xx_i2c

--- a/esphome/components/bmp3xx_i2c/bmp3xx_i2c.h
+++ b/esphome/components/bmp3xx_i2c/bmp3xx_i2c.h
@@ -2,8 +2,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/bmp3xx_base/bmp3xx_base.h"
 
-namespace esphome {
-namespace bmp3xx_i2c {
+namespace esphome::bmp3xx_i2c {
 
 class BMP3XXI2CComponent : public bmp3xx_base::BMP3XXComponent, public i2c::I2CDevice {
   bool read_byte(uint8_t a_register, uint8_t *data) override;
@@ -13,5 +12,4 @@ class BMP3XXI2CComponent : public bmp3xx_base::BMP3XXComponent, public i2c::I2CD
   void dump_config() override;
 };
 
-}  // namespace bmp3xx_i2c
-}  // namespace esphome
+}  // namespace esphome::bmp3xx_i2c

--- a/esphome/components/bmp3xx_spi/bmp3xx_spi.cpp
+++ b/esphome/components/bmp3xx_spi/bmp3xx_spi.cpp
@@ -1,8 +1,7 @@
 #include "bmp3xx_spi.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace bmp3xx_spi {
+namespace esphome::bmp3xx_spi {
 
 static const char *const TAG = "bmp3xx_spi.sensor";
 
@@ -53,5 +52,4 @@ bool BMP3XXSPIComponent::write_bytes(uint8_t a_register, uint8_t *data, size_t l
   return true;
 }
 
-}  // namespace bmp3xx_spi
-}  // namespace esphome
+}  // namespace esphome::bmp3xx_spi

--- a/esphome/components/bmp3xx_spi/bmp3xx_spi.h
+++ b/esphome/components/bmp3xx_spi/bmp3xx_spi.h
@@ -2,8 +2,7 @@
 #include "esphome/components/bmp3xx_base/bmp3xx_base.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace bmp3xx_spi {
+namespace esphome::bmp3xx_spi {
 
 class BMP3XXSPIComponent : public bmp3xx_base::BMP3XXComponent,
                            public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
@@ -15,5 +14,4 @@ class BMP3XXSPIComponent : public bmp3xx_base::BMP3XXComponent,
   bool write_bytes(uint8_t a_register, uint8_t *data, size_t len) override;
 };
 
-}  // namespace bmp3xx_spi
-}  // namespace esphome
+}  // namespace esphome::bmp3xx_spi

--- a/esphome/components/bp1658cj/bp1658cj.cpp
+++ b/esphome/components/bp1658cj/bp1658cj.cpp
@@ -1,8 +1,7 @@
 #include "bp1658cj.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace bp1658cj {
+namespace esphome::bp1658cj {
 
 static const char *const TAG = "bp1658cj";
 
@@ -128,5 +127,4 @@ void BP1658CJ::write_buffer_(uint8_t *buffer, uint8_t size) {
   delayMicroseconds(BP1658CJ_DELAY);
 }
 
-}  // namespace bp1658cj
-}  // namespace esphome
+}  // namespace esphome::bp1658cj

--- a/esphome/components/bp1658cj/bp1658cj.h
+++ b/esphome/components/bp1658cj/bp1658cj.h
@@ -5,8 +5,7 @@
 #include "esphome/components/output/float_output.h"
 #include <vector>
 
-namespace esphome {
-namespace bp1658cj {
+namespace esphome::bp1658cj {
 
 class BP1658CJ : public Component {
  public:
@@ -60,5 +59,4 @@ class BP1658CJ : public Component {
   bool update_{true};
 };
 
-}  // namespace bp1658cj
-}  // namespace esphome
+}  // namespace esphome::bp1658cj

--- a/esphome/components/bp5758d/bp5758d.cpp
+++ b/esphome/components/bp5758d/bp5758d.cpp
@@ -1,8 +1,7 @@
 #include "bp5758d.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace bp5758d {
+namespace esphome::bp5758d {
 
 static const char *const TAG = "bp5758d";
 
@@ -164,5 +163,4 @@ void BP5758D::write_buffer_(uint8_t *buffer, uint8_t size) {
   delayMicroseconds(BP5758D_DELAY);
 }
 
-}  // namespace bp5758d
-}  // namespace esphome
+}  // namespace esphome::bp5758d

--- a/esphome/components/bp5758d/bp5758d.h
+++ b/esphome/components/bp5758d/bp5758d.h
@@ -5,8 +5,7 @@
 #include "esphome/components/output/float_output.h"
 #include <vector>
 
-namespace esphome {
-namespace bp5758d {
+namespace esphome::bp5758d {
 
 class BP5758D : public Component {
  public:
@@ -60,5 +59,4 @@ class BP5758D : public Component {
   bool update_{true};
 };
 
-}  // namespace bp5758d
-}  // namespace esphome
+}  // namespace esphome::bp5758d

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -17,8 +17,7 @@
 #include "mbedtls/ccm.h"
 #endif
 
-namespace esphome {
-namespace bthome_mithermometer {
+namespace esphome::bthome_mithermometer {
 
 static const char *const TAG = "bthome_mithermometer";
 static constexpr size_t BTHOME_BINDKEY_SIZE = 16;
@@ -434,7 +433,6 @@ bool BTHomeMiThermometer::handle_service_data_(const esp32_ble_tracker::ServiceD
   return reported;
 }
 
-}  // namespace bthome_mithermometer
-}  // namespace esphome
+}  // namespace esphome::bthome_mithermometer
 
 #endif

--- a/esphome/components/bthome_mithermometer/bthome_ble.h
+++ b/esphome/components/bthome_mithermometer/bthome_ble.h
@@ -10,8 +10,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace bthome_mithermometer {
+namespace esphome::bthome_mithermometer {
 
 class BTHomeMiThermometer : public esp32_ble_tracker::ESPBTDeviceListener, public Component {
  public:
@@ -45,7 +44,6 @@ class BTHomeMiThermometer : public esp32_ble_tracker::ESPBTDeviceListener, publi
   sensor::Sensor *signal_strength_{nullptr};
 };
 
-}  // namespace bthome_mithermometer
-}  // namespace esphome
+}  // namespace esphome::bthome_mithermometer
 
 #endif

--- a/esphome/components/bytebuffer/bytebuffer.h
+++ b/esphome/components/bytebuffer/bytebuffer.h
@@ -6,8 +6,7 @@
 #include <cstddef>
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace bytebuffer {
+namespace esphome::bytebuffer {
 
 enum Endian { LITTLE, BIG };
 
@@ -417,5 +416,4 @@ class ByteBuffer {
   size_t limit_{0};
 };
 
-}  // namespace bytebuffer
-}  // namespace esphome
+}  // namespace esphome::bytebuffer

--- a/esphome/components/camera/camera.cpp
+++ b/esphome/components/camera/camera.cpp
@@ -1,7 +1,6 @@
 #include "camera.h"
 
-namespace esphome {
-namespace camera {
+namespace esphome::camera {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 Camera *Camera::global_camera = nullptr;
@@ -18,5 +17,4 @@ Camera::Camera() {
 
 Camera *Camera::instance() { return global_camera; }
 
-}  // namespace camera
-}  // namespace esphome
+}  // namespace esphome::camera

--- a/esphome/components/camera/camera.h
+++ b/esphome/components/camera/camera.h
@@ -5,8 +5,7 @@
 #include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace camera {
+namespace esphome::camera {
 
 /** Different sources for filtering.
  *  IDLE: Camera requests to send an image to the API.
@@ -134,5 +133,4 @@ class Camera : public EntityBase, public Component {
   static Camera *global_camera;
 };
 
-}  // namespace camera
-}  // namespace esphome
+}  // namespace esphome::camera

--- a/esphome/components/canbus/canbus.cpp
+++ b/esphome/components/canbus/canbus.cpp
@@ -2,8 +2,7 @@
 #include <algorithm>
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace canbus {
+namespace esphome::canbus {
 
 static const char *const TAG = "canbus";
 
@@ -103,5 +102,4 @@ void Canbus::loop() {
   }
 }
 
-}  // namespace canbus
-}  // namespace esphome
+}  // namespace esphome::canbus

--- a/esphome/components/canbus/canbus.h
+++ b/esphome/components/canbus/canbus.h
@@ -7,8 +7,7 @@
 #include <cinttypes>
 #include <vector>
 
-namespace esphome {
-namespace canbus {
+namespace esphome::canbus {
 
 enum Error : uint8_t {
   ERROR_OK = 0,
@@ -177,5 +176,4 @@ class CanbusTrigger : public Trigger<std::vector<uint8_t>, uint32_t, bool>, publ
   optional<bool> remote_transmission_request_{};
 };
 
-}  // namespace canbus
-}  // namespace esphome
+}  // namespace esphome::canbus

--- a/esphome/components/cap1188/cap1188.cpp
+++ b/esphome/components/cap1188/cap1188.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace cap1188 {
+namespace esphome::cap1188 {
 
 static const char *const TAG = "cap1188";
 
@@ -100,5 +99,4 @@ void CAP1188Component::loop() {
   }
 }
 
-}  // namespace cap1188
-}  // namespace esphome
+}  // namespace esphome::cap1188

--- a/esphome/components/cap1188/cap1188.h
+++ b/esphome/components/cap1188/cap1188.h
@@ -8,8 +8,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace cap1188 {
+namespace esphome::cap1188 {
 
 enum {
   CAP1188_I2CADDR = 0x29,
@@ -67,5 +66,4 @@ class CAP1188Component : public Component, public i2c::I2CDevice {
   } error_code_{NONE};
 };
 
-}  // namespace cap1188
-}  // namespace esphome
+}  // namespace esphome::cap1188

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -5,8 +5,7 @@
 #include "esphome/components/wifi/wifi_component.h"
 #include "captive_index.h"
 
-namespace esphome {
-namespace captive_portal {
+namespace esphome::captive_portal {
 
 static const char *const TAG = "captive_portal";
 
@@ -135,6 +134,6 @@ void CaptivePortal::dump_config() { ESP_LOGCONFIG(TAG, "Captive Portal:"); }
 
 CaptivePortal *global_captive_portal = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace captive_portal
-}  // namespace esphome
+}  // namespace esphome::captive_portal
+
 #endif

--- a/esphome/components/captive_portal/captive_portal.h
+++ b/esphome/components/captive_portal/captive_portal.h
@@ -12,9 +12,7 @@
 #include "esphome/core/preferences.h"
 #include "esphome/components/web_server_base/web_server_base.h"
 
-namespace esphome {
-
-namespace captive_portal {
+namespace esphome::captive_portal {
 
 class CaptivePortal : public AsyncWebHandler, public Component {
  public:
@@ -69,6 +67,6 @@ class CaptivePortal : public AsyncWebHandler, public Component {
 
 extern CaptivePortal *global_captive_portal;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace captive_portal
-}  // namespace esphome
+}  // namespace esphome::captive_portal
+
 #endif

--- a/esphome/components/ccs811/ccs811.cpp
+++ b/esphome/components/ccs811/ccs811.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ccs811 {
+namespace esphome::ccs811 {
 
 static const char *const TAG = "ccs811";
 
@@ -186,5 +185,4 @@ void CCS811Component::dump_config() {
   }
 }
 
-}  // namespace ccs811
-}  // namespace esphome
+}  // namespace esphome::ccs811

--- a/esphome/components/ccs811/ccs811.h
+++ b/esphome/components/ccs811/ccs811.h
@@ -6,8 +6,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ccs811 {
+namespace esphome::ccs811 {
 
 class CCS811Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -51,5 +50,4 @@ class CCS811Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *temperature_{nullptr};
 };
 
-}  // namespace ccs811
-}  // namespace esphome
+}  // namespace esphome::ccs811

--- a/esphome/components/cd74hc4067/cd74hc4067.cpp
+++ b/esphome/components/cd74hc4067/cd74hc4067.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace cd74hc4067 {
+namespace esphome::cd74hc4067 {
 
 static const char *const TAG = "cd74hc4067";
 
@@ -81,5 +80,4 @@ void CD74HC4067Sensor::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace cd74hc4067
-}  // namespace esphome
+}  // namespace esphome::cd74hc4067

--- a/esphome/components/cd74hc4067/cd74hc4067.h
+++ b/esphome/components/cd74hc4067/cd74hc4067.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/voltage_sampler/voltage_sampler.h"
 
-namespace esphome {
-namespace cd74hc4067 {
+namespace esphome::cd74hc4067 {
 
 class CD74HC4067Component : public Component {
  public:
@@ -60,5 +59,4 @@ class CD74HC4067Sensor : public sensor::Sensor, public PollingComponent, public 
 
   uint8_t pin_;
 };
-}  // namespace cd74hc4067
-}  // namespace esphome
+}  // namespace esphome::cd74hc4067

--- a/esphome/components/ch422g/ch422g.cpp
+++ b/esphome/components/ch422g/ch422g.cpp
@@ -1,8 +1,7 @@
 #include "ch422g.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ch422g {
+namespace esphome::ch422g {
 
 static const uint8_t CH422G_REG_MODE = 0x24;
 static const uint8_t CH422G_MODE_OUTPUT = 0x01;      // enables output mode on 0-7
@@ -136,5 +135,4 @@ void CH422GGPIOPin::set_flags(gpio::Flags flags) {
   this->parent_->pin_mode(this->pin_, flags);
 }
 
-}  // namespace ch422g
-}  // namespace esphome
+}  // namespace esphome::ch422g

--- a/esphome/components/ch422g/ch422g.h
+++ b/esphome/components/ch422g/ch422g.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ch422g {
+namespace esphome::ch422g {
 
 class CH422GComponent : public Component, public i2c::I2CDevice {
  public:
@@ -65,5 +64,4 @@ class CH422GGPIOPin : public GPIOPin {
   gpio::Flags flags_{};
 };
 
-}  // namespace ch422g
-}  // namespace esphome
+}  // namespace esphome::ch422g

--- a/esphome/components/chsc6x/chsc6x_touchscreen.cpp
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.cpp
@@ -1,7 +1,6 @@
 #include "chsc6x_touchscreen.h"
 
-namespace esphome {
-namespace chsc6x {
+namespace esphome::chsc6x {
 
 void CHSC6XTouchscreen::setup() {
   if (this->interrupt_pin_ != nullptr) {
@@ -42,5 +41,4 @@ void CHSC6XTouchscreen::dump_config() {
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
 }
 
-}  // namespace chsc6x
-}  // namespace esphome
+}  // namespace esphome::chsc6x

--- a/esphome/components/chsc6x/chsc6x_touchscreen.h
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.h
@@ -6,8 +6,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace chsc6x {
+namespace esphome::chsc6x {
 
 static const char *const TAG = "chsc6x.touchscreen";
 
@@ -30,5 +29,4 @@ class CHSC6XTouchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice
   InternalGPIOPin *interrupt_pin_{};
 };
 
-}  // namespace chsc6x
-}  // namespace esphome
+}  // namespace esphome::chsc6x

--- a/esphome/components/climate_ir/climate_ir.cpp
+++ b/esphome/components/climate_ir/climate_ir.cpp
@@ -1,8 +1,7 @@
 #include "climate_ir.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace climate_ir {
+namespace esphome::climate_ir {
 
 static const char *const TAG = "climate_ir";
 
@@ -100,5 +99,4 @@ void ClimateIR::dump_config() {
                 YESNO(this->supports_cool_));
 }
 
-}  // namespace climate_ir
-}  // namespace esphome
+}  // namespace esphome::climate_ir

--- a/esphome/components/climate_ir/climate_ir.h
+++ b/esphome/components/climate_ir/climate_ir.h
@@ -7,8 +7,7 @@
 #include "esphome/components/remote_transmitter/remote_transmitter.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace climate_ir {
+namespace esphome::climate_ir {
 
 /* A base for climate which works by sending (and receiving) IR codes
 
@@ -71,5 +70,4 @@ class ClimateIR : public Component,
   sensor::Sensor *humidity_sensor_{nullptr};
 };
 
-}  // namespace climate_ir
-}  // namespace esphome
+}  // namespace esphome::climate_ir

--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -1,8 +1,7 @@
 #include "climate_ir_lg.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace climate_ir_lg {
+namespace esphome::climate_ir_lg {
 
 static const char *const TAG = "climate.climate_ir_lg";
 
@@ -218,5 +217,4 @@ void LgIrClimate::calc_checksum_(uint32_t &value) {
   value |= (sum & mask);
 }
 
-}  // namespace climate_ir_lg
-}  // namespace esphome
+}  // namespace esphome::climate_ir_lg

--- a/esphome/components/climate_ir_lg/climate_ir_lg.h
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.h
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace climate_ir_lg {
+namespace esphome::climate_ir_lg {
 
 // Temperature
 const uint8_t TEMP_MIN = 18;  // Celsius
@@ -54,5 +53,4 @@ class LgIrClimate : public climate_ir::ClimateIR {
   climate::ClimateMode mode_before_{climate::CLIMATE_MODE_OFF};
 };
 
-}  // namespace climate_ir_lg
-}  // namespace esphome
+}  // namespace esphome::climate_ir_lg

--- a/esphome/components/cm1106/cm1106.cpp
+++ b/esphome/components/cm1106/cm1106.cpp
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace cm1106 {
+namespace esphome::cm1106 {
 
 static const char *const TAG = "cm1106";
 static const uint8_t C_M1106_CMD_GET_CO2[4] = {0x11, 0x01, 0x01, 0xED};
@@ -107,5 +106,4 @@ void CM1106Component::dump_config() {
   }
 }
 
-}  // namespace cm1106
-}  // namespace esphome
+}  // namespace esphome::cm1106

--- a/esphome/components/cm1106/cm1106.h
+++ b/esphome/components/cm1106/cm1106.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace cm1106 {
+namespace esphome::cm1106 {
 
 class CM1106Component : public PollingComponent, public uart::UARTDevice {
  public:
@@ -34,5 +33,4 @@ template<typename... Ts> class CM1106CalibrateZeroAction : public Action<Ts...> 
   CM1106Component *cm1106_;
 };
 
-}  // namespace cm1106
-}  // namespace esphome
+}  // namespace esphome::cm1106

--- a/esphome/components/color_temperature/ct_light_output.h
+++ b/esphome/components/color_temperature/ct_light_output.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace color_temperature {
+namespace esphome::color_temperature {
 
 class CTLightOutput : public light::LightOutput {
  public:
@@ -34,5 +33,4 @@ class CTLightOutput : public light::LightOutput {
   float warm_white_temperature_;
 };
 
-}  // namespace color_temperature
-}  // namespace esphome
+}  // namespace esphome::color_temperature

--- a/esphome/components/combination/combination.cpp
+++ b/esphome/components/combination/combination.cpp
@@ -5,8 +5,7 @@
 
 #include <cmath>
 
-namespace esphome {
-namespace combination {
+namespace esphome::combination {
 
 static const char *const TAG = "combination";
 
@@ -267,5 +266,4 @@ void SumCombinationComponent::handle_new_value(float value) {
   this->publish_state(sum);
 }
 
-}  // namespace combination
-}  // namespace esphome
+}  // namespace esphome::combination

--- a/esphome/components/combination/combination.h
+++ b/esphome/components/combination/combination.h
@@ -6,8 +6,7 @@
 
 #include <functional>
 
-namespace esphome {
-namespace combination {
+namespace esphome::combination {
 
 class CombinationComponent : public Component, public sensor::Sensor {
  public:
@@ -143,5 +142,4 @@ class SumCombinationComponent : public CombinationNoParameterComponent {
   void handle_new_value(float value) override;
 };
 
-}  // namespace combination
-}  // namespace esphome
+}  // namespace esphome::combination

--- a/esphome/components/coolix/coolix.cpp
+++ b/esphome/components/coolix/coolix.cpp
@@ -2,8 +2,7 @@
 #include "esphome/components/remote_base/coolix_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace coolix {
+namespace esphome::coolix {
 
 static const char *const TAG = "coolix.climate";
 
@@ -159,5 +158,4 @@ bool CoolixClimate::on_coolix(climate::Climate *parent, remote_base::RemoteRecei
   return true;
 }
 
-}  // namespace coolix
-}  // namespace esphome
+}  // namespace esphome::coolix

--- a/esphome/components/coolix/coolix.h
+++ b/esphome/components/coolix/coolix.h
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace coolix {
+namespace esphome::coolix {
 
 // Temperature
 const uint8_t COOLIX_TEMP_MIN = 17;  // Celsius
@@ -42,5 +41,4 @@ class CoolixClimate : public climate_ir::ClimateIR {
   bool send_swing_cmd_{false};
 };
 
-}  // namespace coolix
-}  // namespace esphome
+}  // namespace esphome::coolix

--- a/esphome/components/copy/binary_sensor/copy_binary_sensor.cpp
+++ b/esphome/components/copy/binary_sensor/copy_binary_sensor.cpp
@@ -1,8 +1,7 @@
 #include "copy_binary_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 static const char *const TAG = "copy.binary_sensor";
 
@@ -14,5 +13,4 @@ void CopyBinarySensor::setup() {
 
 void CopyBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Copy Binary Sensor", this); }
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/binary_sensor/copy_binary_sensor.h
+++ b/esphome/components/copy/binary_sensor/copy_binary_sensor.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 class CopyBinarySensor : public binary_sensor::BinarySensor, public Component {
  public:
@@ -16,5 +15,4 @@ class CopyBinarySensor : public binary_sensor::BinarySensor, public Component {
   binary_sensor::BinarySensor *source_;
 };
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/button/copy_button.cpp
+++ b/esphome/components/copy/button/copy_button.cpp
@@ -1,8 +1,7 @@
 #include "copy_button.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 static const char *const TAG = "copy.button";
 
@@ -10,5 +9,4 @@ void CopyButton::dump_config() { LOG_BUTTON("", "Copy Button", this); }
 
 void CopyButton::press_action() { source_->press(); }
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/button/copy_button.h
+++ b/esphome/components/copy/button/copy_button.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 class CopyButton : public button::Button, public Component {
  public:
@@ -17,5 +16,4 @@ class CopyButton : public button::Button, public Component {
   button::Button *source_;
 };
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/cover/copy_cover.cpp
+++ b/esphome/components/copy/cover/copy_cover.cpp
@@ -1,8 +1,7 @@
 #include "copy_cover.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 static const char *const TAG = "copy.cover";
 
@@ -50,5 +49,4 @@ void CopyCover::control(const cover::CoverCall &call) {
   call2.perform();
 }
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/cover/copy_cover.h
+++ b/esphome/components/copy/cover/copy_cover.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/cover/cover.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 class CopyCover : public cover::Cover, public Component {
  public:
@@ -20,5 +19,4 @@ class CopyCover : public cover::Cover, public Component {
   cover::Cover *source_;
 };
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/fan/copy_fan.cpp
+++ b/esphome/components/copy/fan/copy_fan.cpp
@@ -1,8 +1,7 @@
 #include "copy_fan.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 static const char *const TAG = "copy.fan";
 
@@ -69,5 +68,4 @@ void CopyFan::control(const fan::FanCall &call) {
   call2.perform();
 }
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/fan/copy_fan.h
+++ b/esphome/components/copy/fan/copy_fan.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/fan/fan.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 class CopyFan : public fan::Fan, public Component {
  public:
@@ -21,5 +20,4 @@ class CopyFan : public fan::Fan, public Component {
   fan::Fan *source_;
 };
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/lock/copy_lock.cpp
+++ b/esphome/components/copy/lock/copy_lock.cpp
@@ -1,8 +1,7 @@
 #include "copy_lock.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 static const char *const TAG = "copy.lock";
 
@@ -25,5 +24,4 @@ void CopyLock::control(const lock::LockCall &call) {
   call2.perform();
 }
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/lock/copy_lock.h
+++ b/esphome/components/copy/lock/copy_lock.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/lock/lock.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 class CopyLock : public lock::Lock, public Component {
  public:
@@ -18,5 +17,4 @@ class CopyLock : public lock::Lock, public Component {
   lock::Lock *source_;
 };
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/number/copy_number.cpp
+++ b/esphome/components/copy/number/copy_number.cpp
@@ -1,8 +1,7 @@
 #include "copy_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 static const char *const TAG = "copy.number";
 
@@ -25,5 +24,4 @@ void CopyNumber::control(float value) {
   call2.perform();
 }
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/number/copy_number.h
+++ b/esphome/components/copy/number/copy_number.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 class CopyNumber : public number::Number, public Component {
  public:
@@ -18,5 +17,4 @@ class CopyNumber : public number::Number, public Component {
   number::Number *source_;
 };
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/select/copy_select.cpp
+++ b/esphome/components/copy/select/copy_select.cpp
@@ -1,8 +1,7 @@
 #include "copy_select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 static const char *const TAG = "copy.select";
 
@@ -24,5 +23,4 @@ void CopySelect::control(size_t index) {
   call.perform();
 }
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/select/copy_select.h
+++ b/esphome/components/copy/select/copy_select.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/select/select.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 class CopySelect : public select::Select, public Component {
  public:
@@ -18,5 +17,4 @@ class CopySelect : public select::Select, public Component {
   select::Select *source_;
 };
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/sensor/copy_sensor.cpp
+++ b/esphome/components/copy/sensor/copy_sensor.cpp
@@ -1,8 +1,7 @@
 #include "copy_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 static const char *const TAG = "copy.sensor";
 
@@ -14,5 +13,4 @@ void CopySensor::setup() {
 
 void CopySensor::dump_config() { LOG_SENSOR("", "Copy Sensor", this); }
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/sensor/copy_sensor.h
+++ b/esphome/components/copy/sensor/copy_sensor.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 class CopySensor : public sensor::Sensor, public Component {
  public:
@@ -16,5 +15,4 @@ class CopySensor : public sensor::Sensor, public Component {
   sensor::Sensor *source_;
 };
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/switch/copy_switch.cpp
+++ b/esphome/components/copy/switch/copy_switch.cpp
@@ -1,8 +1,7 @@
 #include "copy_switch.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 static const char *const TAG = "copy.switch";
 
@@ -22,5 +21,4 @@ void CopySwitch::write_state(bool state) {
   }
 }
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/switch/copy_switch.h
+++ b/esphome/components/copy/switch/copy_switch.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 class CopySwitch : public switch_::Switch, public Component {
  public:
@@ -18,5 +17,4 @@ class CopySwitch : public switch_::Switch, public Component {
   switch_::Switch *source_;
 };
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/text/copy_text.cpp
+++ b/esphome/components/copy/text/copy_text.cpp
@@ -1,8 +1,7 @@
 #include "copy_text.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 static const char *const TAG = "copy.text";
 
@@ -21,5 +20,4 @@ void CopyText::control(const std::string &value) {
   call2.perform();
 }
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/text/copy_text.h
+++ b/esphome/components/copy/text/copy_text.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/text/text.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 class CopyText : public text::Text, public Component {
  public:
@@ -18,5 +17,4 @@ class CopyText : public text::Text, public Component {
   text::Text *source_;
 };
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/text_sensor/copy_text_sensor.cpp
+++ b/esphome/components/copy/text_sensor/copy_text_sensor.cpp
@@ -1,8 +1,7 @@
 #include "copy_text_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 static const char *const TAG = "copy.text_sensor";
 
@@ -14,5 +13,4 @@ void CopyTextSensor::setup() {
 
 void CopyTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Copy Sensor", this); }
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/copy/text_sensor/copy_text_sensor.h
+++ b/esphome/components/copy/text_sensor/copy_text_sensor.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
-namespace esphome {
-namespace copy {
+namespace esphome::copy {
 
 class CopyTextSensor : public text_sensor::TextSensor, public Component {
  public:
@@ -16,5 +15,4 @@ class CopyTextSensor : public text_sensor::TextSensor, public Component {
   text_sensor::TextSensor *source_;
 };
 
-}  // namespace copy
-}  // namespace esphome
+}  // namespace esphome::copy

--- a/esphome/components/cs5460a/cs5460a.cpp
+++ b/esphome/components/cs5460a/cs5460a.cpp
@@ -1,8 +1,7 @@
 #include "cs5460a.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace cs5460a {
+namespace esphome::cs5460a {
 
 static const char *const TAG = "cs5460a";
 
@@ -339,5 +338,4 @@ void CS5460AComponent::dump_config() {
   LOG_SENSOR("  ", "Power", power_sensor_);
 }
 
-}  // namespace cs5460a
-}  // namespace esphome
+}  // namespace esphome::cs5460a

--- a/esphome/components/cs5460a/cs5460a.h
+++ b/esphome/components/cs5460a/cs5460a.h
@@ -7,8 +7,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace cs5460a {
+namespace esphome::cs5460a {
 
 enum CS5460ACommand {
   CMD_SYNC0 = 0xfe,
@@ -119,5 +118,4 @@ template<typename... Ts> class CS5460ARestartAction : public Action<Ts...> {
   CS5460AComponent *cs5460a_;
 };
 
-}  // namespace cs5460a
-}  // namespace esphome
+}  // namespace esphome::cs5460a

--- a/esphome/components/cse7761/cse7761.cpp
+++ b/esphome/components/cse7761/cse7761.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace cse7761 {
+namespace esphome::cse7761 {
 
 static const char *const TAG = "cse7761";
 
@@ -244,5 +243,4 @@ void CSE7761Component::get_data_() {
   }
 }
 
-}  // namespace cse7761
-}  // namespace esphome
+}  // namespace esphome::cse7761

--- a/esphome/components/cse7761/cse7761.h
+++ b/esphome/components/cse7761/cse7761.h
@@ -4,8 +4,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace cse7761 {
+namespace esphome::cse7761 {
 
 struct CSE7761DataStruct {
   uint32_t frequency = 0;
@@ -45,5 +44,4 @@ class CSE7761Component : public PollingComponent, public uart::UARTDevice {
   void get_data_();
 };
 
-}  // namespace cse7761
-}  // namespace esphome
+}  // namespace esphome::cse7761

--- a/esphome/components/cst226/binary_sensor/cs226_button.h
+++ b/esphome/components/cst226/binary_sensor/cs226_button.h
@@ -4,8 +4,7 @@
 #include "../touchscreen/cst226_touchscreen.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace cst226 {
+namespace esphome::cst226 {
 
 class CST226Button : public binary_sensor::BinarySensor,
                      public Component,
@@ -18,5 +17,4 @@ class CST226Button : public binary_sensor::BinarySensor,
   void update_button(bool state) override;
 };
 
-}  // namespace cst226
-}  // namespace esphome
+}  // namespace esphome::cst226

--- a/esphome/components/cst226/binary_sensor/cstt6_button.cpp
+++ b/esphome/components/cst226/binary_sensor/cstt6_button.cpp
@@ -1,8 +1,7 @@
 #include "cs226_button.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace cst226 {
+namespace esphome::cst226 {
 
 static const char *const TAG = "CST226.binary_sensor";
 
@@ -15,5 +14,4 @@ void CST226Button::dump_config() { LOG_BINARY_SENSOR("", "CST226 Button", this);
 
 void CST226Button::update_button(bool state) { this->publish_state(state); }
 
-}  // namespace cst226
-}  // namespace esphome
+}  // namespace esphome::cst226

--- a/esphome/components/cst226/touchscreen/cst226_touchscreen.cpp
+++ b/esphome/components/cst226/touchscreen/cst226_touchscreen.cpp
@@ -1,7 +1,6 @@
 #include "cst226_touchscreen.h"
 
-namespace esphome {
-namespace cst226 {
+namespace esphome::cst226 {
 
 static const char *const TAG = "cst226.touchscreen";
 
@@ -110,5 +109,4 @@ void CST226Touchscreen::dump_config() {
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
 }
 
-}  // namespace cst226
-}  // namespace esphome
+}  // namespace esphome::cst226

--- a/esphome/components/cst226/touchscreen/cst226_touchscreen.h
+++ b/esphome/components/cst226/touchscreen/cst226_touchscreen.h
@@ -6,8 +6,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace cst226 {
+namespace esphome::cst226 {
 
 static const uint8_t CST226_REG_STATUS = 0x00;
 
@@ -40,5 +39,4 @@ class CST226Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice
   bool button_touched_{};
 };
 
-}  // namespace cst226
-}  // namespace esphome
+}  // namespace esphome::cst226

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -1,8 +1,7 @@
 #include "cst816_touchscreen.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace cst816 {
+namespace esphome::cst816 {
 
 void CST816Touchscreen::continue_setup_() {
   if (this->interrupt_pin_ != nullptr) {
@@ -121,5 +120,4 @@ void CST816Touchscreen::dump_config() {
   ESP_LOGCONFIG(TAG, "  Chip type: %s", name);
 }
 
-}  // namespace cst816
-}  // namespace esphome
+}  // namespace esphome::cst816

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.h
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.h
@@ -6,8 +6,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace cst816 {
+namespace esphome::cst816 {
 
 static const char *const TAG = "cst816.touchscreen";
 
@@ -57,5 +56,4 @@ class CST816Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice
   bool skip_probe_{};  // if set, do not expect to be able to probe the controller on the i2c bus.
 };
 
-}  // namespace cst816
-}  // namespace esphome
+}  // namespace esphome::cst816

--- a/esphome/components/ct_clamp/ct_clamp_sensor.cpp
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.cpp
@@ -4,8 +4,7 @@
 #include <cinttypes>
 #include <cmath>
 
-namespace esphome {
-namespace ct_clamp {
+namespace esphome::ct_clamp {
 
 static const char *const TAG = "ct_clamp";
 
@@ -70,5 +69,4 @@ void CTClampSensor::loop() {
   this->sample_squared_sum_ += value * value;
 }
 
-}  // namespace ct_clamp
-}  // namespace esphome
+}  // namespace esphome::ct_clamp

--- a/esphome/components/ct_clamp/ct_clamp_sensor.h
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/voltage_sampler/voltage_sampler.h"
 
-namespace esphome {
-namespace ct_clamp {
+namespace esphome::ct_clamp {
 
 class CTClampSensor : public sensor::Sensor, public PollingComponent {
  public:
@@ -50,5 +49,4 @@ class CTClampSensor : public sensor::Sensor, public PollingComponent {
   bool is_sampling_ = false;
 };
 
-}  // namespace ct_clamp
-}  // namespace esphome
+}  // namespace esphome::ct_clamp

--- a/esphome/components/current_based/current_based_cover.cpp
+++ b/esphome/components/current_based/current_based_cover.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/application.h"
 #include <cfloat>
 
-namespace esphome {
-namespace current_based {
+namespace esphome::current_based {
 
 static const char *const TAG = "current_based.cover";
 
@@ -271,5 +270,4 @@ void CurrentBasedCover::recompute_position_() {
   this->last_recompute_time_ = now;
 }
 
-}  // namespace current_based
-}  // namespace esphome
+}  // namespace esphome::current_based

--- a/esphome/components/current_based/current_based_cover.h
+++ b/esphome/components/current_based/current_based_cover.h
@@ -6,8 +6,7 @@
 #include "esphome/core/component.h"
 #include <cfloat>
 
-namespace esphome {
-namespace current_based {
+namespace esphome::current_based {
 
 class CurrentBasedCover : public cover::Cover, public Component {
  public:
@@ -92,5 +91,4 @@ class CurrentBasedCover : public cover::Cover, public Component {
   cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
 };
 
-}  // namespace current_based
-}  // namespace esphome
+}  // namespace esphome::current_based

--- a/esphome/components/cwww/cwww_light_output.h
+++ b/esphome/components/cwww/cwww_light_output.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/components/light/light_output.h"
 
-namespace esphome {
-namespace cwww {
+namespace esphome::cwww {
 
 class CWWWLightOutput : public light::LightOutput {
  public:
@@ -36,5 +35,4 @@ class CWWWLightOutput : public light::LightOutput {
   bool constant_brightness_;
 };
 
-}  // namespace cwww
-}  // namespace esphome
+}  // namespace esphome::cwww


### PR DESCRIPTION
# What does this implement/fix?

Mechanical conversion of `namespace foo { namespace bar { ... } }` to `namespace foo::bar { ... }` (C++17 nested namespace concatenation), applied via `clang-tidy --fix` with `modernize-concat-nested-namespaces` temporarily re-enabled, followed by `clang-format`. **No semantic changes.**

This is **part 1 of 7** for the cleanup tracked in [esphome/backlog#114](https://github.com/esphome/backlog/issues/114), toward enabling `modernize-concat-nested-namespaces` project-wide and matching the convention already documented in `CLAUDE.md`. Splitting by component letter range to keep each PR reviewable.

The `.clang-tidy` disable line stays in place until the final PR so CI remains green throughout the rollout.

## Scope of this PR

- `esphome/components/[a-c]/` — 259 files

## Reproduction

```bash
# remove the disable line from .clang-tidy
# then:
script/clang-tidy --fix --environment esp32-arduino-tidy --all-headers
git ls-files 'esphome/components/[abc]*/**' | xargs clang-format -i
```

## Series

- 1/7 components a-c (this PR)
- 2/7 components d-h
- 3/7 components i-m
- 4/7 components n-r
- 5/7 components s
- 6/7 components t-z
- 7/7 tests + drop the `.clang-tidy` disable line

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/backlog#114

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

(Mechanical, no platform-specific code paths affected.)

## Example entry for `config.yaml`:

```yaml
# n/a
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).