### PR TITLE
[clang-tidy] Concatenate nested namespaces (3/7: components i-m)

### DIFF
--- a/esphome/components/i2c_device/i2c_device.cpp
+++ b/esphome/components/i2c_device/i2c_device.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace i2c_device {
+namespace esphome::i2c_device {
 
 static const char *const TAG = "i2c_device";
 
@@ -13,5 +12,4 @@ void I2CDeviceComponent::dump_config() {
   LOG_I2C_DEVICE(this);
 }
 
-}  // namespace i2c_device
-}  // namespace esphome
+}  // namespace esphome::i2c_device

--- a/esphome/components/i2c_device/i2c_device.h
+++ b/esphome/components/i2c_device/i2c_device.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace i2c_device {
+namespace esphome::i2c_device {
 
 class I2CDeviceComponent : public Component, public i2c::I2CDevice {
  public:
@@ -13,5 +12,4 @@ class I2CDeviceComponent : public Component, public i2c::I2CDevice {
  protected:
 };
 
-}  // namespace i2c_device
-}  // namespace esphome
+}  // namespace esphome::i2c_device

--- a/esphome/components/i2s_audio/i2s_audio.h
+++ b/esphome/components/i2s_audio/i2s_audio.h
@@ -8,8 +8,7 @@
 #include <esp_idf_version.h>
 #include <driver/i2s_std.h>
 
-namespace esphome {
-namespace i2s_audio {
+namespace esphome::i2s_audio {
 
 class I2SAudioComponent;
 
@@ -77,7 +76,6 @@ class I2SAudioComponent : public Component {
   int port_{};
 };
 
-}  // namespace i2s_audio
-}  // namespace esphome
+}  // namespace esphome::i2s_audio
 
 #endif  // USE_ESP32

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -10,8 +10,7 @@
 
 #include "esphome/components/audio/audio.h"
 
-namespace esphome {
-namespace i2s_audio {
+namespace esphome::i2s_audio {
 
 static const UBaseType_t MAX_LISTENERS = 16;
 
@@ -426,7 +425,6 @@ void I2SAudioMicrophone::loop() {
   }
 }
 
-}  // namespace i2s_audio
-}  // namespace esphome
+}  // namespace esphome::i2s_audio
 
 #endif  // USE_ESP32

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -12,8 +12,7 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 
-namespace esphome {
-namespace i2s_audio {
+namespace esphome::i2s_audio {
 
 class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, public Component {
  public:
@@ -65,7 +64,6 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   int32_t dc_offset_prev_output_{0};
 };
 
-}  // namespace i2s_audio
-}  // namespace esphome
+}  // namespace esphome::i2s_audio
 
 #endif  // USE_ESP32

--- a/esphome/components/iaqcore/iaqcore.cpp
+++ b/esphome/components/iaqcore/iaqcore.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace iaqcore {
+namespace esphome::iaqcore {
 
 static const char *const TAG = "iaqcore";
 
@@ -97,5 +96,4 @@ void IAQCore::dump_config() {
   LOG_SENSOR("  ", "TVOC", this->tvoc_);
 }
 
-}  // namespace iaqcore
-}  // namespace esphome
+}  // namespace esphome::iaqcore

--- a/esphome/components/iaqcore/iaqcore.h
+++ b/esphome/components/iaqcore/iaqcore.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace iaqcore {
+namespace esphome::iaqcore {
 
 class IAQCore : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -23,5 +22,4 @@ class IAQCore : public PollingComponent, public i2c::I2CDevice {
   void publish_nans_();
 };
 
-}  // namespace iaqcore
-}  // namespace esphome
+}  // namespace esphome::iaqcore

--- a/esphome/components/ili9xxx/ili9xxx_defines.h
+++ b/esphome/components/ili9xxx/ili9xxx_defines.h
@@ -2,8 +2,7 @@
 
 #include <cstdint>
 
-namespace esphome {
-namespace ili9xxx {
+namespace esphome::ili9xxx {
 
 // Color definitions
 // clang-format off
@@ -98,5 +97,4 @@ static const uint8_t ILI9XXX_DELAY_FLAG = 0xFF;
 // special marker for delay - command byte reprents ms, length byte is an impossible value
 #define ILI9XXX_DELAY(ms) ((uint8_t) ((ms) | 0x80)), ILI9XXX_DELAY_FLAG
 
-}  // namespace ili9xxx
-}  // namespace esphome
+}  // namespace esphome::ili9xxx

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ili9xxx {
+namespace esphome::ili9xxx {
 
 static const uint16_t SPI_SETUP_US = 100;         // estimated fixed overhead in microseconds for an SPI write
 static const uint16_t SPI_MAX_BLOCK_SIZE = 4092;  // Max size of continuous SPI transfer
@@ -470,5 +469,4 @@ void ILI9XXXDisplay::invert_colors(bool invert) {
 int ILI9XXXDisplay::get_width_internal() { return this->width_; }
 int ILI9XXXDisplay::get_height_internal() { return this->height_; }
 
-}  // namespace ili9xxx
-}  // namespace esphome
+}  // namespace esphome::ili9xxx

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -5,8 +5,7 @@
 #include "ili9xxx_defines.h"
 #include "ili9xxx_init.h"
 
-namespace esphome {
-namespace ili9xxx {
+namespace esphome::ili9xxx {
 
 static const char *const TAG = "ili9xxx";
 const size_t ILI9XXX_TRANSFER_BUFFER_SIZE = 126;  // ensure this is divisible by 6
@@ -283,5 +282,4 @@ class ILI9XXXST7735 : public ILI9XXXDisplay {
   ILI9XXXST7735() : ILI9XXXDisplay(INITCMD_ST7735, 128, 160) {}
 };
 
-}  // namespace ili9xxx
-}  // namespace esphome
+}  // namespace esphome::ili9xxx

--- a/esphome/components/ili9xxx/ili9xxx_init.h
+++ b/esphome/components/ili9xxx/ili9xxx_init.h
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace ili9xxx {
+namespace esphome::ili9xxx {
 
 // clang-format off
 static constexpr uint8_t PROGMEM INITCMD_M5STACK[] = {
@@ -478,5 +477,4 @@ static constexpr uint8_t PROGMEM INITCMD_ST7735[] = {
 };
 
 // clang-format on
-}  // namespace ili9xxx
-}  // namespace esphome
+}  // namespace esphome::ili9xxx

--- a/esphome/components/image/image.cpp
+++ b/esphome/components/image/image.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace image {
+namespace esphome::image {
 
 void Image::draw(int x, int y, display::Display *display, Color color_on, Color color_off) {
   int img_x0 = 0;
@@ -243,5 +242,4 @@ Image::Image(const uint8_t *data_start, int width, int height, ImageType type, T
   }
 }
 
-}  // namespace image
-}  // namespace esphome
+}  // namespace esphome::image

--- a/esphome/components/image/image.h
+++ b/esphome/components/image/image.h
@@ -6,8 +6,7 @@
 #include "esphome/components/lvgl/lvgl_proxy.h"
 #endif  // USE_LVGL
 
-namespace esphome {
-namespace image {
+namespace esphome::image {
 
 enum ImageType {
   IMAGE_TYPE_BINARY = 0,
@@ -61,5 +60,4 @@ class Image : public display::BaseImage {
 #endif
 };
 
-}  // namespace image
-}  // namespace esphome
+}  // namespace esphome::image

--- a/esphome/components/improv_base/improv_base.cpp
+++ b/esphome/components/improv_base/improv_base.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 
-namespace esphome {
-namespace improv_base {
+namespace esphome::improv_base {
 
 #if defined(USE_ESP32_IMPROV_NEXT_URL) || defined(USE_IMPROV_SERIAL_NEXT_URL)
 static constexpr const char DEVICE_NAME_PLACEHOLDER[] = "{{device_name}}";
@@ -65,5 +64,4 @@ size_t ImprovBase::get_formatted_next_url_(char *buffer, size_t buffer_size) {
 }
 #endif
 
-}  // namespace improv_base
-}  // namespace esphome
+}  // namespace esphome::improv_base

--- a/esphome/components/improv_base/improv_base.h
+++ b/esphome/components/improv_base/improv_base.h
@@ -3,8 +3,7 @@
 #include <cstddef>
 #include "esphome/core/defines.h"
 
-namespace esphome {
-namespace improv_base {
+namespace esphome::improv_base {
 
 class ImprovBase {
  public:
@@ -20,5 +19,4 @@ class ImprovBase {
 #endif
 };
 
-}  // namespace improv_base
-}  // namespace esphome
+}  // namespace esphome::improv_base

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -8,8 +8,7 @@
 
 #include "esphome/components/logger/logger.h"
 
-namespace esphome {
-namespace improv_serial {
+namespace esphome::improv_serial {
 
 static const char *const TAG = "improv_serial";
 
@@ -329,6 +328,6 @@ void ImprovSerialComponent::on_wifi_connect_timeout_() {
 ImprovSerialComponent *global_improv_serial_component =  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
     nullptr;                                             // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace improv_serial
-}  // namespace esphome
+}  // namespace esphome::improv_serial
+
 #endif

--- a/esphome/components/improv_serial/improv_serial_component.h
+++ b/esphome/components/improv_serial/improv_serial_component.h
@@ -23,8 +23,7 @@
 #include <HardwareSerial.h>
 #endif
 
-namespace esphome {
-namespace improv_serial {
+namespace esphome::improv_serial {
 
 // TX buffer layout constants
 static constexpr uint8_t TX_HEADER_SIZE = 6;  // Bytes 0-5 = "IMPROV"
@@ -99,6 +98,6 @@ class ImprovSerialComponent : public Component, public improv_base::ImprovBase {
 extern ImprovSerialComponent
     *global_improv_serial_component;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace improv_serial
-}  // namespace esphome
+}  // namespace esphome::improv_serial
+
 #endif

--- a/esphome/components/ina219/ina219.cpp
+++ b/esphome/components/ina219/ina219.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace ina219 {
+namespace esphome::ina219 {
 
 static const char *const TAG = "ina219";
 
@@ -196,5 +195,4 @@ void INA219Component::update() {
   this->status_clear_warning();
 }
 
-}  // namespace ina219
-}  // namespace esphome
+}  // namespace esphome::ina219

--- a/esphome/components/ina219/ina219.h
+++ b/esphome/components/ina219/ina219.h
@@ -6,8 +6,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace ina219 {
+namespace esphome::ina219 {
 
 class INA219Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -35,5 +34,4 @@ class INA219Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *power_sensor_{nullptr};
 };
 
-}  // namespace ina219
-}  // namespace esphome
+}  // namespace esphome::ina219

--- a/esphome/components/ina226/ina226.cpp
+++ b/esphome/components/ina226/ina226.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace ina226 {
+namespace esphome::ina226 {
 
 static const char *const TAG = "ina226";
 
@@ -161,5 +160,4 @@ int32_t INA226Component::twos_complement_(int32_t val, uint8_t bits) {
   return val;
 }
 
-}  // namespace ina226
-}  // namespace esphome
+}  // namespace esphome::ina226

--- a/esphome/components/ina226/ina226.h
+++ b/esphome/components/ina226/ina226.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ina226 {
+namespace esphome::ina226 {
 
 enum AdcTime : uint16_t {
   ADC_TIME_140US = 0,
@@ -73,5 +72,4 @@ class INA226Component : public PollingComponent, public i2c::I2CDevice {
   int32_t twos_complement_(int32_t val, uint8_t bits);
 };
 
-}  // namespace ina226
-}  // namespace esphome
+}  // namespace esphome::ina226

--- a/esphome/components/ina260/ina260.cpp
+++ b/esphome/components/ina260/ina260.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace ina260 {
+namespace esphome::ina260 {
 
 static const char *const TAG = "ina260";
 
@@ -122,5 +121,4 @@ void INA260Component::update() {
   this->status_clear_warning();
 }
 
-}  // namespace ina260
-}  // namespace esphome
+}  // namespace esphome::ina260

--- a/esphome/components/ina260/ina260.h
+++ b/esphome/components/ina260/ina260.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ina260 {
+namespace esphome::ina260 {
 
 class INA260Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -33,5 +32,4 @@ class INA260Component : public PollingComponent, public i2c::I2CDevice {
   } error_code_{NONE};
 };
 
-}  // namespace ina260
-}  // namespace esphome
+}  // namespace esphome::ina260

--- a/esphome/components/ina2xx_base/ina2xx_base.cpp
+++ b/esphome/components/ina2xx_base/ina2xx_base.cpp
@@ -5,8 +5,7 @@
 #include <cinttypes>
 #include <cmath>
 
-namespace esphome {
-namespace ina2xx_base {
+namespace esphome::ina2xx_base {
 
 static const char *const TAG = "ina2xx";
 
@@ -600,5 +599,4 @@ bool INA2XX::read_unsigned_16_(uint8_t reg, uint16_t &out) {
 int64_t INA2XX::two_complement_(uint64_t value, uint8_t bits) {
   return (int64_t) (value << (64 - bits)) >> (64 - bits);
 }
-}  // namespace ina2xx_base
-}  // namespace esphome
+}  // namespace esphome::ina2xx_base

--- a/esphome/components/ina2xx_base/ina2xx_base.h
+++ b/esphome/components/ina2xx_base/ina2xx_base.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace ina2xx_base {
+namespace esphome::ina2xx_base {
 
 enum RegisterMap : uint8_t {
   REG_CONFIG = 0x00,
@@ -250,5 +249,4 @@ class INA2XX : public PollingComponent {
   virtual bool read_ina_register(uint8_t a_register, uint8_t *data, size_t len) = 0;
   virtual bool write_ina_register(uint8_t a_register, const uint8_t *data, size_t len) = 0;
 };
-}  // namespace ina2xx_base
-}  // namespace esphome
+}  // namespace esphome::ina2xx_base

--- a/esphome/components/ina2xx_i2c/ina2xx_i2c.cpp
+++ b/esphome/components/ina2xx_i2c/ina2xx_i2c.cpp
@@ -1,8 +1,7 @@
 #include "ina2xx_i2c.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ina2xx_i2c {
+namespace esphome::ina2xx_i2c {
 
 static const char *const TAG = "ina2xx_i2c";
 
@@ -35,5 +34,4 @@ bool INA2XXI2C::write_ina_register(uint8_t reg, const uint8_t *data, size_t len)
   }
   return ret == i2c::ERROR_OK;
 }
-}  // namespace ina2xx_i2c
-}  // namespace esphome
+}  // namespace esphome::ina2xx_i2c

--- a/esphome/components/ina2xx_i2c/ina2xx_i2c.h
+++ b/esphome/components/ina2xx_i2c/ina2xx_i2c.h
@@ -4,8 +4,7 @@
 #include "esphome/components/ina2xx_base/ina2xx_base.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ina2xx_i2c {
+namespace esphome::ina2xx_i2c {
 
 class INA2XXI2C : public ina2xx_base::INA2XX, public i2c::I2CDevice {
  public:
@@ -17,5 +16,4 @@ class INA2XXI2C : public ina2xx_base::INA2XX, public i2c::I2CDevice {
   bool write_ina_register(uint8_t reg, const uint8_t *data, size_t len) override;
 };
 
-}  // namespace ina2xx_i2c
-}  // namespace esphome
+}  // namespace esphome::ina2xx_i2c

--- a/esphome/components/ina2xx_spi/ina2xx_spi.cpp
+++ b/esphome/components/ina2xx_spi/ina2xx_spi.cpp
@@ -1,8 +1,7 @@
 #include "ina2xx_spi.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ina2xx_spi {
+namespace esphome::ina2xx_spi {
 
 static const char *const TAG = "ina2xx_spi";
 
@@ -34,5 +33,4 @@ bool INA2XXSPI::write_ina_register(uint8_t reg, const uint8_t *data, size_t len)
   this->disable();
   return true;
 }
-}  // namespace ina2xx_spi
-}  // namespace esphome
+}  // namespace esphome::ina2xx_spi

--- a/esphome/components/ina2xx_spi/ina2xx_spi.h
+++ b/esphome/components/ina2xx_spi/ina2xx_spi.h
@@ -4,8 +4,7 @@
 #include "esphome/components/ina2xx_base/ina2xx_base.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace ina2xx_spi {
+namespace esphome::ina2xx_spi {
 
 class INA2XXSPI : public ina2xx_base::INA2XX,
                   public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_TRAILING,
@@ -18,5 +17,4 @@ class INA2XXSPI : public ina2xx_base::INA2XX,
   bool read_ina_register(uint8_t reg, uint8_t *data, size_t len) override;
   bool write_ina_register(uint8_t reg, const uint8_t *data, size_t len) override;
 };
-}  // namespace ina2xx_spi
-}  // namespace esphome
+}  // namespace esphome::ina2xx_spi

--- a/esphome/components/ina3221/ina3221.cpp
+++ b/esphome/components/ina3221/ina3221.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace ina3221 {
+namespace esphome::ina3221 {
 
 static const char *const TAG = "ina3221";
 
@@ -128,5 +127,4 @@ bool INA3221Component::INA3221Channel::should_measure_bus_voltage() {
   return this->bus_voltage_sensor_ != nullptr || this->power_sensor_ != nullptr;
 }
 
-}  // namespace ina3221
-}  // namespace esphome
+}  // namespace esphome::ina3221

