### PR TITLE
[clang-tidy] Concatenate nested namespaces (4/7: components n-r)

### DIFF
--- a/esphome/components/nau7802/nau7802.cpp
+++ b/esphome/components/nau7802/nau7802.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace nau7802 {
+namespace esphome::nau7802 {
 
 static const char *const TAG = "nau7802";
 
@@ -313,5 +312,4 @@ void NAU7802Sensor::update() {
 
 bool NAU7802Sensor::is_data_ready_() { return this->reg(PU_CTRL_REG).get() & PU_CTRL_CYCLE_READY; }
 
-}  // namespace nau7802
-}  // namespace esphome
+}  // namespace esphome::nau7802

--- a/esphome/components/nau7802/nau7802.h
+++ b/esphome/components/nau7802/nau7802.h
@@ -7,8 +7,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace nau7802 {
+namespace esphome::nau7802 {
 
 enum NAU7802Gain {
   NAU7802_GAIN_128 = 0b111,
@@ -114,5 +113,4 @@ template<typename... Ts> class NAU7802CalbrateGainAction : public Action<Ts...>,
   void play(const Ts &...x) override { this->parent_->calibrate_gain(); }
 };
 
-}  // namespace nau7802
-}  // namespace esphome
+}  // namespace esphome::nau7802

--- a/esphome/components/nfc/automation.cpp
+++ b/esphome/components/nfc/automation.cpp
@@ -1,13 +1,11 @@
 #include "automation.h"
 #include "nfc.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 void NfcOnTagTrigger::process(const std::unique_ptr<NfcTag> &tag) {
   char uid_buf[FORMAT_UID_BUFFER_SIZE];
   this->trigger(std::string(format_uid_to(uid_buf, tag->get_uid())), *tag);
 }
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/automation.h
+++ b/esphome/components/nfc/automation.h
@@ -5,13 +5,11 @@
 
 #include "nfc.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 class NfcOnTagTrigger : public Trigger<std::string, NfcTag> {
  public:
   void process(const std::unique_ptr<NfcTag> &tag);
 };
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/binary_sensor/nfc_binary_sensor.cpp
+++ b/esphome/components/nfc/binary_sensor/nfc_binary_sensor.cpp
@@ -3,8 +3,7 @@
 #include "../nfc_helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static const char *const TAG = "nfc.binary_sensor";
 
@@ -112,5 +111,4 @@ void NfcTagBinarySensor::tag_on(NfcTag &tag) {
   }
 }
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/binary_sensor/nfc_binary_sensor.h
+++ b/esphome/components/nfc/binary_sensor/nfc_binary_sensor.h
@@ -6,8 +6,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 class NfcTagBinarySensor : public binary_sensor::BinarySensor,
                            public Component,
@@ -34,5 +33,4 @@ class NfcTagBinarySensor : public binary_sensor::BinarySensor,
   NfcTagUid uid_;
 };
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/nci_core.h
+++ b/esphome/components/nfc/nci_core.h
@@ -4,8 +4,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 // Header info
 static constexpr uint8_t NCI_PKT_HEADER_SIZE = 3;     // NCI packet (pkt) headers are always three bytes
@@ -140,5 +139,4 @@ static constexpr uint8_t RF_INTF_ACTIVATED_NTF_INIT_CRED = 5 + NCI_PKT_HEADER_SI
 static constexpr uint8_t RF_INTF_ACTIVATED_NTF_RF_TECH_LENGTH = 6 + NCI_PKT_HEADER_SIZE;
 static constexpr uint8_t RF_INTF_ACTIVATED_NTF_RF_TECH_PARAMS = 7 + NCI_PKT_HEADER_SIZE;
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/nci_message.cpp
+++ b/esphome/components/nfc/nci_message.cpp
@@ -4,8 +4,7 @@
 
 #include <cstdio>
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static const char *const TAG = "NciMessage";
 
@@ -162,5 +161,4 @@ void NciMessage::set_payload(const std::vector<uint8_t> &payload) {
   this->nci_message_ = message;
 }
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/nci_message.h
+++ b/esphome/components/nfc/nci_message.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 class NciMessage {
  public:
@@ -46,5 +45,4 @@ class NciMessage {
   std::vector<uint8_t> nci_message_{0, 0, 0};  // three bytes, MT/PBF/GID, OID, payload length/size
 };
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -1,8 +1,7 @@
 #include "ndef_message.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static const char *const TAG = "nfc.ndef_message";
 
@@ -120,5 +119,4 @@ std::vector<uint8_t> NdefMessage::encode() {
   return data;
 }
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/ndef_message.h
+++ b/esphome/components/nfc/ndef_message.h
@@ -9,8 +9,7 @@
 #include "ndef_record_text.h"
 #include "ndef_record_uri.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static constexpr uint8_t MAX_NDEF_RECORDS = 4;
 
@@ -38,5 +37,4 @@ class NdefMessage {
   std::vector<std::shared_ptr<NdefRecord>> records_;
 };
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/ndef_record.cpp
+++ b/esphome/components/nfc/ndef_record.cpp
@@ -1,7 +1,6 @@
 #include "ndef_record.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static const char *const TAG = "nfc.ndef_record";
 
@@ -61,5 +60,4 @@ uint8_t NdefRecord::create_flag_byte(bool first, bool last, size_t payload_size)
   return value;
 };
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/ndef_record.h
+++ b/esphome/components/nfc/ndef_record.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static constexpr uint8_t TNF_EMPTY = 0x00;
 static constexpr uint8_t TNF_WELL_KNOWN = 0x01;
@@ -53,5 +52,4 @@ class NdefRecord {
   std::string payload_;
 };
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/ndef_record_text.cpp
+++ b/esphome/components/nfc/ndef_record_text.cpp
@@ -1,8 +1,7 @@
 #include "ndef_record_text.h"
 #include "ndef_record.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static const char *const TAG = "nfc.ndef_record_text";
 
@@ -41,5 +40,4 @@ std::vector<uint8_t> NdefRecordText::get_encoded_payload() {
   return data;
 }
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/ndef_record_text.h
+++ b/esphome/components/nfc/ndef_record_text.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 class NdefRecordText : public NdefRecord {
  public:
@@ -39,5 +38,4 @@ class NdefRecordText : public NdefRecord {
   std::string language_code_;
 };
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/ndef_record_uri.cpp
+++ b/esphome/components/nfc/ndef_record_uri.cpp
@@ -1,7 +1,6 @@
 #include "ndef_record_uri.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static const char *const TAG = "nfc.ndef_record_uri";
 
@@ -44,5 +43,4 @@ std::vector<uint8_t> NdefRecordUri::get_encoded_payload() {
   return data;
 }
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/ndef_record_uri.h
+++ b/esphome/components/nfc/ndef_record_uri.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static constexpr uint8_t PAYLOAD_IDENTIFIERS_COUNT = 0x23;
 static const char *const PAYLOAD_IDENTIFIERS[] = {"",
@@ -74,5 +73,4 @@ class NdefRecordUri : public NdefRecord {
   std::string uri_;
 };
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static const char *const TAG = "nfc";
 
@@ -108,5 +107,4 @@ bool mifare_classic_is_trailer_block(uint8_t block_num) {
   }
 }
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -9,8 +9,7 @@
 #include <span>
 #include <vector>
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static constexpr uint8_t MIFARE_CLASSIC_BLOCK_SIZE = 16;
 static constexpr uint8_t MIFARE_CLASSIC_LONG_TLV_SIZE = 4;
@@ -95,5 +94,4 @@ class Nfcc {
   std::vector<NfcTagListener *> tag_listeners_;
 };
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/nfc_helpers.cpp
+++ b/esphome/components/nfc/nfc_helpers.cpp
@@ -1,7 +1,6 @@
 #include "nfc_helpers.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static const char *const TAG = "nfc.helpers";
 
@@ -43,5 +42,4 @@ std::string get_random_ha_tag_ndef() {
   return uri;
 }
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/nfc_helpers.h
+++ b/esphome/components/nfc/nfc_helpers.h
@@ -2,8 +2,7 @@
 
 #include "nfc_tag.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static const char HA_TAG_ID_EXT_RECORD_TYPE[] = "android.com:pkg";
 static const char HA_TAG_ID_EXT_RECORD_PAYLOAD[] = "io.homeassistant.companion.android";
@@ -13,5 +12,4 @@ std::string get_ha_tag_ndef(NfcTag &tag);
 std::string get_random_ha_tag_ndef();
 bool has_ha_tag_ndef(NfcTag &tag);
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/nfc_tag.cpp
+++ b/esphome/components/nfc/nfc_tag.cpp
@@ -1,9 +1,7 @@
 #include "nfc_tag.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 static const char *const TAG = "nfc.tag";
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/nfc/nfc_tag.h
+++ b/esphome/components/nfc/nfc_tag.h
@@ -7,8 +7,7 @@
 #include "esphome/core/log.h"
 #include "ndef_message.h"
 
-namespace esphome {
-namespace nfc {
+namespace esphome::nfc {
 
 // NFC UIDs are 4, 7, or 10 bytes depending on tag type
 static constexpr size_t NFC_UID_MAX_LENGTH = 10;
@@ -54,5 +53,4 @@ class NfcTag {
   std::shared_ptr<NdefMessage> ndef_message_;
 };
 
-}  // namespace nfc
-}  // namespace esphome
+}  // namespace esphome::nfc

--- a/esphome/components/noblex/noblex.cpp
+++ b/esphome/components/noblex/noblex.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace noblex {
+namespace esphome::noblex {
 
 static const char *const TAG = "noblex.climate";
 
@@ -299,5 +298,4 @@ bool NoblexClimate::on_receive(remote_base::RemoteReceiveData data) {
   return true;
 }  // end on_receive()
 
-}  // namespace noblex
-}  // namespace esphome
+}  // namespace esphome::noblex

--- a/esphome/components/noblex/noblex.h
+++ b/esphome/components/noblex/noblex.h
@@ -2,8 +2,7 @@
 
 #include "esphome/components/climate_ir/climate_ir.h"
 
-namespace esphome {
-namespace noblex {
+namespace esphome::noblex {
 
 // Temperature
 const uint8_t NOBLEX_TEMP_MIN = 16;  // Celsius
@@ -45,5 +44,4 @@ class NoblexClimate : public climate_ir::ClimateIR {
   uint8_t remote_state_[8]{};
 };
 
-}  // namespace noblex
-}  // namespace esphome
+}  // namespace esphome::noblex

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace npi19 {
+namespace esphome::npi19 {
 
 static const char *const TAG = "npi19";
 
@@ -101,5 +100,4 @@ void NPI19Component::update() {
   this->status_clear_warning();
 }
 
-}  // namespace npi19
-}  // namespace esphome
+}  // namespace esphome::npi19

--- a/esphome/components/npi19/npi19.h
+++ b/esphome/components/npi19/npi19.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace npi19 {
+namespace esphome::npi19 {
 
 /// This class implements support for the npi19 pressure and temperature i2c sensors.
 class NPI19Component : public PollingComponent, public i2c::I2CDevice {
@@ -25,5 +24,4 @@ class NPI19Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *raw_pressure_sensor_{nullptr};
 };
 
-}  // namespace npi19
-}  // namespace esphome
+}  // namespace esphome::npi19

--- a/esphome/components/ntc/ntc.cpp
+++ b/esphome/components/ntc/ntc.cpp
@@ -1,8 +1,7 @@
 #include "ntc.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ntc {
+namespace esphome::ntc {
 
 static const char *const TAG = "ntc";
 
@@ -26,5 +25,4 @@ void NTC::process_(float value) {
   this->publish_state(temp);
 }
 
-}  // namespace ntc
-}  // namespace esphome
+}  // namespace esphome::ntc

--- a/esphome/components/ntc/ntc.h
+++ b/esphome/components/ntc/ntc.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace ntc {
+namespace esphome::ntc {
 
 class NTC : public Component, public sensor::Sensor {
  public:
@@ -24,5 +23,4 @@ class NTC : public Component, public sensor::Sensor {
   double c_;
 };
 
-}  // namespace ntc
-}  // namespace esphome
+}  // namespace esphome::ntc

--- a/esphome/components/one_wire/one_wire.cpp
+++ b/esphome/components/one_wire/one_wire.cpp
@@ -1,7 +1,6 @@
 #include "one_wire.h"
 
-namespace esphome {
-namespace one_wire {
+namespace esphome::one_wire {
 
 static const char *const TAG = "one_wire";
 
@@ -51,5 +50,4 @@ bool OneWireDevice::check_address_or_index_() {
   return true;
 }
 
-}  // namespace one_wire
-}  // namespace esphome
+}  // namespace esphome::one_wire

--- a/esphome/components/one_wire/one_wire.h
+++ b/esphome/components/one_wire/one_wire.h
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace one_wire {
+namespace esphome::one_wire {
 
 #define LOG_ONE_WIRE_DEVICE(this) \
   ESP_LOGCONFIG(TAG, "  Address: %s (%s)", this->get_address_name().c_str(), \
@@ -43,5 +42,4 @@ class OneWireDevice {
   bool send_command_(uint8_t cmd);
 };
 
-}  // namespace one_wire
-}  // namespace esphome
+}  // namespace esphome::one_wire

--- a/esphome/components/one_wire/one_wire_bus.cpp
+++ b/esphome/components/one_wire/one_wire_bus.cpp
@@ -1,8 +1,7 @@
 #include "one_wire_bus.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace one_wire {
+namespace esphome::one_wire {
 
 static const char *const TAG = "one_wire";
 
@@ -93,5 +92,4 @@ void OneWireBus::dump_devices_(const char *tag) {
   }
 }
 
-}  // namespace one_wire
-}  // namespace esphome
+}  // namespace esphome::one_wire

--- a/esphome/components/one_wire/one_wire_bus.h
+++ b/esphome/components/one_wire/one_wire_bus.h
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include <vector>
 