--- a/esphome/components/ina3221/ina3221.h
+++ b/esphome/components/ina3221/ina3221.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ina3221 {
+namespace esphome::ina3221 {
 
 class INA3221Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -35,5 +34,4 @@ class INA3221Component : public PollingComponent, public i2c::I2CDevice {
   } channels_[3];
 };
 
-}  // namespace ina3221
-}  // namespace esphome
+}  // namespace esphome::ina3221

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace inkbird_ibsth1_mini {
+namespace esphome::inkbird_ibsth1_mini {
 
 static const char *const TAG = "inkbird_ibsth1_mini";
 
@@ -104,7 +103,6 @@ bool InkbirdIbstH1Mini::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
   return true;
 }
 
-}  // namespace inkbird_ibsth1_mini
-}  // namespace esphome
+}  // namespace esphome::inkbird_ibsth1_mini
 
 #endif

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
@@ -6,8 +6,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace inkbird_ibsth1_mini {
+namespace esphome::inkbird_ibsth1_mini {
 
 class InkbirdIbstH1Mini : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -29,7 +28,6 @@ class InkbirdIbstH1Mini : public Component, public esp32_ble_tracker::ESPBTDevic
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace inkbird_ibsth1_mini
-}  // namespace esphome
+}  // namespace esphome::inkbird_ibsth1_mini
 
 #endif

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -7,8 +7,7 @@
 
 #include <hal/gpio_hal.h>
 
-namespace esphome {
-namespace inkplate {
+namespace esphome::inkplate {
 
 static const char *const TAG = "inkplate";
 
@@ -820,5 +819,4 @@ void Inkplate::pins_as_outputs_() {
   this->display_data_7_pin_->pin_mode(gpio::FLAG_OUTPUT);
 }
 
-}  // namespace inkplate
-}  // namespace esphome
+}  // namespace esphome::inkplate

--- a/esphome/components/inkplate/inkplate.h
+++ b/esphome/components/inkplate/inkplate.h
@@ -7,8 +7,7 @@
 
 #include <array>
 
-namespace esphome {
-namespace inkplate {
+namespace esphome::inkplate {
 
 enum InkplateModel : uint8_t {
   INKPLATE_6 = 0,
@@ -210,5 +209,4 @@ class Inkplate : public display::DisplayBuffer, public i2c::I2CDevice {
   GPIOPin *wakeup_pin_;
 };
 
-}  // namespace inkplate
-}  // namespace esphome
+}  // namespace esphome::inkplate

--- a/esphome/components/integration/integration_sensor.cpp
+++ b/esphome/components/integration/integration_sensor.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace integration {
+namespace esphome::integration {
 
 static const char *const TAG = "integration";
 
@@ -47,5 +46,4 @@ void IntegrationSensor::process_sensor_value_(float value) {
   this->publish_and_save_(this->result_ + area);
 }
 
-}  // namespace integration
-}  // namespace esphome
+}  // namespace esphome::integration

--- a/esphome/components/integration/integration_sensor.h
+++ b/esphome/components/integration/integration_sensor.h
@@ -6,8 +6,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace integration {
+namespace esphome::integration {
 
 enum IntegrationSensorTime {
   INTEGRATION_SENSOR_TIME_MILLISECOND = 0,
@@ -84,5 +83,4 @@ template<typename... Ts> class SetValueAction : public Action<Ts...>, public Par
   void play(const Ts &...x) override { this->parent_->set_value(this->value_.value(x...)); }
 };
 
-}  // namespace integration
-}  // namespace esphome
+}  // namespace esphome::integration

--- a/esphome/components/interval/interval.h
+++ b/esphome/components/interval/interval.h
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace interval {
+namespace esphome::interval {
 
 class IntervalTrigger : public Trigger<>, public PollingComponent {
  public:
@@ -24,5 +23,4 @@ class IntervalTrigger : public Trigger<>, public PollingComponent {
   uint32_t startup_delay_{0};
 };
 
-}  // namespace interval
-}  // namespace esphome
+}  // namespace esphome::interval

--- a/esphome/components/jsn_sr04t/jsn_sr04t.cpp
+++ b/esphome/components/jsn_sr04t/jsn_sr04t.cpp
@@ -4,8 +4,7 @@
 
 // Very basic support for JSN_SR04T V3.0 distance sensor in mode 2
 
-namespace esphome {
-namespace jsn_sr04t {
+namespace esphome::jsn_sr04t {
 
 static const char *const TAG = "jsn_sr04t.sensor";
 
@@ -62,5 +61,4 @@ void Jsnsr04tComponent::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace jsn_sr04t
-}  // namespace esphome
+}  // namespace esphome::jsn_sr04t

--- a/esphome/components/jsn_sr04t/jsn_sr04t.h
+++ b/esphome/components/jsn_sr04t/jsn_sr04t.h
@@ -6,8 +6,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace jsn_sr04t {
+namespace esphome::jsn_sr04t {
 
 enum Model {
   JSN_SR04T,
@@ -30,5 +29,4 @@ class Jsnsr04tComponent : public sensor::Sensor, public PollingComponent, public
   std::vector<uint8_t> buffer_;
 };
 
-}  // namespace jsn_sr04t
-}  // namespace esphome
+}  // namespace esphome::jsn_sr04t

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -3,8 +3,7 @@
 
 // ArduinoJson::Allocator is included via ArduinoJson.h in json_util.h
 
-namespace esphome {
-namespace json {
+namespace esphome::json {
 
 static const char *const TAG = "json";
 
@@ -149,5 +148,4 @@ SerializationBuffer<> JsonBuilder::serialize() {
   return result;
 }
 
-}  // namespace json
-}  // namespace esphome
+}  // namespace esphome::json

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -13,8 +13,7 @@
 
 #include <ArduinoJson.h>
 
-namespace esphome {
-namespace json {
+namespace esphome::json {
 
 /// Buffer for JSON serialization that uses stack allocation for small payloads.
 /// Template parameter STACK_SIZE specifies the stack buffer size (default 512 bytes).
@@ -192,5 +191,4 @@ class JsonBuilder {
   bool root_created_{false};
 };
 
-}  // namespace json
-}  // namespace esphome
+}  // namespace esphome::json

--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace kamstrup_kmp {
+namespace esphome::kamstrup_kmp {
 
 static const char *const TAG = "kamstrup_kmp";
 
@@ -303,5 +302,4 @@ uint16_t crc16_ccitt(const uint8_t *buffer, int len) {
   return (uint16_t) reg;
 }
 
-}  // namespace kamstrup_kmp
-}  // namespace esphome
+}  // namespace esphome::kamstrup_kmp

--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.h
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.h
@@ -5,8 +5,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace kamstrup_kmp {
+namespace esphome::kamstrup_kmp {
 
 /*
     ===========================================================================
@@ -127,5 +126,4 @@ class KamstrupKMPComponent : public PollingComponent, public uart::UARTDevice {
 // "true" CCITT CRC-16
 uint16_t crc16_ccitt(const uint8_t *buffer, int len);
 
-}  // namespace kamstrup_kmp
-}  // namespace esphome
+}  // namespace esphome::kamstrup_kmp

--- a/esphome/components/key_collector/key_collector.cpp
+++ b/esphome/components/key_collector/key_collector.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace key_collector {
+namespace esphome::key_collector {
 
 static const char *const TAG = "key_collector";
 
@@ -102,5 +101,4 @@ void KeyCollector::send_key(uint8_t key) {
   this->progress_callbacks_.call(this->result_, this->start_key_);
 }
 
-}  // namespace key_collector
-}  // namespace esphome
+}  // namespace esphome::key_collector

--- a/esphome/components/key_collector/key_collector.h
+++ b/esphome/components/key_collector/key_collector.h
@@ -5,8 +5,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace key_collector {
+namespace esphome::key_collector {
 
 class KeyCollector : public Component {
  public:
@@ -63,5 +62,4 @@ template<typename... Ts> class DisableAction : public Action<Ts...>, public Pare
   void play(const Ts &...x) override { this->parent_->set_enabled(false); }
 };
 
-}  // namespace key_collector
-}  // namespace esphome
+}  // namespace esphome::key_collector

--- a/esphome/components/key_provider/key_provider.cpp
+++ b/esphome/components/key_provider/key_provider.cpp
@@ -1,9 +1,7 @@
 #include "key_provider.h"
 
-namespace esphome {
-namespace key_provider {
+namespace esphome::key_provider {
 
 void KeyProvider::send_key_(uint8_t key) { this->key_callback_.call(key); }
 
-}  // namespace key_provider
-}  // namespace esphome
+}  // namespace esphome::key_provider

--- a/esphome/components/key_provider/key_provider.h
+++ b/esphome/components/key_provider/key_provider.h
@@ -3,8 +3,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace key_provider {
+namespace esphome::key_provider {
 
 /// interface for components that provide keypresses
 class KeyProvider {
@@ -17,5 +16,4 @@ class KeyProvider {
   CallbackManager<void(uint8_t)> key_callback_{};
 };
 
-}  // namespace key_provider
-}  // namespace esphome
+}  // namespace esphome::key_provider

--- a/esphome/components/kmeteriso/kmeteriso.cpp
+++ b/esphome/components/kmeteriso/kmeteriso.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace kmeteriso {
+namespace esphome::kmeteriso {
 
 static const char *const TAG = "kmeteriso.sensor";
 
@@ -74,5 +73,4 @@ void KMeterISOComponent::update() {
   }
 }
 
-}  // namespace kmeteriso
-}  // namespace esphome
+}  // namespace esphome::kmeteriso

--- a/esphome/components/kmeteriso/kmeteriso.h
+++ b/esphome/components/kmeteriso/kmeteriso.h
@@ -5,8 +5,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/i2c/i2c_bus.h"
 
-namespace esphome {
-namespace kmeteriso {
+namespace esphome::kmeteriso {
 
 /// This class implements support for the KMeterISO thermocouple sensor.
 class KMeterISOComponent : public PollingComponent, public i2c::I2CDevice {
@@ -29,5 +28,4 @@ class KMeterISOComponent : public PollingComponent, public i2c::I2CDevice {
   } error_code_{NONE};
 };
 
-}  // namespace kmeteriso
-}  // namespace esphome
+}  // namespace esphome::kmeteriso

--- a/esphome/components/kuntze/kuntze.cpp
+++ b/esphome/components/kuntze/kuntze.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace kuntze {
+namespace esphome::kuntze {
 
 static const char *const TAG = "kuntze";
 
@@ -97,5 +96,4 @@ void Kuntze::dump_config() {
   LOG_SENSOR("", "OCI", this->oci_sensor_);
 }
 
-}  // namespace kuntze
-}  // namespace esphome
+}  // namespace esphome::kuntze

--- a/esphome/components/kuntze/kuntze.h
+++ b/esphome/components/kuntze/kuntze.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/modbus/modbus.h"
 
-namespace esphome {
-namespace kuntze {
+namespace esphome::kuntze {
 
 class Kuntze : public PollingComponent, public modbus::ModbusDevice {
  public:
@@ -38,5 +37,4 @@ class Kuntze : public PollingComponent, public modbus::ModbusDevice {
   sensor::Sensor *oci_sensor_{nullptr};
 };
 
-}  // namespace kuntze
-}  // namespace esphome
+}  // namespace esphome::kuntze

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace lc709203f {
+namespace esphome::lc709203f {
 
 static const char *const TAG = "lc709203f.sensor";
 
@@ -279,5 +278,4 @@ void Lc709203f::set_thermistor_b_constant(uint16_t b_constant) { this->b_constan
 
 void Lc709203f::set_pack_voltage(LC709203FBatteryVoltage pack_voltage) { this->pack_voltage_ = pack_voltage; }
 
-}  // namespace lc709203f
-}  // namespace esphome
+}  // namespace esphome::lc709203f

--- a/esphome/components/lc709203f/lc709203f.h
+++ b/esphome/components/lc709203f/lc709203f.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace lc709203f {
+namespace esphome::lc709203f {
 
 enum LC709203FState {
   STATE_INIT,
@@ -50,5 +49,4 @@ class Lc709203f : public sensor::Sensor, public PollingComponent, public i2c::I2
   uint16_t pack_voltage_;
 };
 
-}  // namespace lc709203f
-}  // namespace esphome
+}  // namespace esphome::lc709203f

--- a/esphome/components/lcd_base/lcd_display.cpp
+++ b/esphome/components/lcd_base/lcd_display.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace lcd_base {
+namespace esphome::lcd_base {
 
 static const char *const TAG = "lcd";
 
@@ -173,5 +172,4 @@ void LCDDisplay::loadchar(uint8_t location, uint8_t charmap[]) {
   }
 }
 
-}  // namespace lcd_base
-}  // namespace esphome
+}  // namespace esphome::lcd_base

--- a/esphome/components/lcd_base/lcd_display.h
+++ b/esphome/components/lcd_base/lcd_display.h
@@ -6,8 +6,7 @@
 #include <map>
 #include <vector>
 
-namespace esphome {
-namespace lcd_base {
+namespace esphome::lcd_base {
 
 class LCDDisplay;
 
@@ -62,5 +61,4 @@ class LCDDisplay : public PollingComponent {
   std::map<uint8_t, std::vector<uint8_t> > user_defined_chars_;
 };
 
-}  // namespace lcd_base
-}  // namespace esphome
+}  // namespace esphome::lcd_base

--- a/esphome/components/lcd_gpio/gpio_lcd_display.cpp
+++ b/esphome/components/lcd_gpio/gpio_lcd_display.cpp
@@ -1,8 +1,7 @@
 #include "gpio_lcd_display.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace lcd_gpio {
+namespace esphome::lcd_gpio {
 
 static const char *const TAG = "lcd_gpio";
 
@@ -63,5 +62,4 @@ void GPIOLCDDisplay::send(uint8_t value, bool rs) {
   }
 }
 
-}  // namespace lcd_gpio
-}  // namespace esphome
+}  // namespace esphome::lcd_gpio

--- a/esphome/components/lcd_gpio/gpio_lcd_display.h
+++ b/esphome/components/lcd_gpio/gpio_lcd_display.h
@@ -4,8 +4,7 @@
 #include "esphome/components/lcd_base/lcd_display.h"
 #include "esphome/components/display/display.h"
 
-namespace esphome {
-namespace lcd_gpio {
+namespace esphome::lcd_gpio {
 
 class GPIOLCDDisplay;
 
@@ -51,5 +50,4 @@ class GPIOLCDDisplay : public lcd_base::LCDDisplay {
   gpio_lcd_writer_t writer_;
 };
 
-}  // namespace lcd_gpio
-}  // namespace esphome
+}  // namespace esphome::lcd_gpio

--- a/esphome/components/lcd_menu/lcd_menu.cpp
+++ b/esphome/components/lcd_menu/lcd_menu.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <algorithm>
 
-namespace esphome {
-namespace lcd_menu {
+namespace esphome::lcd_menu {
 
 static const char *const TAG = "lcd_menu";
 
@@ -72,5 +71,4 @@ void LCDCharacterMenuComponent::draw_item(const display_menu_base::MenuItem *ite
   this->display_->print(0, row, data);
 }
 
-}  // namespace lcd_menu
-}  // namespace esphome
+}  // namespace esphome::lcd_menu

--- a/esphome/components/lcd_menu/lcd_menu.h
+++ b/esphome/components/lcd_menu/lcd_menu.h
@@ -6,8 +6,7 @@
 #include <forward_list>
 #include <vector>
 
-namespace esphome {
-namespace lcd_menu {
+namespace esphome::lcd_menu {
 
 /** Class to display a hierarchical menu.
  *
@@ -41,5 +40,4 @@ class LCDCharacterMenuComponent : public display_menu_base::DisplayMenuComponent
   char mark_back_;
 };
 
-}  // namespace lcd_menu
-}  // namespace esphome
+}  // namespace esphome::lcd_menu

--- a/esphome/components/lcd_pcf8574/pcf8574_display.cpp
+++ b/esphome/components/lcd_pcf8574/pcf8574_display.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace lcd_pcf8574 {
+namespace esphome::lcd_pcf8574 {
 
 static const char *const TAG = "lcd_pcf8574";
 
@@ -56,5 +55,4 @@ void PCF8574LCDDisplay::no_backlight() {
   this->write_bytes(this->backlight_value_, nullptr, 0);
 }
 
-}  // namespace lcd_pcf8574
-}  // namespace esphome
+}  // namespace esphome::lcd_pcf8574

--- a/esphome/components/lcd_pcf8574/pcf8574_display.h
+++ b/esphome/components/lcd_pcf8574/pcf8574_display.h
@@ -5,8 +5,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/display/display.h"
 
-namespace esphome {
-namespace lcd_pcf8574 {
+namespace esphome::lcd_pcf8574 {
 
 class PCF8574LCDDisplay;
 
@@ -32,5 +31,4 @@ class PCF8574LCDDisplay : public lcd_base::LCDDisplay, public i2c::I2CDevice {
   pcf8574_lcd_writer_t writer_;
 };
 
-}  // namespace lcd_pcf8574
-}  // namespace esphome
+}  // namespace esphome::lcd_pcf8574

--- a/esphome/components/lightwaverf/LwRx.h
+++ b/esphome/components/lightwaverf/LwRx.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace lightwaverf {
+namespace esphome::lightwaverf {
 
 // LwRx.h
 //
@@ -138,5 +137,4 @@ class LwRx {
   InternalGPIOPin *rx_pin_;
 };
 
-}  // namespace lightwaverf
-}  // namespace esphome
+}  // namespace esphome::lightwaverf

--- a/esphome/components/lightwaverf/LwTx.h
+++ b/esphome/components/lightwaverf/LwTx.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace lightwaverf {
+namespace esphome::lightwaverf {
 
 // LxTx.h
 //
@@ -90,5 +89,4 @@ class LwTx {
   uint32_t duty_off_;
 };
 
-}  // namespace lightwaverf
-}  // namespace esphome
+}  // namespace esphome::lightwaverf

--- a/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.cpp
+++ b/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace lilygo_t5_47 {
+namespace esphome::lilygo_t5_47 {
 
 static const char *const TAG = "lilygo_t5_47.touchscreen";
 
@@ -104,5 +103,4 @@ void LilygoT547Touchscreen::dump_config() {
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
 }
 
-}  // namespace lilygo_t5_47
-}  // namespace esphome
+}  // namespace esphome::lilygo_t5_47

--- a/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.h
+++ b/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.h
@@ -8,8 +8,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace lilygo_t5_47 {
+namespace esphome::lilygo_t5_47 {
 
 using namespace touchscreen;
 
@@ -27,5 +26,4 @@ class LilygoT547Touchscreen : public Touchscreen, public i2c::I2CDevice {
   InternalGPIOPin *interrupt_pin_;
 };
 
-}  // namespace lilygo_t5_47
-}  // namespace esphome
+}  // namespace esphome::lilygo_t5_47

--- a/esphome/components/lm75b/lm75b.cpp
+++ b/esphome/components/lm75b/lm75b.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace lm75b {
+namespace esphome::lm75b {
 
 static const char *const TAG = "lm75b";
 
@@ -35,5 +34,4 @@ void LM75BComponent::update() {
   }
 }
 
-}  // namespace lm75b
-}  // namespace esphome
+}  // namespace esphome::lm75b

--- a/esphome/components/lm75b/lm75b.h
+++ b/esphome/components/lm75b/lm75b.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace lm75b {
+namespace esphome::lm75b {
 
 static const uint8_t LM75B_REG_TEMPERATURE = 0x00;
 
@@ -15,5 +14,4 @@ class LM75BComponent : public PollingComponent, public i2c::I2CDevice, public se
   void update() override;
 };
 
-}  // namespace lm75b
-}  // namespace esphome
+}  // namespace esphome::lm75b

--- a/esphome/components/lps22/lps22.cpp
+++ b/esphome/components/lps22/lps22.cpp
@@ -1,7 +1,6 @@
 #include "lps22.h"
 
-namespace esphome {
-namespace lps22 {
+namespace esphome::lps22 {
 
 static constexpr const char *const TAG = "lps22";
 
@@ -78,5 +77,4 @@ void LPS22Component::try_read_() {
   }
 }
 
-}  // namespace lps22
-}  // namespace esphome
+}  // namespace esphome::lps22

--- a/esphome/components/lps22/lps22.h
+++ b/esphome/components/lps22/lps22.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace lps22 {
+namespace esphome::lps22 {
 
 class LPS22Component : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
  public:
@@ -24,5 +23,4 @@ class LPS22Component : public sensor::Sensor, public PollingComponent, public i2
   uint8_t read_attempts_remaining_{0};
 };
 
-}  // namespace lps22
-}  // namespace esphome
+}  // namespace esphome::lps22

--- a/esphome/components/ltr390/ltr390.cpp
+++ b/esphome/components/ltr390/ltr390.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ltr390 {
+namespace esphome::ltr390 {
 
 static const char *const TAG = "ltr390";
 
@@ -203,5 +202,4 @@ void LTR390Component::update() {
   this->read_mode_((this->enabled_modes_ & ENABLED_MODE_ALS) ? LTR390_MODE_ALS : LTR390_MODE_UVS);
 }
 
-}  // namespace ltr390
-}  // namespace esphome
+}  // namespace esphome::ltr390

--- a/esphome/components/ltr390/ltr390.h
+++ b/esphome/components/ltr390/ltr390.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/optional.h"
 
-namespace esphome {
-namespace ltr390 {
+namespace esphome::ltr390 {
 
 enum LTR390CTRL {
   LTR390_CTRL_EN = 1,
@@ -85,5 +84,4 @@ class LTR390Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *uv_sensor_{nullptr};
 };
 
-}  // namespace ltr390
-}  // namespace esphome
+}  // namespace esphome::ltr390

--- a/esphome/components/ltr501/ltr501.cpp
+++ b/esphome/components/ltr501/ltr501.cpp
@@ -6,8 +6,7 @@
 
 using esphome::i2c::ErrorCode;
 
-namespace esphome {
-namespace ltr501 {
+namespace esphome::ltr501 {
 
 static const char *const TAG = "ltr501";
 
@@ -542,5 +541,4 @@ void LTRAlsPs501Component::publish_data_part_2_(AlsReadings &data) {
     this->actual_integration_time_sensor_->publish_state(get_itime_ms(data.integration_time));
   }
 }
-}  // namespace ltr501
-}  // namespace esphome
+}  // namespace esphome::ltr501

--- a/esphome/components/ltr501/ltr501.h
+++ b/esphome/components/ltr501/ltr501.h
@@ -8,8 +8,7 @@
 
 #include "ltr_definitions_501.h"
 
-namespace esphome {
-namespace ltr501 {
+namespace esphome::ltr501 {
 
 enum LtrDataAvail : uint8_t { LTR_NO_DATA, LTR_BAD_DATA, LTR_DATA_OK };
 
@@ -162,5 +161,4 @@ class LTRAlsPs501Component : public PollingComponent, public i2c::I2CDevice {
   CallbackManager<void()> on_ps_high_trigger_callback_;
   CallbackManager<void()> on_ps_low_trigger_callback_;
 };
-}  // namespace ltr501
-}  // namespace esphome
+}  // namespace esphome::ltr501

--- a/esphome/components/ltr501/ltr_definitions_501.h
+++ b/esphome/components/ltr501/ltr_definitions_501.h
@@ -2,8 +2,7 @@
 
 #include <cstdint>
 
-namespace esphome {
-namespace ltr501 {
+namespace esphome::ltr501 {
 
 enum class CommandRegisters : uint8_t {
   ALS_CONTR = 0x80,         // ALS operation mode control and SW reset
@@ -256,5 +255,4 @@ union InterruptPersistRegister {
   } __attribute__((packed));
 };
 
-}  // namespace ltr501
-}  // namespace esphome
+}  // namespace esphome::ltr501

--- a/esphome/components/ltr_als_ps/ltr_als_ps.cpp
+++ b/esphome/components/ltr_als_ps/ltr_als_ps.cpp
@@ -6,8 +6,7 @@
 
 using esphome::i2c::ErrorCode;
 
-namespace esphome {
-namespace ltr_als_ps {
+namespace esphome::ltr_als_ps {
 
 static const char *const TAG = "ltr_als_ps";
 
@@ -521,5 +520,4 @@ void LTRAlsPsComponent::publish_data_part_2_(AlsReadings &data) {
     this->actual_integration_time_sensor_->publish_state(get_itime_ms(data.integration_time));
   }
 }
-}  // namespace ltr_als_ps
-}  // namespace esphome
+}  // namespace esphome::ltr_als_ps

--- a/esphome/components/ltr_als_ps/ltr_als_ps.h
+++ b/esphome/components/ltr_als_ps/ltr_als_ps.h
@@ -8,8 +8,7 @@
 
 #include "ltr_definitions.h"
 
-namespace esphome {
-namespace ltr_als_ps {
+namespace esphome::ltr_als_ps {
 
 enum LtrDataAvail : uint8_t { LTR_NO_DATA, LTR_BAD_DATA, LTR_DATA_OK };
 
@@ -162,5 +161,4 @@ class LTRAlsPsComponent : public PollingComponent, public i2c::I2CDevice {
   CallbackManager<void()> on_ps_high_trigger_callback_;
   CallbackManager<void()> on_ps_low_trigger_callback_;
 };
-}  // namespace ltr_als_ps
-}  // namespace esphome
+}  // namespace esphome::ltr_als_ps

--- a/esphome/components/ltr_als_ps/ltr_definitions.h
+++ b/esphome/components/ltr_als_ps/ltr_definitions.h
@@ -2,8 +2,7 @@
 
 #include <cstdint>
 
-namespace esphome {
-namespace ltr_als_ps {
+namespace esphome::ltr_als_ps {
 
 enum class CommandRegisters : uint8_t {
   ALS_CONTR = 0x80,         // ALS operation mode control and SW reset
@@ -271,5 +270,4 @@ union InterruptPersistRegister {
   } __attribute__((packed));
 };
 
-}  // namespace ltr_als_ps
-}  // namespace esphome
+}  // namespace esphome::ltr_als_ps

--- a/esphome/components/lvgl/light/lvgl_light.h
+++ b/esphome/components/lvgl/light/lvgl_light.h
@@ -4,8 +4,7 @@
 #include "esphome/components/light/light_output.h"
 #include "../lvgl_esphome.h"
 
-namespace esphome {
-namespace lvgl {
+namespace esphome::lvgl {
 
 class LVLight : public light::LightOutput {
  public:
@@ -44,5 +43,4 @@ class LVLight : public light::LightOutput {
   optional<lv_color_t> initial_value_{};
 };
 
-}  // namespace lvgl
-}  // namespace esphome
+}  // namespace esphome::lvgl

--- a/esphome/components/lvgl/lvgl_proxy.h
+++ b/esphome/components/lvgl/lvgl_proxy.h
@@ -11,7 +11,5 @@ file is included in the build, LVGL is always included.
 #endif                  // LV_CONF_H
 
 #include <lvgl.h>
-namespace esphome {
-namespace lvgl {}  // namespace lvgl
-}  // namespace esphome
-#endif  // USE_LVGL
+namespace esphome::lvgl {}  // namespace esphome::lvgl
+#endif                      // USE_LVGL

--- a/esphome/components/lvgl/number/lvgl_number.h
+++ b/esphome/components/lvgl/number/lvgl_number.h
@@ -6,8 +6,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace lvgl {
+namespace esphome::lvgl {
 
 class LVGLNumber : public number::Number, public Component {
  public:
@@ -48,5 +47,4 @@ class LVGLNumber : public number::Number, public Component {
   ESPPreferenceObject pref_{};
 };
 
-}  // namespace lvgl
-}  // namespace esphome
+}  // namespace esphome::lvgl

--- a/esphome/components/lvgl/select/lvgl_select.h
+++ b/esphome/components/lvgl/select/lvgl_select.h
@@ -8,8 +8,7 @@
 #include "esphome/core/preferences.h"
 #include "esphome/components/lvgl/lvgl_esphome.h"
 
-namespace esphome {
-namespace lvgl {
+namespace esphome::lvgl {
 
 class LVGLSelect : public select::Select, public Component {
  public:
@@ -71,5 +70,4 @@ class LVGLSelect : public select::Select, public Component {
   ESPPreferenceObject pref_{};
 };
 
-}  // namespace lvgl
-}  // namespace esphome
+}  // namespace esphome::lvgl

--- a/esphome/components/lvgl/switch/lvgl_switch.h
+++ b/esphome/components/lvgl/switch/lvgl_switch.h
@@ -7,8 +7,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace lvgl {
+namespace esphome::lvgl {
 
 class LVGLSwitch : public switch_::Switch, public Component {
  public:
@@ -21,5 +20,4 @@ class LVGLSwitch : public switch_::Switch, public Component {
   std::function<void(bool)> state_lambda_{};
 };
 
-}  // namespace lvgl
-}  // namespace esphome
+}  // namespace esphome::lvgl

--- a/esphome/components/lvgl/text/lvgl_text.h
+++ b/esphome/components/lvgl/text/lvgl_text.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace lvgl {
+namespace esphome::lvgl {
 
 class LVGLText : public text::Text {
  public:
@@ -29,5 +28,4 @@ class LVGLText : public text::Text {
   optional<std::string> initial_state_{};
 };
 
-}  // namespace lvgl
-}  // namespace esphome
+}  // namespace esphome::lvgl

--- a/esphome/components/m5stack_8angle/binary_sensor/m5stack_8angle_binary_sensor.cpp
+++ b/esphome/components/m5stack_8angle/binary_sensor/m5stack_8angle_binary_sensor.cpp
@@ -1,7 +1,6 @@
 #include "m5stack_8angle_binary_sensor.h"
 
-namespace esphome {
-namespace m5stack_8angle {
+namespace esphome::m5stack_8angle {
 
 void M5Stack8AngleSwitchBinarySensor::update() {
   int8_t out = this->parent_->read_switch();
@@ -13,5 +12,4 @@ void M5Stack8AngleSwitchBinarySensor::update() {
   this->status_clear_warning();
 }
 
-}  // namespace m5stack_8angle
-}  // namespace esphome
+}  // namespace esphome::m5stack_8angle

--- a/esphome/components/m5stack_8angle/binary_sensor/m5stack_8angle_binary_sensor.h
+++ b/esphome/components/m5stack_8angle/binary_sensor/m5stack_8angle_binary_sensor.h
@@ -5,8 +5,7 @@
 
 #include "../m5stack_8angle.h"
 
-namespace esphome {
-namespace m5stack_8angle {
+namespace esphome::m5stack_8angle {
 
 class M5Stack8AngleSwitchBinarySensor : public binary_sensor::BinarySensor,
                                         public PollingComponent,
@@ -15,5 +14,4 @@ class M5Stack8AngleSwitchBinarySensor : public binary_sensor::BinarySensor,
   void update() override;
 };
 
-}  // namespace m5stack_8angle
-}  // namespace esphome
+}  // namespace esphome::m5stack_8angle

--- a/esphome/components/m5stack_8angle/light/m5stack_8angle_light.cpp
+++ b/esphome/components/m5stack_8angle/light/m5stack_8angle_light.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace m5stack_8angle {
+namespace esphome::m5stack_8angle {
 
 static const char *const TAG = "m5stack_8angle.light";
 
@@ -41,5 +40,4 @@ light::ESPColorView M5Stack8AngleLightOutput::get_view_internal(int32_t index) c
           nullptr,          this->effect_data_ + index, &this->correction_};
 }
 
-}  // namespace m5stack_8angle
-}  // namespace esphome
+}  // namespace esphome::m5stack_8angle

--- a/esphome/components/m5stack_8angle/light/m5stack_8angle_light.h
+++ b/esphome/components/m5stack_8angle/light/m5stack_8angle_light.h
@@ -5,8 +5,7 @@
 
 #include "../m5stack_8angle.h"
 
-namespace esphome {
-namespace m5stack_8angle {
+namespace esphome::m5stack_8angle {
 
 static const uint8_t M5STACK_8ANGLE_NUM_LEDS = 9;
 static const uint8_t M5STACK_8ANGLE_BYTES_PER_LED = 4;
@@ -33,5 +32,4 @@ class M5Stack8AngleLightOutput : public light::AddressableLight, public Parented
   uint8_t *effect_data_{nullptr};
 };
 
-}  // namespace m5stack_8angle
-}  // namespace esphome
+}  // namespace esphome::m5stack_8angle

--- a/esphome/components/m5stack_8angle/m5stack_8angle.cpp
+++ b/esphome/components/m5stack_8angle/m5stack_8angle.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace m5stack_8angle {
+namespace esphome::m5stack_8angle {
 
 static const char *const TAG = "m5stack_8angle";
 
@@ -69,5 +68,4 @@ int8_t M5Stack8AngleComponent::read_switch() {
   }
 }
 
-}  // namespace m5stack_8angle
-}  // namespace esphome
+}  // namespace esphome::m5stack_8angle

--- a/esphome/components/m5stack_8angle/m5stack_8angle.h
+++ b/esphome/components/m5stack_8angle/m5stack_8angle.h
@@ -3,8 +3,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace m5stack_8angle {
+namespace esphome::m5stack_8angle {
 
 static const uint8_t M5STACK_8ANGLE_REGISTER_ANALOG_INPUT_12B = 0x00;
 static const uint8_t M5STACK_8ANGLE_REGISTER_ANALOG_INPUT_8B = 0x10;
@@ -29,5 +28,4 @@ class M5Stack8AngleComponent : public i2c::I2CDevice, public Component {
   uint8_t fw_version_;
 };
 
-}  // namespace m5stack_8angle
-}  // namespace esphome
+}  // namespace esphome::m5stack_8angle

--- a/esphome/components/m5stack_8angle/sensor/m5stack_8angle_sensor.cpp
+++ b/esphome/components/m5stack_8angle/sensor/m5stack_8angle_sensor.cpp
@@ -1,7 +1,6 @@
 #include "m5stack_8angle_sensor.h"
 
-namespace esphome {
-namespace m5stack_8angle {
+namespace esphome::m5stack_8angle {
 
 void M5Stack8AngleKnobSensor::update() {
   if (this->parent_ != nullptr) {
@@ -20,5 +19,4 @@ void M5Stack8AngleKnobSensor::update() {
   };
 }
 
-}  // namespace m5stack_8angle
-}  // namespace esphome
+}  // namespace esphome::m5stack_8angle

--- a/esphome/components/m5stack_8angle/sensor/m5stack_8angle_sensor.h
+++ b/esphome/components/m5stack_8angle/sensor/m5stack_8angle_sensor.h
@@ -5,8 +5,7 @@
 
 #include "../m5stack_8angle.h"
 
-namespace esphome {
-namespace m5stack_8angle {
+namespace esphome::m5stack_8angle {
 
 class M5Stack8AngleKnobSensor : public sensor::Sensor,
                                 public PollingComponent,
@@ -23,5 +22,4 @@ class M5Stack8AngleKnobSensor : public sensor::Sensor,
   bool raw_;
 };
 
-}  // namespace m5stack_8angle
-}  // namespace esphome
+}  // namespace esphome::m5stack_8angle

--- a/esphome/components/matrix_keypad/binary_sensor/matrix_keypad_binary_sensor.h
+++ b/esphome/components/matrix_keypad/binary_sensor/matrix_keypad_binary_sensor.h
@@ -3,8 +3,7 @@
 #include "esphome/components/matrix_keypad/matrix_keypad.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace matrix_keypad {
+namespace esphome::matrix_keypad {
 
 class MatrixKeypadBinarySensor : public MatrixKeypadListener, public binary_sensor::BinarySensorInitiallyOff {
  public:
@@ -47,5 +46,4 @@ class MatrixKeypadBinarySensor : public MatrixKeypadListener, public binary_sens
   int col_;
 };
 
-}  // namespace matrix_keypad
-}  // namespace esphome
+}  // namespace esphome::matrix_keypad

--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace matrix_keypad {
+namespace esphome::matrix_keypad {
 
 static const char *const TAG = "matrix_keypad";
 
@@ -110,5 +109,4 @@ void MatrixKeypad::register_listener(MatrixKeypadListener *listener) { this->lis
 
 void MatrixKeypad::register_key_trigger(MatrixKeyTrigger *trig) { this->key_triggers_.push_back(trig); }
 
-}  // namespace matrix_keypad
-}  // namespace esphome
+}  // namespace esphome::matrix_keypad

--- a/esphome/components/matrix_keypad/matrix_keypad.h
+++ b/esphome/components/matrix_keypad/matrix_keypad.h
@@ -8,8 +8,7 @@
 #include <cstdlib>
 #include <utility>
 
-namespace esphome {
-namespace matrix_keypad {
+namespace esphome::matrix_keypad {
 
 class MatrixKeypadListener {
  public:
@@ -51,5 +50,4 @@ class MatrixKeypad : public key_provider::KeyProvider, public Component {
   std::vector<MatrixKeyTrigger *> key_triggers_;
 };
 
-}  // namespace matrix_keypad
-}  // namespace esphome
+}  // namespace esphome::matrix_keypad

--- a/esphome/components/max17043/automation.h
+++ b/esphome/components/max17043/automation.h
@@ -3,8 +3,7 @@
 #include "esphome/core/automation.h"
 #include "max17043.h"
 
-namespace esphome {
-namespace max17043 {
+namespace esphome::max17043 {
 
 template<typename... Ts> class SleepAction : public Action<Ts...> {
  public:
@@ -16,5 +15,4 @@ template<typename... Ts> class SleepAction : public Action<Ts...> {
   MAX17043Component *max17043_;
 };
 
-}  // namespace max17043
-}  // namespace esphome
+}  // namespace esphome::max17043

--- a/esphome/components/max17043/max17043.cpp
+++ b/esphome/components/max17043/max17043.cpp
@@ -1,8 +1,7 @@
 #include "max17043.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace max17043 {
+namespace esphome::max17043 {
 
 // MAX174043 is a 1-Cell Fuel Gauge with ModelGauge and Low-Battery Alert
 // Consult the datasheet at https://www.analog.com/en/products/max17043.html
@@ -90,5 +89,4 @@ void MAX17043Component::sleep_mode() {
   }
 }
 
-}  // namespace max17043
-}  // namespace esphome
+}  // namespace esphome::max17043

--- a/esphome/components/max17043/max17043.h
+++ b/esphome/components/max17043/max17043.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace max17043 {
+namespace esphome::max17043 {
 
 class MAX17043Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -24,5 +23,4 @@ class MAX17043Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *battery_remaining_sensor_{nullptr};
 };
 
-}  // namespace max17043
-}  // namespace esphome
+}  // namespace esphome::max17043

--- a/esphome/components/max31855/max31855.cpp
+++ b/esphome/components/max31855/max31855.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace max31855 {
+namespace esphome::max31855 {
 
 static const char *const TAG = "max31855";
 
@@ -100,5 +99,4 @@ void MAX31855Sensor::read_data_() {
   this->status_clear_warning();
 }
 
-}  // namespace max31855
-}  // namespace esphome
+}  // namespace esphome::max31855

--- a/esphome/components/max31855/max31855.h
+++ b/esphome/components/max31855/max31855.h
@@ -6,8 +6,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace max31855 {
+namespace esphome::max31855 {
 
 class MAX31855Sensor : public sensor::Sensor,
                        public PollingComponent,
@@ -26,5 +25,4 @@ class MAX31855Sensor : public sensor::Sensor,
   sensor::Sensor *temperature_reference_{nullptr};
 };
 
-}  // namespace max31855
-}  // namespace esphome
+}  // namespace esphome::max31855

--- a/esphome/components/max31856/max31856.cpp
+++ b/esphome/components/max31856/max31856.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include <cmath>
 
-namespace esphome {
-namespace max31856 {
+namespace esphome::max31856 {
 
 static const char *const TAG = "max31856";
 
@@ -197,5 +196,4 @@ uint32_t MAX31856Sensor::read_register24_(uint8_t reg) {
   return value;
 }
 
-}  // namespace max31856
-}  // namespace esphome
+}  // namespace esphome::max31856

--- a/esphome/components/max31856/max31856.h
+++ b/esphome/components/max31856/max31856.h
@@ -6,8 +6,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace max31856 {
+namespace esphome::max31856 {
 
 enum MAX31856RegisterMasks { SPI_WRITE_M = 0x80 };
 
@@ -98,5 +97,4 @@ class MAX31856Sensor : public sensor::Sensor,
   void set_noise_filter_();
 };
 
-}  // namespace max31856
-}  // namespace esphome
+}  // namespace esphome::max31856

--- a/esphome/components/max31865/max31865.cpp
+++ b/esphome/components/max31865/max31865.cpp
@@ -4,8 +4,7 @@
 #include <cmath>
 #include <cinttypes>
 
-namespace esphome {
-namespace max31865 {
+namespace esphome::max31865 {
 
 static const char *const TAG = "max31865";
 
@@ -226,5 +225,4 @@ float MAX31865Sensor::calc_temperature_(float rtd_ratio) {
   return neg_temp;
 }
 
-}  // namespace max31865
-}  // namespace esphome
+}  // namespace esphome::max31865

--- a/esphome/components/max31865/max31865.h
+++ b/esphome/components/max31865/max31865.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace max31865 {
+namespace esphome::max31865 {
 
 enum MAX31865RegisterMasks { SPI_WRITE_M = 0x80 };
 enum MAX31865Registers {
@@ -53,5 +52,4 @@ class MAX31865Sensor : public sensor::Sensor,
   float calc_temperature_(float rtd_ratio);
 };
 
-}  // namespace max31865
-}  // namespace esphome
+}  // namespace esphome::max31865

--- a/esphome/components/max44009/max44009.cpp
+++ b/esphome/components/max44009/max44009.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace max44009 {
+namespace esphome::max44009 {
 
 static const char *const TAG = "max44009.sensor";
 
@@ -137,5 +136,4 @@ void MAX44009Sensor::write_(uint8_t reg, uint8_t value) {
 
 void MAX44009Sensor::set_mode(MAX44009Mode mode) { this->mode_ = mode; }
 
-}  // namespace max44009
-}  // namespace esphome
+}  // namespace esphome::max44009

--- a/esphome/components/max44009/max44009.h
+++ b/esphome/components/max44009/max44009.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace max44009 {
+namespace esphome::max44009 {
 
 enum MAX44009Mode { MAX44009_MODE_AUTO, MAX44009_MODE_LOW_POWER, MAX44009_MODE_CONTINUOUS };
 
@@ -32,5 +31,4 @@ class MAX44009Sensor : public sensor::Sensor, public PollingComponent, public i2
   MAX44009Mode mode_{MAX44009_MODE_AUTO};
 };
 
-}  // namespace max44009
-}  // namespace esphome
+}  // namespace esphome::max44009

--- a/esphome/components/max6675/max6675.cpp
+++ b/esphome/components/max6675/max6675.cpp
@@ -1,8 +1,7 @@
 #include "max6675.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace max6675 {
+namespace esphome::max6675 {
 
 static const char *const TAG = "max6675";
 
@@ -43,5 +42,4 @@ void MAX6675Sensor::read_data_() {
   this->status_clear_warning();
 }
 
-}  // namespace max6675
-}  // namespace esphome
+}  // namespace esphome::max6675

--- a/esphome/components/max6675/max6675.h
+++ b/esphome/components/max6675/max6675.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace max6675 {
+namespace esphome::max6675 {
 
 class MAX6675Sensor : public sensor::Sensor,
                       public PollingComponent,
@@ -21,5 +20,4 @@ class MAX6675Sensor : public sensor::Sensor,
   void read_data_();
 };
 
-}  // namespace max6675
-}  // namespace esphome
+}  // namespace esphome::max6675

--- a/esphome/components/max6956/automation.h
+++ b/esphome/components/max6956/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/max6956/max6956.h"
 
-namespace esphome {
-namespace max6956 {
+namespace esphome::max6956 {
 
 template<typename... Ts> class SetCurrentGlobalAction : public Action<Ts...> {
  public:
@@ -36,5 +35,4 @@ template<typename... Ts> class SetCurrentModeAction : public Action<Ts...> {
  protected:
   MAX6956 *max6956_;
 };
-}  // namespace max6956
-}  // namespace esphome
+}  // namespace esphome::max6956

--- a/esphome/components/max6956/max6956.cpp
+++ b/esphome/components/max6956/max6956.cpp
@@ -1,8 +1,7 @@
 #include "max6956.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace max6956 {
+namespace esphome::max6956 {
 
 static const char *const TAG = "max6956";
 
@@ -167,5 +166,4 @@ size_t MAX6956GPIOPin::dump_summary(char *buffer, size_t len) const {
   return buf_append_printf(buffer, len, 0, "%u via Max6956", this->pin_);
 }
 
-}  // namespace max6956
-}  // namespace esphome
+}  // namespace esphome::max6956

--- a/esphome/components/max6956/max6956.h
+++ b/esphome/components/max6956/max6956.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace max6956 {
+namespace esphome::max6956 {
 
 /// Modes for MAX6956 pins
 enum MAX6956GPIOMode : uint8_t {
@@ -92,5 +91,4 @@ class MAX6956GPIOPin : public GPIOPin {
   gpio::Flags flags_;
 };
 
-}  // namespace max6956
-}  // namespace esphome
+}  // namespace esphome::max6956

--- a/esphome/components/max6956/output/max6956_led_output.cpp
+++ b/esphome/components/max6956/output/max6956_led_output.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace max6956 {
+namespace esphome::max6956 {
 
 static const char *const TAG = "max6956_led_channel";
 
@@ -22,5 +21,4 @@ void MAX6956LedChannel::dump_config() {
   LOG_FLOAT_OUTPUT(this);
 }
 
-}  // namespace max6956
-}  // namespace esphome
+}  // namespace esphome::max6956

--- a/esphome/components/max6956/output/max6956_led_output.h
+++ b/esphome/components/max6956/output/max6956_led_output.h
@@ -3,8 +3,7 @@
 #include "esphome/components/max6956/max6956.h"
 #include "esphome/components/output/float_output.h"
 
-namespace esphome {
-namespace max6956 {
+namespace esphome::max6956 {
 
 class MAX6956;
 
@@ -24,5 +23,4 @@ class MAX6956LedChannel : public output::FloatOutput, public Component {
   uint8_t pin_;
 };
 
-}  // namespace max6956
-}  // namespace esphome
+}  // namespace esphome::max6956

--- a/esphome/components/max7219digit/automation.h
+++ b/esphome/components/max7219digit/automation.h
@@ -5,8 +5,7 @@
 
 #include "max7219digit.h"
 
-namespace esphome {
-namespace max7219digit {
+namespace esphome::max7219digit {
 
 template<typename... Ts> class DisplayInvertAction : public Action<Ts...>, public Parented<MAX7219Component> {
  public:
@@ -48,5 +47,4 @@ template<typename... Ts> class DisplayIntensityAction : public Action<Ts...>, pu
   }
 };
 
-}  // namespace max7219digit
-}  // namespace esphome
+}  // namespace esphome::max7219digit

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -8,8 +8,7 @@
 #include <algorithm>
 #include <cinttypes>
 
-namespace esphome {
-namespace max7219digit {
+namespace esphome::max7219digit {
 
 static const char *const TAG = "max7219DIGIT";
 
@@ -352,5 +351,4 @@ uint8_t MAX7219Component::strftimedigit(const char *format, ESPTime time) {
   return this->strftimedigit(0, format, time);
 }
 
-}  // namespace max7219digit
-}  // namespace esphome
+}  // namespace esphome::max7219digit

--- a/esphome/components/max7219digit/max7219digit.h
+++ b/esphome/components/max7219digit/max7219digit.h
@@ -8,8 +8,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace max7219digit {
+namespace esphome::max7219digit {
 
 enum ChipLinesStyle {
   ZIGZAG = 0,
@@ -120,5 +119,4 @@ class MAX7219Component : public display::DisplayBuffer,
   max7219_writer_t writer_local_{};
 };
 
-}  // namespace max7219digit
-}  // namespace esphome
+}  // namespace esphome::max7219digit

--- a/esphome/components/max7219digit/max7219font.h
+++ b/esphome/components/max7219digit/max7219font.h
@@ -2,8 +2,7 @@
 
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace max7219digit {
+namespace esphome::max7219digit {
 
 // bit patterns for the CP437 font
 
@@ -266,5 +265,4 @@ constexpr uint8_t MAX7219_DOT_MATRIX_FONT[256][8] PROGMEM = {
     {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},  // 0xFF
 };                                                     // end of MAX7219_Dot_Matrix_font
 
-}  // namespace max7219digit
-}  // namespace esphome
+}  // namespace esphome::max7219digit

--- a/esphome/components/max9611/max9611.cpp
+++ b/esphome/components/max9611/max9611.cpp
@@ -1,8 +1,8 @@
 #include "max9611.h"
 #include "esphome/core/log.h"
 #include "esphome/components/i2c/i2c_bus.h"
-namespace esphome {
-namespace max9611 {
+
+namespace esphome::max9611 {
 using namespace esphome::i2c;
 // Sign extend
 // http://graphics.stanford.edu/~seander/bithacks.html#FixedSignExtend
@@ -91,5 +91,4 @@ void MAX9611Component::update() {
 
   ESP_LOGD(TAG, "V: %f, A: %f, W: %f, Deg C: %f", voltage, amps, watts, temp);
 }
-}  // namespace max9611
-}  // namespace esphome
+}  // namespace esphome::max9611

--- a/esphome/components/max9611/max9611.h
+++ b/esphome/components/max9611/max9611.h
@@ -5,8 +5,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace max9611 {
+namespace esphome::max9611 {
 
 enum MAX9611Multiplexer {
   MAX9611_MULTIPLEXER_CSA_GAIN1 = 0b000,
@@ -57,5 +56,4 @@ class MAX9611Component : public PollingComponent, public i2c::I2CDevice {
   MAX9611Multiplexer gain_;
 };
 
-}  // namespace max9611
-}  // namespace esphome
+}  // namespace esphome::max9611

--- a/esphome/components/mcp23008/mcp23008.cpp
+++ b/esphome/components/mcp23008/mcp23008.cpp
@@ -1,8 +1,7 @@
 #include "mcp23008.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp23008 {
+namespace esphome::mcp23008 {
 
 static const char *const TAG = "mcp23008";
 
@@ -45,5 +44,4 @@ bool MCP23008::write_reg(uint8_t reg, uint8_t value) {
   return this->write_byte(reg, value);
 }
 
-}  // namespace mcp23008
-}  // namespace esphome
+}  // namespace esphome::mcp23008

--- a/esphome/components/mcp23008/mcp23008.h
+++ b/esphome/components/mcp23008/mcp23008.h
@@ -5,8 +5,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mcp23008 {
+namespace esphome::mcp23008 {
 
 class MCP23008 : public mcp23x08_base::MCP23X08Base, public i2c::I2CDevice {
  public:
@@ -20,5 +19,4 @@ class MCP23008 : public mcp23x08_base::MCP23X08Base, public i2c::I2CDevice {
   bool write_reg(uint8_t reg, uint8_t value) override;
 };
 
-}  // namespace mcp23008
-}  // namespace esphome
+}  // namespace esphome::mcp23008

--- a/esphome/components/mcp23016/mcp23016.cpp
+++ b/esphome/components/mcp23016/mcp23016.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <cstdio>
 
-namespace esphome {
-namespace mcp23016 {
+namespace esphome::mcp23016 {
 
 static const char *const TAG = "mcp23016";
 
@@ -101,5 +100,4 @@ size_t MCP23016GPIOPin::dump_summary(char *buffer, size_t len) const {
   return buf_append_printf(buffer, len, 0, "%u via MCP23016", this->pin_);
 }
 
-}  // namespace mcp23016
-}  // namespace esphome
+}  // namespace esphome::mcp23016

--- a/esphome/components/mcp23016/mcp23016.h
+++ b/esphome/components/mcp23016/mcp23016.h
@@ -5,8 +5,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/gpio_expander/cached_gpio.h"
 
-namespace esphome {
-namespace mcp23016 {
+namespace esphome::mcp23016 {
 
 enum MCP23016GPIORegisters {
   // 0 side
@@ -79,5 +78,4 @@ class MCP23016GPIOPin : public GPIOPin {
   gpio::Flags flags_;
 };
 
-}  // namespace mcp23016
-}  // namespace esphome
+}  // namespace esphome::mcp23016

--- a/esphome/components/mcp23017/mcp23017.cpp
+++ b/esphome/components/mcp23017/mcp23017.cpp
@@ -1,8 +1,7 @@
 #include "mcp23017.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp23017 {
+namespace esphome::mcp23017 {
 
 static const char *const TAG = "mcp23017";
 
@@ -54,5 +53,4 @@ bool MCP23017::write_reg(uint8_t reg, uint8_t value) {
   return this->write_byte(reg, value);
 }
 
-}  // namespace mcp23017
-}  // namespace esphome
+}  // namespace esphome::mcp23017

--- a/esphome/components/mcp23017/mcp23017.h
+++ b/esphome/components/mcp23017/mcp23017.h
@@ -5,8 +5,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mcp23017 {
+namespace esphome::mcp23017 {
 
 class MCP23017 : public mcp23x17_base::MCP23X17Base, public i2c::I2CDevice {
  public:
@@ -20,5 +19,4 @@ class MCP23017 : public mcp23x17_base::MCP23X17Base, public i2c::I2CDevice {
   bool write_reg(uint8_t reg, uint8_t value) override;
 };
 
-}  // namespace mcp23017
-}  // namespace esphome
+}  // namespace esphome::mcp23017

--- a/esphome/components/mcp23s08/mcp23s08.cpp
+++ b/esphome/components/mcp23s08/mcp23s08.cpp
@@ -1,8 +1,7 @@
 #include "mcp23s08.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp23s08 {
+namespace esphome::mcp23s08 {
 
 static const char *const TAG = "mcp23s08";
 
@@ -62,5 +61,4 @@ bool MCP23S08::write_reg(uint8_t reg, uint8_t value) {
   return true;
 }
 
-}  // namespace mcp23s08
-}  // namespace esphome
+}  // namespace esphome::mcp23s08

--- a/esphome/components/mcp23s08/mcp23s08.h
+++ b/esphome/components/mcp23s08/mcp23s08.h
@@ -5,8 +5,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace mcp23s08 {
+namespace esphome::mcp23s08 {
 
 class MCP23S08 : public mcp23x08_base::MCP23X08Base,
                  public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
@@ -26,5 +25,4 @@ class MCP23S08 : public mcp23x08_base::MCP23X08Base,
   uint8_t device_opcode_ = 0x40;
 };
 
-}  // namespace mcp23s08
-}  // namespace esphome
+}  // namespace esphome::mcp23s08

--- a/esphome/components/mcp23s17/mcp23s17.cpp
+++ b/esphome/components/mcp23s17/mcp23s17.cpp
@@ -1,8 +1,7 @@
 #include "mcp23s17.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp23s17 {
+namespace esphome::mcp23s17 {
 
 static const char *const TAG = "mcp23s17";
 
@@ -79,5 +78,4 @@ bool MCP23S17::write_reg(uint8_t reg, uint8_t value) {
   return true;
 }
 
-}  // namespace mcp23s17
-}  // namespace esphome
+}  // namespace esphome::mcp23s17

--- a/esphome/components/mcp23s17/mcp23s17.h
+++ b/esphome/components/mcp23s17/mcp23s17.h
@@ -5,8 +5,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace mcp23s17 {
+namespace esphome::mcp23s17 {
 
 class MCP23S17 : public mcp23x17_base::MCP23X17Base,
                  public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
@@ -25,5 +24,4 @@ class MCP23S17 : public mcp23x17_base::MCP23X17Base,
   uint8_t device_opcode_ = 0x40;
 };
 
-}  // namespace mcp23s17
-}  // namespace esphome
+}  // namespace esphome::mcp23s17

--- a/esphome/components/mcp23x08_base/mcp23x08_base.cpp
+++ b/esphome/components/mcp23x08_base/mcp23x08_base.cpp
@@ -1,8 +1,7 @@
 #include "mcp23x08_base.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp23x08_base {
+namespace esphome::mcp23x08_base {
 
 static const char *const TAG = "mcp23x08_base";
 
@@ -92,5 +91,4 @@ void MCP23X08Base::update_reg(uint8_t pin, bool pin_value, uint8_t reg_addr) {
   }
 }
 
-}  // namespace mcp23x08_base
-}  // namespace esphome
+}  // namespace esphome::mcp23x08_base

--- a/esphome/components/mcp23x08_base/mcp23x08_base.h
+++ b/esphome/components/mcp23x08_base/mcp23x08_base.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace mcp23x08_base {
+namespace esphome::mcp23x08_base {
 
 enum MCP23S08GPIORegisters {
   // A side
@@ -40,5 +39,4 @@ class MCP23X08Base : public mcp23xxx_base::MCP23XXXBase<8> {
   uint8_t input_mask_{0x00};
 };
 
-}  // namespace mcp23x08_base
-}  // namespace esphome
+}  // namespace esphome::mcp23x08_base

--- a/esphome/components/mcp23x17_base/mcp23x17_base.cpp
+++ b/esphome/components/mcp23x17_base/mcp23x17_base.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp23x17_base {
+namespace esphome::mcp23x17_base {
 
 static const char *const TAG = "mcp23x17_base";
 
@@ -108,5 +107,4 @@ void MCP23X17Base::update_reg(uint8_t pin, bool pin_value, uint8_t reg_addr) {
   }
 }
 
-}  // namespace mcp23x17_base
-}  // namespace esphome
+}  // namespace esphome::mcp23x17_base

--- a/esphome/components/mcp23x17_base/mcp23x17_base.h
+++ b/esphome/components/mcp23x17_base/mcp23x17_base.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace mcp23x17_base {
+namespace esphome::mcp23x17_base {
 
 enum MCP23X17GPIORegisters {
   // A side
@@ -53,5 +52,4 @@ class MCP23X17Base : public mcp23xxx_base::MCP23XXXBase<16> {
   uint16_t input_mask_{0x00};
 };
 
-}  // namespace mcp23x17_base
-}  // namespace esphome
+}  // namespace esphome::mcp23x17_base

--- a/esphome/components/mcp23xxx_base/mcp23xxx_base.cpp
+++ b/esphome/components/mcp23xxx_base/mcp23xxx_base.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp23xxx_base {
+namespace esphome::mcp23xxx_base {
 
 template<uint8_t N> void MCP23XXXGPIOPin<N>::setup() {
   this->pin_mode(flags_);
@@ -28,5 +27,4 @@ template<uint8_t N> size_t MCP23XXXGPIOPin<N>::dump_summary(char *buffer, size_t
 template class MCP23XXXGPIOPin<8>;
 template class MCP23XXXGPIOPin<16>;
 
-}  // namespace mcp23xxx_base
-}  // namespace esphome
+}  // namespace esphome::mcp23xxx_base

--- a/esphome/components/mcp23xxx_base/mcp23xxx_base.h
+++ b/esphome/components/mcp23xxx_base/mcp23xxx_base.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace mcp23xxx_base {
+namespace esphome::mcp23xxx_base {
 
 enum MCP23XXXInterruptMode : uint8_t { MCP23XXX_NO_INTERRUPT = 0, MCP23XXX_CHANGE, MCP23XXX_RISING, MCP23XXX_FALLING };
 
@@ -81,5 +80,4 @@ template<uint8_t N> class MCP23XXXGPIOPin : public GPIOPin {
   MCP23XXXInterruptMode interrupt_mode_;
 };
 
-}  // namespace mcp23xxx_base
-}  // namespace esphome
+}  // namespace esphome::mcp23xxx_base

--- a/esphome/components/mcp2515/mcp2515.cpp
+++ b/esphome/components/mcp2515/mcp2515.cpp
@@ -1,8 +1,7 @@
 #include "mcp2515.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp2515 {
+namespace esphome::mcp2515 {
 
 static const char *const TAG = "mcp2515";
 
@@ -707,5 +706,4 @@ canbus::Error MCP2515::set_bitrate_(canbus::CanSpeed can_speed, CanClock can_clo
     return canbus::ERROR_FAIL;
   }
 }
-}  // namespace mcp2515
-}  // namespace esphome
+}  // namespace esphome::mcp2515

--- a/esphome/components/mcp2515/mcp2515.h
+++ b/esphome/components/mcp2515/mcp2515.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "mcp2515_defs.h"
 
-namespace esphome {
-namespace mcp2515 {
+namespace esphome::mcp2515 {
 static const uint32_t SPI_CLOCK = 10000000;  // 10MHz
 
 static const int N_TXBUFFERS = 3;
@@ -108,5 +107,4 @@ class MCP2515 : public canbus::Canbus,
   void clear_merr_();
   void clear_errif_();
 };
-}  // namespace mcp2515
-}  // namespace esphome
+}  // namespace esphome::mcp2515

--- a/esphome/components/mcp2515/mcp2515_defs.h
+++ b/esphome/components/mcp2515/mcp2515_defs.h
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace esphome {
-namespace mcp2515 {
+namespace esphome::mcp2515 {
 
 static const uint8_t CANCTRL_REQOP = 0xE0;
 static const uint8_t CANCTRL_ABAT = 0x10;
@@ -371,5 +370,4 @@ static const uint8_t MCP_20MHZ_33K3BPS_CFG1 = 0x0B;
 static const uint8_t MCP_20MHZ_33K3BPS_CFG2 = 0xFF;
 static const uint8_t MCP_20MHZ_33K3BPS_CFG3 = 0x87;
 
-}  // namespace mcp2515
-}  // namespace esphome
+}  // namespace esphome::mcp2515

--- a/esphome/components/mcp3008/mcp3008.cpp
+++ b/esphome/components/mcp3008/mcp3008.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp3008 {
+namespace esphome::mcp3008 {
 
 static const char *const TAG = "mcp3008";
 
@@ -36,5 +35,4 @@ float MCP3008::read_data(uint8_t pin) {
   return data / 1023.0f;
 }
 
-}  // namespace mcp3008
-}  // namespace esphome
+}  // namespace esphome::mcp3008

--- a/esphome/components/mcp3008/mcp3008.h
+++ b/esphome/components/mcp3008/mcp3008.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace mcp3008 {
+namespace esphome::mcp3008 {
 
 class MCP3008 : public Component,
                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
@@ -18,5 +17,4 @@ class MCP3008 : public Component,
   float read_data(uint8_t pin);
 };
 
-}  // namespace mcp3008
-}  // namespace esphome
+}  // namespace esphome::mcp3008

--- a/esphome/components/mcp3008/sensor/mcp3008_sensor.cpp
+++ b/esphome/components/mcp3008/sensor/mcp3008_sensor.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp3008 {
+namespace esphome::mcp3008 {
 
 static const char *const TAG = "mcp3008.sensor";
 
@@ -23,5 +22,4 @@ float MCP3008Sensor::sample() {
 
 void MCP3008Sensor::update() { this->publish_state(this->sample()); }
 
-}  // namespace mcp3008
-}  // namespace esphome
+}  // namespace esphome::mcp3008

--- a/esphome/components/mcp3008/sensor/mcp3008_sensor.h
+++ b/esphome/components/mcp3008/sensor/mcp3008_sensor.h
@@ -6,8 +6,7 @@
 
 #include "../mcp3008.h"
 
-namespace esphome {
-namespace mcp3008 {
+namespace esphome::mcp3008 {
 
 class MCP3008Sensor : public PollingComponent,
                       public sensor::Sensor,
@@ -26,5 +25,4 @@ class MCP3008Sensor : public PollingComponent,
   float reference_voltage_;
 };
 
-}  // namespace mcp3008
-}  // namespace esphome
+}  // namespace esphome::mcp3008

--- a/esphome/components/mcp3204/mcp3204.cpp
+++ b/esphome/components/mcp3204/mcp3204.cpp
@@ -1,8 +1,7 @@
 #include "mcp3204.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp3204 {
+namespace esphome::mcp3204 {
 
 static const char *const TAG = "mcp3204";
 
@@ -35,5 +34,4 @@ float MCP3204::read_data(uint8_t pin, bool differential) {
   return float(digital_value) / 4096.000 * this->reference_voltage_;  // in V
 }
 
-}  // namespace mcp3204
-}  // namespace esphome
+}  // namespace esphome::mcp3204

--- a/esphome/components/mcp3204/mcp3204.h
+++ b/esphome/components/mcp3204/mcp3204.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace mcp3204 {
+namespace esphome::mcp3204 {
 
 class MCP3204 : public Component,
                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
@@ -24,5 +23,4 @@ class MCP3204 : public Component,
   float reference_voltage_;
 };
 
-}  // namespace mcp3204
-}  // namespace esphome
+}  // namespace esphome::mcp3204

--- a/esphome/components/mcp3204/sensor/mcp3204_sensor.cpp
+++ b/esphome/components/mcp3204/sensor/mcp3204_sensor.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp3204 {
+namespace esphome::mcp3204 {
 
 static const char *const TAG = "mcp3204.sensor";
 
@@ -18,5 +17,4 @@ void MCP3204Sensor::dump_config() {
 float MCP3204Sensor::sample() { return this->parent_->read_data(this->pin_, this->differential_mode_); }
 void MCP3204Sensor::update() { this->publish_state(this->sample()); }
 
-}  // namespace mcp3204
-}  // namespace esphome
+}  // namespace esphome::mcp3204

--- a/esphome/components/mcp3204/sensor/mcp3204_sensor.h
+++ b/esphome/components/mcp3204/sensor/mcp3204_sensor.h
@@ -7,8 +7,7 @@
 
 #include "../mcp3204.h"
 
-namespace esphome {
-namespace mcp3204 {
+namespace esphome::mcp3204 {
 
 class MCP3204Sensor : public PollingComponent,
                       public Parented<MCP3204>,
@@ -26,5 +25,4 @@ class MCP3204Sensor : public PollingComponent,
   bool differential_mode_;
 };
 
-}  // namespace mcp3204
-}  // namespace esphome
+}  // namespace esphome::mcp3204

--- a/esphome/components/mcp3221/mcp3221_sensor.cpp
+++ b/esphome/components/mcp3221/mcp3221_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp3221 {
+namespace esphome::mcp3221 {
 
 static const char *const TAG = "mcp3221";
 
@@ -27,5 +26,4 @@ void MCP3221Sensor::update() {
   this->publish_state(v);
 }
 
-}  // namespace mcp3221
-}  // namespace esphome
+}  // namespace esphome::mcp3221

--- a/esphome/components/mcp3221/mcp3221_sensor.h
+++ b/esphome/components/mcp3221/mcp3221_sensor.h
@@ -8,8 +8,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace mcp3221 {
+namespace esphome::mcp3221 {
 
 class MCP3221Sensor : public sensor::Sensor,
                       public PollingComponent,
@@ -24,5 +23,4 @@ class MCP3221Sensor : public sensor::Sensor,
   float reference_voltage_;
 };
 
-}  // namespace mcp3221
-}  // namespace esphome
+}  // namespace esphome::mcp3221

--- a/esphome/components/mcp4461/mcp4461.cpp
+++ b/esphome/components/mcp4461/mcp4461.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace mcp4461 {
+namespace esphome::mcp4461 {
 
 static const char *const TAG = "mcp4461";
 constexpr uint8_t EEPROM_WRITE_TIMEOUT_MS = 10;
@@ -628,5 +627,4 @@ bool Mcp4461Component::mcp4461_write_(uint8_t addr, uint16_t data, bool nonvolat
   }
   return this->write_byte(reg, value_byte);
 }
-}  // namespace mcp4461
-}  // namespace esphome
+}  // namespace esphome::mcp4461

--- a/esphome/components/mcp4461/mcp4461.h
+++ b/esphome/components/mcp4461/mcp4461.h
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mcp4461 {
+namespace esphome::mcp4461 {
 
 struct WiperState {
   bool enabled = true;
@@ -168,5 +167,4 @@ class Mcp4461Component : public Component, public i2c::I2CDevice {
   bool wiper_2_disabled_{false};
   bool wiper_3_disabled_{false};
 };
-}  // namespace mcp4461
-}  // namespace esphome
+}  // namespace esphome::mcp4461

--- a/esphome/components/mcp4461/output/mcp4461_output.cpp
+++ b/esphome/components/mcp4461/output/mcp4461_output.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp4461 {
+namespace esphome::mcp4461 {
 
 static const char *const TAG = "mcp4461.output";
 
@@ -69,5 +68,4 @@ void Mcp4461Wiper::enable_terminal(char terminal) { this->parent_->enable_termin
 
 void Mcp4461Wiper::disable_terminal(char terminal) { this->parent_->disable_terminal_(this->wiper_, terminal); }
 
-}  // namespace mcp4461
-}  // namespace esphome
+}  // namespace esphome::mcp4461

--- a/esphome/components/mcp4461/output/mcp4461_output.h
+++ b/esphome/components/mcp4461/output/mcp4461_output.h
@@ -5,8 +5,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mcp4461 {
+namespace esphome::mcp4461 {
 
 class Mcp4461Wiper : public output::FloatOutput, public Parented<Mcp4461Component> {
  public:
@@ -45,5 +44,4 @@ class Mcp4461Wiper : public output::FloatOutput, public Parented<Mcp4461Componen
   float state_;
 };
 
-}  // namespace mcp4461
-}  // namespace esphome
+}  // namespace esphome::mcp4461

--- a/esphome/components/mcp4725/mcp4725.cpp
+++ b/esphome/components/mcp4725/mcp4725.cpp
@@ -1,8 +1,7 @@
 #include "mcp4725.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp4725 {
+namespace esphome::mcp4725 {
 
 static const char *const TAG = "mcp4725";
 
@@ -30,5 +29,4 @@ void MCP4725::write_state(float state) {
   this->write_byte_16(64, value << 4);
 }
 
-}  // namespace mcp4725
-}  // namespace esphome
+}  // namespace esphome::mcp4725

--- a/esphome/components/mcp4725/mcp4725.h
+++ b/esphome/components/mcp4725/mcp4725.h
@@ -7,8 +7,7 @@
 static const uint8_t MCP4725_ADDR = 0x60;
 static const uint8_t MCP4725_RES = 12;
 
-namespace esphome {
-namespace mcp4725 {
+namespace esphome::mcp4725 {
 class MCP4725 : public Component, public output::FloatOutput, public i2c::I2CDevice {
  public:
   void setup() override;
@@ -19,5 +18,4 @@ class MCP4725 : public Component, public output::FloatOutput, public i2c::I2CDev
   enum ErrorCode { NONE = 0, COMMUNICATION_FAILED } error_code_{NONE};
 };
 
-}  // namespace mcp4725
-}  // namespace esphome
+}  // namespace esphome::mcp4725

--- a/esphome/components/mcp4728/mcp4728.cpp
+++ b/esphome/components/mcp4728/mcp4728.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp4728 {
+namespace esphome::mcp4728 {
 
 static const char *const TAG = "mcp4728";
 
@@ -109,5 +108,4 @@ void MCP4728Component::select_gain_(MCP4728ChannelIdx channel, MCP4728Gain gain)
   this->update_ = true;
 }
 
-}  // namespace mcp4728
-}  // namespace esphome
+}  // namespace esphome::mcp4728

--- a/esphome/components/mcp4728/mcp4728.h
+++ b/esphome/components/mcp4728/mcp4728.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mcp4728 {
+namespace esphome::mcp4728 {
 
 enum class CMD {
   FAST_WRITE = 0x00,
@@ -63,5 +62,4 @@ class MCP4728Component : public Component, public i2c::I2CDevice {
   bool update_ = false;
 };
 
-}  // namespace mcp4728
-}  // namespace esphome
+}  // namespace esphome::mcp4728

--- a/esphome/components/mcp4728/output/mcp4728_output.cpp
+++ b/esphome/components/mcp4728/output/mcp4728_output.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp4728 {
+namespace esphome::mcp4728 {
 
 void MCP4728Channel::write_state(float state) {
   const uint16_t max_duty = 4095;
@@ -13,5 +12,4 @@ void MCP4728Channel::write_state(float state) {
   this->parent_->set_channel_value_(this->channel_, duty);
 }
 
-}  // namespace mcp4728
-}  // namespace esphome
+}  // namespace esphome::mcp4728

--- a/esphome/components/mcp4728/output/mcp4728_output.h
+++ b/esphome/components/mcp4728/output/mcp4728_output.h
@@ -5,8 +5,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mcp4728 {
+namespace esphome::mcp4728 {
 
 class MCP4728Channel : public output::FloatOutput {
  public:
@@ -28,5 +27,4 @@ class MCP4728Channel : public output::FloatOutput {
   MCP4728ChannelIdx channel_;
 };
 
-}  // namespace mcp4728
-}  // namespace esphome
+}  // namespace esphome::mcp4728

--- a/esphome/components/mcp47a1/mcp47a1.cpp
+++ b/esphome/components/mcp47a1/mcp47a1.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp47a1 {
+namespace esphome::mcp47a1 {
 
 static const char *const TAG = "mcp47a1";
 
@@ -17,5 +16,4 @@ void MCP47A1::write_state(float state) {
   this->write_byte(0, value);
 }
 
-}  // namespace mcp47a1
-}  // namespace esphome
+}  // namespace esphome::mcp47a1

--- a/esphome/components/mcp47a1/mcp47a1.h
+++ b/esphome/components/mcp47a1/mcp47a1.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace mcp47a1 {
+namespace esphome::mcp47a1 {
 
 class MCP47A1 : public Component, public output::FloatOutput, public i2c::I2CDevice {
  public:
@@ -13,5 +12,4 @@ class MCP47A1 : public Component, public output::FloatOutput, public i2c::I2CDev
   void write_state(float state) override;
 };
 
-}  // namespace mcp47a1
-}  // namespace esphome
+}  // namespace esphome::mcp47a1

--- a/esphome/components/mcp9600/mcp9600.cpp
+++ b/esphome/components/mcp9600/mcp9600.cpp
@@ -1,8 +1,7 @@
 #include "mcp9600.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp9600 {
+namespace esphome::mcp9600 {
 
 static const char *const TAG = "mcp9600";
 
@@ -109,5 +108,4 @@ void MCP9600Component::update() {
   this->status_clear_warning();
 }
 
-}  // namespace mcp9600
-}  // namespace esphome
+}  // namespace esphome::mcp9600

--- a/esphome/components/mcp9600/mcp9600.h
+++ b/esphome/components/mcp9600/mcp9600.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mcp9600 {
+namespace esphome::mcp9600 {
 
 enum MCP9600ThermocoupleType : uint8_t {
   MCP9600_THERMOCOUPLE_TYPE_K = 0b000,
@@ -45,5 +44,4 @@ class MCP9600Component : public PollingComponent, public i2c::I2CDevice {
   } error_code_{NONE};
 };
 
-}  // namespace mcp9600
-}  // namespace esphome
+}  // namespace esphome::mcp9600

--- a/esphome/components/mcp9808/mcp9808.cpp
+++ b/esphome/components/mcp9808/mcp9808.cpp
@@ -1,8 +1,7 @@
 #include "mcp9808.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mcp9808 {
+namespace esphome::mcp9808 {
 
 static const uint8_t MCP9808_REG_AMBIENT_TEMP = 0x05;
 static const uint8_t MCP9808_REG_MANUF_ID = 0x06;
@@ -74,5 +73,4 @@ void MCP9808Sensor::update() {
   this->status_clear_warning();
 }
 
-}  // namespace mcp9808
-}  // namespace esphome
+}  // namespace esphome::mcp9808

--- a/esphome/components/mcp9808/mcp9808.h
+++ b/esphome/components/mcp9808/mcp9808.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mcp9808 {
+namespace esphome::mcp9808 {
 
 class MCP9808Sensor : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
  public:
@@ -15,5 +14,4 @@ class MCP9808Sensor : public sensor::Sensor, public PollingComponent, public i2c
   void update() override;
 };
 
-}  // namespace mcp9808
-}  // namespace esphome
+}  // namespace esphome::mcp9808

--- a/esphome/components/md5/md5.cpp
+++ b/esphome/components/md5/md5.cpp
@@ -3,8 +3,7 @@
 #ifdef USE_MD5
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace md5 {
+namespace esphome::md5 {
 
 #if defined(USE_ARDUINO) && !defined(USE_RP2040) && !defined(USE_ESP32)
 void MD5Digest::init() {
@@ -77,6 +76,6 @@ void MD5Digest::calculate() {
 MD5Digest::~MD5Digest() = default;
 #endif  // USE_HOST
 
-}  // namespace md5
-}  // namespace esphome
+}  // namespace esphome::md5
+
 #endif

--- a/esphome/components/md5/md5.h
+++ b/esphome/components/md5/md5.h
@@ -29,8 +29,7 @@
 #define MD5_CTX_TYPE LT_MD5_CTX_T
 #endif
 
-namespace esphome {
-namespace md5 {
+namespace esphome::md5 {
 
 class MD5Digest final : public HashBase {
  public:
@@ -59,6 +58,6 @@ class MD5Digest final : public HashBase {
 #endif
 };
 
-}  // namespace md5
-}  // namespace esphome
+}  // namespace esphome::md5
+
 #endif

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -3,9 +3,7 @@
 #include "esphome/core/automation.h"
 #include "media_player.h"
 
-namespace esphome {
-
-namespace media_player {
+namespace esphome::media_player {
 
 template<MediaPlayerCommand Command, typename... Ts>
 class MediaPlayerCommandAction : public Action<Ts...>, public Parented<MediaPlayer> {
@@ -136,5 +134,4 @@ template<typename... Ts> class IsMutedCondition : public Condition<Ts...>, publi
   bool check(const Ts &...x) override { return this->parent_->is_muted(); }
 };
 
-}  // namespace media_player
-}  // namespace esphome
+}  // namespace esphome::media_player

--- a/esphome/components/media_player/media_player.cpp
+++ b/esphome/components/media_player/media_player.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/progmem.h"
 
-namespace esphome {
-namespace media_player {
+namespace esphome::media_player {
 
 static const char *const TAG = "media_player";
 
@@ -205,5 +204,4 @@ void MediaPlayer::publish_state() {
 #endif
 }
 
-}  // namespace media_player
-}  // namespace esphome
+}  // namespace esphome::media_player

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -3,8 +3,7 @@
 #include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace media_player {
+namespace esphome::media_player {
 
 enum MediaPlayerEntityFeature : uint32_t {
   PAUSE = 1 << 0,
@@ -171,5 +170,4 @@ class MediaPlayer : public EntityBase {
   LazyCallbackManager<void(MediaPlayerState)> state_callback_{};
 };
 
-}  // namespace media_player
-}  // namespace esphome
+}  // namespace esphome::media_player

--- a/esphome/components/micro_wake_word/automation.h
+++ b/esphome/components/micro_wake_word/automation.h
@@ -4,8 +4,8 @@
 #include "streaming_model.h"
 
 #ifdef USE_ESP32
-namespace esphome {
-namespace micro_wake_word {
+
+namespace esphome::micro_wake_word {
 
 template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<MicroWakeWord> {
  public:
@@ -49,6 +49,6 @@ template<typename... Ts> class ModelIsEnabledCondition : public Condition<Ts...>
   WakeWordModel *wake_word_model_;
 };
 
-}  // namespace micro_wake_word
-}  // namespace esphome
+}  // namespace esphome::micro_wake_word
+
 #endif

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -13,8 +13,7 @@
 #include "esphome/components/ota/ota_backend.h"
 #endif
 
-namespace esphome {
-namespace micro_wake_word {
+namespace esphome::micro_wake_word {
 
 static const char *const TAG = "micro_wake_word";
 
@@ -468,7 +467,6 @@ bool MicroWakeWord::update_model_probabilities_(const int8_t audio_features[PREP
   return success;
 }
 
-}  // namespace micro_wake_word
-}  // namespace esphome
+}  // namespace esphome::micro_wake_word
 
 #endif  // USE_ESP32

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -21,8 +21,7 @@
 #include <frontend.h>
 #include <frontend_util.h>
 
-namespace esphome {
-namespace micro_wake_word {
+namespace esphome::micro_wake_word {
 
 enum State {
   STARTING,
@@ -137,7 +136,6 @@ class MicroWakeWord : public Component
   bool update_model_probabilities_(const int8_t audio_features[PREPROCESSOR_FEATURE_SIZE]);
 };
 
-}  // namespace micro_wake_word
-}  // namespace esphome
+}  // namespace esphome::micro_wake_word
 
 #endif  // USE_ESP32

--- a/esphome/components/micro_wake_word/preprocessor_settings.h
+++ b/esphome/components/micro_wake_word/preprocessor_settings.h
@@ -4,8 +4,7 @@
 
 #include <cstdint>
 
-namespace esphome {
-namespace micro_wake_word {
+namespace esphome::micro_wake_word {
 
 // Settings for controlling the spectrogram feature generation by the preprocessor.
 // These must match the settings used when training a particular model.
@@ -31,7 +30,6 @@ static const uint8_t PCAN_GAIN_CONTROL_GAIN_BITS = 21;
 
 static const bool LOG_SCALE_ENABLE_LOG = true;
 static const uint8_t LOG_SCALE_SCALE_SHIFT = 6;
-}  // namespace micro_wake_word
-}  // namespace esphome
+}  // namespace esphome::micro_wake_word
 
 #endif

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -7,8 +7,7 @@
 
 static const char *const TAG = "micro_wake_word";
 
-namespace esphome {
-namespace micro_wake_word {
+namespace esphome::micro_wake_word {
 
 void WakeWordModel::log_model_config() {
   ESP_LOGCONFIG(TAG,
@@ -387,7 +386,6 @@ bool StreamingModel::register_streaming_ops_(tflite::MicroMutableOpResolver<20> 
   return true;
 }
 
-}  // namespace micro_wake_word
-}  // namespace esphome
+}  // namespace esphome::micro_wake_word
 
 #endif

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -10,8 +10,7 @@
 #include <tensorflow/lite/micro/micro_interpreter.h>
 #include <tensorflow/lite/micro/micro_mutable_op_resolver.h>
 
-namespace esphome {
-namespace micro_wake_word {
+namespace esphome::micro_wake_word {
 
 static const uint8_t MIN_SLICES_BEFORE_DETECTION = 100;
 static const uint32_t STREAMING_MODEL_VARIABLE_ARENA_SIZE = 1024;
@@ -155,7 +154,6 @@ class VADModel final : public StreamingModel {
   DetectionEvent determine_detected() override;
 };
 
-}  // namespace micro_wake_word
-}  // namespace esphome
+}  // namespace esphome::micro_wake_word
 
 #endif

--- a/esphome/components/microphone/automation.h
+++ b/esphome/components/microphone/automation.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace microphone {
+namespace esphome::microphone {
 
 template<typename... Ts> class CaptureAction : public Action<Ts...>, public Parented<Microphone> {
   void play(const Ts &...x) override { this->parent_->start(); }
@@ -40,5 +39,4 @@ template<typename... Ts> class IsMutedCondition : public Condition<Ts...>, publi
   bool check(const Ts &...x) override { return this->parent_->get_mute_state(); }
 };
 
-}  // namespace microphone
-}  // namespace esphome
+}  // namespace esphome::microphone

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -7,8 +7,7 @@
 #include <vector>
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace microphone {
+namespace esphome::microphone {
 
 enum State : uint8_t {
   STATE_STOPPED = 0,
@@ -48,5 +47,4 @@ class Microphone {
   CallbackManager<void(const std::vector<uint8_t> &)> data_callbacks_{};
 };
 
-}  // namespace microphone
-}  // namespace esphome
+}  // namespace esphome::microphone

--- a/esphome/components/microphone/microphone_source.cpp
+++ b/esphome/components/microphone/microphone_source.cpp
@@ -1,7 +1,6 @@
 #include "microphone_source.h"
 
-namespace esphome {
-namespace microphone {
+namespace esphome::microphone {
 
 static const int32_t Q25_MAX_VALUE = (1 << 25) - 1;
 static const int32_t Q25_MIN_VALUE = ~Q25_MAX_VALUE;
@@ -73,5 +72,4 @@ void MicrophoneSource::process_audio_(const std::vector<uint8_t> &data, std::vec
   }
 }
 
-}  // namespace microphone
-}  // namespace esphome
+}  // namespace esphome::microphone

--- a/esphome/components/microphone/microphone_source.h
+++ b/esphome/components/microphone/microphone_source.h
@@ -9,8 +9,7 @@
 #include <cstdint>
 #include <vector>
 
-namespace esphome {
-namespace microphone {
+namespace esphome::microphone {
 
 static const int32_t MAX_GAIN_FACTOR = 64;
 
@@ -89,5 +88,4 @@ class MicrophoneSource {
   bool passive_;  // Only pass audio if ``mic_`` is already running
 };
 
-}  // namespace microphone
-}  // namespace esphome
+}  // namespace esphome::microphone

--- a/esphome/components/mics_4514/mics_4514.cpp
+++ b/esphome/components/mics_4514/mics_4514.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mics_4514 {
+namespace esphome::mics_4514 {
 
 static const char *const TAG = "mics_4514";
 
@@ -131,5 +130,4 @@ void MICS4514Component::update() {
   }
 }
 
-}  // namespace mics_4514
-}  // namespace esphome
+}  // namespace esphome::mics_4514

--- a/esphome/components/mics_4514/mics_4514.h
+++ b/esphome/components/mics_4514/mics_4514.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace mics_4514 {
+namespace esphome::mics_4514 {
 
 class MICS4514Component : public PollingComponent, public i2c::I2CDevice {
   SUB_SENSOR(carbon_monoxide)
@@ -29,5 +28,4 @@ class MICS4514Component : public PollingComponent, public i2c::I2CDevice {
   float red_calibration_{0};
 };
 
-}  // namespace mics_4514
-}  // namespace esphome
+}  // namespace esphome::mics_4514

--- a/esphome/components/midea/ac_adapter.cpp
+++ b/esphome/components/midea/ac_adapter.cpp
@@ -3,9 +3,7 @@
 #include "esphome/core/log.h"
 #include "ac_adapter.h"
 
-namespace esphome {
-namespace midea {
-namespace ac {
+namespace esphome::midea::ac {
 
 const char *const Constants::TAG = "midea";
 const char *const Constants::FREEZE_PROTECTION = "freeze protection";
@@ -172,8 +170,6 @@ void Converters::to_climate_traits(ClimateTraits &traits, const dudanov::midea::
   // since custom presets are stored on the Climate base class
 }
 
-}  // namespace ac
-}  // namespace midea
-}  // namespace esphome
+}  // namespace esphome::midea::ac
 
 #endif  // USE_ARDUINO

--- a/esphome/components/midea/ac_adapter.h
+++ b/esphome/components/midea/ac_adapter.h
@@ -8,9 +8,7 @@
 #include "esphome/components/climate/climate_traits.h"
 #include "air_conditioner.h"
 
-namespace esphome {
-namespace midea {
-namespace ac {
+namespace esphome::midea::ac {
 
 using MideaMode = dudanov::midea::ac::Mode;
 using MideaSwingMode = dudanov::midea::ac::SwingMode;
@@ -44,8 +42,6 @@ class Converters {
   static void to_climate_traits(ClimateTraits &traits, const dudanov::midea::ac::Capabilities &capabilities);
 };
 
-}  // namespace ac
-}  // namespace midea
-}  // namespace esphome
+}  // namespace esphome::midea::ac
 
 #endif  // USE_ARDUINO

--- a/esphome/components/midea/ac_automations.h
+++ b/esphome/components/midea/ac_automations.h
@@ -5,9 +5,7 @@
 #include "esphome/core/automation.h"
 #include "air_conditioner.h"
 
-namespace esphome {
-namespace midea {
-namespace ac {
+namespace esphome::midea::ac {
 
 template<typename... Ts> class MideaActionBase : public Action<Ts...> {
  public:
@@ -63,8 +61,6 @@ template<typename... Ts> class PowerToggleAction : public MideaActionBase<Ts...>
   void play(const Ts &...x) override { this->parent_->do_power_toggle(); }
 };
 
-}  // namespace ac
-}  // namespace midea
-}  // namespace esphome
+}  // namespace esphome::midea::ac
 
 #endif  // USE_ARDUINO

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -7,9 +7,7 @@
 #include <cmath>
 #include <cstdint>
 
-namespace esphome {
-namespace midea {
-namespace ac {
+namespace esphome::midea::ac {
 
 static void set_sensor(Sensor *sensor, float value) {
   if (sensor != nullptr && (!sensor->has_state() || sensor->get_raw_state() != value))
@@ -197,8 +195,6 @@ void AirConditioner::do_display_toggle() {
   }
 }
 
-}  // namespace ac
-}  // namespace midea
-}  // namespace esphome
+}  // namespace esphome::midea::ac
 
 #endif  // USE_ARDUINO

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -8,9 +8,7 @@
 #include "appliance_base.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace midea {
-namespace ac {
+namespace esphome::midea::ac {
 
 using sensor::Sensor;
 using climate::ClimateCall;
@@ -61,8 +59,6 @@ class AirConditioner : public ApplianceBase<dudanov::midea::ac::AirConditioner>,
   Sensor *power_sensor_{nullptr};
 };
 
-}  // namespace ac
-}  // namespace midea
-}  // namespace esphome
+}  // namespace esphome::midea::ac
 
 #endif  // USE_ARDUINO

--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -15,8 +15,7 @@
 #include "esphome/components/climate/climate.h"
 #include "ir_transmitter.h"
 
-namespace esphome {
-namespace midea {
+namespace esphome::midea {
 
 /* Stream from UART component */
 class UARTStream : public Stream {
@@ -98,7 +97,6 @@ template<typename T> class ApplianceBase : public Component {
 #endif
 };
 
-}  // namespace midea
-}  // namespace esphome
+}  // namespace esphome::midea
 
 #endif  // USE_ARDUINO