-namespace esphome {
-namespace one_wire {
+namespace esphome::one_wire {
 
 class OneWireBus {
  public:
@@ -64,5 +63,4 @@ class OneWireBus {
   virtual uint64_t search_int() = 0;
 };
 
-}  // namespace one_wire
-}  // namespace esphome
+}  // namespace esphome::one_wire

--- a/esphome/components/opentherm/automation.h
+++ b/esphome/components/opentherm/automation.h
@@ -4,8 +4,7 @@
 #include "hub.h"
 #include "opentherm.h"
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 class BeforeSendTrigger : public Trigger<OpenthermData &> {
  public:
@@ -21,5 +20,4 @@ class BeforeProcessResponseTrigger : public Trigger<OpenthermData &> {
   }
 };
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/hub.cpp
+++ b/esphome/components/opentherm/hub.cpp
@@ -3,8 +3,7 @@
 
 #include <string>
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 static const char *const TAG = "opentherm";
 namespace message_data {
@@ -419,5 +418,4 @@ void OpenthermHub::dump_config() {
   }
 }
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/hub.h
+++ b/esphome/components/opentherm/hub.h
@@ -35,8 +35,7 @@
 
 #include "opentherm_macros.h"
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 static const uint8_t REPEATING_MESSAGE_ORDER = 255;
 static const uint8_t INITIAL_UNORDERED_MESSAGE_ORDER = 254;
@@ -175,5 +174,4 @@ class OpenthermHub : public Component {
   void dump_config() override;
 };
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/input.h
+++ b/esphome/components/opentherm/input.h
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 class OpenthermInput {
  public:
@@ -14,5 +13,4 @@ class OpenthermInput {
   virtual void set_auto_max_value(bool auto_max_value) { this->auto_max_value = auto_max_value; }
 };
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/number/opentherm_number.cpp
+++ b/esphome/components/opentherm/number/opentherm_number.cpp
@@ -1,7 +1,6 @@
 #include "opentherm_number.h"
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 static const char *const TAG = "opentherm.number";
 
@@ -38,5 +37,4 @@ void OpenthermNumber::dump_config() {
                 this->restore_value_, this->initial_value_, this->state);
 }
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/number/opentherm_number.h
+++ b/esphome/components/opentherm/number/opentherm_number.h
@@ -5,8 +5,7 @@
 #include "esphome/core/log.h"
 #include "esphome/components/opentherm/input.h"
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 // Just a simple number, which stores the number
 class OpenthermNumber : public number::Number, public Component, public OpenthermInput {
@@ -27,5 +26,4 @@ class OpenthermNumber : public number::Number, public Component, public Openther
   void set_restore_value(bool restore_value) { this->restore_value_ = restore_value; }
 };
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -16,8 +16,7 @@
 #endif
 #include <string>
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 using std::string;
 
@@ -566,5 +565,4 @@ void OpenthermData::s16(int16_t value) {
   this->valueHB = (value >> 8) & 0xFF;
 }
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/opentherm.h
+++ b/esphome/components/opentherm/opentherm.h
@@ -16,8 +16,7 @@
 #include "driver/gptimer.h"
 #endif
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 template<class T> constexpr T read_bit(T value, uint8_t bit) { return (value >> bit) & 0x01; }
 
@@ -403,5 +402,4 @@ class OpenTherm {
 #endif
 };
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/opentherm_macros.h
+++ b/esphome/components/opentherm/opentherm_macros.h
@@ -1,6 +1,6 @@
 #pragma once
-namespace esphome {
-namespace opentherm {
+
+namespace esphome::opentherm {
 
 // ===== hub.h macros =====
 
@@ -158,5 +158,4 @@ namespace opentherm {
 #define SHOW_INNER(x) #x
 #define SHOW(x) SHOW_INNER(x)
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/output/opentherm_output.cpp
+++ b/esphome/components/opentherm/output/opentherm_output.cpp
@@ -1,8 +1,7 @@
 #include "esphome/core/helpers.h"  // for clamp() and lerp()
 #include "opentherm_output.h"
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 static const char *const TAG = "opentherm.output";
 
@@ -14,5 +13,4 @@ void opentherm::OpenthermOutput::write_state(float state) {
   this->has_state_ = true;
   ESP_LOGD(TAG, "Output %s set to %.2f", this->id_, this->state);
 }
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/output/opentherm_output.h
+++ b/esphome/components/opentherm/output/opentherm_output.h
@@ -4,8 +4,7 @@
 #include "esphome/components/opentherm/input.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 class OpenthermOutput : public output::FloatOutput, public Component, public OpenthermInput {
  protected:
@@ -29,5 +28,4 @@ class OpenthermOutput : public output::FloatOutput, public Component, public Ope
   float get_max_value() { return this->max_value_; }
 };
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/switch/opentherm_switch.cpp
+++ b/esphome/components/opentherm/switch/opentherm_switch.cpp
@@ -1,7 +1,6 @@
 #include "opentherm_switch.h"
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 static const char *const TAG = "opentherm.switch";
 
@@ -24,5 +23,4 @@ void OpenthermSwitch::dump_config() {
   ESP_LOGCONFIG(TAG, "  Current state: %d", this->state);
 }
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opentherm/switch/opentherm_switch.h
+++ b/esphome/components/opentherm/switch/opentherm_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace opentherm {
+namespace esphome::opentherm {
 
 class OpenthermSwitch : public switch_::Switch, public Component {
  protected:
@@ -16,5 +15,4 @@ class OpenthermSwitch : public switch_::Switch, public Component {
   void dump_config() override;
 };
 
-}  // namespace opentherm
-}  // namespace esphome
+}  // namespace esphome::opentherm

--- a/esphome/components/opt3001/opt3001.cpp
+++ b/esphome/components/opt3001/opt3001.cpp
@@ -1,8 +1,7 @@
 #include "opt3001.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace opt3001 {
+namespace esphome::opt3001 {
 
 static const char *const TAG = "opt3001.sensor";
 
@@ -116,5 +115,4 @@ void OPT3001Sensor::update() {
   });
 }
 
-}  // namespace opt3001
-}  // namespace esphome
+}  // namespace esphome::opt3001

--- a/esphome/components/opt3001/opt3001.h
+++ b/esphome/components/opt3001/opt3001.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace opt3001 {
+namespace esphome::opt3001 {
 
 /// This class implements support for the i2c-based OPT3001 ambient light sensor.
 class OPT3001Sensor : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
@@ -22,5 +21,4 @@ class OPT3001Sensor : public sensor::Sensor, public PollingComponent, public i2c
   bool updating_{false};
 };
 
-}  // namespace opt3001
-}  // namespace esphome
+}  // namespace esphome::opt3001

--- a/esphome/components/output/automation.cpp
+++ b/esphome/components/output/automation.cpp
@@ -1,10 +1,8 @@
 #include "automation.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace output {
+namespace esphome::output {
 
 static const char *const TAG = "output.automation";
 
-}  // namespace output
-}  // namespace esphome
+}  // namespace esphome::output

--- a/esphome/components/output/automation.h
+++ b/esphome/components/output/automation.h
@@ -6,8 +6,7 @@
 #include "esphome/components/output/binary_output.h"
 #include "esphome/components/output/float_output.h"
 
-namespace esphome {
-namespace output {
+namespace esphome::output {
 
 template<typename... Ts> class TurnOffAction : public Action<Ts...> {
  public:
@@ -67,5 +66,4 @@ template<typename... Ts> class SetMaxPowerAction : public Action<Ts...> {
 };
 #endif  // USE_OUTPUT_FLOAT_POWER_SCALING
 
-}  // namespace output
-}  // namespace esphome
+}  // namespace esphome::output

--- a/esphome/components/output/binary_output.h
+++ b/esphome/components/output/binary_output.h
@@ -7,8 +7,7 @@
 #include "esphome/components/power_supply/power_supply.h"
 #endif
 
-namespace esphome {
-namespace output {
+namespace esphome::output {
 
 #define LOG_BINARY_OUTPUT(this) \
   if (this->inverted_) { \
@@ -69,5 +68,4 @@ class BinaryOutput {
 #endif
 };
 
-}  // namespace output
-}  // namespace esphome
+}  // namespace esphome::output

--- a/esphome/components/output/button/output_button.cpp
+++ b/esphome/components/output/button/output_button.cpp
@@ -1,8 +1,7 @@
 #include "output_button.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace output {
+namespace esphome::output {
 
 static const char *const TAG = "output.button";
 
@@ -17,5 +16,4 @@ void OutputButton::press_action() {
   this->set_timeout("reset", this->duration_, [this]() { this->output_->turn_off(); });
 }
 
-}  // namespace output
-}  // namespace esphome
+}  // namespace esphome::output

--- a/esphome/components/output/button/output_button.h
+++ b/esphome/components/output/button/output_button.h
@@ -4,8 +4,7 @@
 #include "esphome/components/button/button.h"
 #include "esphome/components/output/binary_output.h"
 
-namespace esphome {
-namespace output {
+namespace esphome::output {
 
 class OutputButton : public button::Button, public Component {
  public:
@@ -21,5 +20,4 @@ class OutputButton : public button::Button, public Component {
   uint32_t duration_;
 };
 
-}  // namespace output
-}  // namespace esphome
+}  // namespace esphome::output

--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace output {
+namespace esphome::output {
 
 static const char *const TAG = "output.float";
 
@@ -40,5 +39,4 @@ void FloatOutput::set_level(float state) {
 
 void FloatOutput::write_state(bool state) { this->set_level(state != this->inverted_ ? 1.0f : 0.0f); }
 
-}  // namespace output
-}  // namespace esphome
+}  // namespace esphome::output

--- a/esphome/components/output/float_output.h
+++ b/esphome/components/output/float_output.h
@@ -4,8 +4,7 @@
 #include "esphome/core/defines.h"
 #include "binary_output.h"
 
-namespace esphome {
-namespace output {
+namespace esphome::output {
 
 #ifdef USE_OUTPUT_FLOAT_POWER_SCALING
 #define LOG_FLOAT_OUTPUT(this) \
@@ -130,5 +129,4 @@ class FloatOutput : public BinaryOutput {
 #endif
 };
 
-}  // namespace output
-}  // namespace esphome
+}  // namespace esphome::output

--- a/esphome/components/output/lock/output_lock.cpp
+++ b/esphome/components/output/lock/output_lock.cpp
@@ -1,8 +1,7 @@
 #include "output_lock.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace output {
+namespace esphome::output {
 
 static const char *const TAG = "output.lock";
 
@@ -21,5 +20,4 @@ void OutputLock::control(const lock::LockCall &call) {
   this->publish_state(state);
 }
 
-}  // namespace output
-}  // namespace esphome
+}  // namespace esphome::output

--- a/esphome/components/output/lock/output_lock.h
+++ b/esphome/components/output/lock/output_lock.h
@@ -4,8 +4,7 @@
 #include "esphome/components/lock/lock.h"
 #include "esphome/components/output/binary_output.h"
 
-namespace esphome {
-namespace output {
+namespace esphome::output {
 
 class OutputLock : public lock::Lock, public Component {
  public:
@@ -20,5 +19,4 @@ class OutputLock : public lock::Lock, public Component {
   output::BinaryOutput *output_;
 };
 
-}  // namespace output
-}  // namespace esphome
+}  // namespace esphome::output

--- a/esphome/components/output/switch/output_switch.cpp
+++ b/esphome/components/output/switch/output_switch.cpp
@@ -1,8 +1,7 @@
 #include "output_switch.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace output {
+namespace esphome::output {
 
 static const char *const TAG = "output.switch";
 
@@ -25,5 +24,4 @@ void OutputSwitch::write_state(bool state) {
   this->publish_state(state);
 }
 
-}  // namespace output
-}  // namespace esphome
+}  // namespace esphome::output

--- a/esphome/components/output/switch/output_switch.h
+++ b/esphome/components/output/switch/output_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/output/binary_output.h"
 
-namespace esphome {
-namespace output {
+namespace esphome::output {
 
 class OutputSwitch : public switch_::Switch, public Component {
  public:
@@ -21,5 +20,4 @@ class OutputSwitch : public switch_::Switch, public Component {
   output::BinaryOutput *output_;
 };
 
-}  // namespace output
-}  // namespace esphome
+}  // namespace esphome::output

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -7,8 +7,7 @@
 
 #include "esphome/components/xxtea/xxtea.h"
 
-namespace esphome {
-namespace packet_transport {
+namespace esphome::packet_transport {
 
 // Maximum bytes to log in hex output (168 * 3 = 504, under TX buffer size of 512)
 static constexpr size_t PACKET_MAX_LOG_BYTES = 168;
@@ -609,5 +608,4 @@ void PacketTransport::send_ping_pong_request_() {
   this->resend_ping_key_ = false;
   ESP_LOGV(TAG, "Sent new ping request %08X", (unsigned) this->ping_key_);
 }
-}  // namespace packet_transport
-}  // namespace esphome
+}  // namespace esphome::packet_transport

--- a/esphome/components/packet_transport/packet_transport.h
+++ b/esphome/components/packet_transport/packet_transport.h
@@ -22,8 +22,7 @@
  * On receipt of a data packet, it should call `this->process_()` with the data.
  */
 
-namespace esphome {
-namespace packet_transport {
+namespace esphome::packet_transport {
 
 // std::less provides allocation-free comparison with const char *
 template<typename T> using string_map_t = std::map<std::string, T, std::less<>>;
@@ -168,5 +167,4 @@ class PacketTransport : public PollingComponent {
   bool is_encrypted_() const { return !this->encryption_key_.empty(); }
 };
 
-}  // namespace packet_transport
-}  // namespace esphome
+}  // namespace esphome::packet_transport

--- a/esphome/components/partition/light_partition.cpp
+++ b/esphome/components/partition/light_partition.cpp
@@ -1,10 +1,8 @@
 #include "light_partition.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace partition {
+namespace esphome::partition {
 
 static const char *const TAG = "partition.light";
 
-}  // namespace partition
-}  // namespace esphome
+}  // namespace esphome::partition

--- a/esphome/components/partition/light_partition.h
+++ b/esphome/components/partition/light_partition.h
@@ -6,8 +6,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/light/addressable_light.h"
 
-namespace esphome {
-namespace partition {
+namespace esphome::partition {
 
 class AddressableSegment {
  public:
@@ -93,5 +92,4 @@ class PartitionLightOutput : public light::AddressableLight {
   std::vector<AddressableSegment> segments_;
 };
 
-}  // namespace partition
-}  // namespace esphome
+}  // namespace esphome::partition

--- a/esphome/components/pca6416a/pca6416a.cpp
+++ b/esphome/components/pca6416a/pca6416a.cpp
@@ -1,8 +1,7 @@
 #include "pca6416a.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pca6416a {
+namespace esphome::pca6416a {
 
 enum PCA6416AGPIORegisters {
   // 0 side
@@ -205,5 +204,4 @@ size_t PCA6416AGPIOPin::dump_summary(char *buffer, size_t len) const {
   return buf_append_printf(buffer, len, 0, "%u via PCA6416A", this->pin_);
 }
 
-}  // namespace pca6416a
-}  // namespace esphome
+}  // namespace esphome::pca6416a

--- a/esphome/components/pca6416a/pca6416a.h
+++ b/esphome/components/pca6416a/pca6416a.h
@@ -5,8 +5,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/gpio_expander/cached_gpio.h"
 
-namespace esphome {
-namespace pca6416a {
+namespace esphome::pca6416a {
 
 class PCA6416AComponent : public Component,
                           public i2c::I2CDevice,
@@ -72,5 +71,4 @@ class PCA6416AGPIOPin : public GPIOPin {
   gpio::Flags flags_;
 };
 
-}  // namespace pca6416a
-}  // namespace esphome
+}  // namespace esphome::pca6416a

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -1,8 +1,7 @@
 #include "pca9554.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pca9554 {
+namespace esphome::pca9554 {
 
 // for 16 bit expanders, these addresses will be doubled.
 const uint8_t INPUT_REG = 0;
@@ -152,5 +151,4 @@ size_t PCA9554GPIOPin::dump_summary(char *buffer, size_t len) const {
   return buf_append_printf(buffer, len, 0, "%u via PCA9554", this->pin_);
 }
 
-}  // namespace pca9554
-}  // namespace esphome
+}  // namespace esphome::pca9554

--- a/esphome/components/pca9554/pca9554.h
+++ b/esphome/components/pca9554/pca9554.h
@@ -5,8 +5,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/gpio_expander/cached_gpio.h"
 
-namespace esphome {
-namespace pca9554 {
+namespace esphome::pca9554 {
 
 class PCA9554Component : public Component,
                          public i2c::I2CDevice,
@@ -76,5 +75,4 @@ class PCA9554GPIOPin : public GPIOPin {
   gpio::Flags flags_;
 };
 
-}  // namespace pca9554
-}  // namespace esphome
+}  // namespace esphome::pca9554

--- a/esphome/components/pca9685/pca9685_output.cpp
+++ b/esphome/components/pca9685/pca9685_output.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pca9685 {
+namespace esphome::pca9685 {
 
 static const char *const TAG = "pca9685";
 
@@ -160,5 +159,4 @@ void PCA9685Channel::write_state(float state) {
   this->parent_->set_channel_value_(this->channel_, duty);
 }
 
-}  // namespace pca9685
-}  // namespace esphome
+}  // namespace esphome::pca9685

--- a/esphome/components/pca9685/pca9685_output.h
+++ b/esphome/components/pca9685/pca9685_output.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace pca9685 {
+namespace esphome::pca9685 {
 
 enum class PhaseBalancer {
   NONE = 0x00,
@@ -76,5 +75,4 @@ class PCA9685Output : public Component, public i2c::I2CDevice {
   bool update_{true};
 };
 
-}  // namespace pca9685
-}  // namespace esphome
+}  // namespace esphome::pca9685

--- a/esphome/components/pcd8544/pcd_8544.cpp
+++ b/esphome/components/pcd8544/pcd_8544.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pcd8544 {
+namespace esphome::pcd8544 {
 
 static const char *const TAG = "pcd_8544";
 
@@ -128,5 +127,4 @@ void PCD8544::fill(Color color) {
     this->buffer_[i] = fill;
 }
 
-}  // namespace pcd8544
-}  // namespace esphome
+}  // namespace esphome::pcd8544

--- a/esphome/components/pcd8544/pcd_8544.h
+++ b/esphome/components/pcd8544/pcd_8544.h
@@ -4,8 +4,7 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/display/display_buffer.h"
 
-namespace esphome {
-namespace pcd8544 {
+namespace esphome::pcd8544 {
 
 class PCD8544 : public display::DisplayBuffer,
                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
@@ -74,5 +73,4 @@ class PCD8544 : public display::DisplayBuffer,
   GPIOPin *dc_pin_;
 };
 
-}  // namespace pcd8544
-}  // namespace esphome
+}  // namespace esphome::pcd8544