--- a/esphome/components/midea_ir/midea_data.h
+++ b/esphome/components/midea_ir/midea_data.h
@@ -3,8 +3,7 @@
 #include "esphome/components/remote_base/midea_protocol.h"
 #include "esphome/components/climate/climate_mode.h"
 
-namespace esphome {
-namespace midea_ir {
+namespace esphome::midea_ir {
 
 using climate::ClimateMode;
 using climate::ClimateFanMode;
@@ -88,5 +87,4 @@ class SpecialData : public MideaData {
   static const uint8_t TURBO_TOGGLE = 9;
 };
 
-}  // namespace midea_ir
-}  // namespace esphome
+}  // namespace esphome::midea_ir

--- a/esphome/components/midea_ir/midea_ir.cpp
+++ b/esphome/components/midea_ir/midea_ir.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include "esphome/components/coolix/coolix.h"
 
-namespace esphome {
-namespace midea_ir {
+namespace esphome::midea_ir {
 
 static const char *const TAG = "midea_ir.climate";
 
@@ -204,5 +203,4 @@ bool MideaIR::on_midea_(const MideaData &data) {
   return false;
 }
 
-}  // namespace midea_ir
-}  // namespace esphome
+}  // namespace esphome::midea_ir

--- a/esphome/components/midea_ir/midea_ir.h
+++ b/esphome/components/midea_ir/midea_ir.h
@@ -3,8 +3,7 @@
 #include "esphome/components/climate_ir/climate_ir.h"
 #include "midea_data.h"
 
-namespace esphome {
-namespace midea_ir {
+namespace esphome::midea_ir {
 
 // Temperature
 const uint8_t MIDEA_TEMPC_MIN = 17;  // Celsius
@@ -43,5 +42,4 @@ class MideaIR : public climate_ir::ClimateIR {
   bool boost_{false};
 };
 
-}  // namespace midea_ir
-}  // namespace esphome
+}  // namespace esphome::midea_ir

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -7,8 +7,7 @@
 #include "esphome/components/display/display_color_utils.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace mipi_spi {
+namespace esphome::mipi_spi {
 
 constexpr static const char *const TAG = "display.mipi_spi";
 
@@ -672,5 +671,4 @@ class MipiSpiBuffer : public MipiSpi<BUFFERTYPE, BUFFERPIXEL, IS_BIG_ENDIAN, DIS
   uint16_t end_line_{1};
 };
 
-}  // namespace mipi_spi
-}  // namespace esphome
+}  // namespace esphome::mipi_spi

--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mitsubishi {
+namespace esphome::mitsubishi {
 
 static const char *const TAG = "mitsubishi.climate";
 
@@ -402,5 +401,4 @@ bool MitsubishiClimate::on_receive(remote_base::RemoteReceiveData data) {
   return true;
 }
 
-}  // namespace mitsubishi
-}  // namespace esphome
+}  // namespace esphome::mitsubishi