--- a/esphome/components/pcf85063/pcf85063.cpp
+++ b/esphome/components/pcf85063/pcf85063.cpp
@@ -4,8 +4,7 @@
 // Datasheet:
 // - https://datasheets.maximintegrated.com/en/ds/DS1307.pdf
 
-namespace esphome {
-namespace pcf85063 {
+namespace esphome::pcf85063 {
 
 static const char *const TAG = "pcf85063";
 
@@ -99,5 +98,4 @@ bool PCF85063Component::write_rtc_() {
            pcf85063_.reg.day_10, pcf85063_.reg.day, ONOFF(!pcf85063_.reg.osc_stop), pcf85063_.reg.clkout_control);
   return true;
 }
-}  // namespace pcf85063
-}  // namespace esphome
+}  // namespace esphome::pcf85063

--- a/esphome/components/pcf85063/pcf85063.h
+++ b/esphome/components/pcf85063/pcf85063.h
@@ -4,8 +4,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/time/real_time_clock.h"
 
-namespace esphome {
-namespace pcf85063 {
+namespace esphome::pcf85063 {
 
 class PCF85063Component : public time::RealTimeClock, public i2c::I2CDevice {
  public:
@@ -91,5 +90,4 @@ template<typename... Ts> class ReadAction : public Action<Ts...>, public Parente
  public:
   void play(const Ts &...x) override { this->parent_->read_time(); }
 };
-}  // namespace pcf85063
-}  // namespace esphome
+}  // namespace esphome::pcf85063

--- a/esphome/components/pcf8563/pcf8563.cpp
+++ b/esphome/components/pcf8563/pcf8563.cpp
@@ -4,8 +4,7 @@
 // Datasheet:
 // - https://nl.mouser.com/datasheet/2/302/PCF8563-1127619.pdf
 
-namespace esphome {
-namespace pcf8563 {
+namespace esphome::pcf8563 {
 
 static const char *const TAG = "PCF8563";
 
@@ -99,5 +98,4 @@ bool PCF8563Component::write_rtc_() {
            pcf8563_.reg.day, ONOFF(!pcf8563_.reg.stop), pcf8563_.reg.clkout_enabled);
   return true;
 }
-}  // namespace pcf8563
-}  // namespace esphome
+}  // namespace esphome::pcf8563

--- a/esphome/components/pcf8563/pcf8563.h
+++ b/esphome/components/pcf8563/pcf8563.h
@@ -4,8 +4,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/time/real_time_clock.h"
 
-namespace esphome {
-namespace pcf8563 {
+namespace esphome::pcf8563 {
 
 class PCF8563Component : public time::RealTimeClock, public i2c::I2CDevice {
  public:
@@ -119,5 +118,4 @@ template<typename... Ts> class ReadAction : public Action<Ts...>, public Parente
  public:
   void play(const Ts &...x) override { this->parent_->read_time(); }
 };
-}  // namespace pcf8563
-}  // namespace esphome
+}  // namespace esphome::pcf8563

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -1,8 +1,7 @@
 #include "pcf8574.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pcf8574 {
+namespace esphome::pcf8574 {
 
 static const char *const TAG = "pcf8574";
 
@@ -131,5 +130,4 @@ size_t PCF8574GPIOPin::dump_summary(char *buffer, size_t len) const {
   return buf_append_printf(buffer, len, 0, "%u via PCF8574", this->pin_);
 }
 
-}  // namespace pcf8574
-}  // namespace esphome
+}  // namespace esphome::pcf8574

--- a/esphome/components/pcf8574/pcf8574.h
+++ b/esphome/components/pcf8574/pcf8574.h
@@ -5,8 +5,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/gpio_expander/cached_gpio.h"
 
-namespace esphome {
-namespace pcf8574 {
+namespace esphome::pcf8574 {
 
 // PCF8574(8 pins)/PCF8575(16 pins) always read/write all pins in a single I2C transaction
 // so we use uint16_t as bank type to ensure all pins are in one bank and cached together
@@ -72,5 +71,4 @@ class PCF8574GPIOPin : public GPIOPin {
   gpio::Flags flags_;
 };
 
-}  // namespace pcf8574
-}  // namespace esphome
+}  // namespace esphome::pcf8574

--- a/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
+++ b/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
@@ -1,8 +1,7 @@
 #include "pi4ioe5v6408.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pi4ioe5v6408 {
+namespace esphome::pi4ioe5v6408 {
 
 static const uint8_t PI4IOE5V6408_REGISTER_DEVICE_ID = 0x01;
 static const uint8_t PI4IOE5V6408_REGISTER_IO_DIR = 0x03;
@@ -204,5 +203,4 @@ size_t PI4IOE5V6408GPIOPin::dump_summary(char *buffer, size_t len) const {
   return buf_append_printf(buffer, len, 0, "%u via PI4IOE5V6408", this->pin_);
 }
 
-}  // namespace pi4ioe5v6408
-}  // namespace esphome
+}  // namespace esphome::pi4ioe5v6408

--- a/esphome/components/pi4ioe5v6408/pi4ioe5v6408.h
+++ b/esphome/components/pi4ioe5v6408/pi4ioe5v6408.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace pi4ioe5v6408 {
+namespace esphome::pi4ioe5v6408 {
 class PI4IOE5V6408Component : public Component,
                               public i2c::I2CDevice,
                               public gpio_expander::CachedGpioExpander<uint8_t, 8> {
@@ -70,5 +69,4 @@ class PI4IOE5V6408GPIOPin : public GPIOPin, public Parented<PI4IOE5V6408Componen
   gpio::Flags flags_;
 };
 
-}  // namespace pi4ioe5v6408
-}  // namespace esphome
+}  // namespace esphome::pi4ioe5v6408

--- a/esphome/components/pid/pid_autotuner.cpp
+++ b/esphome/components/pid/pid_autotuner.cpp
@@ -6,8 +6,7 @@
 #define M_PI 3.1415926535897932384626433
 #endif
 
-namespace esphome {
-namespace pid {
+namespace esphome::pid {
 
 static const char *const TAG = "pid.autotune";
 
@@ -368,5 +367,4 @@ bool PIDAutotuner::OscillationAmplitudeDetector::is_amplitude_convergent() const
   return (mean_amplitude - global_amplitude) / (global_amplitude) < 0.05f;
 }
 
-}  // namespace pid
-}  // namespace esphome
+}  // namespace esphome::pid

--- a/esphome/components/pid/pid_autotuner.h
+++ b/esphome/components/pid/pid_autotuner.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace pid {
+namespace esphome::pid {
 
 class PIDAutotuner {
  public:
@@ -110,5 +109,4 @@ class PIDAutotuner {
   std::string id_;
 };
 
-}  // namespace pid
-}  // namespace esphome
+}  // namespace esphome::pid

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -1,8 +1,7 @@
 #include "pid_climate.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pid {
+namespace esphome::pid {
 
 static const char *const TAG = "pid.climate";
 
@@ -186,5 +185,4 @@ void PIDClimate::start_autotune(std::unique_ptr<PIDAutotuner> &&autotune) {
 
 void PIDClimate::reset_integral_term() { this->controller_.reset_accumulated_integral(); }
 
-}  // namespace pid
-}  // namespace esphome
+}  // namespace esphome::pid

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -9,8 +9,7 @@
 #include "pid_controller.h"
 #include "pid_autotuner.h"
 
-namespace esphome {
-namespace pid {
+namespace esphome::pid {
 
 class PIDClimate : public climate::Climate, public Component {
  public:
@@ -164,5 +163,4 @@ template<typename... Ts> class PIDSetControlParametersAction : public Action<Ts.
   PIDClimate *parent_;
 };
 
-}  // namespace pid
-}  // namespace esphome
+}  // namespace esphome::pid

--- a/esphome/components/pid/pid_controller.cpp
+++ b/esphome/components/pid/pid_controller.cpp
@@ -1,7 +1,6 @@
 #include "pid_controller.h"
 
-namespace esphome {
-namespace pid {
+namespace esphome::pid {
 
 float PIDController::update(float setpoint, float process_value) {
   // e(t) ... error at timestamp t
@@ -123,5 +122,4 @@ float PIDController::calculate_relative_time_() {
   return dt / 1000.0f;
 }
 
-}  // namespace pid
-}  // namespace esphome
+}  // namespace esphome::pid

--- a/esphome/components/pid/pid_controller.h
+++ b/esphome/components/pid/pid_controller.h
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include <cmath>
 
-namespace esphome {
-namespace pid {
+namespace esphome::pid {
 
 struct PIDController {
   float update(float setpoint, float process_value);
@@ -71,5 +70,4 @@ struct PIDController {
   FixedRingBuffer<float> output_window_;
 
 };  // Struct PIDController
-}  // namespace pid
-}  // namespace esphome
+}  // namespace esphome::pid

--- a/esphome/components/pid/sensor/pid_climate_sensor.cpp
+++ b/esphome/components/pid/sensor/pid_climate_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pid {
+namespace esphome::pid {
 
 static const char *const TAG = "pid.sensor";
 
@@ -55,5 +54,4 @@ void PIDClimateSensor::update_from_parent_() {
 }
 void PIDClimateSensor::dump_config() { LOG_SENSOR("", "PID Climate Sensor", this); }
 
-}  // namespace pid
-}  // namespace esphome
+}  // namespace esphome::pid

--- a/esphome/components/pid/sensor/pid_climate_sensor.h
+++ b/esphome/components/pid/sensor/pid_climate_sensor.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/pid/pid_climate.h"
 
-namespace esphome {
-namespace pid {
+namespace esphome::pid {
 
 enum PIDClimateSensorType {
   PID_SENSOR_TYPE_RESULT,
@@ -33,5 +32,4 @@ class PIDClimateSensor : public sensor::Sensor, public Component {
   PIDClimateSensorType type_;
 };
 
-}  // namespace pid
-}  // namespace esphome
+}  // namespace esphome::pid

--- a/esphome/components/pipsolar/output/pipsolar_output.cpp
+++ b/esphome/components/pipsolar/output/pipsolar_output.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pipsolar {
+namespace esphome::pipsolar {
 
 static const char *const TAG = "pipsolar.output";
 
@@ -18,5 +17,4 @@ void PipsolarOutput::write_state(float state) {
     ESP_LOGD(TAG, "Will not write: %s as it is not in list of allowed values", tmp);
   }
 }
-}  // namespace pipsolar
-}  // namespace esphome
+}  // namespace esphome::pipsolar

--- a/esphome/components/pipsolar/output/pipsolar_output.h
+++ b/esphome/components/pipsolar/output/pipsolar_output.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace pipsolar {
+namespace esphome::pipsolar {
 
 class Pipsolar;
 
@@ -40,5 +39,4 @@ template<typename... Ts> class SetOutputAction : public Action<Ts...> {
   PipsolarOutput *output_;
 };
 
-}  // namespace pipsolar
-}  // namespace esphome
+}  // namespace esphome::pipsolar

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pipsolar {
+namespace esphome::pipsolar {
 
 static const char *const TAG = "pipsolar";
 
@@ -811,5 +810,4 @@ uint16_t Pipsolar::pipsolar_crc_(uint8_t *msg, uint8_t len) {
   return crc;
 }
 
-}  // namespace pipsolar
-}  // namespace esphome
+}  // namespace esphome::pipsolar

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -9,8 +9,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace pipsolar {
+namespace esphome::pipsolar {
 
 enum ENUMPollingCommand {
   POLLING_QPIRI = 0,
@@ -246,5 +245,4 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   PollingCommand enabled_polling_commands_[POLLING_COMMANDS_MAX];
 };
 
-}  // namespace pipsolar
-}  // namespace esphome
+}  // namespace esphome::pipsolar

--- a/esphome/components/pipsolar/switch/pipsolar_switch.cpp
+++ b/esphome/components/pipsolar/switch/pipsolar_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace pipsolar {
+namespace esphome::pipsolar {
 
 static const char *const TAG = "pipsolar.switch";
 
@@ -15,5 +14,4 @@ void PipsolarSwitch::write_state(bool state) {
   }
 }
 
-}  // namespace pipsolar
-}  // namespace esphome
+}  // namespace esphome::pipsolar

--- a/esphome/components/pipsolar/switch/pipsolar_switch.h
+++ b/esphome/components/pipsolar/switch/pipsolar_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace pipsolar {
+namespace esphome::pipsolar {
 class Pipsolar;
 class PipsolarSwitch : public switch_::Switch, public Component {
  public:
@@ -24,5 +23,4 @@ class PipsolarSwitch : public switch_::Switch, public Component {
   Pipsolar *parent_;
 };
 
-}  // namespace pipsolar
-}  // namespace esphome
+}  // namespace esphome::pipsolar

--- a/esphome/components/pm1006/pm1006.cpp
+++ b/esphome/components/pm1006/pm1006.cpp
@@ -1,8 +1,7 @@
 #include "pm1006.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pm1006 {
+namespace esphome::pm1006 {
 
 static const char *const TAG = "pm1006";
 
@@ -93,5 +92,4 @@ void PM1006Component::parse_data_() {
   }
 }
 
-}  // namespace pm1006
-}  // namespace esphome
+}  // namespace esphome::pm1006

--- a/esphome/components/pm1006/pm1006.h
+++ b/esphome/components/pm1006/pm1006.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace pm1006 {
+namespace esphome::pm1006 {
 
 class PM1006Component : public PollingComponent, public uart::UARTDevice {
  public:
@@ -33,5 +32,4 @@ class PM1006Component : public PollingComponent, public uart::UARTDevice {
   uint32_t last_transmission_{0};
 };
 
-}  // namespace pm1006
-}  // namespace esphome
+}  // namespace esphome::pm1006

--- a/esphome/components/pm2005/pm2005.cpp
+++ b/esphome/components/pm2005/pm2005.cpp
@@ -1,8 +1,7 @@
 #include "esphome/core/log.h"
 #include "pm2005.h"
 
-namespace esphome {
-namespace pm2005 {
+namespace esphome::pm2005 {
 
 static const char *const TAG = "pm2005";
 
@@ -117,5 +116,4 @@ void PM2005Component::dump_config() {
   LOG_SENSOR("  ", "PM10 ", this->pm_10_0_sensor_);
 }
 
-}  // namespace pm2005
-}  // namespace esphome
+}  // namespace esphome::pm2005

--- a/esphome/components/pm2005/pm2005.h
+++ b/esphome/components/pm2005/pm2005.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace pm2005 {
+namespace esphome::pm2005 {
 
 enum SensorType {
   PM2005,
@@ -40,5 +39,4 @@ class PM2005Component : public PollingComponent, public i2c::I2CDevice {
   uint8_t measuring_value_index_{10};
 };
 
-}  // namespace pm2005
-}  // namespace esphome
+}  // namespace esphome::pm2005

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include <cstring>
 
-namespace esphome {
-namespace pmsa003i {
+namespace esphome::pmsa003i {
 
 static const char *const TAG = "pmsa003i";
 
@@ -131,5 +130,4 @@ bool PMSA003IComponent::read_data_(PM25AQIData *data) {
   return true;
 }
 
-}  // namespace pmsa003i
-}  // namespace esphome
+}  // namespace esphome::pmsa003i

--- a/esphome/components/pmsa003i/pmsa003i.h
+++ b/esphome/components/pmsa003i/pmsa003i.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace pmsa003i {
+namespace esphome::pmsa003i {
 
 /**! Structure holding Plantower's standard packet **/
 // From https://github.com/adafruit/Adafruit_PM25AQI
@@ -63,5 +62,4 @@ class PMSA003IComponent : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *pmc_10_0_sensor_{nullptr};
 };
 
-}  // namespace pmsa003i
-}  // namespace esphome
+}  // namespace esphome::pmsa003i

--- a/esphome/components/pmwcs3/pmwcs3.cpp
+++ b/esphome/components/pmwcs3/pmwcs3.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pmwcs3 {
+namespace esphome::pmwcs3 {
 
 static const uint8_t PMWCS3_I2C_ADDRESS = 0x63;
 static const uint8_t PMWCS3_REG_READ_START = 0x01;
@@ -106,5 +105,4 @@ void PMWCS3Component::read_data_() {
   });
 }
 
-}  // namespace pmwcs3
-}  // namespace esphome
+}  // namespace esphome::pmwcs3

--- a/esphome/components/pmwcs3/pmwcs3.h
+++ b/esphome/components/pmwcs3/pmwcs3.h
@@ -7,8 +7,7 @@
 // ref:
 // https://github.com/tinovi/i2cArduino/blob/master/i2cArduino.h
 