--- a/esphome/components/mitsubishi/mitsubishi.h
+++ b/esphome/components/mitsubishi/mitsubishi.h
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace mitsubishi {
+namespace esphome::mitsubishi {
 
 // Temperature
 const uint8_t MITSUBISHI_TEMP_MIN = 16;  // Celsius
@@ -79,5 +78,4 @@ class MitsubishiClimate : public climate_ir::ClimateIR {
   climate::ClimateTraits traits() override;
 };
 
-}  // namespace mitsubishi
-}  // namespace esphome
+}  // namespace esphome::mitsubishi

--- a/esphome/components/mixer/speaker/automation.h
+++ b/esphome/components/mixer/speaker/automation.h
@@ -5,8 +5,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace mixer_speaker {
+namespace esphome::mixer_speaker {
 template<typename... Ts> class DuckingApplyAction : public Action<Ts...>, public Parented<SourceSpeaker> {
   TEMPLATABLE_VALUE(uint8_t, decibel_reduction);
   TEMPLATABLE_VALUE(uint32_t, duration);
@@ -14,7 +13,6 @@ template<typename... Ts> class DuckingApplyAction : public Action<Ts...>, public
     this->parent_->apply_ducking(this->decibel_reduction_.value(x...), this->duration_.value(x...));
   }
 };
-}  // namespace mixer_speaker
-}  // namespace esphome
+}  // namespace esphome::mixer_speaker
 
 #endif