-namespace esphome {
-namespace pmwcs3 {
+namespace esphome::pmwcs3 {
 
 class PMWCS3Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -64,5 +63,4 @@ template<typename... Ts> class PMWCS3NewI2cAddressAction : public Action<Ts...> 
   PMWCS3Component *parent_;
 };
 
-}  // namespace pmwcs3
-}  // namespace esphome
+}  // namespace esphome::pmwcs3

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -9,8 +9,7 @@
 // - https://www.nxp.com/docs/en/nxp/application-notes/AN133910.pdf
 // - https://www.nxp.com/docs/en/nxp/application-notes/153710.pdf
 
-namespace esphome {
-namespace pn532 {
+namespace esphome::pn532 {
 
 static const char *const TAG = "pn532";
 
@@ -458,5 +457,4 @@ bool PN532BinarySensor::process(const nfc::NfcTagUid &data) {
   return true;
 }
 
-}  // namespace pn532
-}  // namespace esphome
+}  // namespace esphome::pn532

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -10,8 +10,7 @@
 #include <cinttypes>
 #include <vector>
 
-namespace esphome {
-namespace pn532 {
+namespace esphome::pn532 {
 
 static const uint8_t PN532_COMMAND_VERSION_DATA = 0x02;
 static const uint8_t PN532_COMMAND_SAMCONFIGURATION = 0x14;
@@ -138,5 +137,4 @@ template<typename... Ts> class PN532IsWritingCondition : public Condition<Ts...>
   bool check(const Ts &...x) override { return this->parent_->is_writing(); }
 };
 
-}  // namespace pn532
-}  // namespace esphome
+}  // namespace esphome::pn532

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -4,8 +4,7 @@
 #include "pn532.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pn532 {
+namespace esphome::pn532 {
 
 static const char *const TAG = "pn532.mifare_classic";
 
@@ -258,5 +257,4 @@ bool PN532::write_mifare_classic_tag_(nfc::NfcTagUid &uid, nfc::NdefMessage *mes
   return true;
 }
 
-}  // namespace pn532
-}  // namespace esphome
+}  // namespace esphome::pn532

--- a/esphome/components/pn532/pn532_mifare_ultralight.cpp
+++ b/esphome/components/pn532/pn532_mifare_ultralight.cpp
@@ -4,8 +4,7 @@
 #include "pn532.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pn532 {
+namespace esphome::pn532 {
 
 static const char *const TAG = "pn532.mifare_ultralight";
 
@@ -189,5 +188,4 @@ bool PN532::write_mifare_ultralight_page_(uint8_t page_num, const uint8_t *write
   return true;
 }
 
-}  // namespace pn532
-}  // namespace esphome
+}  // namespace esphome::pn532

--- a/esphome/components/pn532_i2c/pn532_i2c.cpp
+++ b/esphome/components/pn532_i2c/pn532_i2c.cpp
@@ -7,8 +7,7 @@
 // - https://www.nxp.com/docs/en/nxp/application-notes/AN133910.pdf
 // - https://www.nxp.com/docs/en/nxp/application-notes/153710.pdf
 
-namespace esphome {
-namespace pn532_i2c {
+namespace esphome::pn532_i2c {
 
 static const char *const TAG = "pn532_i2c";
 
@@ -125,5 +124,4 @@ void PN532I2C::dump_config() {
   LOG_I2C_DEVICE(this);
 }
 
-}  // namespace pn532_i2c
-}  // namespace esphome
+}  // namespace esphome::pn532_i2c

--- a/esphome/components/pn532_i2c/pn532_i2c.h
+++ b/esphome/components/pn532_i2c/pn532_i2c.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace pn532_i2c {
+namespace esphome::pn532_i2c {
 
 class PN532I2C : public pn532::PN532, public i2c::I2CDevice {
  public:
@@ -21,5 +20,4 @@ class PN532I2C : public pn532::PN532, public i2c::I2CDevice {
   uint8_t read_response_length_();
 };
 
-}  // namespace pn532_i2c
-}  // namespace esphome
+}  // namespace esphome::pn532_i2c

--- a/esphome/components/pn532_spi/pn532_spi.cpp
+++ b/esphome/components/pn532_spi/pn532_spi.cpp
@@ -7,8 +7,7 @@
 // - https://www.nxp.com/docs/en/nxp/application-notes/AN133910.pdf
 // - https://www.nxp.com/docs/en/nxp/application-notes/153710.pdf
 
-namespace esphome {
-namespace pn532_spi {
+namespace esphome::pn532_spi {
 
 static const char *const TAG = "pn532_spi";
 
@@ -151,5 +150,4 @@ void PN532Spi::dump_config() {
   LOG_PIN("  CS Pin: ", this->cs_);
 }
 
-}  // namespace pn532_spi
-}  // namespace esphome
+}  // namespace esphome::pn532_spi

--- a/esphome/components/pn532_spi/pn532_spi.h
+++ b/esphome/components/pn532_spi/pn532_spi.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace pn532_spi {
+namespace esphome::pn532_spi {
 
 class PN532Spi : public pn532::PN532,
                  public spi::SPIDevice<spi::BIT_ORDER_LSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
@@ -24,5 +23,4 @@ class PN532Spi : public pn532::PN532,
   bool read_response(uint8_t command, std::vector<uint8_t> &data) override;
 };
 
-}  // namespace pn532_spi
-}  // namespace esphome
+}  // namespace esphome::pn532_spi

--- a/esphome/components/pn7150/automation.h
+++ b/esphome/components/pn7150/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/pn7150/pn7150.h"
 
-namespace esphome {
-namespace pn7150 {
+namespace esphome::pn7150 {
 
 template<typename... Ts> class PN7150IsWritingCondition : public Condition<Ts...>, public Parented<PN7150> {
  public:
@@ -64,5 +63,4 @@ template<typename... Ts> class SetWriteModeAction : public Action<Ts...>, public
   void play(const Ts &...x) override { this->parent_->write_mode(); }
 };
 
-}  // namespace pn7150
-}  // namespace esphome
+}  // namespace esphome::pn7150

--- a/esphome/components/pn7150/pn7150.cpp
+++ b/esphome/components/pn7150/pn7150.cpp
@@ -7,8 +7,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pn7150 {
+namespace esphome::pn7150 {
 
 static const char *const TAG = "pn7150";
 
@@ -1160,5 +1159,4 @@ uint8_t PN7150::wait_for_irq_(uint16_t timeout, bool pin_state) {
   return nfc::STATUS_FAILED;
 }
 
-}  // namespace pn7150
-}  // namespace esphome
+}  // namespace esphome::pn7150

--- a/esphome/components/pn7150/pn7150.h
+++ b/esphome/components/pn7150/pn7150.h
@@ -11,8 +11,7 @@
 
 #include <functional>
 
-namespace esphome {
-namespace pn7150 {
+namespace esphome::pn7150 {
 
 static constexpr uint16_t NFCC_DEFAULT_TIMEOUT = 10;
 static constexpr uint16_t NFCC_INIT_TIMEOUT = 50;
@@ -292,5 +291,4 @@ class PN7150 : public nfc::Nfcc, public Component {
   std::vector<nfc::NfcOnTagTrigger *> triggers_ontagremoved_;
 };
 
-}  // namespace pn7150
-}  // namespace esphome
+}  // namespace esphome::pn7150

--- a/esphome/components/pn7150/pn7150_mifare_classic.cpp
+++ b/esphome/components/pn7150/pn7150_mifare_classic.cpp
@@ -4,8 +4,7 @@
 #include "pn7150.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pn7150 {
+namespace esphome::pn7150 {
 
 static const char *const TAG = "pn7150.mifare_classic";
 
@@ -324,5 +323,4 @@ uint8_t PN7150::halt_mifare_classic_tag_() {
   return nfc::STATUS_OK;
 }
 
-}  // namespace pn7150
-}  // namespace esphome
+}  // namespace esphome::pn7150

--- a/esphome/components/pn7150/pn7150_mifare_ultralight.cpp
+++ b/esphome/components/pn7150/pn7150_mifare_ultralight.cpp
@@ -5,8 +5,7 @@
 #include "pn7150.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pn7150 {
+namespace esphome::pn7150 {
 
 static const char *const TAG = "pn7150.mifare_ultralight";
 
@@ -183,5 +182,4 @@ uint8_t PN7150::write_mifare_ultralight_page_(uint8_t page_num, const uint8_t *w
   return nfc::STATUS_OK;
 }
 
-}  // namespace pn7150
-}  // namespace esphome
+}  // namespace esphome::pn7150

--- a/esphome/components/pn7150_i2c/pn7150_i2c.cpp
+++ b/esphome/components/pn7150_i2c/pn7150_i2c.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace pn7150_i2c {
+namespace esphome::pn7150_i2c {
 
 static const char *const TAG = "pn7150_i2c";
 
@@ -46,5 +45,4 @@ void PN7150I2C::dump_config() {
   LOG_I2C_DEVICE(this);
 }
 
-}  // namespace pn7150_i2c
-}  // namespace esphome
+}  // namespace esphome::pn7150_i2c

--- a/esphome/components/pn7150_i2c/pn7150_i2c.h
+++ b/esphome/components/pn7150_i2c/pn7150_i2c.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace pn7150_i2c {
+namespace esphome::pn7150_i2c {
 
 class PN7150I2C : public pn7150::PN7150, public i2c::I2CDevice {
  public:
@@ -18,5 +17,4 @@ class PN7150I2C : public pn7150::PN7150, public i2c::I2CDevice {
   uint8_t write_nfcc(nfc::NciMessage &tx) override;
 };
 
-}  // namespace pn7150_i2c
-}  // namespace esphome
+}  // namespace esphome::pn7150_i2c

--- a/esphome/components/pn7160/automation.h
+++ b/esphome/components/pn7160/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/pn7160/pn7160.h"
 
-namespace esphome {
-namespace pn7160 {
+namespace esphome::pn7160 {
 
 template<typename... Ts> class PN7160IsWritingCondition : public Condition<Ts...>, public Parented<PN7160> {
  public:
@@ -64,5 +63,4 @@ template<typename... Ts> class SetWriteModeAction : public Action<Ts...>, public
   void play(const Ts &...x) override { this->parent_->write_mode(); }
 };
 
-}  // namespace pn7160
-}  // namespace esphome
+}  // namespace esphome::pn7160

--- a/esphome/components/pn7160/pn7160.cpp
+++ b/esphome/components/pn7160/pn7160.cpp
@@ -7,8 +7,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pn7160 {
+namespace esphome::pn7160 {
 
 static const char *const TAG = "pn7160";
 
@@ -1186,5 +1185,4 @@ uint8_t PN7160::wait_for_irq_(uint16_t timeout, bool pin_state) {
   return nfc::STATUS_FAILED;
 }
 
-}  // namespace pn7160
-}  // namespace esphome
+}  // namespace esphome::pn7160

--- a/esphome/components/pn7160/pn7160.h
+++ b/esphome/components/pn7160/pn7160.h
@@ -11,8 +11,7 @@
 
 #include <functional>
 
-namespace esphome {
-namespace pn7160 {
+namespace esphome::pn7160 {
 
 static constexpr uint16_t NFCC_DEFAULT_TIMEOUT = 10;
 static constexpr uint16_t NFCC_INIT_TIMEOUT = 50;
@@ -56,16 +55,17 @@ static constexpr uint8_t CORE_CONFIG_RW_CE[] = {0x01,   // Number of parameter f
                                                 0x02};  // TOTAL_DURATION (high): 760 ms
 
 static constexpr uint8_t PMU_CFG[] = {
-    0x01,        // Number of parameters
-    0xA0, 0x0E,  // ext. tag
-    11,          // length
-    0x11,        // IRQ Enable: PVDD + temp sensor IRQs
-    0x01,        // RFU
-    0x01,        // Power and Clock Configuration, device on (CFG1)
-    0x01,        // Power and Clock Configuration, device off (CFG1)
-    0x00,        // RFU
-    0x00,        // DC-DC 0
-    0x00,        // DC-DC 1
+    0x01,  // Number of parameters
+    0xA0,
+    0x0E,  // ext. tag
+    11,    // length
+    0x11,  // IRQ Enable: PVDD + temp sensor IRQs
+    0x01,  // RFU
+    0x01,  // Power and Clock Configuration, device on (CFG1)
+    0x01,  // Power and Clock Configuration, device off (CFG1)
+    0x00,  // RFU
+    0x00,  // DC-DC 0
+    0x00,  // DC-DC 1
     // 0x14,        // TXLDO (3.3V / 4.75V)
     // 0xBB,        // TXLDO (4.7V / 4.7V)
     0xFF,  // TXLDO (5.0V / 5.0V)
@@ -311,5 +311,4 @@ class PN7160 : public nfc::Nfcc, public Component {
   std::vector<nfc::NfcOnTagTrigger *> triggers_ontagremoved_;
 };
 
-}  // namespace pn7160
-}  // namespace esphome
+}  // namespace esphome::pn7160

--- a/esphome/components/pn7160/pn7160.h
+++ b/esphome/components/pn7160/pn7160.h
@@ -55,17 +55,16 @@ static constexpr uint8_t CORE_CONFIG_RW_CE[] = {0x01,   // Number of parameter f
                                                 0x02};  // TOTAL_DURATION (high): 760 ms
 
 static constexpr uint8_t PMU_CFG[] = {
-    0x01,  // Number of parameters
-    0xA0,
-    0x0E,  // ext. tag
-    11,    // length
-    0x11,  // IRQ Enable: PVDD + temp sensor IRQs
-    0x01,  // RFU
-    0x01,  // Power and Clock Configuration, device on (CFG1)
-    0x01,  // Power and Clock Configuration, device off (CFG1)
-    0x00,  // RFU
-    0x00,  // DC-DC 0
-    0x00,  // DC-DC 1
+    0x01,        // Number of parameters
+    0xA0, 0x0E,  // ext. tag
+    11,          // length
+    0x11,        // IRQ Enable: PVDD + temp sensor IRQs
+    0x01,        // RFU
+    0x01,        // Power and Clock Configuration, device on (CFG1)
+    0x01,        // Power and Clock Configuration, device off (CFG1)
+    0x00,        // RFU
+    0x00,        // DC-DC 0
+    0x00,        // DC-DC 1
     // 0x14,        // TXLDO (3.3V / 4.75V)
     // 0xBB,        // TXLDO (4.7V / 4.7V)
     0xFF,  // TXLDO (5.0V / 5.0V)

--- a/esphome/components/pn7160/pn7160_mifare_classic.cpp
+++ b/esphome/components/pn7160/pn7160_mifare_classic.cpp
@@ -4,8 +4,7 @@
 #include "pn7160.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pn7160 {
+namespace esphome::pn7160 {
 
 static const char *const TAG = "pn7160.mifare_classic";
 
@@ -324,5 +323,4 @@ uint8_t PN7160::halt_mifare_classic_tag_() {
   return nfc::STATUS_OK;
 }
 
-}  // namespace pn7160
-}  // namespace esphome
+}  // namespace esphome::pn7160

--- a/esphome/components/pn7160/pn7160_mifare_ultralight.cpp
+++ b/esphome/components/pn7160/pn7160_mifare_ultralight.cpp
@@ -5,8 +5,7 @@
 #include "pn7160.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pn7160 {
+namespace esphome::pn7160 {
 
 static const char *const TAG = "pn7160.mifare_ultralight";
 
@@ -183,5 +182,4 @@ uint8_t PN7160::write_mifare_ultralight_page_(uint8_t page_num, const uint8_t *w
   return nfc::STATUS_OK;
 }
 
-}  // namespace pn7160
-}  // namespace esphome
+}  // namespace esphome::pn7160

--- a/esphome/components/pn7160_i2c/pn7160_i2c.cpp
+++ b/esphome/components/pn7160_i2c/pn7160_i2c.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace pn7160_i2c {
+namespace esphome::pn7160_i2c {
 
 static const char *const TAG = "pn7160_i2c";
 
@@ -46,5 +45,4 @@ void PN7160I2C::dump_config() {
   LOG_I2C_DEVICE(this);
 }
 
-}  // namespace pn7160_i2c
-}  // namespace esphome
+}  // namespace esphome::pn7160_i2c