--- a/esphome/components/mlx90393/sensor_mlx90393.cpp
+++ b/esphome/components/mlx90393/sensor_mlx90393.cpp
@@ -1,8 +1,7 @@
 #include "sensor_mlx90393.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mlx90393 {
+namespace esphome::mlx90393 {
 
 static const char *const TAG = "mlx90393";
 
@@ -270,5 +269,4 @@ void MLX90393Cls::verify_settings_timeout_(MLX90393Setting stage) {
   this->set_timeout("verify settings", 3000, [this, next_stage]() { this->verify_settings_timeout_(next_stage); });
 }
 
-}  // namespace mlx90393
-}  // namespace esphome
+}  // namespace esphome::mlx90393

--- a/esphome/components/mlx90393/sensor_mlx90393.h
+++ b/esphome/components/mlx90393/sensor_mlx90393.h
@@ -7,8 +7,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace mlx90393 {
+namespace esphome::mlx90393 {
 
 enum MLX90393Setting {
   MLX90393_GAIN_SEL = 0,
@@ -76,5 +75,4 @@ class MLX90393Cls : public PollingComponent, public i2c::I2CDevice, public MLX90
   void verify_settings_timeout_(MLX90393Setting stage);
 };
 
-}  // namespace mlx90393
-}  // namespace esphome
+}  // namespace esphome::mlx90393

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mlx90614 {
+namespace esphome::mlx90614 {
 
 static const uint8_t MLX90614_RAW_IR_1 = 0x04;
 static const uint8_t MLX90614_RAW_IR_2 = 0x05;
@@ -101,5 +100,4 @@ void MLX90614Component::update() {
   this->status_clear_warning();
 }
 
-}  // namespace mlx90614
-}  // namespace esphome
+}  // namespace esphome::mlx90614

--- a/esphome/components/mlx90614/mlx90614.h
+++ b/esphome/components/mlx90614/mlx90614.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace mlx90614 {
+namespace esphome::mlx90614 {
 
 class MLX90614Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -28,5 +27,4 @@ class MLX90614Component : public PollingComponent, public i2c::I2CDevice {
 
   float emissivity_{NAN};
 };
-}  // namespace mlx90614
-}  // namespace esphome
+}  // namespace esphome::mlx90614

--- a/esphome/components/mmc5603/mmc5603.cpp
+++ b/esphome/components/mmc5603/mmc5603.cpp
@@ -1,8 +1,7 @@
 #include "mmc5603.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mmc5603 {
+namespace esphome::mmc5603 {
 
 static const char *const TAG = "mmc5603";
 static const uint8_t MMC5603_ADDRESS = 0x30;
@@ -157,5 +156,4 @@ void MMC5603Component::update() {
     this->heading_sensor_->publish_state(heading);
 }
 
-}  // namespace mmc5603
-}  // namespace esphome
+}  // namespace esphome::mmc5603

--- a/esphome/components/mmc5603/mmc5603.h
+++ b/esphome/components/mmc5603/mmc5603.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mmc5603 {
+namespace esphome::mmc5603 {
 
 enum MMC5603Datarate {
   MMC5603_DATARATE_75_0_HZ,
@@ -40,5 +39,4 @@ class MMC5603Component : public PollingComponent, public i2c::I2CDevice {
   } error_code_{NONE};
 };
 
-}  // namespace mmc5603
-}  // namespace esphome
+}  // namespace esphome::mmc5603

--- a/esphome/components/mmc5983/mmc5983.cpp
+++ b/esphome/components/mmc5983/mmc5983.cpp
@@ -4,8 +4,7 @@
 #include "mmc5983.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mmc5983 {
+namespace esphome::mmc5983 {
 
 static const char *const TAG = "mmc5983";
 
@@ -133,5 +132,4 @@ void MMC5983Component::dump_config() {
   LOG_SENSOR("  ", "Z", this->z_sensor_);
 }
 
-}  // namespace mmc5983
-}  // namespace esphome
+}  // namespace esphome::mmc5983

--- a/esphome/components/mmc5983/mmc5983.h
+++ b/esphome/components/mmc5983/mmc5983.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mmc5983 {
+namespace esphome::mmc5983 {
 
 class MMC5983Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -23,5 +22,4 @@ class MMC5983Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *z_sensor_{nullptr};
 };
 
-}  // namespace mmc5983
-}  // namespace esphome
+}  // namespace esphome::mmc5983

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace modbus {
+namespace esphome::modbus {
 
 static const char *const TAG = "modbus";
 
@@ -425,5 +424,4 @@ void Modbus::clear_rx_buffer_(const LogString *reason, bool warn) {
   }
 }
 
-}  // namespace modbus
-}  // namespace esphome
+}  // namespace esphome::modbus

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -10,8 +10,7 @@
 #include <vector>
 #include <queue>
 
-namespace esphome {
-namespace modbus {
+namespace esphome::modbus {
 
 static constexpr uint16_t MODBUS_TX_BUFFER_SIZE = 15;
 
@@ -122,5 +121,4 @@ class ModbusDevice {
   uint8_t address_;
 };
 
-}  // namespace modbus
-}  // namespace esphome
+}  // namespace esphome::modbus

--- a/esphome/components/modbus/modbus_definitions.h
+++ b/esphome/components/modbus/modbus_definitions.h
@@ -2,8 +2,7 @@
 
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace modbus {
+namespace esphome::modbus {
 
 /// Modbus definitions from specs:
 /// https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf
@@ -84,5 +83,4 @@ const uint8_t MAX_NUM_OF_REGISTERS_TO_READ = 125;  // 0x7D
 
 static constexpr uint16_t MAX_FRAME_SIZE = 256;
 /// End of Modbus definitions
-}  // namespace modbus
-}  // namespace esphome
+}  // namespace esphome::modbus

--- a/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.cpp
+++ b/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.cpp
@@ -1,8 +1,7 @@
 #include "modbus_binarysensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 static const char *const TAG = "modbus_controller.binary_sensor";
 
@@ -34,5 +33,4 @@ void ModbusBinarySensor::parse_and_publish(const std::vector<uint8_t> &data) {
   this->publish_state(value);
 }
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
+++ b/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 class ModbusBinarySensor : public Component, public binary_sensor::BinarySensor, public SensorItem {
  public:
@@ -40,5 +39,4 @@ class ModbusBinarySensor : public Component, public binary_sensor::BinarySensor,
   optional<transform_func_t> transform_func_{nullopt};
 };
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 static const char *const TAG = "modbus_controller";
 
@@ -539,5 +538,4 @@ bool ModbusCommandItem::is_equal(const ModbusCommandItem &other) {
                    other.register_type == this->register_type && other.function_code == this->function_code;
 }
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -12,8 +12,7 @@
 #include <utility>
 #include <vector>
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 class ModbusController;
 
@@ -391,5 +390,4 @@ inline float payload_to_float(const std::vector<uint8_t> &data, const SensorItem
   return float_value;
 }
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/number/modbus_number.cpp
+++ b/esphome/components/modbus_controller/number/modbus_number.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 static const char *const TAG = "modbus.number";
 
@@ -90,5 +89,4 @@ void ModbusNumber::control(float value) {
 }
 void ModbusNumber::dump_config() { LOG_NUMBER(TAG, "Modbus Number", this); }
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/number/modbus_number.h
+++ b/esphome/components/modbus_controller/number/modbus_number.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 using value_to_data_t = std::function<float>(float);
 
@@ -46,5 +45,4 @@ class ModbusNumber : public number::Number, public Component, public SensorItem 
   bool use_write_multiple_{false};
 };
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 static const char *const TAG = "modbus_controller.output";
 
@@ -118,5 +117,4 @@ void ModbusBinaryOutput::dump_config() {
                 this->start_address, this->register_count, static_cast<int>(this->sensor_value_type));
 }
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/output/modbus_output.h
+++ b/esphome/components/modbus_controller/output/modbus_output.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 class ModbusFloatOutput : public output::FloatOutput, public Component, public SensorItem {
  public:
@@ -72,5 +71,4 @@ class ModbusBinaryOutput : public output::BinaryOutput, public Component, public
   bool use_write_multiple_{false};
 };
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -1,8 +1,7 @@
 #include "modbus_select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 static const char *const TAG = "modbus_controller.select";
 
@@ -86,5 +85,4 @@ void ModbusSelect::control(size_t index) {
     this->publish_state(index);
 }
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -7,8 +7,7 @@
 #include "esphome/components/select/select.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 class ModbusSelect : public Component, public select::Select, public SensorItem {
  public:
@@ -49,5 +48,4 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
   optional<write_transform_func_t> write_transform_func_{nullopt};
 };
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/sensor/modbus_sensor.cpp
+++ b/esphome/components/modbus_controller/sensor/modbus_sensor.cpp
@@ -2,8 +2,7 @@
 #include "modbus_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 static const char *const TAG = "modbus_controller.sensor";
 
@@ -27,5 +26,4 @@ void ModbusSensor::parse_and_publish(const std::vector<uint8_t> &data) {
   this->publish_state(result);
 }
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/sensor/modbus_sensor.h
+++ b/esphome/components/modbus_controller/sensor/modbus_sensor.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 class ModbusSensor : public Component, public sensor::Sensor, public SensorItem {
  public:
@@ -33,5 +32,4 @@ class ModbusSensor : public Component, public sensor::Sensor, public SensorItem 
   optional<transform_func_t> transform_func_{nullopt};
 };
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/switch/modbus_switch.cpp
+++ b/esphome/components/modbus_controller/switch/modbus_switch.cpp
@@ -2,8 +2,8 @@
 #include "modbus_switch.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-namespace esphome {
-namespace modbus_controller {
+
+namespace esphome::modbus_controller {
 
 static const char *const TAG = "modbus_controller.switch";
 
@@ -112,5 +112,4 @@ void ModbusSwitch::write_state(bool state) {
   this->publish_state(state);
 }
 // ModbusSwitch end
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/switch/modbus_switch.h
+++ b/esphome/components/modbus_controller/switch/modbus_switch.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 class ModbusSwitch : public Component, public switch_::Switch, public SensorItem {
  public:
@@ -49,5 +48,4 @@ class ModbusSwitch : public Component, public switch_::Switch, public SensorItem
   bool assumed_state_{false};
 };
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -2,8 +2,7 @@
 #include "modbus_textsensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 static const char *const TAG = "modbus_controller.text_sensor";
 
@@ -56,5 +55,4 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
   this->publish_state(output_str);
 }
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace modbus_controller {
+namespace esphome::modbus_controller {
 
 enum class RawEncoding { NONE = 0, HEXBYTES = 1, COMMA = 2, ANSI = 3 };
 
@@ -39,5 +38,4 @@ class ModbusTextSensor : public Component, public text_sensor::TextSensor, publi
   RawEncoding encode_;
 };
 
-}  // namespace modbus_controller
-}  // namespace esphome
+}  // namespace esphome::modbus_controller

--- a/esphome/components/monochromatic/monochromatic_light_output.h
+++ b/esphome/components/monochromatic/monochromatic_light_output.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/components/light/light_output.h"
 
-namespace esphome {
-namespace monochromatic {
+namespace esphome::monochromatic {
 
 class MonochromaticLightOutput : public light::LightOutput {
  public:
@@ -25,5 +24,4 @@ class MonochromaticLightOutput : public light::LightOutput {
   output::FloatOutput *output_;
 };
 
-}  // namespace monochromatic
-}  // namespace esphome
+}  // namespace esphome::monochromatic

--- a/esphome/components/mopeka_ble/mopeka_ble.cpp
+++ b/esphome/components/mopeka_ble/mopeka_ble.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace mopeka_ble {
+namespace esphome::mopeka_ble {
 
 static const char *const TAG = "mopeka_ble";
 
@@ -86,7 +85,6 @@ bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   return false;
 }
 
-}  // namespace mopeka_ble
-}  // namespace esphome
+}  // namespace esphome::mopeka_ble
 
 #endif