--- a/esphome/components/pn7160_i2c/pn7160_i2c.h
+++ b/esphome/components/pn7160_i2c/pn7160_i2c.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace pn7160_i2c {
+namespace esphome::pn7160_i2c {
 
 class PN7160I2C : public pn7160::PN7160, public i2c::I2CDevice {
  public:
@@ -18,5 +17,4 @@ class PN7160I2C : public pn7160::PN7160, public i2c::I2CDevice {
   uint8_t write_nfcc(nfc::NciMessage &tx) override;
 };
 
-}  // namespace pn7160_i2c
-}  // namespace esphome
+}  // namespace esphome::pn7160_i2c

--- a/esphome/components/pn7160_spi/pn7160_spi.cpp
+++ b/esphome/components/pn7160_spi/pn7160_spi.cpp
@@ -1,8 +1,7 @@
 #include "pn7160_spi.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pn7160_spi {
+namespace esphome::pn7160_spi {
 
 static const char *const TAG = "pn7160_spi";
 
@@ -50,5 +49,4 @@ void PN7160Spi::dump_config() {
   LOG_PIN("  CS Pin: ", this->cs_);
 }
 
-}  // namespace pn7160_spi
-}  // namespace esphome
+}  // namespace esphome::pn7160_spi

--- a/esphome/components/pn7160_spi/pn7160_spi.h
+++ b/esphome/components/pn7160_spi/pn7160_spi.h
@@ -7,8 +7,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace pn7160_spi {
+namespace esphome::pn7160_spi {
 
 static constexpr uint8_t TDD_SPI_READ = 0xFF;
 static constexpr uint8_t TDD_SPI_WRITE = 0x0A;
@@ -26,5 +25,4 @@ class PN7160Spi : public pn7160::PN7160,
   uint8_t write_nfcc(nfc::NciMessage &tx) override;
 };
 
-}  // namespace pn7160_spi
-}  // namespace esphome
+}  // namespace esphome::pn7160_spi

--- a/esphome/components/power_supply/power_supply.cpp
+++ b/esphome/components/power_supply/power_supply.cpp
@@ -1,8 +1,7 @@
 #include "power_supply.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace power_supply {
+namespace esphome::power_supply {
 
 static const char *const TAG = "power_supply";
 
@@ -54,5 +53,4 @@ void PowerSupply::on_powerdown() {
   this->pin_->digital_write(false);
 }
 
-}  // namespace power_supply
-}  // namespace esphome
+}  // namespace esphome::power_supply

--- a/esphome/components/power_supply/power_supply.h
+++ b/esphome/components/power_supply/power_supply.h
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace power_supply {
+namespace esphome::power_supply {
 
 class PowerSupply : public Component {
  public:
@@ -63,5 +62,4 @@ class PowerSupplyRequester {
   bool requested_{false};
 };
 
-}  // namespace power_supply
-}  // namespace esphome
+}  // namespace esphome::power_supply

--- a/esphome/components/preferences/syncer.h
+++ b/esphome/components/preferences/syncer.h
@@ -3,8 +3,7 @@
 #include "esphome/core/preferences.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace preferences {
+namespace esphome::preferences {
 
 class IntervalSyncer final : public Component {
  public:
@@ -25,5 +24,4 @@ class IntervalSyncer final : public Component {
 #endif
 };
 
-}  // namespace preferences
-}  // namespace esphome
+}  // namespace esphome::preferences

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -2,8 +2,7 @@
 #ifdef USE_NETWORK
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace prometheus {
+namespace esphome::prometheus {
 
 void PrometheusHandler::handleRequest(AsyncWebServerRequest *req) {
   AsyncResponseStream *stream = req->beginResponseStream("text/plain; version=0.0.4; charset=utf-8");
@@ -1098,6 +1097,6 @@ void PrometheusHandler::climate_row_(AsyncResponseStream *stream, climate::Clima
 }
 #endif
 
-}  // namespace prometheus
-}  // namespace esphome
+}  // namespace esphome::prometheus
+
 #endif

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -12,8 +12,7 @@
 #include "esphome/core/log.h"
 #endif
 
-namespace esphome {
-namespace prometheus {
+namespace esphome::prometheus {
 
 class PrometheusHandler : public AsyncWebHandler, public Component {
  public:
@@ -218,6 +217,6 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
   std::map<EntityBase *, std::string> relabel_map_name_;
 };
 
-}  // namespace prometheus
-}  // namespace esphome
+}  // namespace esphome::prometheus
+
 #endif

--- a/esphome/components/psram/psram.cpp
+++ b/esphome/components/psram/psram.cpp
@@ -8,8 +8,7 @@
 
 #include <esp_heap_caps.h>
 
-namespace esphome {
-namespace psram {
+namespace esphome::psram {
 static const char *const TAG = "psram";
 
 void PsramComponent::dump_config() {
@@ -25,7 +24,6 @@ void PsramComponent::dump_config() {
   }
 }
 
-}  // namespace psram
-}  // namespace esphome
+}  // namespace esphome::psram
 
 #endif

--- a/esphome/components/psram/psram.h
+++ b/esphome/components/psram/psram.h
@@ -4,14 +4,12 @@
 
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace psram {
+namespace esphome::psram {
 
 class PsramComponent : public Component {
   void dump_config() override;
 };
 
-}  // namespace psram
-}  // namespace esphome
+}  // namespace esphome::psram
 
 #endif

--- a/esphome/components/pulse_counter/automation.h
+++ b/esphome/components/pulse_counter/automation.h
@@ -4,9 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/pulse_counter/pulse_counter_sensor.h"
 
-namespace esphome {
-
-namespace pulse_counter {
+namespace esphome::pulse_counter {
 
 template<typename... Ts> class SetTotalPulsesAction : public Action<Ts...> {
  public:
@@ -20,5 +18,4 @@ template<typename... Ts> class SetTotalPulsesAction : public Action<Ts...> {
   PulseCounterSensor *pulse_counter_;
 };
 
-}  // namespace pulse_counter
-}  // namespace esphome
+}  // namespace esphome::pulse_counter

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -7,8 +7,7 @@
 #include <hal/pcnt_ll.h>
 #endif
 
-namespace esphome {
-namespace pulse_counter {
+namespace esphome::pulse_counter {
 
 static const char *const TAG = "pulse_counter";
 
@@ -210,5 +209,4 @@ void PulseCounterSensor::update() {
   this->last_time_ = now;
 }
 
-}  // namespace pulse_counter
-}  // namespace esphome
+}  // namespace esphome::pulse_counter

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -14,8 +14,7 @@
 #endif  // defined(SOC_PCNT_SUPPORTED) && __has_include(<driver/pulse_cnt.h>)
 #endif  // USE_ESP32
 
-namespace esphome {
-namespace pulse_counter {
+namespace esphome::pulse_counter {
 
 enum PulseCounterCountMode {
   PULSE_COUNTER_DISABLE = 0,
@@ -85,5 +84,4 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   sensor::Sensor *total_sensor_{nullptr};
 };
 
-}  // namespace pulse_counter
-}  // namespace esphome
+}  // namespace esphome::pulse_counter

--- a/esphome/components/pulse_meter/automation.h
+++ b/esphome/components/pulse_meter/automation.h
@@ -4,9 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/pulse_meter/pulse_meter_sensor.h"
 
-namespace esphome {
-
-namespace pulse_meter {
+namespace esphome::pulse_meter {
 
 template<typename... Ts> class SetTotalPulsesAction : public Action<Ts...> {
  public:
@@ -20,5 +18,4 @@ template<typename... Ts> class SetTotalPulsesAction : public Action<Ts...> {
   PulseMeterSensor *pulse_meter_;
 };
 
-}  // namespace pulse_meter
-}  // namespace esphome
+}  // namespace esphome::pulse_meter

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -2,8 +2,7 @@
 #include <utility>
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pulse_meter {
+namespace esphome::pulse_meter {
 
 static const char *const TAG = "pulse_meter";
 
@@ -186,5 +185,4 @@ void IRAM_ATTR PulseMeterSensor::pulse_intr(PulseMeterSensor *sensor) {
   sensor->last_pin_val_ = pin_val;
 }
 
-}  // namespace pulse_meter
-}  // namespace esphome
+}  // namespace esphome::pulse_meter

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -7,8 +7,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace pulse_meter {
+namespace esphome::pulse_meter {
 
 class PulseMeterSensor : public sensor::Sensor, public Component {
  public:
@@ -77,5 +76,4 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   PulseState pulse_state_{};
 };
 
-}  // namespace pulse_meter
-}  // namespace esphome
+}  // namespace esphome::pulse_meter

--- a/esphome/components/pulse_width/pulse_width.cpp
+++ b/esphome/components/pulse_width/pulse_width.cpp
@@ -1,8 +1,7 @@
 #include "pulse_width.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pulse_width {
+namespace esphome::pulse_width {
 
 static const char *const TAG = "pulse_width";
 
@@ -27,5 +26,4 @@ void PulseWidthSensor::update() {
   this->publish_state(width);
 }
 
-}  // namespace pulse_width
-}  // namespace esphome
+}  // namespace esphome::pulse_width

--- a/esphome/components/pulse_width/pulse_width.h
+++ b/esphome/components/pulse_width/pulse_width.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace pulse_width {
+namespace esphome::pulse_width {
 
 /// Store data in a class that doesn't use multiple-inheritance (vtables in flash)
 class PulseWidthSensorStore {
@@ -39,5 +38,4 @@ class PulseWidthSensor : public sensor::Sensor, public PollingComponent {
   InternalGPIOPin *pin_;
 };
 
-}  // namespace pulse_width
-}  // namespace esphome
+}  // namespace esphome::pulse_width

--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
@@ -3,8 +3,8 @@
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
-namespace esphome {
-namespace pvvx_mithermometer {
+
+namespace esphome::pvvx_mithermometer {
 
 static const char *const TAG = "display.pvvx_mithermometer";
 
@@ -186,7 +186,6 @@ void PVVXDisplay::sync_time_() {
 }
 #endif
 
-}  // namespace pvvx_mithermometer
-}  // namespace esphome
+}  // namespace esphome::pvvx_mithermometer
 
 #endif

--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.h
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.h
@@ -13,8 +13,7 @@
 #include "esphome/components/time/real_time_clock.h"
 #endif
 
-namespace esphome {
-namespace pvvx_mithermometer {
+namespace esphome::pvvx_mithermometer {
 
 class PVVXDisplay;
 
@@ -130,7 +129,6 @@ class PVVXDisplay : public ble_client::BLEClientNode, public PollingComponent {
   pvvx_writer_t writer_{};
 };
 
-}  // namespace pvvx_mithermometer
-}  // namespace esphome
+}  // namespace esphome::pvvx_mithermometer
 
 #endif

--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.cpp
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace pvvx_mithermometer {
+namespace esphome::pvvx_mithermometer {
 
 static const char *const TAG = "pvvx_mithermometer";
 
@@ -140,7 +139,6 @@ bool PVVXMiThermometer::report_results_(const optional<ParseResult> &result, con
   return true;
 }
 
-}  // namespace pvvx_mithermometer
-}  // namespace esphome
+}  // namespace esphome::pvvx_mithermometer
 
 #endif

--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
@@ -8,8 +8,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace pvvx_mithermometer {
+namespace esphome::pvvx_mithermometer {
 
 struct ParseResult {
   optional<float> temperature;
@@ -46,7 +45,6 @@ class PVVXMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevic
   bool report_results_(const optional<ParseResult> &result, const char *address);
 };
 
-}  // namespace pvvx_mithermometer
-}  // namespace esphome
+}  // namespace esphome::pvvx_mithermometer
 
 #endif

--- a/esphome/components/pylontech/pylontech.cpp
+++ b/esphome/components/pylontech/pylontech.cpp
@@ -24,8 +24,7 @@
     } \
   }
 
-namespace esphome {
-namespace pylontech {
+namespace esphome::pylontech {
 
 static const char *const TAG = "pylontech";
 static const int MAX_DATA_LENGTH_BYTES = 256;
@@ -198,8 +197,7 @@ void PylontechComponent::process_line_(std::string &buffer) {
   }
 }
 
-}  // namespace pylontech
-}  // namespace esphome
+}  // namespace esphome::pylontech
 
 #undef PARSE_INT
 #undef PARSE_STR

--- a/esphome/components/pylontech/pylontech.h
+++ b/esphome/components/pylontech/pylontech.h
@@ -4,8 +4,7 @@
 #include "esphome/core/defines.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace pylontech {
+namespace esphome::pylontech {
 
 static const uint8_t NUM_BUFFERS = 20;
 static const uint8_t TEXT_SENSOR_MAX_LEN = 14;
@@ -48,5 +47,4 @@ class PylontechComponent : public PollingComponent, public uart::UARTDevice {
   std::vector<PylontechListener *> listeners_{};
 };
 
-}  // namespace pylontech
-}  // namespace esphome
+}  // namespace esphome::pylontech

--- a/esphome/components/pylontech/sensor/pylontech_sensor.cpp
+++ b/esphome/components/pylontech/sensor/pylontech_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pylontech {
+namespace esphome::pylontech {
 
 static const char *const TAG = "pylontech.sensor";
 
@@ -58,5 +57,4 @@ void PylontechSensor::on_line_read(PylontechListener::LineContents *line) {
   }
 }
 
-}  // namespace pylontech
-}  // namespace esphome
+}  // namespace esphome::pylontech

--- a/esphome/components/pylontech/sensor/pylontech_sensor.h
+++ b/esphome/components/pylontech/sensor/pylontech_sensor.h
@@ -3,8 +3,7 @@
 #include "../pylontech.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace pylontech {
+namespace esphome::pylontech {
 
 class PylontechSensor : public PylontechListener {
  public:
@@ -28,5 +27,4 @@ class PylontechSensor : public PylontechListener {
   int8_t bat_num_;
 };
 
-}  // namespace pylontech
-}  // namespace esphome
+}  // namespace esphome::pylontech

--- a/esphome/components/pylontech/text_sensor/pylontech_text_sensor.cpp
+++ b/esphome/components/pylontech/text_sensor/pylontech_text_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pylontech {
+namespace esphome::pylontech {
 
 static const char *const TAG = "pylontech.textsensor";
 
@@ -38,5 +37,4 @@ void PylontechTextSensor::on_line_read(PylontechListener::LineContents *line) {
   }
 }
 
-}  // namespace pylontech
-}  // namespace esphome
+}  // namespace esphome::pylontech

--- a/esphome/components/pylontech/text_sensor/pylontech_text_sensor.h
+++ b/esphome/components/pylontech/text_sensor/pylontech_text_sensor.h
@@ -3,8 +3,7 @@
 #include "../pylontech.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
-namespace esphome {
-namespace pylontech {
+namespace esphome::pylontech {
 
 class PylontechTextSensor : public PylontechListener {
  public:
@@ -22,5 +21,4 @@ class PylontechTextSensor : public PylontechListener {
   int8_t bat_num_;
 };
 
-}  // namespace pylontech
-}  // namespace esphome
+}  // namespace esphome::pylontech

--- a/esphome/components/pzem004t/pzem004t.cpp
+++ b/esphome/components/pzem004t/pzem004t.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/application.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace pzem004t {
+namespace esphome::pzem004t {
 
 static const char *const TAG = "pzem004t";
 
@@ -126,5 +125,4 @@ void PZEM004T::dump_config() {
   LOG_SENSOR("", "Power", this->power_sensor_);
 }
 
-}  // namespace pzem004t
-}  // namespace esphome
+}  // namespace esphome::pzem004t

--- a/esphome/components/pzem004t/pzem004t.h
+++ b/esphome/components/pzem004t/pzem004t.h
@@ -4,8 +4,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace pzem004t {
+namespace esphome::pzem004t {
 
 class PZEM004T : public PollingComponent, public uart::UARTDevice {
  public:
@@ -42,5 +41,4 @@ class PZEM004T : public PollingComponent, public uart::UARTDevice {
   uint32_t last_read_{0};
 };
 
-}  // namespace pzem004t
-}  // namespace esphome
+}  // namespace esphome::pzem004t

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -1,8 +1,7 @@
 #include "pzemac.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pzemac {
+namespace esphome::pzemac {
 
 static const char *const TAG = "pzemac";
 
@@ -83,5 +82,4 @@ void PZEMAC::reset_energy_() {
   this->send_raw(cmd);
 }
 
-}  // namespace pzemac
-}  // namespace esphome
+}  // namespace esphome::pzemac

--- a/esphome/components/pzemac/pzemac.h
+++ b/esphome/components/pzemac/pzemac.h
@@ -7,8 +7,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace pzemac {
+namespace esphome::pzemac {
 
 template<typename... Ts> class ResetEnergyAction;
 
@@ -49,5 +48,4 @@ template<typename... Ts> class ResetEnergyAction : public Action<Ts...> {
   PZEMAC *pzemac_;
 };
 
-}  // namespace pzemac
-}  // namespace esphome
+}  // namespace esphome::pzemac

--- a/esphome/components/pzemdc/pzemdc.cpp
+++ b/esphome/components/pzemdc/pzemdc.cpp
@@ -1,8 +1,7 @@
 #include "pzemdc.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pzemdc {
+namespace esphome::pzemdc {
 
 static const char *const TAG = "pzemdc";
 
@@ -71,5 +70,4 @@ void PZEMDC::reset_energy() {
   this->send_raw(cmd);
 }
 
-}  // namespace pzemdc
-}  // namespace esphome
+}  // namespace esphome::pzemdc

--- a/esphome/components/pzemdc/pzemdc.h
+++ b/esphome/components/pzemdc/pzemdc.h
@@ -7,8 +7,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace pzemdc {
+namespace esphome::pzemdc {
 
 class PZEMDC : public PollingComponent, public modbus::ModbusDevice {
  public:
@@ -42,5 +41,4 @@ template<typename... Ts> class ResetEnergyAction : public Action<Ts...> {
   PZEMDC *pzemdc_;
 };
 
-}  // namespace pzemdc
-}  // namespace esphome
+}  // namespace esphome::pzemdc

--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include <cmath>
 
-namespace esphome {
-namespace qmc5883l {
+namespace esphome::qmc5883l {
 
 static const char *const TAG = "qmc5883l";
 
@@ -213,5 +212,4 @@ i2c::ErrorCode QMC5883LComponent::read_bytes_16_le_(uint8_t a_register, uint16_t
   return err;
 }
 
-}  // namespace qmc5883l
-}  // namespace esphome
+}  // namespace esphome::qmc5883l

--- a/esphome/components/qmc5883l/qmc5883l.h
+++ b/esphome/components/qmc5883l/qmc5883l.h
@@ -5,8 +5,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace qmc5883l {
+namespace esphome::qmc5883l {
 
 enum QMC5883LDatarate {
   QMC5883L_DATARATE_10_HZ = 0b00,
@@ -66,5 +65,4 @@ class QMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
   HighFrequencyLoopRequester high_freq_;
 };
 
-}  // namespace qmc5883l
-}  // namespace esphome
+}  // namespace esphome::qmc5883l

--- a/esphome/components/qmp6988/qmp6988.cpp
+++ b/esphome/components/qmp6988/qmp6988.cpp
@@ -3,8 +3,7 @@
 #include <cinttypes>
 #include <cmath>
 
-namespace esphome {
-namespace qmp6988 {
+namespace esphome::qmp6988 {
 
 static const uint8_t QMP6988_CHIP_ID = 0x5C;
 
@@ -351,5 +350,4 @@ void QMP6988Component::update() {
     this->pressure_sensor_->publish_state(pressurehectopascals);
 }
 
-}  // namespace qmp6988
-}  // namespace esphome
+}  // namespace esphome::qmp6988

--- a/esphome/components/qmp6988/qmp6988.h
+++ b/esphome/components/qmp6988/qmp6988.h
@@ -7,8 +7,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace qmp6988 {
+namespace esphome::qmp6988 {
 
 /* oversampling */
 enum QMP6988Oversampling : uint8_t {
@@ -106,5 +105,4 @@ class QMP6988Component : public PollingComponent, public i2c::I2CDevice {
   int16_t get_compensated_temperature_(qmp6988_ik_data_t *ik, int32_t dt);
 };
 
-}  // namespace qmp6988
-}  // namespace esphome
+}  // namespace esphome::qmp6988

--- a/esphome/components/qr_code/qr_code.cpp
+++ b/esphome/components/qr_code/qr_code.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/color.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace qr_code {
+namespace esphome::qr_code {
 
 static const char *const TAG = "qr_code";
 
@@ -74,5 +73,4 @@ uint8_t QrCode::get_size() {
   return size;
 }
 
-}  // namespace qr_code
-}  // namespace esphome
+}  // namespace esphome::qr_code

--- a/esphome/components/qwiic_pir/qwiic_pir.cpp
+++ b/esphome/components/qwiic_pir/qwiic_pir.cpp
@@ -1,8 +1,7 @@
 #include "qwiic_pir.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace qwiic_pir {
+namespace esphome::qwiic_pir {
 
 static const char *const TAG = "qwiic_pir";
 
@@ -129,5 +128,4 @@ void QwiicPIRComponent::clear_events_() {
     ESP_LOGW(TAG, "Failed to clear events");
 }
 
-}  // namespace qwiic_pir
-}  // namespace esphome
+}  // namespace esphome::qwiic_pir

--- a/esphome/components/qwiic_pir/qwiic_pir.h
+++ b/esphome/components/qwiic_pir/qwiic_pir.h
@@ -12,8 +12,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace qwiic_pir {
+namespace esphome::qwiic_pir {
 
 // Qwiic PIR I2C Register Addresses
 enum {
@@ -65,5 +64,4 @@ class QwiicPIRComponent : public Component, public i2c::I2CDevice, public binary
   void clear_events_();
 };
 
-}  // namespace qwiic_pir
-}  // namespace esphome
+}  // namespace esphome::qwiic_pir

--- a/esphome/components/radon_eye_ble/radon_eye_listener.cpp
+++ b/esphome/components/radon_eye_ble/radon_eye_listener.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace radon_eye_ble {
+namespace esphome::radon_eye_ble {
 
 static const char *const TAG = "radon_eye_ble";
 
@@ -19,7 +18,6 @@ bool RadonEyeListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device
   return false;
 }
 
-}  // namespace radon_eye_ble
-}  // namespace esphome
+}  // namespace esphome::radon_eye_ble
 
 #endif

--- a/esphome/components/radon_eye_ble/radon_eye_listener.h
+++ b/esphome/components/radon_eye_ble/radon_eye_listener.h
@@ -5,15 +5,13 @@
 #include "esphome/core/component.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
-namespace esphome {
-namespace radon_eye_ble {
+namespace esphome::radon_eye_ble {
 
 class RadonEyeListener : public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 };
 
-}  // namespace radon_eye_ble
-}  // namespace esphome
+}  // namespace esphome::radon_eye_ble
 
 #endif

--- a/esphome/components/radon_eye_rd200/radon_eye_rd200.cpp
+++ b/esphome/components/radon_eye_rd200/radon_eye_rd200.cpp
@@ -5,8 +5,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace radon_eye_rd200 {
+namespace esphome::radon_eye_rd200 {
 
 static const char *const TAG = "radon_eye_rd200";
 
@@ -211,7 +210,6 @@ void RadonEyeRD200::dump_config() {
 
 RadonEyeRD200::RadonEyeRD200() : PollingComponent(10000) {}
 
-}  // namespace radon_eye_rd200
-}  // namespace esphome
+}  // namespace esphome::radon_eye_rd200
 
 #endif  // USE_ESP32

--- a/esphome/components/radon_eye_rd200/radon_eye_rd200.h
+++ b/esphome/components/radon_eye_rd200/radon_eye_rd200.h
@@ -11,8 +11,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace radon_eye_rd200 {
+namespace esphome::radon_eye_rd200 {
 
 class RadonEyeRD200 : public PollingComponent, public ble_client::BLEClientNode {
  public:
@@ -41,7 +40,6 @@ class RadonEyeRD200 : public PollingComponent, public ble_client::BLEClientNode 
   esp32_ble_tracker::ESPBTUUID sensors_read_characteristic_uuid_;
 };
 
-}  // namespace radon_eye_rd200
-}  // namespace esphome
+}  // namespace esphome::radon_eye_rd200
 
 #endif  // USE_ESP32

--- a/esphome/components/rc522/rc522.cpp
+++ b/esphome/components/rc522/rc522.cpp
@@ -5,8 +5,7 @@
 // Based on:
 // - https://github.com/miguelbalboa/rfid
 
-namespace esphome {
-namespace rc522 {
+namespace esphome::rc522 {
 
 static const uint8_t WAIT_I_RQ = 0x30;  // RxIRq and IdleIRq
 
@@ -498,5 +497,4 @@ void RC522Trigger::process(std::vector<uint8_t> &data) {
   this->trigger(format_hex_pretty_to(uid_buf, data.data(), data.size(), '-'));
 }
 
-}  // namespace rc522
-}  // namespace esphome
+}  // namespace esphome::rc522

--- a/esphome/components/rc522/rc522.h
+++ b/esphome/components/rc522/rc522.h
@@ -7,8 +7,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace rc522 {
+namespace esphome::rc522 {
 
 class RC522BinarySensor;
 class RC522Trigger;
@@ -275,5 +274,4 @@ class RC522Trigger : public Trigger<std::string> {
   void process(std::vector<uint8_t> &data);
 };
 
-}  // namespace rc522
-}  // namespace esphome
+}  // namespace esphome::rc522

--- a/esphome/components/rc522_i2c/rc522_i2c.cpp
+++ b/esphome/components/rc522_i2c/rc522_i2c.cpp
@@ -1,8 +1,7 @@
 #include "rc522_i2c.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace rc522_i2c {
+namespace esphome::rc522_i2c {
 
 static const char *const TAG = "rc522_i2c";
 
@@ -66,5 +65,4 @@ void RC522I2C::pcd_write_register(PcdRegister reg,  ///< The register to write t
   write_bytes(reg >> 1, values, count);
 }
 
-}  // namespace rc522_i2c
-}  // namespace esphome
+}  // namespace esphome::rc522_i2c

--- a/esphome/components/rc522_i2c/rc522_i2c.h
+++ b/esphome/components/rc522_i2c/rc522_i2c.h
@@ -4,8 +4,7 @@
 #include "esphome/components/rc522/rc522.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace rc522_i2c {
+namespace esphome::rc522_i2c {
 
 class RC522I2C : public rc522::RC522, public i2c::I2CDevice {
  public:
@@ -38,5 +37,4 @@ class RC522I2C : public rc522::RC522, public i2c::I2CDevice {
                           ) override;
 };
 
-}  // namespace rc522_i2c
-}  // namespace esphome
+}  // namespace esphome::rc522_i2c

--- a/esphome/components/rc522_spi/rc522_spi.cpp
+++ b/esphome/components/rc522_spi/rc522_spi.cpp
@@ -5,8 +5,7 @@
 // Based on:
 // - https://github.com/miguelbalboa/rfid
 
-namespace esphome {
-namespace rc522_spi {
+namespace esphome::rc522_spi {
 
 static const char *const TAG = "rc522_spi";
 
@@ -136,5 +135,4 @@ void RC522Spi::pcd_write_register(PcdRegister reg,  ///< The register to write t
   ESP_LOGVV(TAG, "write_register_(%d, %d) -> %s", reg, count, buf.c_str());
 }
 
-}  // namespace rc522_spi
-}  // namespace esphome
+}  // namespace esphome::rc522_spi

--- a/esphome/components/rc522_spi/rc522_spi.h
+++ b/esphome/components/rc522_spi/rc522_spi.h
@@ -4,7 +4,6 @@
 #include "esphome/components/rc522/rc522.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
 /**
  * Library based on https://github.com/miguelbalboa/rfid
  * and adapted to ESPHome by @glmnet
@@ -13,7 +12,7 @@ namespace esphome {
  *
  *
  */
-namespace rc522_spi {
+namespace esphome::rc522_spi {
 
 class RC522Spi : public rc522::RC522,
                  public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
@@ -50,5 +49,4 @@ class RC522Spi : public rc522::RC522,
                           ) override;
 };
 
-}  // namespace rc522_spi
-}  // namespace esphome
+}  // namespace esphome::rc522_spi

--- a/esphome/components/rdm6300/rdm6300.cpp
+++ b/esphome/components/rdm6300/rdm6300.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace rdm6300 {
+namespace esphome::rdm6300 {
 
 static const char *const TAG = "rdm6300";
 
@@ -67,5 +66,4 @@ void rdm6300::RDM6300Component::loop() {
   }
 }
 
-}  // namespace rdm6300
-}  // namespace esphome
+}  // namespace esphome::rdm6300

--- a/esphome/components/rdm6300/rdm6300.h
+++ b/esphome/components/rdm6300/rdm6300.h
@@ -8,8 +8,7 @@
 #include <cinttypes>
 #include <vector>
 
-namespace esphome {
-namespace rdm6300 {
+namespace esphome::rdm6300 {
 
 class RDM6300BinarySensor;
 class RDM6300Trigger;
@@ -52,5 +51,4 @@ class RDM6300Trigger : public Trigger<uint32_t> {
   void process(uint32_t uid) { this->trigger(uid); }
 };
 
-}  // namespace rdm6300
-}  // namespace esphome
+}  // namespace esphome::rdm6300

--- a/esphome/components/remote_base/abbwelcome_protocol.cpp
+++ b/esphome/components/remote_base/abbwelcome_protocol.cpp
@@ -1,8 +1,7 @@
 #include "abbwelcome_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.abbwelcome";
 
@@ -123,5 +122,4 @@ void ABBWelcomeProtocol::dump(const ABBWelcomeData &data) {
   ESP_LOGD(TAG, "Received ABBWelcome: %s", data.format_to(buf));
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/abbwelcome_protocol.h
+++ b/esphome/components/remote_base/abbwelcome_protocol.h
@@ -8,8 +8,7 @@
 #include <utility>
 #include <vector>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static constexpr uint8_t MAX_DATA_LENGTH = 15;
 static constexpr uint8_t DATA_LENGTH_MASK = 0x3f;
@@ -272,5 +271,4 @@ template<typename... Ts> class ABBWelcomeAction : public RemoteTransmitterAction
   } data_;
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/aeha_protocol.cpp
+++ b/esphome/components/remote_base/aeha_protocol.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.aeha";
 