--- a/esphome/components/mopeka_ble/mopeka_ble.h
+++ b/esphome/components/mopeka_ble/mopeka_ble.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace mopeka_ble {
+namespace esphome::mopeka_ble {
 
 class MopekaListener : public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -21,7 +20,6 @@ class MopekaListener : public esp32_ble_tracker::ESPBTDeviceListener {
   bool show_sensors_without_sync_;
 };
 
-}  // namespace mopeka_ble
-}  // namespace esphome
+}  // namespace esphome::mopeka_ble
 
 #endif

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace mopeka_pro_check {
+namespace esphome::mopeka_pro_check {
 
 static const char *const TAG = "mopeka_pro_check";
 static const uint8_t MANUFACTURER_DATA_LENGTH = 10;
@@ -154,7 +153,6 @@ SensorReadQuality MopekaProCheck::parse_read_quality_(const std::vector<uint8_t>
   return static_cast<SensorReadQuality>(message[4] >> 6);
 }
 
-}  // namespace mopeka_pro_check
-}  // namespace esphome
+}  // namespace esphome::mopeka_pro_check
 
 #endif

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.h
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.h
@@ -9,8 +9,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace mopeka_pro_check {
+namespace esphome::mopeka_pro_check {
 
 enum SensorType {
   STANDARD_BOTTOM_UP = 0x03,
@@ -65,7 +64,6 @@ class MopekaProCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   SensorReadQuality parse_read_quality_(const std::vector<uint8_t> &message);
 };
 
-}  // namespace mopeka_pro_check
-}  // namespace esphome
+}  // namespace esphome::mopeka_pro_check
 
 #endif

--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -5,8 +5,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace mopeka_std_check {
+namespace esphome::mopeka_std_check {
 
 static const char *const TAG = "mopeka_std_check";
 static const uint16_t SERVICE_UUID = 0xADA0;
@@ -232,7 +231,6 @@ int8_t MopekaStdCheck::parse_temperature_(const mopeka_std_package *message) {
   }
 }
 
-}  // namespace mopeka_std_check
-}  // namespace esphome
+}  // namespace esphome::mopeka_std_check
 
 #endif

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -9,8 +9,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace mopeka_std_check {
+namespace esphome::mopeka_std_check {
 
 enum SensorType {
   STANDARD = 0x02,
@@ -74,7 +73,6 @@ class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   int8_t parse_temperature_(const mopeka_std_package *message);
 };
 
-}  // namespace mopeka_std_check
-}  // namespace esphome
+}  // namespace esphome::mopeka_std_check
 
 #endif

--- a/esphome/components/mpl3115a2/mpl3115a2.cpp
+++ b/esphome/components/mpl3115a2/mpl3115a2.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mpl3115a2 {
+namespace esphome::mpl3115a2 {
 
 static const char *const TAG = "mpl3115a2";
 
@@ -94,5 +93,4 @@ void MPL3115A2Component::update() {
   this->status_clear_warning();
 }
 
-}  // namespace mpl3115a2
-}  // namespace esphome
+}  // namespace esphome::mpl3115a2

--- a/esphome/components/mpl3115a2/mpl3115a2.h
+++ b/esphome/components/mpl3115a2/mpl3115a2.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mpl3115a2 {
+namespace esphome::mpl3115a2 {
 
 // enums from https://github.com/adafruit/Adafruit_MPL3115A2_Library/
 /** MPL3115A2 registers **/
@@ -102,5 +101,4 @@ class MPL3115A2Component : public PollingComponent, public i2c::I2CDevice {
   } error_code_{NONE};
 };
 
-}  // namespace mpl3115a2
-}  // namespace esphome
+}  // namespace esphome::mpl3115a2

--- a/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.cpp
+++ b/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.cpp
@@ -1,7 +1,6 @@
 #include "mpr121_binary_sensor.h"
 
-namespace esphome {
-namespace mpr121 {
+namespace esphome::mpr121 {
 
 void MPR121BinarySensor::setup() {
   uint8_t touch_threshold = this->touch_threshold_.value_or(this->parent_->get_touch_threshold());
@@ -16,5 +15,4 @@ void MPR121BinarySensor::process(uint16_t data) {
   this->publish_state(new_state);
 }
 
-}  // namespace mpr121
-}  // namespace esphome
+}  // namespace esphome::mpr121

--- a/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.h
+++ b/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.h
@@ -4,8 +4,7 @@
 
 #include "../mpr121.h"
 
-namespace esphome {
-namespace mpr121 {
+namespace esphome::mpr121 {
 
 class MPR121BinarySensor : public binary_sensor::BinarySensor, public MPR121Channel, public Parented<MPR121Component> {
  public:
@@ -22,5 +21,4 @@ class MPR121BinarySensor : public binary_sensor::BinarySensor, public MPR121Chan
   optional<uint8_t> release_threshold_{};
 };
 
-}  // namespace mpr121
-}  // namespace esphome
+}  // namespace esphome::mpr121

--- a/esphome/components/mpr121/mpr121.cpp
+++ b/esphome/components/mpr121/mpr121.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mpr121 {
+namespace esphome::mpr121 {
 
 static const char *const TAG = "mpr121";
 
@@ -157,5 +156,4 @@ size_t MPR121GPIOPin::dump_summary(char *buffer, size_t len) const {
   return buf_append_printf(buffer, len, 0, "ELE%u on MPR121", this->pin_);
 }
 
-}  // namespace mpr121
-}  // namespace esphome
+}  // namespace esphome::mpr121

--- a/esphome/components/mpr121/mpr121.h
+++ b/esphome/components/mpr121/mpr121.h
@@ -8,8 +8,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace mpr121 {
+namespace esphome::mpr121 {
 
 enum {
   MPR121_TOUCHSTATUS_L = 0x00,
@@ -125,5 +124,4 @@ class MPR121GPIOPin : public GPIOPin {
   gpio::Flags flags_;
 };
 
-}  // namespace mpr121
-}  // namespace esphome
+}  // namespace esphome::mpr121

--- a/esphome/components/mpu6050/mpu6050.cpp
+++ b/esphome/components/mpu6050/mpu6050.cpp
@@ -1,8 +1,7 @@
 #include "mpu6050.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mpu6050 {
+namespace esphome::mpu6050 {
 
 static const char *const TAG = "mpu6050";
 
@@ -141,5 +140,4 @@ void MPU6050Component::update() {
   this->status_clear_warning();
 }
 
-}  // namespace mpu6050
-}  // namespace esphome
+}  // namespace esphome::mpu6050

--- a/esphome/components/mpu6050/mpu6050.h
+++ b/esphome/components/mpu6050/mpu6050.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mpu6050 {
+namespace esphome::mpu6050 {
 
 class MPU6050Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -33,5 +32,4 @@ class MPU6050Component : public PollingComponent, public i2c::I2CDevice {
 };
 ;
 
-}  // namespace mpu6050
-}  // namespace esphome
+}  // namespace esphome::mpu6050

--- a/esphome/components/mpu6050/mpu6050.h
+++ b/esphome/components/mpu6050/mpu6050.h
@@ -30,6 +30,5 @@ class MPU6050Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *gyro_y_sensor_{nullptr};
   sensor::Sensor *gyro_z_sensor_{nullptr};
 };
-;
 
 }  // namespace esphome::mpu6050

--- a/esphome/components/mpu6886/mpu6886.cpp
+++ b/esphome/components/mpu6886/mpu6886.cpp
@@ -1,8 +1,7 @@
 #include "mpu6886.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mpu6886 {
+namespace esphome::mpu6886 {
 
 static const char *const TAG = "mpu6886";
 
@@ -146,5 +145,4 @@ void MPU6886Component::update() {
   this->status_clear_warning();
 }
 
-}  // namespace mpu6886
-}  // namespace esphome
+}  // namespace esphome::mpu6886

--- a/esphome/components/mpu6886/mpu6886.h
+++ b/esphome/components/mpu6886/mpu6886.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace mpu6886 {
+namespace esphome::mpu6886 {
 
 class MPU6886Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -33,5 +32,4 @@ class MPU6886Component : public PollingComponent, public i2c::I2CDevice {
 };
 ;
 
-}  // namespace mpu6886
-}  // namespace esphome
+}  // namespace esphome::mpu6886

--- a/esphome/components/mpu6886/mpu6886.h
+++ b/esphome/components/mpu6886/mpu6886.h
@@ -30,6 +30,5 @@ class MPU6886Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *gyro_y_sensor_{nullptr};
   sensor::Sensor *gyro_z_sensor_{nullptr};
 };
-;
 
 }  // namespace esphome::mpu6886

--- a/esphome/components/mqtt_subscribe/sensor/mqtt_subscribe_sensor.cpp
+++ b/esphome/components/mqtt_subscribe/sensor/mqtt_subscribe_sensor.cpp
@@ -4,8 +4,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mqtt_subscribe {
+namespace esphome::mqtt_subscribe {
 
 static const char *const TAG = "mqtt_subscribe.sensor";
 
@@ -32,7 +31,6 @@ void MQTTSubscribeSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "  Topic: %s", this->topic_.c_str());
 }
 
-}  // namespace mqtt_subscribe
-}  // namespace esphome
+}  // namespace esphome::mqtt_subscribe
 
 #endif  // USE_MQTT

--- a/esphome/components/mqtt_subscribe/sensor/mqtt_subscribe_sensor.h
+++ b/esphome/components/mqtt_subscribe/sensor/mqtt_subscribe_sensor.h
@@ -8,8 +8,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/mqtt/mqtt_client.h"
 
-namespace esphome {
-namespace mqtt_subscribe {
+namespace esphome::mqtt_subscribe {
 
 class MQTTSubscribeSensor : public sensor::Sensor, public Component {
  public:
@@ -27,7 +26,6 @@ class MQTTSubscribeSensor : public sensor::Sensor, public Component {
   uint8_t qos_{0};
 };
 
-}  // namespace mqtt_subscribe
-}  // namespace esphome
+}  // namespace esphome::mqtt_subscribe
 
 #endif  // USE_MQTT

--- a/esphome/components/mqtt_subscribe/text_sensor/mqtt_subscribe_text_sensor.cpp
+++ b/esphome/components/mqtt_subscribe/text_sensor/mqtt_subscribe_text_sensor.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/log.h"
 #include <utility>
 
-namespace esphome {
-namespace mqtt_subscribe {
+namespace esphome::mqtt_subscribe {
 
 static const char *const TAG = "mqtt_subscribe.text_sensor";
 
@@ -22,7 +21,6 @@ void MQTTSubscribeTextSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "  Topic: %s", this->topic_.c_str());
 }
 
-}  // namespace mqtt_subscribe
-}  // namespace esphome
+}  // namespace esphome::mqtt_subscribe
 
 #endif  // USE_MQTT

--- a/esphome/components/mqtt_subscribe/text_sensor/mqtt_subscribe_text_sensor.h
+++ b/esphome/components/mqtt_subscribe/text_sensor/mqtt_subscribe_text_sensor.h
@@ -8,8 +8,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/mqtt/mqtt_client.h"
 
-namespace esphome {
-namespace mqtt_subscribe {
+namespace esphome::mqtt_subscribe {
 
 class MQTTSubscribeTextSensor : public text_sensor::TextSensor, public Component {
  public:
@@ -26,7 +25,6 @@ class MQTTSubscribeTextSensor : public text_sensor::TextSensor, public Component
   uint8_t qos_{};
 };
 
-}  // namespace mqtt_subscribe
-}  // namespace esphome
+}  // namespace esphome::mqtt_subscribe
 
 #endif  // USE_MQTT

--- a/esphome/components/ms5611/ms5611.cpp
+++ b/esphome/components/ms5611/ms5611.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace ms5611 {
+namespace esphome::ms5611 {
 
 static const char *const TAG = "ms5611";
 
@@ -123,5 +122,4 @@ void MS5611Component::calculate_values_(uint32_t raw_temperature, uint32_t raw_p
   this->status_clear_warning();
 }
 
-}  // namespace ms5611
-}  // namespace esphome
+}  // namespace esphome::ms5611

--- a/esphome/components/ms5611/ms5611.h
+++ b/esphome/components/ms5611/ms5611.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ms5611 {
+namespace esphome::ms5611 {
 
 class MS5611Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -26,5 +25,4 @@ class MS5611Component : public PollingComponent, public i2c::I2CDevice {
   uint16_t prom_[6];
 };
 
-}  // namespace ms5611
-}  // namespace esphome
+}  // namespace esphome::ms5611

--- a/esphome/components/ms8607/ms8607.cpp
+++ b/esphome/components/ms8607/ms8607.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ms8607 {
+namespace esphome::ms8607 {
 
 /// TAG used for logging calls
 static const char *const TAG = "ms8607";
@@ -438,5 +437,4 @@ void MS8607Component::calculate_values_(uint32_t d2_raw_temperature, uint32_t d1
   }
 }
 
-}  // namespace ms8607
-}  // namespace esphome
+}  // namespace esphome::ms8607

--- a/esphome/components/ms8607/ms8607.h
+++ b/esphome/components/ms8607/ms8607.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ms8607 {
+namespace esphome::ms8607 {
 
 /**
  Class for I2CDevice used to communicate with the Humidity sensor
@@ -108,5 +107,4 @@ class MS8607Component : public PollingComponent, public i2c::I2CDevice {
   uint8_t reset_attempts_remaining_{0};
 };
 
-}  // namespace ms8607
-}  // namespace esphome
+}  // namespace esphome::ms8607

--- a/esphome/components/msa3xx/msa3xx.cpp
+++ b/esphome/components/msa3xx/msa3xx.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace msa3xx {
+namespace esphome::msa3xx {
 
 static const char *const TAG = "msa3xx";
 
@@ -410,5 +409,4 @@ void MSA3xxComponent::process_motions_(RegMotionInterrupt old) {
   }
 }
 
-}  // namespace msa3xx
-}  // namespace esphome
+}  // namespace esphome::msa3xx

--- a/esphome/components/msa3xx/msa3xx.h
+++ b/esphome/components/msa3xx/msa3xx.h
@@ -14,8 +14,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #endif
 
-namespace esphome {
-namespace msa3xx {
+namespace esphome::msa3xx {
 
 // Combined register map of MSA301 and MSA311
 // Differences
@@ -305,5 +304,4 @@ class MSA3xxComponent : public PollingComponent, public i2c::I2CDevice {
   void process_motions_(RegMotionInterrupt old);
 };
 
-}  // namespace msa3xx
-}  // namespace esphome
+}  // namespace esphome::msa3xx

--- a/esphome/components/my9231/my9231.cpp
+++ b/esphome/components/my9231/my9231.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace my9231 {
+namespace esphome::my9231 {
 
 static const char *const TAG = "my9231.output";
 
@@ -123,5 +122,4 @@ void MY9231OutputComponent::send_dcki_pulses_(uint8_t count) {
   }
 }
 
-}  // namespace my9231
-}  // namespace esphome
+}  // namespace esphome::my9231

--- a/esphome/components/my9231/my9231.h
+++ b/esphome/components/my9231/my9231.h
@@ -5,8 +5,7 @@
 #include "esphome/components/output/float_output.h"
 #include <vector>
 
-namespace esphome {
-namespace my9231 {
+namespace esphome::my9231 {
 
 /// MY9231 float output component.
 class MY9231OutputComponent : public Component {
@@ -60,5 +59,4 @@ class MY9231OutputComponent : public Component {
   bool update_{true};
 };
 
-}  // namespace my9231
-}  // namespace esphome
+}  // namespace esphome::my9231


### PR DESCRIPTION
# What does this implement/fix?

Mechanical conversion of `namespace foo { namespace bar { ... } }` to `namespace foo::bar { ... }` (C++17 nested namespace concatenation), applied via `clang-tidy --fix` with `modernize-concat-nested-namespaces` temporarily re-enabled, followed by `clang-format`. **No semantic changes.**

This is **part 3 of 7** for the cleanup tracked in [esphome/backlog#114](https://github.com/esphome/backlog/issues/114), toward enabling `modernize-concat-nested-namespaces` project-wide and matching the convention already documented in `CLAUDE.md`. Splitting by component letter range to keep each PR reviewable.

The `.clang-tidy` disable line stays in place until the final PR so CI remains green throughout the rollout.

## Scope of this PR

- `esphome/components/[i-m]/` — 250 files

## Note on lvgl_proxy.h

`esphome/components/lvgl/lvgl_proxy.h` had an empty `namespace esphome { namespace lvgl {} }` placeholder whose only purpose was to satisfy `script/ci-custom.py`'s namespace lint rule. The auto-fix collapsed it into nothing, so it was restored as `namespace esphome::lvgl {}` (the concatenated form the lint rule explicitly accepts).

## Reproduction

```bash
# remove the disable line from .clang-tidy
# then:
script/clang-tidy --fix --environment esp32-arduino-tidy --all-headers
git ls-files 'esphome/components/[i-m]*/**' | xargs clang-format -i
```

## Series

- 1/7 components a-c — #16294
- 2/7 components d-h — #16295
- 3/7 components i-m (this PR)
- 4/7 components n-r
- 5/7 components s
- 6/7 components t-z
- 7/7 tests + drop the `.clang-tidy` disable line

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/backlog#114

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

(Mechanical, no platform-specific code paths affected.)

## Example entry for config.yaml:

```yaml
# n/a
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under tests/ folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).