@@ -98,5 +97,4 @@ void AEHAProtocol::dump(const AEHAData &data) {
   ESP_LOGI(TAG, "Received AEHA: address=0x%04X, data=[%s]", data.address, data_str.c_str());
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/aeha_protocol.h
+++ b/esphome/components/remote_base/aeha_protocol.h
@@ -4,8 +4,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct AEHAData {
   uint16_t address;
@@ -42,5 +41,4 @@ template<typename... Ts> class AEHAAction : public RemoteTransmitterActionBase<T
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/beo4_protocol.cpp
+++ b/esphome/components/remote_base/beo4_protocol.cpp
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.beo4";
 
@@ -149,5 +148,4 @@ void Beo4Protocol::dump(const Beo4Data &data) {
   ESP_LOGI(TAG, "Beo4: source=0x%02x command=0x%02x repeats=%d ", data.source, data.command, data.repeats);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/beo4_protocol.h
+++ b/esphome/components/remote_base/beo4_protocol.h
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct Beo4Data {
   uint8_t source;   // beoSource, e.g. video, audio, light...
@@ -39,5 +38,4 @@ template<typename... Ts> class Beo4Action : public RemoteTransmitterActionBase<T
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/byronsx_protocol.cpp
+++ b/esphome/components/remote_base/byronsx_protocol.cpp
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.byronsx";
 
@@ -135,5 +134,4 @@ void ByronSXProtocol::dump(const ByronSXData &data) {
   ESP_LOGD(TAG, "Received ByronSX: address=0x%08X, command=0x%02x", data.address, data.command);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/byronsx_protocol.h
+++ b/esphome/components/remote_base/byronsx_protocol.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct ByronSXData {
   uint8_t address;
@@ -42,5 +41,4 @@ template<typename... Ts> class ByronSXAction : public RemoteTransmitterActionBas
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/canalsat_protocol.cpp
+++ b/esphome/components/remote_base/canalsat_protocol.cpp
@@ -1,8 +1,7 @@
 #include "canalsat_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const CANALSAT_TAG = "remote.canalsat";
 static const char *const CANALSATLD_TAG = "remote.canalsatld";
@@ -104,5 +103,4 @@ void CanalSatBaseProtocol::dump(const CanalSatData &data) {
   }
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/canalsat_protocol.h
+++ b/esphome/components/remote_base/canalsat_protocol.h
@@ -2,8 +2,7 @@
 
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct CanalSatData {
   uint8_t device : 7;
@@ -74,5 +73,4 @@ template<typename... Ts> class CanalSatLDAction : public RemoteTransmitterAction
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/coolix_protocol.cpp
+++ b/esphome/components/remote_base/coolix_protocol.cpp
@@ -1,8 +1,7 @@
 #include "coolix_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.coolix";
 
@@ -109,5 +108,4 @@ void CoolixProtocol::dump(const CoolixData &data) {
   }
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/coolix_protocol.h
+++ b/esphome/components/remote_base/coolix_protocol.h
@@ -6,8 +6,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct CoolixData {
   CoolixData() {}
@@ -37,5 +36,4 @@ template<typename... Ts> class CoolixAction : public RemoteTransmitterActionBase
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/dish_protocol.cpp
+++ b/esphome/components/remote_base/dish_protocol.cpp
@@ -1,8 +1,7 @@
 #include "dish_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.dish";
 
@@ -90,5 +89,4 @@ void DishProtocol::dump(const DishData &data) {
   ESP_LOGI(TAG, "Received Dish: address=0x%02X, command=0x%02X", data.address, data.command);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/dish_protocol.h
+++ b/esphome/components/remote_base/dish_protocol.h
@@ -2,8 +2,7 @@
 
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct DishData {
   uint8_t address;
@@ -34,5 +33,4 @@ template<typename... Ts> class DishAction : public RemoteTransmitterActionBase<T
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/dooya_protocol.cpp
+++ b/esphome/components/remote_base/dooya_protocol.cpp
@@ -1,8 +1,7 @@
 #include "dooya_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.dooya";
 
@@ -116,5 +115,4 @@ void DooyaProtocol::dump(const DooyaData &data) {
            data.button, data.check);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/dooya_protocol.h
+++ b/esphome/components/remote_base/dooya_protocol.h
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct DooyaData {
   uint32_t id;
@@ -45,5 +44,4 @@ template<typename... Ts> class DooyaAction : public RemoteTransmitterActionBase<
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.drayton";
 
@@ -236,5 +235,4 @@ void DraytonProtocol::dump(const DraytonData &data) {
            ((data.address << 1) & 0xffff), data.channel, data.command);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/drayton_protocol.h
+++ b/esphome/components/remote_base/drayton_protocol.h
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct DraytonData {
   uint16_t address;
@@ -42,5 +41,4 @@ template<typename... Ts> class DraytonAction : public RemoteTransmitterActionBas
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/dyson_protocol.cpp
+++ b/esphome/components/remote_base/dyson_protocol.cpp
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.dyson";
 
@@ -67,5 +66,4 @@ void DysonProtocol::dump(const DysonData &data) {
   ESP_LOGI(TAG, "Dyson: code=0x%x rolling index=%d", data.code, data.index);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/dyson_protocol.h
+++ b/esphome/components/remote_base/dyson_protocol.h
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static constexpr uint8_t IGNORE_INDEX = 0xFF;
 
@@ -42,5 +41,4 @@ template<typename... Ts> class DysonAction : public RemoteTransmitterActionBase<
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/gobox_protocol.cpp
+++ b/esphome/components/remote_base/gobox_protocol.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.gobox";
 
@@ -128,5 +127,4 @@ void GoboxProtocol::dump(const GoboxData &data) {
   }
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/gobox_protocol.h
+++ b/esphome/components/remote_base/gobox_protocol.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct GoboxData {
   int code;
@@ -50,5 +49,4 @@ template<typename... Ts> class GoboxAction : public RemoteTransmitterActionBase<
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/haier_protocol.cpp
+++ b/esphome/components/remote_base/haier_protocol.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.haier";
 
@@ -84,5 +83,4 @@ void HaierProtocol::dump(const HaierData &data) {
   ESP_LOGI(TAG, "Received Haier: %s", format_hex_pretty_to(hex_buf, data.data.data(), data.data.size()));
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/haier_protocol.h
+++ b/esphome/components/remote_base/haier_protocol.h
@@ -3,8 +3,7 @@
 #include "remote_base.h"
 #include <vector>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct HaierData {
   std::vector<uint8_t> data;
@@ -35,5 +34,4 @@ template<typename... Ts> class HaierAction : public RemoteTransmitterActionBase<
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/jvc_protocol.cpp
+++ b/esphome/components/remote_base/jvc_protocol.cpp
@@ -1,8 +1,7 @@
 #include "jvc_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.jvc";
 
@@ -48,5 +47,4 @@ optional<JVCData> JVCProtocol::decode(RemoteReceiveData src) {
 }
 void JVCProtocol::dump(const JVCData &data) { ESP_LOGI(TAG, "Received JVC: data=0x%04" PRIX32, data.data); }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/jvc_protocol.h
+++ b/esphome/components/remote_base/jvc_protocol.h
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct JVCData {
   uint32_t data;
@@ -33,5 +32,4 @@ template<typename... Ts> class JVCAction : public RemoteTransmitterActionBase<Ts
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/keeloq_protocol.cpp
+++ b/esphome/components/remote_base/keeloq_protocol.cpp
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.keeloq";
 
@@ -190,5 +189,4 @@ void KeeloqProtocol::dump(const KeeloqData &data) {
   ESP_LOGD(TAG, "Received Keeloq: address=0x%08" PRIx32 ", command=0x%02x", data.address, data.command);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/keeloq_protocol.h
+++ b/esphome/components/remote_base/keeloq_protocol.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct KeeloqData {
   uint32_t encrypted;  // 32 bit encrypted field
@@ -49,5 +48,4 @@ template<typename... Ts> class KeeloqAction : public RemoteTransmitterActionBase
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/lg_protocol.cpp
+++ b/esphome/components/remote_base/lg_protocol.cpp
@@ -1,8 +1,7 @@
 #include "lg_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.lg";
 
@@ -54,5 +53,4 @@ void LGProtocol::dump(const LGData &data) {
   ESP_LOGI(TAG, "Received LG: data=0x%08" PRIX32 ", nbits=%d", data.data, data.nbits);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/lg_protocol.h
+++ b/esphome/components/remote_base/lg_protocol.h
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct LGData {
   uint32_t data;
@@ -37,5 +36,4 @@ template<typename... Ts> class LGAction : public RemoteTransmitterActionBase<Ts.
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/magiquest_protocol.cpp
+++ b/esphome/components/remote_base/magiquest_protocol.cpp
@@ -5,8 +5,7 @@
  * https://arduino-irremote.github.io/Arduino-IRremote/ir__MagiQuest_8cpp_source.html
  */
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.magiquest";
 
@@ -79,5 +78,4 @@ void MagiQuestProtocol::dump(const MagiQuestData &data) {
   ESP_LOGI(TAG, "Received MagiQuest: wand_id=0x%08" PRIX32 ", magnitude=0x%04X", data.wand_id, data.magnitude);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/magiquest_protocol.h
+++ b/esphome/components/remote_base/magiquest_protocol.h
@@ -8,8 +8,7 @@
  * https://arduino-irremote.github.io/Arduino-IRremote/ir__MagiQuest_8cpp_source.html
  */
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct MagiQuestData {
   uint16_t magnitude;
@@ -48,5 +47,4 @@ template<typename... Ts> class MagiQuestAction : public RemoteTransmitterActionB
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/midea_protocol.cpp
+++ b/esphome/components/remote_base/midea_protocol.cpp
@@ -1,8 +1,7 @@
 #include "midea_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.midea";
 
@@ -75,5 +74,4 @@ void MideaProtocol::dump(const MideaData &data) {
   ESP_LOGI(TAG, "Received Midea: %s", data.to_str(buf));
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -7,8 +7,7 @@
 #include "esphome/core/helpers.h"
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 class MideaData {
  public:
@@ -88,5 +87,4 @@ template<typename... Ts> class MideaAction : public RemoteTransmitterActionBase<
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/mirage_protocol.cpp
+++ b/esphome/components/remote_base/mirage_protocol.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.mirage";
 
@@ -85,5 +84,4 @@ void MirageProtocol::dump(const MirageData &data) {
   ESP_LOGI(TAG, "Received Mirage: %s", format_hex_pretty_to(hex_buf, data.data.data(), data.data.size()));
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/mirage_protocol.h
+++ b/esphome/components/remote_base/mirage_protocol.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct MirageData {
   std::vector<uint8_t> data;
@@ -35,5 +34,4 @@ template<typename... Ts> class MirageAction : public RemoteTransmitterActionBase
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/nec_protocol.cpp
+++ b/esphome/components/remote_base/nec_protocol.cpp
@@ -1,8 +1,7 @@
 #include "nec_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.nec";
 
@@ -98,5 +97,4 @@ void NECProtocol::dump(const NECData &data) {
            data.command_repeats);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/nec_protocol.h
+++ b/esphome/components/remote_base/nec_protocol.h
@@ -2,8 +2,7 @@
 
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct NECData {
   uint16_t address;
@@ -37,5 +36,4 @@ template<typename... Ts> class NECAction : public RemoteTransmitterActionBase<Ts
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/nexa_protocol.cpp
+++ b/esphome/components/remote_base/nexa_protocol.cpp
@@ -1,8 +1,7 @@
 #include "nexa_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.nexa";
 
@@ -236,5 +235,4 @@ void NexaProtocol::dump(const NexaData &data) {
            data.state, data.channel, data.level);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/nexa_protocol.h
+++ b/esphome/components/remote_base/nexa_protocol.h
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct NexaData {
   uint32_t device;
@@ -50,5 +49,4 @@ template<typename... Ts> class NexaAction : public RemoteTransmitterActionBase<T
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/panasonic_protocol.cpp
+++ b/esphome/components/remote_base/panasonic_protocol.cpp
@@ -1,8 +1,7 @@
 #include "panasonic_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.panasonic";
 
@@ -70,5 +69,4 @@ void PanasonicProtocol::dump(const PanasonicData &data) {
   ESP_LOGI(TAG, "Received Panasonic: address=0x%04X, command=0x%08" PRIX32, data.address, data.command);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/panasonic_protocol.h
+++ b/esphome/components/remote_base/panasonic_protocol.h
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct PanasonicData {
   uint16_t address;
@@ -37,5 +36,4 @@ template<typename... Ts> class PanasonicAction : public RemoteTransmitterActionB
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/pioneer_protocol.cpp
+++ b/esphome/components/remote_base/pioneer_protocol.cpp
@@ -1,8 +1,7 @@
 #include "pioneer_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.pioneer";
 
@@ -152,5 +151,4 @@ void PioneerProtocol::dump(const PioneerData &data) {
   }
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/pioneer_protocol.h
+++ b/esphome/components/remote_base/pioneer_protocol.h
@@ -2,8 +2,7 @@
 
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct PioneerData {
   uint16_t rc_code_1;
@@ -34,5 +33,4 @@ template<typename... Ts> class PioneerAction : public RemoteTransmitterActionBas
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/pronto_protocol.cpp
+++ b/esphome/components/remote_base/pronto_protocol.cpp
@@ -35,8 +35,7 @@
 #include "pronto_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.pronto";
 
@@ -243,5 +242,4 @@ void ProntoProtocol::dump(const ProntoData &data) {
   } while (remaining > 0);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/pronto_protocol.h
+++ b/esphome/components/remote_base/pronto_protocol.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 std::vector<uint16_t> encode_pronto(const std::string &str);
 
@@ -51,5 +50,4 @@ template<typename... Ts> class ProntoAction : public RemoteTransmitterActionBase
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/raw_protocol.cpp
+++ b/esphome/components/remote_base/raw_protocol.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.raw";
 
@@ -38,5 +37,4 @@ bool RawDumper::dump(RemoteReceiveData src) {
   return true;
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/raw_protocol.h
+++ b/esphome/components/remote_base/raw_protocol.h
@@ -6,8 +6,7 @@
 #include <cinttypes>
 #include <vector>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 class RawBinarySensor : public RemoteReceiverBinarySensorBase {
  public:
@@ -82,5 +81,4 @@ class RawDumper : public RemoteReceiverDumperBase {
   bool is_secondary() override { return true; }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/rc5_protocol.cpp
+++ b/esphome/components/remote_base/rc5_protocol.cpp
@@ -1,8 +1,7 @@
 #include "rc5_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.rc5";
 
@@ -86,5 +85,4 @@ void RC5Protocol::dump(const RC5Data &data) {
   ESP_LOGI(TAG, "Received RC5: address=0x%02X, command=0x%02X", data.address, data.command);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/rc5_protocol.h
+++ b/esphome/components/remote_base/rc5_protocol.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct RC5Data {
   uint8_t address;
@@ -35,5 +34,4 @@ template<typename... Ts> class RC5Action : public RemoteTransmitterActionBase<Ts
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/rc6_protocol.cpp
+++ b/esphome/components/remote_base/rc6_protocol.cpp
@@ -1,8 +1,7 @@
 #include "rc6_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const RC6_TAG = "remote.rc6";
 
@@ -177,5 +176,4 @@ void RC6Protocol::dump(const RC6Data &data) {
            data.command, data.toggle);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/rc6_protocol.h
+++ b/esphome/components/remote_base/rc6_protocol.h
@@ -2,8 +2,7 @@
 
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct RC6Data {
   uint8_t mode : 3;
@@ -42,5 +41,4 @@ template<typename... Ts> class RC6Action : public RemoteTransmitterActionBase<Ts
   uint8_t toggle_{0};
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -1,8 +1,7 @@
 #include "rc_switch_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.rc_switch";
 
@@ -267,5 +266,4 @@ bool RCSwitchDumper::dump(RemoteReceiveData src) {
   return false;
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/rc_switch_protocol.h
+++ b/esphome/components/remote_base/rc_switch_protocol.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct RCSwitchData {
   uint64_t code;
@@ -217,5 +216,4 @@ class RCSwitchDumper : public RemoteReceiverDumperBase {
 
 using RCSwitchTrigger = RemoteReceiverTrigger<RCSwitchBase>;
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/remote_base.cpp
+++ b/esphome/components/remote_base/remote_base.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote_base";
 
@@ -198,5 +197,4 @@ void RemoteTransmitterBase::send_(uint32_t send_times, uint32_t send_wait) {
 #endif
   this->send_internal(send_times, send_wait);
 }
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -8,8 +8,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 enum ToleranceMode : uint8_t {
   TOLERANCE_MODE_PERCENTAGE = 0,
@@ -317,5 +316,4 @@ template<typename T> class RemoteReceiverDumper : public RemoteReceiverDumperBas
   using prefix##Dumper = RemoteReceiverDumper<prefix##Protocol>;
 #define DECLARE_REMOTE_PROTOCOL(prefix) DECLARE_REMOTE_PROTOCOL_(prefix)
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/roomba_protocol.cpp
+++ b/esphome/components/remote_base/roomba_protocol.cpp
@@ -1,8 +1,7 @@
 #include "roomba_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.roomba";
 
@@ -52,5 +51,4 @@ optional<RoombaData> RoombaProtocol::decode(RemoteReceiveData src) {
 }
 void RoombaProtocol::dump(const RoombaData &data) { ESP_LOGD(TAG, "Received Roomba: data=0x%02X", data.data); }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/roomba_protocol.h
+++ b/esphome/components/remote_base/roomba_protocol.h
@@ -2,8 +2,7 @@
 
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct RoombaData {
   uint8_t data;
@@ -31,5 +30,4 @@ template<typename... Ts> class RoombaAction : public RemoteTransmitterActionBase
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/samsung36_protocol.cpp
+++ b/esphome/components/remote_base/samsung36_protocol.cpp
@@ -1,8 +1,7 @@
 #include "samsung36_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.samsung36";
 
@@ -99,5 +98,4 @@ void Samsung36Protocol::dump(const Samsung36Data &data) {
   ESP_LOGI(TAG, "Received Samsung36: address=0x%04X, command=0x%08" PRIX32, data.address, data.command);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/samsung36_protocol.h
+++ b/esphome/components/remote_base/samsung36_protocol.h
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct Samsung36Data {
   uint16_t address;
@@ -37,5 +36,4 @@ template<typename... Ts> class Samsung36Action : public RemoteTransmitterActionB
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/samsung_protocol.cpp
+++ b/esphome/components/remote_base/samsung_protocol.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.samsung";
 
@@ -61,5 +60,4 @@ void SamsungProtocol::dump(const SamsungData &data) {
   ESP_LOGI(TAG, "Received Samsung: data=0x%" PRIX64 ", nbits=%d", data.data, data.nbits);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/samsung_protocol.h
+++ b/esphome/components/remote_base/samsung_protocol.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct SamsungData {
   uint64_t data;
@@ -35,5 +34,4 @@ template<typename... Ts> class SamsungAction : public RemoteTransmitterActionBas
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/sony_protocol.cpp
+++ b/esphome/components/remote_base/sony_protocol.cpp
@@ -1,8 +1,7 @@
 #include "sony_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.sony";
 
@@ -65,5 +64,4 @@ void SonyProtocol::dump(const SonyData &data) {
   ESP_LOGI(TAG, "Received Sony: data=0x%08" PRIX32 ", nbits=%d", data.data, data.nbits);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/sony_protocol.h
+++ b/esphome/components/remote_base/sony_protocol.h
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct SonyData {
   uint32_t data;
@@ -37,5 +36,4 @@ template<typename... Ts> class SonyAction : public RemoteTransmitterActionBase<T
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/symphony_protocol.cpp
+++ b/esphome/components/remote_base/symphony_protocol.cpp
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.symphony";
 
@@ -118,5 +117,4 @@ void SymphonyProtocol::dump(const SymphonyData &data) {
   ESP_LOGI(TAG, "Received Symphony: data=0x%0*" PRIX32 ", nbits=%" PRIu8, hex_width, (uint32_t) data.data, data.nbits);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/symphony_protocol.h
+++ b/esphome/components/remote_base/symphony_protocol.h
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct SymphonyData {
   uint32_t data;
@@ -40,5 +39,4 @@ template<typename... Ts> class SymphonyAction : public RemoteTransmitterActionBa
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/toshiba_ac_protocol.cpp
+++ b/esphome/components/remote_base/toshiba_ac_protocol.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.toshibaac";
 
@@ -111,5 +110,4 @@ void ToshibaAcProtocol::dump(const ToshibaAcData &data) {
   }
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/toshiba_ac_protocol.h
+++ b/esphome/components/remote_base/toshiba_ac_protocol.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct ToshibaAcData {
   uint64_t rc_code_1;
@@ -35,5 +34,4 @@ template<typename... Ts> class ToshibaAcAction : public RemoteTransmitterActionB
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/toto_protocol.cpp
+++ b/esphome/components/remote_base/toto_protocol.cpp
@@ -1,8 +1,7 @@
 #include "toto_protocol.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 static const char *const TAG = "remote.toto";
 
@@ -96,5 +95,4 @@ void TotoProtocol::dump(const TotoData &data) {
            data.rc_code_2, data.command);
 }
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/remote_base/toto_protocol.h
+++ b/esphome/components/remote_base/toto_protocol.h
@@ -2,8 +2,7 @@
 
 #include "remote_base.h"
 
-namespace esphome {
-namespace remote_base {
+namespace esphome::remote_base {
 
 struct TotoData {
   uint8_t rc_code_1 : 4;
@@ -39,5 +38,4 @@ template<typename... Ts> class TotoAction : public RemoteTransmitterActionBase<T
   }
 };
 
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base

--- a/esphome/components/resampler/speaker/resampler_speaker.cpp
+++ b/esphome/components/resampler/speaker/resampler_speaker.cpp
@@ -12,8 +12,7 @@
 #include <algorithm>
 #include <cstring>
 
-namespace esphome {
-namespace resampler {
+namespace esphome::resampler {
 
 static const UBaseType_t RESAMPLER_TASK_PRIORITY = 1;
 
@@ -373,7 +372,6 @@ void ResamplerSpeaker::resample_task(void *params) {
   vTaskSuspend(nullptr);  // Suspend this task indefinitely until the loop method deletes it
 }
 
-}  // namespace resampler
-}  // namespace esphome
+}  // namespace esphome::resampler
 
 #endif

--- a/esphome/components/resampler/speaker/resampler_speaker.h
+++ b/esphome/components/resampler/speaker/resampler_speaker.h
@@ -11,8 +11,7 @@
 
 #include <freertos/event_groups.h>
 
-namespace esphome {
-namespace resampler {
+namespace esphome::resampler {
 
 class ResamplerSpeaker : public Component, public speaker::Speaker {
  public:
@@ -99,7 +98,6 @@ class ResamplerSpeaker : public Component, public speaker::Speaker {
   uint64_t callback_remainder_{0};
 };
 
-}  // namespace resampler
-}  // namespace esphome
+}  // namespace esphome::resampler
 
 #endif

--- a/esphome/components/resistance/resistance_sensor.cpp
+++ b/esphome/components/resistance/resistance_sensor.cpp
@@ -1,8 +1,7 @@
 #include "resistance_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace resistance {
+namespace esphome::resistance {
 
 static const char *const TAG = "resistance";
 
@@ -43,5 +42,4 @@ void ResistanceSensor::process_(float value) {
   this->publish_state(res);
 }
 
-}  // namespace resistance
-}  // namespace esphome
+}  // namespace esphome::resistance

--- a/esphome/components/resistance/resistance_sensor.h
+++ b/esphome/components/resistance/resistance_sensor.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace resistance {
+namespace esphome::resistance {
 
 enum ResistanceConfiguration {
   UPSTREAM,
@@ -33,5 +32,4 @@ class ResistanceSensor : public Component, public sensor::Sensor {
   float reference_voltage_;
 };
 
-}  // namespace resistance
-}  // namespace esphome
+}  // namespace esphome::resistance

--- a/esphome/components/restart/button/restart_button.cpp
+++ b/esphome/components/restart/button/restart_button.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace restart {
+namespace esphome::restart {
 
 static const char *const TAG = "restart.button";
 
@@ -16,5 +15,4 @@ void RestartButton::press_action() {
 }
 void RestartButton::dump_config() { LOG_BUTTON("", "Restart Button", this); }
 
-}  // namespace restart
-}  // namespace esphome
+}  // namespace esphome::restart

--- a/esphome/components/restart/button/restart_button.h
+++ b/esphome/components/restart/button/restart_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace restart {
+namespace esphome::restart {
 
 class RestartButton final : public button::Button, public Component {
  public:
@@ -14,5 +13,4 @@ class RestartButton final : public button::Button, public Component {
   void press_action() override;
 };
 
-}  // namespace restart
-}  // namespace esphome
+}  // namespace esphome::restart

--- a/esphome/components/restart/switch/restart_switch.cpp
+++ b/esphome/components/restart/switch/restart_switch.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace restart {
+namespace esphome::restart {
 
 static const char *const TAG = "restart";
 
@@ -21,5 +20,4 @@ void RestartSwitch::write_state(bool state) {
 }
 void RestartSwitch::dump_config() { LOG_SWITCH("", "Restart Switch", this); }
 
-}  // namespace restart
-}  // namespace esphome
+}  // namespace esphome::restart

--- a/esphome/components/restart/switch/restart_switch.h
+++ b/esphome/components/restart/switch/restart_switch.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace restart {
+namespace esphome::restart {
 
 class RestartSwitch : public switch_::Switch, public Component {
  public:
@@ -14,5 +13,4 @@ class RestartSwitch : public switch_::Switch, public Component {
   void write_state(bool state) override;
 };
 
-}  // namespace restart
-}  // namespace esphome
+}  // namespace esphome::restart

--- a/esphome/components/rf_bridge/rf_bridge.cpp
+++ b/esphome/components/rf_bridge/rf_bridge.cpp
@@ -5,8 +5,7 @@
 #include <cinttypes>
 #include <cstring>
 
-namespace esphome {
-namespace rf_bridge {
+namespace esphome::rf_bridge {
 
 static const char *const TAG = "rf_bridge";
 
@@ -243,5 +242,4 @@ void RFBridgeComponent::beep(uint16_t ms) {
   this->flush();
 }
 
-}  // namespace rf_bridge
-}  // namespace esphome
+}  // namespace esphome::rf_bridge

--- a/esphome/components/rf_bridge/rf_bridge.h
+++ b/esphome/components/rf_bridge/rf_bridge.h
@@ -7,8 +7,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace rf_bridge {
+namespace esphome::rf_bridge {
 
 static const uint8_t RF_MESSAGE_SIZE = 9;
 static const uint8_t RF_CODE_START = 0xAA;
@@ -179,5 +178,4 @@ template<typename... Ts> class RFBridgeBeepAction : public Action<Ts...> {
   RFBridgeComponent *parent_;
 };
 
-}  // namespace rf_bridge
-}  // namespace esphome
+}  // namespace esphome::rf_bridge

--- a/esphome/components/rgb/rgb_light_output.h
+++ b/esphome/components/rgb/rgb_light_output.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/components/light/light_output.h"
 
-namespace esphome {
-namespace rgb {
+namespace esphome::rgb {
 
 class RGBLightOutput : public light::LightOutput {
  public:
@@ -32,5 +31,4 @@ class RGBLightOutput : public light::LightOutput {
   output::FloatOutput *blue_;
 };
 
-}  // namespace rgb
-}  // namespace esphome
+}  // namespace esphome::rgb

--- a/esphome/components/rgbct/rgbct_light_output.h
+++ b/esphome/components/rgbct/rgbct_light_output.h
@@ -5,8 +5,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace rgbct {
+namespace esphome::rgbct {
 
 class RGBCTLightOutput : public light::LightOutput {
  public:
@@ -55,5 +54,4 @@ class RGBCTLightOutput : public light::LightOutput {
   bool color_interlock_{true};
 };
 
-}  // namespace rgbct
-}  // namespace esphome
+}  // namespace esphome::rgbct

--- a/esphome/components/rgbw/rgbw_light_output.h
+++ b/esphome/components/rgbw/rgbw_light_output.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/components/light/light_output.h"
 
-namespace esphome {
-namespace rgbw {
+namespace esphome::rgbw {
 
 class RGBWLightOutput : public light::LightOutput {
  public:
@@ -40,5 +39,4 @@ class RGBWLightOutput : public light::LightOutput {
   bool color_interlock_{false};
 };
 
-}  // namespace rgbw
-}  // namespace esphome
+}  // namespace esphome::rgbw

--- a/esphome/components/rgbww/rgbww_light_output.h
+++ b/esphome/components/rgbww/rgbww_light_output.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/components/light/light_output.h"
 
-namespace esphome {
-namespace rgbww {
+namespace esphome::rgbww {
 
 class RGBWWLightOutput : public light::LightOutput {
  public:
@@ -51,5 +50,4 @@ class RGBWWLightOutput : public light::LightOutput {
   bool color_interlock_{false};
 };
 
-}  // namespace rgbww
-}  // namespace esphome
+}  // namespace esphome::rgbww

--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace rotary_encoder {
+namespace esphome::rotary_encoder {
 
 static const char *const TAG = "rotary_encoder";
 
@@ -242,5 +241,4 @@ void RotaryEncoderSensor::set_resolution(RotaryEncoderResolution mode) { this->s
 void RotaryEncoderSensor::set_min_value(int32_t min_value) { this->store_.min_value = min_value; }
 void RotaryEncoderSensor::set_max_value(int32_t max_value) { this->store_.max_value = max_value; }
 
-}  // namespace rotary_encoder
-}  // namespace esphome
+}  // namespace esphome::rotary_encoder

--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -7,8 +7,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace rotary_encoder {
+namespace esphome::rotary_encoder {
 
 /// All possible restore modes for the rotary encoder
 enum RotaryEncoderRestoreMode {
@@ -118,5 +117,4 @@ template<typename... Ts> class RotaryEncoderSetValueAction : public Action<Ts...
   RotaryEncoderSensor *encoder_;
 };
 
-}  // namespace rotary_encoder
-}  // namespace esphome
+}  // namespace esphome::rotary_encoder

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ruuvi_ble {
+namespace esphome::ruuvi_ble {
 
 static const char *const TAG = "ruuvi_ble";
 
@@ -142,7 +141,6 @@ bool RuuviListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return true;
 }
 
-}  // namespace ruuvi_ble
-}  // namespace esphome
+}  // namespace esphome::ruuvi_ble
 
 #endif

--- a/esphome/components/ruuvi_ble/ruuvi_ble.h
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.h
@@ -5,8 +5,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ruuvi_ble {
+namespace esphome::ruuvi_ble {
 
 struct RuuviParseResult {
   optional<float> humidity;
@@ -31,7 +30,6 @@ class RuuviListener : public esp32_ble_tracker::ESPBTDeviceListener {
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 };
 
-}  // namespace ruuvi_ble
-}  // namespace esphome
+}  // namespace esphome::ruuvi_ble
 
 #endif

--- a/esphome/components/ruuvitag/ruuvitag.cpp
+++ b/esphome/components/ruuvitag/ruuvitag.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ruuvitag {
+namespace esphome::ruuvitag {
 
 static const char *const TAG = "ruuvitag";
 
@@ -23,7 +22,6 @@ void RuuviTag::dump_config() {
   LOG_SENSOR("  ", "Measurement Sequence Number", this->measurement_sequence_number_);
 }
 
-}  // namespace ruuvitag
-}  // namespace esphome
+}  // namespace esphome::ruuvitag
 
 #endif

--- a/esphome/components/ruuvitag/ruuvitag.h
+++ b/esphome/components/ruuvitag/ruuvitag.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ruuvitag {
+namespace esphome::ruuvitag {
 
 class RuuviTag : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -77,7 +76,6 @@ class RuuviTag : public Component, public esp32_ble_tracker::ESPBTDeviceListener
   sensor::Sensor *measurement_sequence_number_{nullptr};
 };
 
-}  // namespace ruuvitag
-}  // namespace esphome
+}  // namespace esphome::ruuvitag
 
 #endif

--- a/esphome/components/rx8130/rx8130.cpp
+++ b/esphome/components/rx8130/rx8130.cpp
@@ -3,8 +3,7 @@
 
 // https://download.epsondevice.com/td/pdf/app/RX8130CE_en.pdf
 
-namespace esphome {
-namespace rx8130 {
+namespace esphome::rx8130 {
 
 static const uint8_t RX8130_REG_SEC = 0x10;
 static const uint8_t RX8130_REG_MIN = 0x11;
@@ -121,5 +120,4 @@ void RX8130Component::stop_(bool stop) {
   }
 }
 
-}  // namespace rx8130
-}  // namespace esphome
+}  // namespace esphome::rx8130

--- a/esphome/components/rx8130/rx8130.h
+++ b/esphome/components/rx8130/rx8130.h
@@ -4,8 +4,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/time/real_time_clock.h"
 
-namespace esphome {
-namespace rx8130 {
+namespace esphome::rx8130 {
 
 class RX8130Component : public time::RealTimeClock, public i2c::I2CDevice {
  public:
@@ -29,5 +28,4 @@ template<typename... Ts> class ReadAction : public Action<Ts...>, public Parente
   void play(const Ts... x) override { this->parent_->read_time(); }
 };
 
-}  // namespace rx8130
-}  // namespace esphome
+}  // namespace esphome::rx8130


### PR DESCRIPTION
# What does this implement/fix?

Mechanical conversion of `namespace foo { namespace bar { ... } }` to `namespace foo::bar { ... }` (C++17 nested namespace concatenation), applied via `clang-tidy --fix` with `modernize-concat-nested-namespaces` temporarily re-enabled, followed by `clang-format`. **No semantic changes.**

This is **part 4 of 7** for the cleanup tracked in [esphome/backlog#114](https://github.com/esphome/backlog/issues/114), toward enabling `modernize-concat-nested-namespaces` project-wide and matching the convention already documented in `CLAUDE.md`. Splitting by component letter range to keep each PR reviewable.

The `.clang-tidy` disable line stays in place until the final PR so CI remains green throughout the rollout.

## Scope of this PR

- `esphome/components/[n-r]/` — 267 files

## Reproduction

```bash
# remove the disable line from .clang-tidy
# then:
script/clang-tidy --fix --environment esp32-arduino-tidy --all-headers
git ls-files 'esphome/components/[n-r]*/**' | xargs clang-format -i
```

## Series

- 1/7 components a-c — #16294
- 2/7 components d-h — #16295
- 3/7 components i-m — #16297
- 4/7 components n-r (this PR)
- 5/7 components s
- 6/7 components t-z
- 7/7 tests + drop the `.clang-tidy` disable line

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/backlog#114

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

(Mechanical, no platform-specific code paths affected.)

## Example entry for `config.yaml`:

```yaml
# n/a
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
