### PR TITLE
[clang-tidy] Concatenate nested namespaces (5/7: components s)

### DIFF
--- a/esphome/components/safe_mode/button/safe_mode_button.cpp
+++ b/esphome/components/safe_mode/button/safe_mode_button.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace safe_mode {
+namespace esphome::safe_mode {
 
 static const char *const TAG = "safe_mode.button";
 
@@ -23,5 +22,4 @@ void SafeModeButton::press_action() {
 
 void SafeModeButton::dump_config() { LOG_BUTTON("", "Safe Mode Button", this); }
 
-}  // namespace safe_mode
-}  // namespace esphome
+}  // namespace esphome::safe_mode

--- a/esphome/components/safe_mode/button/safe_mode_button.h
+++ b/esphome/components/safe_mode/button/safe_mode_button.h
@@ -4,8 +4,7 @@
 #include "esphome/components/safe_mode/safe_mode.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace safe_mode {
+namespace esphome::safe_mode {
 
 class SafeModeButton final : public button::Button, public Component {
  public:
@@ -17,5 +16,4 @@ class SafeModeButton final : public button::Button, public Component {
   void press_action() override;
 };
 
-}  // namespace safe_mode
-}  // namespace esphome
+}  // namespace esphome::safe_mode

--- a/esphome/components/safe_mode/switch/safe_mode_switch.cpp
+++ b/esphome/components/safe_mode/switch/safe_mode_switch.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace safe_mode {
+namespace esphome::safe_mode {
 
 static const char *const TAG = "safe_mode.switch";
 
@@ -28,5 +27,4 @@ void SafeModeSwitch::write_state(bool state) {
 
 void SafeModeSwitch::dump_config() { LOG_SWITCH("", "Safe Mode Switch", this); }
 
-}  // namespace safe_mode
-}  // namespace esphome
+}  // namespace esphome::safe_mode

--- a/esphome/components/safe_mode/switch/safe_mode_switch.h
+++ b/esphome/components/safe_mode/switch/safe_mode_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace safe_mode {
+namespace esphome::safe_mode {
 
 class SafeModeSwitch : public switch_::Switch, public Component {
  public:
@@ -17,5 +16,4 @@ class SafeModeSwitch : public switch_::Switch, public Component {
   void write_state(bool state) override;
 };
 
-}  // namespace safe_mode
-}  // namespace esphome
+}  // namespace esphome::safe_mode

--- a/esphome/components/scd30/automation.h
+++ b/esphome/components/scd30/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "scd30.h"
 
-namespace esphome {
-namespace scd30 {
+namespace esphome::scd30 {
 
 template<typename... Ts> class ForceRecalibrationWithReference : public Action<Ts...>, public Parented<SCD30Component> {
  public:
@@ -19,5 +18,4 @@ template<typename... Ts> class ForceRecalibrationWithReference : public Action<T
   TEMPLATABLE_VALUE(uint16_t, value)
 };
 
-}  // namespace scd30
-}  // namespace esphome
+}  // namespace esphome::scd30

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -6,8 +6,7 @@
 #include <Wire.h>
 #endif
 
-namespace esphome {
-namespace scd30 {
+namespace esphome::scd30 {
 
 static const char *const TAG = "scd30";
 
@@ -230,5 +229,4 @@ uint16_t SCD30Component::get_forced_calibration_reference() {
   return forced_calibration_reference;
 }
 
-}  // namespace scd30
-}  // namespace esphome
+}  // namespace esphome::scd30

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/sensirion_common/i2c_sensirion.h"
 
-namespace esphome {
-namespace scd30 {
+namespace esphome::scd30 {
 
 /// This class implements support for the Sensirion scd30 i2c GAS (VOC and CO2eq) sensors.
 class SCD30Component : public Component, public sensirion_common::SensirionI2CDevice {
@@ -48,5 +47,4 @@ class SCD30Component : public Component, public sensirion_common::SensirionI2CDe
   sensor::Sensor *temperature_sensor_{nullptr};
 };
 
-}  // namespace scd30
-}  // namespace esphome
+}  // namespace esphome::scd30

--- a/esphome/components/scd4x/automation.h
+++ b/esphome/components/scd4x/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "scd4x.h"
 
-namespace esphome {
-namespace scd4x {
+namespace esphome::scd4x {
 
 template<typename... Ts> class PerformForcedCalibrationAction : public Action<Ts...>, public Parented<SCD4XComponent> {
  public:
@@ -24,5 +23,4 @@ template<typename... Ts> class FactoryResetAction : public Action<Ts...>, public
   void play(const Ts &...x) override { this->parent_->factory_reset(); }
 };
 
-}  // namespace scd4x
-}  // namespace esphome
+}  // namespace esphome::scd4x

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace scd4x {
+namespace esphome::scd4x {
 
 static const char *const TAG = "scd4x";
 
@@ -324,5 +323,4 @@ bool SCD4XComponent::start_measurement_() {
   return false;
 }
 
-}  // namespace scd4x
-}  // namespace esphome
+}  // namespace esphome::scd4x

--- a/esphome/components/scd4x/scd4x.h
+++ b/esphome/components/scd4x/scd4x.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/sensirion_common/i2c_sensirion.h"
 
-namespace esphome {
-namespace scd4x {
+namespace esphome::scd4x {
 
 enum ErrorCode : uint8_t {
   COMMUNICATION_FAILED,
@@ -59,5 +58,4 @@ class SCD4XComponent : public PollingComponent, public sensirion_common::Sensiri
   MeasurementMode measurement_mode_{PERIODIC};
 };
 
-}  // namespace scd4x
-}  // namespace esphome
+}  // namespace esphome::scd4x

--- a/esphome/components/script/script.cpp
+++ b/esphome/components/script/script.cpp
@@ -1,8 +1,7 @@
 #include "script.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace script {
+namespace esphome::script {
 
 static const char *const TAG = "script";
 
@@ -16,5 +15,4 @@ void ScriptLogger::esp_log_(int level, int line, const char *format, const char 
 }
 #endif
 
-}  // namespace script
-}  // namespace esphome
+}  // namespace esphome::script

--- a/esphome/components/script/script.h
+++ b/esphome/components/script/script.h
@@ -7,8 +7,8 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-namespace esphome {
-namespace script {
+
+namespace esphome::script {
 
 class ScriptLogger {
  protected:
@@ -338,5 +338,4 @@ template<class C, typename... Ts> class ScriptWaitAction : public Action<Ts...>,
   std::list<std::tuple<Ts...>> param_queue_;
 };
 
-}  // namespace script
-}  // namespace esphome
+}  // namespace esphome::script

--- a/esphome/components/sdm_meter/sdm_meter.cpp
+++ b/esphome/components/sdm_meter/sdm_meter.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sdm_meter {
+namespace esphome::sdm_meter {
 
 static const char *const TAG = "sdm_meter";
 
@@ -110,5 +109,4 @@ void SDMMeter::dump_config() {
   LOG_SENSOR("  ", "Export Reactive Energy", this->export_reactive_energy_sensor_);
 }
 
-}  // namespace sdm_meter
-}  // namespace esphome
+}  // namespace esphome::sdm_meter

--- a/esphome/components/sdm_meter/sdm_meter.h
+++ b/esphome/components/sdm_meter/sdm_meter.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace sdm_meter {
+namespace esphome::sdm_meter {
 
 class SDMMeter : public PollingComponent, public modbus::ModbusDevice {
  public:
@@ -79,5 +78,4 @@ class SDMMeter : public PollingComponent, public modbus::ModbusDevice {
   sensor::Sensor *export_reactive_energy_sensor_{nullptr};
 };
 
-}  // namespace sdm_meter
-}  // namespace esphome
+}  // namespace esphome::sdm_meter

--- a/esphome/components/sdm_meter/sdm_meter_registers.h
+++ b/esphome/components/sdm_meter/sdm_meter_registers.h
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace esphome {
-namespace sdm_meter {
+namespace esphome::sdm_meter {
 
 /* PHASE STATUS REGISTERS */
 static const uint16_t SDM_PHASE_1_VOLTAGE = 0x0000;
@@ -110,5 +109,4 @@ static const uint16_t SDM_CURRENT_RESETTABLE_EXPORT_ENERGY = 0x0186;
 static const uint16_t SDM_IMPORT_POWER = 0x0500;
 static const uint16_t SDM_EXPORT_POWER = 0x0502;
 
-}  // namespace sdm_meter
-}  // namespace esphome
+}  // namespace esphome::sdm_meter

--- a/esphome/components/sdp3x/sdp3x.cpp
+++ b/esphome/components/sdp3x/sdp3x.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sdp3x {
+namespace esphome::sdp3x {
 
 static const char *const TAG = "sdp3x.sensor";
 static const uint16_t SDP3X_SOFT_RESET = 0x0006;
@@ -114,5 +113,4 @@ void SDP3XComponent::read_pressure_() {
   this->status_clear_warning();
 }
 
-}  // namespace sdp3x
-}  // namespace esphome
+}  // namespace esphome::sdp3x

--- a/esphome/components/sdp3x/sdp3x.h
+++ b/esphome/components/sdp3x/sdp3x.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/sensirion_common/i2c_sensirion.h"
 
-namespace esphome {
-namespace sdp3x {
+namespace esphome::sdp3x {
 
 enum MeasurementMode { MASS_FLOW_AVG, DP_AVG };
 
@@ -25,5 +24,4 @@ class SDP3XComponent : public PollingComponent, public sensirion_common::Sensiri
   MeasurementMode measurement_mode_;
 };
 
-}  // namespace sdp3x
-}  // namespace esphome
+}  // namespace esphome::sdp3x

--- a/esphome/components/sds011/sds011.cpp
+++ b/esphome/components/sds011/sds011.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace sds011 {
+namespace esphome::sds011 {
 
 static const char *const TAG = "sds011";
 
@@ -184,5 +183,4 @@ void SDS011Component::set_update_interval_min(uint8_t update_interval_min) {
   this->update_interval_min_ = update_interval_min;
 }
 
-}  // namespace sds011
-}  // namespace esphome
+}  // namespace esphome::sds011

--- a/esphome/components/sds011/sds011.h
+++ b/esphome/components/sds011/sds011.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace sds011 {
+namespace esphome::sds011 {
 
 class SDS011Component : public Component, public uart::UARTDevice {
  public:
@@ -44,5 +43,4 @@ class SDS011Component : public Component, public uart::UARTDevice {
   bool rx_mode_only_;
 };
 
-}  // namespace sds011
-}  // namespace esphome
+}  // namespace esphome::sds011

--- a/esphome/components/seeed_mr24hpc1/button/custom_mode_end_button.cpp
+++ b/esphome/components/seeed_mr24hpc1/button/custom_mode_end_button.cpp
@@ -1,9 +1,7 @@
 #include "custom_mode_end_button.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void CustomSetEndButton::press_action() { this->parent_->set_custom_end_mode(); }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/button/custom_mode_end_button.h
+++ b/esphome/components/seeed_mr24hpc1/button/custom_mode_end_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class CustomSetEndButton : public button::Button, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class CustomSetEndButton : public button::Button, public Parented<MR24HPC1Compon
   void press_action() override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/button/restart_button.cpp
+++ b/esphome/components/seeed_mr24hpc1/button/restart_button.cpp
@@ -1,9 +1,7 @@
 #include "restart_button.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void RestartButton::press_action() { this->parent_->set_restart(); }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/button/restart_button.h
+++ b/esphome/components/seeed_mr24hpc1/button/restart_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class RestartButton : public button::Button, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class RestartButton : public button::Button, public Parented<MR24HPC1Component> 
   void press_action() override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/custom_mode_number.cpp
+++ b/esphome/components/seeed_mr24hpc1/number/custom_mode_number.cpp
@@ -1,12 +1,10 @@
 #include "custom_mode_number.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void CustomModeNumber::control(float value) {
   this->publish_state(value);
   this->parent_->set_custom_mode(value);
 }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/custom_mode_number.h
+++ b/esphome/components/seeed_mr24hpc1/number/custom_mode_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class CustomModeNumber : public number::Number, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class CustomModeNumber : public number::Number, public Parented<MR24HPC1Componen
   void control(float value) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/custom_unman_time_number.cpp
+++ b/esphome/components/seeed_mr24hpc1/number/custom_unman_time_number.cpp
@@ -1,9 +1,7 @@
 #include "custom_unman_time_number.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void CustomUnmanTimeNumber::control(float value) { this->parent_->set_custom_unman_time(value); }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/custom_unman_time_number.h
+++ b/esphome/components/seeed_mr24hpc1/number/custom_unman_time_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class CustomUnmanTimeNumber : public number::Number, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class CustomUnmanTimeNumber : public number::Number, public Parented<MR24HPC1Com
   void control(float value) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/existence_threshold_number.cpp
+++ b/esphome/components/seeed_mr24hpc1/number/existence_threshold_number.cpp
@@ -1,9 +1,7 @@
 #include "existence_threshold_number.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void ExistenceThresholdNumber::control(float value) { this->parent_->set_existence_threshold(value); }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/existence_threshold_number.h
+++ b/esphome/components/seeed_mr24hpc1/number/existence_threshold_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class ExistenceThresholdNumber : public number::Number, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class ExistenceThresholdNumber : public number::Number, public Parented<MR24HPC1
   void control(float value) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/motion_threshold_number.cpp
+++ b/esphome/components/seeed_mr24hpc1/number/motion_threshold_number.cpp
@@ -1,9 +1,7 @@
 #include "motion_threshold_number.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void MotionThresholdNumber::control(float value) { this->parent_->set_motion_threshold(value); }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/motion_threshold_number.h
+++ b/esphome/components/seeed_mr24hpc1/number/motion_threshold_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class MotionThresholdNumber : public number::Number, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class MotionThresholdNumber : public number::Number, public Parented<MR24HPC1Com
   void control(float value) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/motion_trigger_time_number.cpp
+++ b/esphome/components/seeed_mr24hpc1/number/motion_trigger_time_number.cpp
@@ -1,9 +1,7 @@
 #include "motion_trigger_time_number.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void MotionTriggerTimeNumber::control(float value) { this->parent_->set_motion_trigger_time(value); }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/motion_trigger_time_number.h
+++ b/esphome/components/seeed_mr24hpc1/number/motion_trigger_time_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class MotionTriggerTimeNumber : public number::Number, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class MotionTriggerTimeNumber : public number::Number, public Parented<MR24HPC1C
   void control(float value) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/motiontorest_time_number.cpp
+++ b/esphome/components/seeed_mr24hpc1/number/motiontorest_time_number.cpp
@@ -1,9 +1,7 @@
 #include "motiontorest_time_number.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void MotionToRestTimeNumber::control(float value) { this->parent_->set_motion_to_rest_time(value); }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/motiontorest_time_number.h
+++ b/esphome/components/seeed_mr24hpc1/number/motiontorest_time_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class MotionToRestTimeNumber : public number::Number, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class MotionToRestTimeNumber : public number::Number, public Parented<MR24HPC1Co
   void control(float value) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/sensitivity_number.cpp
+++ b/esphome/components/seeed_mr24hpc1/number/sensitivity_number.cpp
@@ -1,9 +1,7 @@
 #include "sensitivity_number.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void SensitivityNumber::control(float value) { this->parent_->set_sensitivity(value); }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/number/sensitivity_number.h
+++ b/esphome/components/seeed_mr24hpc1/number/sensitivity_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class SensitivityNumber : public number::Number, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class SensitivityNumber : public number::Number, public Parented<MR24HPC1Compone
   void control(float value) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -5,8 +5,7 @@
 
 #include <utility>
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 static const char *const TAG = "seeed_mr24hpc1";
 
@@ -1002,5 +1001,4 @@ void MR24HPC1Component::set_custom_unman_time(uint16_t value) {
   this->get_custom_unman_time();
 }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.h
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.h
@@ -30,8 +30,7 @@
 
 #include <map>
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 enum FrameState {
   FRAME_IDLE,
@@ -213,5 +212,4 @@ class MR24HPC1Component : public Component,
   void set_custom_unman_time(uint16_t value);
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1_constants.h
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1_constants.h
@@ -2,8 +2,7 @@
 
 #include <cstdint>
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 static const uint8_t FRAME_BUF_MAX_SIZE = 128;
 static const uint8_t PRODUCT_BUF_MAX_SIZE = 32;
@@ -169,5 +168,4 @@ static const uint8_t GET_KEEP_AWAY[] = {
     FRAME_TAIL1_VALUE,   FRAME_TAIL2_VALUE,
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/select/existence_boundary_select.cpp
+++ b/esphome/components/seeed_mr24hpc1/select/existence_boundary_select.cpp
@@ -1,12 +1,10 @@
 #include "existence_boundary_select.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void ExistenceBoundarySelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_existence_boundary(index);
 }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/select/existence_boundary_select.h
+++ b/esphome/components/seeed_mr24hpc1/select/existence_boundary_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class ExistenceBoundarySelect : public select::Select, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class ExistenceBoundarySelect : public select::Select, public Parented<MR24HPC1C
   void control(size_t index) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/select/motion_boundary_select.cpp
+++ b/esphome/components/seeed_mr24hpc1/select/motion_boundary_select.cpp
@@ -1,12 +1,10 @@
 #include "motion_boundary_select.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void MotionBoundarySelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_motion_boundary(index);
 }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/select/motion_boundary_select.h
+++ b/esphome/components/seeed_mr24hpc1/select/motion_boundary_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class MotionBoundarySelect : public select::Select, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class MotionBoundarySelect : public select::Select, public Parented<MR24HPC1Comp
   void control(size_t index) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/select/scene_mode_select.cpp
+++ b/esphome/components/seeed_mr24hpc1/select/scene_mode_select.cpp
@@ -1,12 +1,10 @@
 #include "scene_mode_select.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void SceneModeSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_scene_mode(index);
 }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/select/scene_mode_select.h
+++ b/esphome/components/seeed_mr24hpc1/select/scene_mode_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class SceneModeSelect : public select::Select, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class SceneModeSelect : public select::Select, public Parented<MR24HPC1Component
   void control(size_t index) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/select/unman_time_select.cpp
+++ b/esphome/components/seeed_mr24hpc1/select/unman_time_select.cpp
@@ -1,12 +1,10 @@
 #include "unman_time_select.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void UnmanTimeSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_unman_time(index);
 }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/select/unman_time_select.h
+++ b/esphome/components/seeed_mr24hpc1/select/unman_time_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class UnmanTimeSelect : public select::Select, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class UnmanTimeSelect : public select::Select, public Parented<MR24HPC1Component
   void control(size_t index) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/switch/underlyFuc_switch.cpp
+++ b/esphome/components/seeed_mr24hpc1/switch/underlyFuc_switch.cpp
@@ -1,12 +1,10 @@
 #include "underlyFuc_switch.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 void UnderlyOpenFunctionSwitch::write_state(bool state) {
   this->publish_state(state);
   this->parent_->set_underlying_open_function(state);
 }
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr24hpc1/switch/underlyFuc_switch.h
+++ b/esphome/components/seeed_mr24hpc1/switch/underlyFuc_switch.h
@@ -3,8 +3,7 @@
 #include "esphome/components/switch/switch.h"
 #include "../seeed_mr24hpc1.h"
 
-namespace esphome {
-namespace seeed_mr24hpc1 {
+namespace esphome::seeed_mr24hpc1 {
 
 class UnderlyOpenFunctionSwitch : public switch_::Switch, public Parented<MR24HPC1Component> {
  public:
@@ -14,5 +13,4 @@ class UnderlyOpenFunctionSwitch : public switch_::Switch, public Parented<MR24HP
   void write_state(bool state) override;
 };
 
-}  // namespace seeed_mr24hpc1
-}  // namespace esphome
+}  // namespace esphome::seeed_mr24hpc1

--- a/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
+++ b/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
@@ -5,8 +5,7 @@
 #include <cinttypes>
 #include <utility>
 
-namespace esphome {
-namespace seeed_mr60bha2 {
+namespace esphome::seeed_mr60bha2 {
 
 static const char *const TAG = "seeed_mr60bha2";
 
@@ -219,5 +218,4 @@ void MR60BHA2Component::process_frame_(uint16_t frame_id, uint16_t frame_type, c
   }
 }
 
-}  // namespace seeed_mr60bha2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60bha2

--- a/esphome/components/seeed_mr60bha2/seeed_mr60bha2.h
+++ b/esphome/components/seeed_mr60bha2/seeed_mr60bha2.h
@@ -13,8 +13,7 @@
 
 #include <map>
 
-namespace esphome {
-namespace seeed_mr60bha2 {
+namespace esphome::seeed_mr60bha2 {
 static const uint8_t FRAME_HEADER_BUFFER = 0x01;
 static const uint16_t BREATH_RATE_TYPE_BUFFER = 0x0A14;
 static const uint16_t PEOPLE_EXIST_TYPE_BUFFER = 0x0F09;
@@ -46,5 +45,4 @@ class MR60BHA2Component : public Component,
   std::vector<uint8_t> rx_message_;
 };
 
-}  // namespace seeed_mr60bha2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60bha2

--- a/esphome/components/seeed_mr60fda2/button/get_radar_parameters_button.cpp
+++ b/esphome/components/seeed_mr60fda2/button/get_radar_parameters_button.cpp
@@ -1,9 +1,7 @@
 #include "get_radar_parameters_button.h"
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 void GetRadarParametersButton::press_action() { this->parent_->get_radar_parameters(); }
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/seeed_mr60fda2/button/get_radar_parameters_button.h
+++ b/esphome/components/seeed_mr60fda2/button/get_radar_parameters_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../seeed_mr60fda2.h"
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 class GetRadarParametersButton : public button::Button, public Parented<MR60FDA2Component> {
  public:
@@ -14,5 +13,4 @@ class GetRadarParametersButton : public button::Button, public Parented<MR60FDA2
   void press_action() override;
 };
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/seeed_mr60fda2/button/reset_radar_button.cpp
+++ b/esphome/components/seeed_mr60fda2/button/reset_radar_button.cpp
@@ -1,9 +1,7 @@
 #include "reset_radar_button.h"
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 void ResetRadarButton::press_action() { this->parent_->factory_reset(); }
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/seeed_mr60fda2/button/reset_radar_button.h
+++ b/esphome/components/seeed_mr60fda2/button/reset_radar_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../seeed_mr60fda2.h"
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 class ResetRadarButton : public button::Button, public Parented<MR60FDA2Component> {
  public:
@@ -14,5 +13,4 @@ class ResetRadarButton : public button::Button, public Parented<MR60FDA2Componen
   void press_action() override;
 };
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -5,8 +5,7 @@
 #include <cinttypes>
 #include <utility>
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 static const char *const TAG = "seeed_mr60fda2";
 
@@ -393,5 +392,4 @@ void MR60FDA2Component::factory_reset() {
   this->get_radar_parameters();
 }
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.h
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.h
@@ -19,8 +19,7 @@
 
 #include <map>
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 static const uint8_t DATA_BUF_MAX_SIZE = 28;
 static const uint8_t FRAME_BUF_MAX_SIZE = 37;
@@ -97,5 +96,4 @@ class MR60FDA2Component : public Component,
   void factory_reset();
 };
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/seeed_mr60fda2/select/height_threshold_select.cpp
+++ b/esphome/components/seeed_mr60fda2/select/height_threshold_select.cpp
@@ -1,12 +1,10 @@
 #include "height_threshold_select.h"
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 void HeightThresholdSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_height_threshold(index);
 }
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/seeed_mr60fda2/select/height_threshold_select.h
+++ b/esphome/components/seeed_mr60fda2/select/height_threshold_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../seeed_mr60fda2.h"
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 class HeightThresholdSelect : public select::Select, public Parented<MR60FDA2Component> {
  public:
@@ -14,5 +13,4 @@ class HeightThresholdSelect : public select::Select, public Parented<MR60FDA2Com
   void control(size_t index) override;
 };
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/seeed_mr60fda2/select/install_height_select.cpp
+++ b/esphome/components/seeed_mr60fda2/select/install_height_select.cpp
@@ -1,12 +1,10 @@
 #include "install_height_select.h"
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 void InstallHeightSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_install_height(index);
 }
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/seeed_mr60fda2/select/install_height_select.h
+++ b/esphome/components/seeed_mr60fda2/select/install_height_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../seeed_mr60fda2.h"
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 class InstallHeightSelect : public select::Select, public Parented<MR60FDA2Component> {
  public:
@@ -14,5 +13,4 @@ class InstallHeightSelect : public select::Select, public Parented<MR60FDA2Compo
   void control(size_t index) override;
 };
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/seeed_mr60fda2/select/sensitivity_select.cpp
+++ b/esphome/components/seeed_mr60fda2/select/sensitivity_select.cpp
@@ -1,12 +1,10 @@
 #include "sensitivity_select.h"
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 void SensitivitySelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_sensitivity(index);
 }
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/seeed_mr60fda2/select/sensitivity_select.h
+++ b/esphome/components/seeed_mr60fda2/select/sensitivity_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../seeed_mr60fda2.h"
 
-namespace esphome {
-namespace seeed_mr60fda2 {
+namespace esphome::seeed_mr60fda2 {
 
 class SensitivitySelect : public select::Select, public Parented<MR60FDA2Component> {
  public:
@@ -14,5 +13,4 @@ class SensitivitySelect : public select::Select, public Parented<MR60FDA2Compone
   void control(size_t index) override;
 };
 
-}  // namespace seeed_mr60fda2
-}  // namespace esphome
+}  // namespace esphome::seeed_mr60fda2

--- a/esphome/components/selec_meter/selec_meter.cpp
+++ b/esphome/components/selec_meter/selec_meter.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace selec_meter {
+namespace esphome::selec_meter {
 
 static const char *const TAG = "selec_meter";
 
@@ -107,5 +106,4 @@ void SelecMeter::dump_config() {
   LOG_SENSOR("  ", "Maximum Demand Apparent Power", this->maximum_demand_apparent_power_sensor_);
 }
 
-}  // namespace selec_meter
-}  // namespace esphome
+}  // namespace esphome::selec_meter

--- a/esphome/components/selec_meter/selec_meter.h
+++ b/esphome/components/selec_meter/selec_meter.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace selec_meter {
+namespace esphome::selec_meter {
 
 #define SELEC_METER_SENSOR(name) \
  protected: \
@@ -43,5 +42,4 @@ class SelecMeter : public PollingComponent, public modbus::ModbusDevice {
   void dump_config() override;
 };
 
-}  // namespace selec_meter
-}  // namespace esphome
+}  // namespace esphome::selec_meter

--- a/esphome/components/selec_meter/selec_meter_registers.h
+++ b/esphome/components/selec_meter/selec_meter_registers.h
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace esphome {
-namespace selec_meter {
+namespace esphome::selec_meter {
 
 static const float TWO_DEC_UNIT = 0.01;
 static const float ONE_DEC_UNIT = 0.1;
@@ -28,5 +27,4 @@ static const uint16_t SELEC_MAXIMUM_DEMAND_ACTIVE_POWER = 0x001C;
 static const uint16_t SELEC_MAXIMUM_DEMAND_REACTIVE_POWER = 0x001E;
 static const uint16_t SELEC_MAXIMUM_DEMAND_APPARENT_POWER = 0x0020;
 
-}  // namespace selec_meter
-}  // namespace esphome
+}  // namespace esphome::selec_meter

--- a/esphome/components/sen0321/sen0321.cpp
+++ b/esphome/components/sen0321/sen0321.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace sen0321_sensor {
+namespace esphome::sen0321_sensor {
 
 static const char *const TAG = "sen0321_sensor.sensor";
 
@@ -31,5 +30,4 @@ void Sen0321Sensor::read_data_() {
   this->publish_state(((uint16_t) (result[0] << 8) + result[1]));
 }
 
-}  // namespace sen0321_sensor
-}  // namespace esphome
+}  // namespace esphome::sen0321_sensor

--- a/esphome/components/sen0321/sen0321.h
+++ b/esphome/components/sen0321/sen0321.h
@@ -7,8 +7,7 @@
 // ref:
 // https://github.com/DFRobot/DFRobot_OzoneSensor
 
-namespace esphome {
-namespace sen0321_sensor {
+namespace esphome::sen0321_sensor {
 // Sensor Mode
 // While passive is supposedly supported, it does not appear to work reliably.
 static const uint8_t SENSOR_MODE_REGISTER = 0x03;
@@ -31,5 +30,4 @@ class Sen0321Sensor : public sensor::Sensor, public PollingComponent, public i2c
   void read_data_();
 };
 
-}  // namespace sen0321_sensor
-}  // namespace esphome
+}  // namespace esphome::sen0321_sensor

--- a/esphome/components/sen21231/sen21231.cpp
+++ b/esphome/components/sen21231/sen21231.cpp
@@ -1,8 +1,7 @@
 #include "sen21231.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sen21231_sensor {
+namespace esphome::sen21231_sensor {
 
 static const char *const TAG = "sen21231_sensor.sensor";
 
@@ -33,5 +32,4 @@ void Sen21231Sensor::read_data_() {
   }
 }
 
-}  // namespace sen21231_sensor
-}  // namespace esphome
+}  // namespace esphome::sen21231_sensor

--- a/esphome/components/sen21231/sen21231.h
+++ b/esphome/components/sen21231/sen21231.h
@@ -7,8 +7,7 @@
 // ref:
 // https://github.com/usefulsensors/person_sensor_pico_c/blob/main/person_sensor.h
 
-namespace esphome {
-namespace sen21231_sensor {
+namespace esphome::sen21231_sensor {
 // The I2C address of the person sensor board.
 static const uint8_t PERSON_SENSOR_I2C_ADDRESS = 0x62;
 static const uint8_t PERSON_SENSOR_REG_MODE = 0x01;
@@ -73,5 +72,4 @@ class Sen21231Sensor : public sensor::Sensor, public PollingComponent, public i2
   void read_data_();
 };
 
-}  // namespace sen21231_sensor
-}  // namespace esphome
+}  // namespace esphome::sen21231_sensor

--- a/esphome/components/sen5x/automation.h
+++ b/esphome/components/sen5x/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "sen5x.h"
 
-namespace esphome {
-namespace sen5x {
+namespace esphome::sen5x {
 
 template<typename... Ts> class StartFanAction : public Action<Ts...> {
  public:
@@ -17,5 +16,4 @@ template<typename... Ts> class StartFanAction : public Action<Ts...> {
   SEN5XComponent *sen5x_;
 };
 
-}  // namespace sen5x
-}  // namespace esphome
+}  // namespace esphome::sen5x

--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace sen5x {
+namespace esphome::sen5x {
 
 static const char *const TAG = "sen5x";
 
@@ -423,5 +422,4 @@ bool SEN5XComponent::start_fan_cleaning() {
   return true;
 }
 
-}  // namespace sen5x
-}  // namespace esphome
+}  // namespace esphome::sen5x

--- a/esphome/components/sen5x/sen5x.h
+++ b/esphome/components/sen5x/sen5x.h
@@ -6,8 +6,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace sen5x {
+namespace esphome::sen5x {
 
 enum ERRORCODE : uint8_t {
   COMMUNICATION_FAILED,
@@ -130,5 +129,4 @@ class SEN5XComponent : public PollingComponent, public sensirion_common::Sensiri
   ESPPreferenceObject pref_;
 };
 
-}  // namespace sen5x
-}  // namespace esphome
+}  // namespace esphome::sen5x

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace senseair {
+namespace esphome::senseair {
 
 static const char *const TAG = "senseair";
 static const uint8_t SENSEAIR_REQUEST_LENGTH = 8;
@@ -150,5 +149,4 @@ void SenseAirComponent::dump_config() {
   this->check_uart_settings(9600);
 }
 
-}  // namespace senseair
-}  // namespace esphome
+}  // namespace esphome::senseair

--- a/esphome/components/senseair/senseair.h
+++ b/esphome/components/senseair/senseair.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace senseair {
+namespace esphome::senseair {
 
 enum SenseAirStatus : uint8_t {
   FATAL_ERROR = 1 << 0,
@@ -88,5 +87,4 @@ template<typename... Ts> class SenseAirABCGetPeriodAction : public Action<Ts...>
   SenseAirComponent *senseair_;
 };
 
-}  // namespace senseair
-}  // namespace esphome
+}  // namespace esphome::senseair

--- a/esphome/components/sensirion_common/i2c_sensirion.cpp
+++ b/esphome/components/sensirion_common/i2c_sensirion.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace sensirion_common {
+namespace esphome::sensirion_common {
 
 static const char *const TAG = "sensirion_i2c";
 // To avoid memory allocations for small writes a stack buffer is used
@@ -79,5 +78,4 @@ bool SensirionI2CDevice::get_register_(uint16_t reg, CommandLen command_len, uin
   return result;
 }
 
-}  // namespace sensirion_common
-}  // namespace esphome
+}  // namespace esphome::sensirion_common

--- a/esphome/components/sensirion_common/i2c_sensirion.h
+++ b/esphome/components/sensirion_common/i2c_sensirion.h
@@ -4,8 +4,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace sensirion_common {
+namespace esphome::sensirion_common {
 
 /**
  * Implementation of I2C functions for Sensirion sensors
@@ -149,5 +148,4 @@ class SensirionI2CDevice : public i2c::I2CDevice {
   i2c::ErrorCode last_error_;
 };
 
-}  // namespace sensirion_common
-}  // namespace esphome
+}  // namespace esphome::sensirion_common

--- a/esphome/components/servo/servo.cpp
+++ b/esphome/components/servo/servo.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace servo {
+namespace esphome::servo {
 
 static const char *const TAG = "servo";
 
@@ -106,5 +105,4 @@ void Servo::save_level_(float v) {
     this->rtc_.save(&v);
 }
 
-}  // namespace servo
-}  // namespace esphome
+}  // namespace esphome::servo

--- a/esphome/components/servo/servo.h
+++ b/esphome/components/servo/servo.h
@@ -6,8 +6,7 @@
 #include "esphome/core/preferences.h"
 #include "esphome/components/output/float_output.h"
 
-namespace esphome {
-namespace servo {
+namespace esphome::servo {
 
 extern uint32_t global_servo_id;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
@@ -73,5 +72,4 @@ template<typename... Ts> class ServoDetachAction : public Action<Ts...> {
   Servo *servo_;
 };
 
-}  // namespace servo
-}  // namespace esphome
+}  // namespace esphome::servo

--- a/esphome/components/sfa30/sfa30.cpp
+++ b/esphome/components/sfa30/sfa30.cpp
@@ -1,8 +1,7 @@
 #include "sfa30.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sfa30 {
+namespace esphome::sfa30 {
 
 static const char *const TAG = "sfa30";
 
@@ -91,5 +90,4 @@ void SFA30Component::update() {
   });
 }
 
-}  // namespace sfa30
-}  // namespace esphome
+}  // namespace esphome::sfa30

--- a/esphome/components/sfa30/sfa30.h
+++ b/esphome/components/sfa30/sfa30.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/sensirion_common/i2c_sensirion.h"
 
-namespace esphome {
-namespace sfa30 {
+namespace esphome::sfa30 {
 
 class SFA30Component : public PollingComponent, public sensirion_common::SensirionI2CDevice {
   enum ErrorCode { DEVICE_MARKING_READ_FAILED, MEASUREMENT_INIT_FAILED, UNKNOWN };
@@ -29,5 +28,4 @@ class SFA30Component : public PollingComponent, public sensirion_common::Sensiri
   sensor::Sensor *temperature_sensor_{nullptr};
 };
 
-}  // namespace sfa30
-}  // namespace esphome
+}  // namespace esphome::sfa30

--- a/esphome/components/sgp30/sgp30.cpp
+++ b/esphome/components/sgp30/sgp30.cpp
@@ -6,8 +6,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace sgp30 {
+namespace esphome::sgp30 {
 
 static const char *const TAG = "sgp30";
 
@@ -302,5 +301,4 @@ void SGP30Component::update() {
   });
 }
 
-}  // namespace sgp30
-}  // namespace esphome
+}  // namespace esphome::sgp30

--- a/esphome/components/sgp30/sgp30.h
+++ b/esphome/components/sgp30/sgp30.h
@@ -8,8 +8,7 @@
 #include <cinttypes>
 #include <cmath>
 
-namespace esphome {
-namespace sgp30 {
+namespace esphome::sgp30 {
 
 struct SGP30Baselines {
   uint16_t eco2;
@@ -67,5 +66,4 @@ class SGP30Component : public PollingComponent, public sensirion_common::Sensiri
   sensor::Sensor *temperature_sensor_{nullptr};
 };
 
-}  // namespace sgp30
-}  // namespace esphome
+}  // namespace esphome::sgp30

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace sgp4x {
+namespace esphome::sgp4x {
 
 static const char *const TAG = "sgp4x";
 
@@ -290,5 +289,4 @@ void SGP4xComponent::dump_config() {
   LOG_SENSOR("  ", "NOx", this->nox_sensor_);
 }
 
-}  // namespace sgp4x
-}  // namespace esphome
+}  // namespace esphome::sgp4x

--- a/esphome/components/sgp4x/sgp4x.h
+++ b/esphome/components/sgp4x/sgp4x.h
@@ -11,8 +11,7 @@
 #include <VOCGasIndexAlgorithm.h>
 #include <NOxGasIndexAlgorithm.h>
 
-namespace esphome {
-namespace sgp4x {
+namespace esphome::sgp4x {
 
 struct SGP4xBaselines {
   int32_t state0;
@@ -134,5 +133,4 @@ class SGP4xComponent : public PollingComponent, public sensor::Sensor, public se
   uint32_t seconds_since_last_store_;
   SGP4xBaselines voc_baselines_storage_;
 };
-}  // namespace sgp4x
-}  // namespace esphome
+}  // namespace esphome::sgp4x

--- a/esphome/components/sht3xd/sht3xd.cpp
+++ b/esphome/components/sht3xd/sht3xd.cpp
@@ -1,8 +1,7 @@
 #include "sht3xd.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sht3xd {
+namespace esphome::sht3xd {
 
 static const char *const TAG = "sht3xd";
 
@@ -82,5 +81,4 @@ void SHT3XDComponent::update() {
   });
 }
 
-}  // namespace sht3xd
-}  // namespace esphome
+}  // namespace esphome::sht3xd

--- a/esphome/components/sht3xd/sht3xd.h
+++ b/esphome/components/sht3xd/sht3xd.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/sensirion_common/i2c_sensirion.h"
 
-namespace esphome {
-namespace sht3xd {
+namespace esphome::sht3xd {
 
 /// This class implements support for the SHT3x-DIS family of temperature+humidity i2c sensors.
 class SHT3XDComponent : public PollingComponent, public sensirion_common::SensirionI2CDevice {
@@ -25,5 +24,4 @@ class SHT3XDComponent : public PollingComponent, public sensirion_common::Sensir
   uint32_t serial_number_{0};
 };
 
-}  // namespace sht3xd
-}  // namespace esphome
+}  // namespace esphome::sht3xd

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sht4x {
+namespace esphome::sht4x {
 
 static const char *const TAG = "sht4x";
 
@@ -127,5 +126,4 @@ void SHT4XComponent::update() {
   });
 }
 
-}  // namespace sht4x
-}  // namespace esphome
+}  // namespace esphome::sht4x

--- a/esphome/components/sht4x/sht4x.h
+++ b/esphome/components/sht4x/sht4x.h
@@ -6,8 +6,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace sht4x {
+namespace esphome::sht4x {
 
 enum SHT4XPRECISION { SHT4X_PRECISION_HIGH = 0, SHT4X_PRECISION_MED, SHT4X_PRECISION_LOW };
 
@@ -45,5 +44,4 @@ class SHT4XComponent : public PollingComponent, public sensirion_common::Sensiri
   sensor::Sensor *humidity_sensor_{nullptr};
 };
 
-}  // namespace sht4x
-}  // namespace esphome
+}  // namespace esphome::sht4x

--- a/esphome/components/shutdown/button/shutdown_button.cpp
+++ b/esphome/components/shutdown/button/shutdown_button.cpp
@@ -10,8 +10,7 @@
 #include <Esp.h>
 #endif
 
-namespace esphome {
-namespace shutdown {
+namespace esphome::shutdown {
 
 static const char *const TAG = "shutdown.button";
 
@@ -29,5 +28,4 @@ void ShutdownButton::press_action() {
 #endif
 }
 
-}  // namespace shutdown
-}  // namespace esphome
+}  // namespace esphome::shutdown

--- a/esphome/components/shutdown/button/shutdown_button.h
+++ b/esphome/components/shutdown/button/shutdown_button.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace shutdown {
+namespace esphome::shutdown {
 
 class ShutdownButton : public button::Button, public Component {
  public:
@@ -14,5 +13,4 @@ class ShutdownButton : public button::Button, public Component {
   void press_action() override;
 };
 
-}  // namespace shutdown
-}  // namespace esphome
+}  // namespace esphome::shutdown

--- a/esphome/components/shutdown/switch/shutdown_switch.cpp
+++ b/esphome/components/shutdown/switch/shutdown_switch.cpp
@@ -10,8 +10,7 @@
 #include <Esp.h>
 #endif
 
-namespace esphome {
-namespace shutdown {
+namespace esphome::shutdown {
 
 static const char *const TAG = "shutdown.switch";
 
@@ -34,5 +33,4 @@ void ShutdownSwitch::write_state(bool state) {
   }
 }
 
-}  // namespace shutdown
-}  // namespace esphome
+}  // namespace esphome::shutdown

--- a/esphome/components/shutdown/switch/shutdown_switch.h
+++ b/esphome/components/shutdown/switch/shutdown_switch.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace shutdown {
+namespace esphome::shutdown {
 
 class ShutdownSwitch : public switch_::Switch, public Component {
  public:
@@ -14,5 +13,4 @@ class ShutdownSwitch : public switch_::Switch, public Component {
   void write_state(bool state) override;
 };
 
-}  // namespace shutdown
-}  // namespace esphome
+}  // namespace esphome::shutdown

--- a/esphome/components/sigma_delta_output/sigma_delta_output.cpp
+++ b/esphome/components/sigma_delta_output/sigma_delta_output.cpp
@@ -1,8 +1,7 @@
 #include "sigma_delta_output.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sigma_delta_output {
+namespace esphome::sigma_delta_output {
 
 static const char *const TAG = "output.sigma_delta";
 
@@ -53,5 +52,4 @@ void SigmaDeltaOutput::update() {
   }
 }
 
-}  // namespace sigma_delta_output
-}  // namespace esphome
+}  // namespace esphome::sigma_delta_output

--- a/esphome/components/sigma_delta_output/sigma_delta_output.h
+++ b/esphome/components/sigma_delta_output/sigma_delta_output.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/output/float_output.h"
 
-namespace esphome {
-namespace sigma_delta_output {
+namespace esphome::sigma_delta_output {
 
 class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
  public:
@@ -43,5 +42,4 @@ class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
   float state_{0.};
   bool value_{false};
 };
-}  // namespace sigma_delta_output
-}  // namespace esphome
+}  // namespace esphome::sigma_delta_output

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include <cstring>
 
-namespace esphome {
-namespace sim800l {
+namespace esphome::sim800l {
 
 static const char *const TAG = "sim800l";
 
@@ -492,5 +491,4 @@ void Sim800LComponent::set_registered_(bool registered) {
 #endif
 }
 
-}  // namespace sim800l
-}  // namespace esphome
+}  // namespace esphome::sim800l

--- a/esphome/components/sim800l/sim800l.h
+++ b/esphome/components/sim800l/sim800l.h
@@ -13,8 +13,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace sim800l {
+namespace esphome::sim800l {
 
 const uint16_t SIM800L_READ_BUFFER_LENGTH = 1024;
 
@@ -184,5 +183,4 @@ template<typename... Ts> class Sim800LDisconnectAction : public Action<Ts...> {
   Sim800LComponent *parent_;
 };
 
-}  // namespace sim800l
-}  // namespace esphome
+}  // namespace esphome::sim800l

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/gpio.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace slow_pwm {
+namespace esphome::slow_pwm {
 
 static const char *const TAG = "output.slow_pwm";
 
@@ -79,5 +78,4 @@ void SlowPWMOutput::write_state(float state) {
     this->restart_cycle();
 }
 
-}  // namespace slow_pwm
-}  // namespace esphome
+}  // namespace esphome::slow_pwm

--- a/esphome/components/slow_pwm/slow_pwm_output.h
+++ b/esphome/components/slow_pwm/slow_pwm_output.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/output/float_output.h"
 
-namespace esphome {
-namespace slow_pwm {
+namespace esphome::slow_pwm {
 
 class SlowPWMOutput : public output::FloatOutput, public Component {
  public:
@@ -57,5 +56,4 @@ class SlowPWMOutput : public output::FloatOutput, public Component {
   bool restart_cycle_on_state_change_;
 };
 
-}  // namespace slow_pwm
-}  // namespace esphome
+}  // namespace esphome::slow_pwm

--- a/esphome/components/sm10bit_base/sm10bit_base.cpp
+++ b/esphome/components/sm10bit_base/sm10bit_base.cpp
@@ -1,8 +1,7 @@
 #include "sm10bit_base.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sm10bit_base {
+namespace esphome::sm10bit_base {
 
 static const char *const TAG = "sm10bit_base";
 
@@ -127,5 +126,4 @@ void Sm10BitBase::write_buffer_(uint8_t *buffer, uint8_t size) {
   delayMicroseconds(SM10BIT_DELAY);
 }
 
-}  // namespace sm10bit_base
-}  // namespace esphome
+}  // namespace esphome::sm10bit_base

--- a/esphome/components/sm10bit_base/sm10bit_base.h
+++ b/esphome/components/sm10bit_base/sm10bit_base.h
@@ -5,8 +5,7 @@
 #include "esphome/components/output/float_output.h"
 #include <vector>
 
-namespace esphome {
-namespace sm10bit_base {
+namespace esphome::sm10bit_base {
 
 class Sm10BitBase : public Component {
  public:
@@ -59,5 +58,4 @@ class Sm10BitBase : public Component {
   bool update_{true};
 };
 
-}  // namespace sm10bit_base
-}  // namespace esphome
+}  // namespace esphome::sm10bit_base

--- a/esphome/components/sm16716/sm16716.cpp
+++ b/esphome/components/sm16716/sm16716.cpp
@@ -1,8 +1,7 @@
 #include "sm16716.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sm16716 {
+namespace esphome::sm16716 {
 
 static const char *const TAG = "sm16716";
 
@@ -49,5 +48,4 @@ void SM16716::loop() {
   this->update_ = false;
 }
 
-}  // namespace sm16716
-}  // namespace esphome
+}  // namespace esphome::sm16716

--- a/esphome/components/sm16716/sm16716.h
+++ b/esphome/components/sm16716/sm16716.h
@@ -5,8 +5,7 @@
 #include "esphome/components/output/float_output.h"
 #include <vector>
 
-namespace esphome {
-namespace sm16716 {
+namespace esphome::sm16716 {
 
 class SM16716 : public Component {
  public:
@@ -68,5 +67,4 @@ class SM16716 : public Component {
   bool update_{true};
 };
 
-}  // namespace sm16716
-}  // namespace esphome
+}  // namespace esphome::sm16716

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -3,8 +3,7 @@
 
 // Tnx to the work of https://github.com/arendst (Tasmota) for making the initial version of the driver
 
-namespace esphome {
-namespace sm2135 {
+namespace esphome::sm2135 {
 
 static const char *const TAG = "sm2135";
 
@@ -149,5 +148,4 @@ void SM2135::sm2135_set_high_(GPIOPin *pin) {
   pin->pin_mode(gpio::FLAG_PULLUP);
 }
 
-}  // namespace sm2135
-}  // namespace esphome
+}  // namespace esphome::sm2135

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace sm2135 {
+namespace esphome::sm2135 {
 
 enum SM2135Current : uint8_t {
   SM2135_CURRENT_10MA = 0x00,
@@ -86,5 +85,4 @@ class SM2135 : public Component {
   bool update_{true};
 };
 
-}  // namespace sm2135
-}  // namespace esphome
+}  // namespace esphome::sm2135

--- a/esphome/components/sm2235/sm2235.cpp
+++ b/esphome/components/sm2235/sm2235.cpp
@@ -1,8 +1,7 @@
 #include "sm2235.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sm2235 {
+namespace esphome::sm2235 {
 
 static const char *const TAG = "sm2235";
 
@@ -24,5 +23,4 @@ void SM2235::dump_config() {
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
 }
 
-}  // namespace sm2235
-}  // namespace esphome
+}  // namespace esphome::sm2235

--- a/esphome/components/sm2235/sm2235.h
+++ b/esphome/components/sm2235/sm2235.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sm10bit_base/sm10bit_base.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace sm2235 {
+namespace esphome::sm2235 {
 
 class SM2235 : public sm10bit_base::Sm10BitBase {
  public:
@@ -15,5 +14,4 @@ class SM2235 : public sm10bit_base::Sm10BitBase {
   void dump_config() override;
 };
 
-}  // namespace sm2235
-}  // namespace esphome
+}  // namespace esphome::sm2235

--- a/esphome/components/sm2335/sm2335.cpp
+++ b/esphome/components/sm2335/sm2335.cpp
@@ -1,8 +1,7 @@
 #include "sm2335.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sm2335 {
+namespace esphome::sm2335 {
 
 static const char *const TAG = "sm2335";
 
@@ -24,5 +23,4 @@ void SM2335::dump_config() {
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
 }
 
-}  // namespace sm2335
-}  // namespace esphome
+}  // namespace esphome::sm2335

--- a/esphome/components/sm2335/sm2335.h
+++ b/esphome/components/sm2335/sm2335.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sm10bit_base/sm10bit_base.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace sm2335 {
+namespace esphome::sm2335 {
 
 class SM2335 : public sm10bit_base::Sm10BitBase {
  public:
@@ -15,5 +14,4 @@ class SM2335 : public sm10bit_base::Sm10BitBase {
   void dump_config() override;
 };
 
-}  // namespace sm2335
-}  // namespace esphome
+}  // namespace esphome::sm2335

--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -1,8 +1,7 @@
 #include "sm300d2.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sm300d2 {
+namespace esphome::sm300d2 {
 
 static const char *const TAG = "sm300d2";
 static const uint8_t SM300D2_RESPONSE_LENGTH = 17;
@@ -104,5 +103,4 @@ void SM300D2Sensor::dump_config() {
   this->check_uart_settings(9600);
 }
 
-}  // namespace sm300d2
-}  // namespace esphome
+}  // namespace esphome::sm300d2

--- a/esphome/components/sm300d2/sm300d2.h
+++ b/esphome/components/sm300d2/sm300d2.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace sm300d2 {
+namespace esphome::sm300d2 {
 
 class SM300D2Sensor : public PollingComponent, public uart::UARTDevice {
  public:
@@ -32,5 +31,4 @@ class SM300D2Sensor : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *humidity_sensor_{nullptr};
 };
 
-}  // namespace sm300d2
-}  // namespace esphome
+}  // namespace esphome::sm300d2

--- a/esphome/components/sml/constants.h
+++ b/esphome/components/sml/constants.h
@@ -3,8 +3,7 @@
 #include <array>
 #include <cstdint>
 
-namespace esphome {
-namespace sml {
+namespace esphome::sml {
 
 enum SmlType : uint8_t {
   SML_OCTET = 0,
@@ -24,5 +23,4 @@ const uint16_t END_MASK = 0x0157;    // 0x1b 1b 1b 1b 1a
 
 constexpr std::array<uint8_t, 8> START_SEQ = {0x1b, 0x1b, 0x1b, 0x1b, 0x01, 0x01, 0x01, 0x01};
 
-}  // namespace sml
-}  // namespace esphome
+}  // namespace esphome::sml

--- a/esphome/components/sml/sensor/sml_sensor.cpp
+++ b/esphome/components/sml/sensor/sml_sensor.cpp
@@ -2,8 +2,7 @@
 #include "sml_sensor.h"
 #include "../sml_parser.h"
 
-namespace esphome {
-namespace sml {
+namespace esphome::sml {
 
 static const char *const TAG = "sml_sensor";
 
@@ -37,5 +36,4 @@ void SmlSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "  OBIS Code: %s", this->obis_code.c_str());
 }
 
-}  // namespace sml
-}  // namespace esphome
+}  // namespace esphome::sml

--- a/esphome/components/sml/sensor/sml_sensor.h
+++ b/esphome/components/sml/sensor/sml_sensor.h
@@ -2,8 +2,7 @@
 #include "esphome/components/sml/sml.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace sml {
+namespace esphome::sml {
 
 class SmlSensor : public SmlListener, public sensor::Sensor, public Component {
  public:
@@ -12,5 +11,4 @@ class SmlSensor : public SmlListener, public sensor::Sensor, public Component {
   void dump_config() override;
 };
 
-}  // namespace sml
-}  // namespace esphome
+}  // namespace esphome::sml

--- a/esphome/components/sml/sml.cpp
+++ b/esphome/components/sml/sml.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include "sml_parser.h"
 
-namespace esphome {
-namespace sml {
+namespace esphome::sml {
 
 static const char *const TAG = "sml";
 
@@ -140,5 +139,4 @@ uint8_t get_code(uint8_t byte) {
   }
 }
 
-}  // namespace sml
-}  // namespace esphome
+}  // namespace esphome::sml

--- a/esphome/components/sml/sml.h
+++ b/esphome/components/sml/sml.h
@@ -7,8 +7,7 @@
 #include "esphome/components/uart/uart.h"
 #include "sml_parser.h"
 
-namespace esphome {
-namespace sml {
+namespace esphome::sml {
 
 class SmlListener {
  public:
@@ -44,5 +43,4 @@ class Sml : public Component, public uart::UARTDevice {
 bool check_sml_data(const bytes &buffer);
 
 uint8_t get_code(uint8_t byte);
-}  // namespace sml
-}  // namespace esphome
+}  // namespace esphome::sml

--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -2,8 +2,7 @@
 #include "constants.h"
 #include "sml_parser.h"
 
-namespace esphome {
-namespace sml {
+namespace esphome::sml {
 
 SmlFile::SmlFile(const BytesView &buffer) : buffer_(buffer) {
   // extract messages
@@ -158,5 +157,4 @@ std::string ObisInfo::code_repr() const {
   return buf;
 }
 
-}  // namespace sml
-}  // namespace esphome
+}  // namespace esphome::sml

--- a/esphome/components/sml/sml_parser.h
+++ b/esphome/components/sml/sml_parser.h
@@ -7,8 +7,7 @@
 #include <vector>
 #include "constants.h"
 
-namespace esphome {
-namespace sml {
+namespace esphome::sml {
 
 using bytes = std::vector<uint8_t>;
 
@@ -80,5 +79,4 @@ uint64_t bytes_to_uint(const BytesView &buffer);
 int64_t bytes_to_int(const BytesView &buffer);
 
 std::string bytes_to_string(const BytesView &buffer);
-}  // namespace sml
-}  // namespace esphome
+}  // namespace esphome::sml

--- a/esphome/components/sml/text_sensor/sml_text_sensor.cpp
+++ b/esphome/components/sml/text_sensor/sml_text_sensor.cpp
@@ -4,8 +4,7 @@
 #include "../sml_parser.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace sml {
+namespace esphome::sml {
 
 static const char *const TAG = "sml_text_sensor";
 
@@ -60,5 +59,4 @@ void SmlTextSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "  OBIS Code: %s", this->obis_code.c_str());
 }
 
-}  // namespace sml
-}  // namespace esphome
+}  // namespace esphome::sml

--- a/esphome/components/sml/text_sensor/sml_text_sensor.h
+++ b/esphome/components/sml/text_sensor/sml_text_sensor.h
@@ -4,8 +4,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "../constants.h"
 
-namespace esphome {
-namespace sml {
+namespace esphome::sml {
 
 class SmlTextSensor : public SmlListener, public text_sensor::TextSensor, public Component {
  public:
@@ -17,5 +16,4 @@ class SmlTextSensor : public SmlListener, public text_sensor::TextSensor, public
   SmlType format_;
 };
 
-}  // namespace sml
-}  // namespace esphome
+}  // namespace esphome::sml

--- a/esphome/components/smt100/smt100.cpp
+++ b/esphome/components/smt100/smt100.cpp
@@ -1,8 +1,7 @@
 #include "smt100.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace smt100 {
+namespace esphome::smt100 {
 
 static const char *const TAG = "smt100";
 
@@ -91,5 +90,4 @@ int SMT100Component::readline_(int readch, char *buffer, int len) {
   return -1;
 }
 
-}  // namespace smt100
-}  // namespace esphome
+}  // namespace esphome::smt100

--- a/esphome/components/smt100/smt100.h
+++ b/esphome/components/smt100/smt100.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace smt100 {
+namespace esphome::smt100 {
 
 class SMT100Component : public PollingComponent, public uart::UARTDevice {
   static const uint16_t MAX_LINE_LENGTH = 31;
@@ -40,5 +39,4 @@ class SMT100Component : public PollingComponent, public uart::UARTDevice {
   uint32_t last_transmission_{0};
 };
 
-}  // namespace smt100
-}  // namespace esphome
+}  // namespace esphome::smt100

--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -1,8 +1,7 @@
 #include "sn74hc165.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sn74hc165 {
+namespace esphome::sn74hc165 {
 
 static const char *const TAG = "sn74hc165";
 
@@ -68,5 +67,4 @@ size_t SN74HC165GPIOPin::dump_summary(char *buffer, size_t len) const {
   return buf_append_printf(buffer, len, 0, "%u via SN74HC165", this->pin_);
 }
 
-}  // namespace sn74hc165
-}  // namespace esphome
+}  // namespace esphome::sn74hc165

--- a/esphome/components/sn74hc165/sn74hc165.h
+++ b/esphome/components/sn74hc165/sn74hc165.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace sn74hc165 {
+namespace esphome::sn74hc165 {
 
 class SN74HC165Component : public Component {
  public:
@@ -60,5 +59,4 @@ class SN74HC165GPIOPin : public GPIOPin, public Parented<SN74HC165Component> {
   bool inverted_;
 };
 
-}  // namespace sn74hc165
-}  // namespace esphome
+}  // namespace esphome::sn74hc165

--- a/esphome/components/sn74hc595/sn74hc595.cpp
+++ b/esphome/components/sn74hc595/sn74hc595.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <ranges>
 
-namespace esphome {
-namespace sn74hc595 {
+namespace esphome::sn74hc595 {
 
 static const char *const TAG = "sn74hc595";
 
@@ -97,5 +96,4 @@ size_t SN74HC595GPIOPin::dump_summary(char *buffer, size_t len) const {
   return buf_append_printf(buffer, len, 0, "%u via SN74HC595", this->pin_);
 }
 
-}  // namespace sn74hc595
-}  // namespace esphome
+}  // namespace esphome::sn74hc595

--- a/esphome/components/sn74hc595/sn74hc595.h
+++ b/esphome/components/sn74hc595/sn74hc595.h
@@ -11,8 +11,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace sn74hc595 {
+namespace esphome::sn74hc595 {
 
 class SN74HC595Component : public Component {
  public:
@@ -93,5 +92,4 @@ class SN74HC595SPIComponent : public SN74HC595Component,
 
 #endif
 
-}  // namespace sn74hc595
-}  // namespace esphome
+}  // namespace esphome::sn74hc595

--- a/esphome/components/sntp/sntp_component.cpp
+++ b/esphome/components/sntp/sntp_component.cpp
@@ -9,8 +9,7 @@
 #include "lwip/apps/sntp.h"
 #endif
 
-namespace esphome {
-namespace sntp {
+namespace esphome::sntp {
 
 static const char *const TAG = "sntp";
 
@@ -102,5 +101,4 @@ void SNTPComponent::time_synced() {
   this->time_sync_callback_.call();
 }
 
-}  // namespace sntp
-}  // namespace esphome
+}  // namespace esphome::sntp

--- a/esphome/components/sntp/sntp_component.h
+++ b/esphome/components/sntp/sntp_component.h
@@ -4,8 +4,7 @@
 #include "esphome/components/time/real_time_clock.h"
 #include <array>
 
-namespace esphome {
-namespace sntp {
+namespace esphome::sntp {
 
 // Server count is calculated at compile time by Python codegen
 // SNTP_SERVER_COUNT will always be defined
@@ -42,5 +41,4 @@ class SNTPComponent : public time::RealTimeClock {
 #endif
 };
 
-}  // namespace sntp
-}  // namespace esphome
+}  // namespace esphome::sntp

--- a/esphome/components/sonoff_d1/sonoff_d1.cpp
+++ b/esphome/components/sonoff_d1/sonoff_d1.cpp
@@ -44,8 +44,7 @@
 #include "sonoff_d1.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace sonoff_d1 {
+namespace esphome::sonoff_d1 {
 
 static const char *const TAG = "sonoff_d1";
 
@@ -321,5 +320,4 @@ void SonoffD1Output::loop() {
   }
 }
 
-}  // namespace sonoff_d1
-}  // namespace esphome
+}  // namespace esphome::sonoff_d1

--- a/esphome/components/sonoff_d1/sonoff_d1.h
+++ b/esphome/components/sonoff_d1/sonoff_d1.h
@@ -39,8 +39,7 @@
 #include "esphome/components/light/light_state.h"
 #include "esphome/components/light/light_traits.h"
 
-namespace esphome {
-namespace sonoff_d1 {
+namespace esphome::sonoff_d1 {
 
 class SonoffD1Output : public light::LightOutput, public uart::UARTDevice, public Component {
  public:
@@ -80,5 +79,4 @@ class SonoffD1Output : public light::LightOutput, public uart::UARTDevice, publi
   void publish_state_(bool is_on, uint8_t brightness);
 };
 
-}  // namespace sonoff_d1
-}  // namespace esphome
+}  // namespace esphome::sonoff_d1

--- a/esphome/components/sound_level/sound_level.cpp
+++ b/esphome/components/sound_level/sound_level.cpp
@@ -7,8 +7,7 @@
 #include <cmath>
 #include <cstdint>
 
-namespace esphome {
-namespace sound_level {
+namespace esphome::sound_level {
 
 static const char *const TAG = "sound_level";
 
@@ -190,7 +189,6 @@ bool SoundLevelComponent::start_() {
 
 void SoundLevelComponent::stop_() { this->audio_buffer_.reset(); }
 
-}  // namespace sound_level
-}  // namespace esphome
+}  // namespace esphome::sound_level
 
 #endif

--- a/esphome/components/sound_level/sound_level.h
+++ b/esphome/components/sound_level/sound_level.h
@@ -10,8 +10,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/ring_buffer.h"
 
-namespace esphome {
-namespace sound_level {
+namespace esphome::sound_level {
 
 class SoundLevelComponent : public Component {
  public:
@@ -69,6 +68,6 @@ template<typename... Ts> class StopAction : public Action<Ts...>, public Parente
   void play(const Ts &...x) override { this->parent_->stop(); }
 };
 
-}  // namespace sound_level
-}  // namespace esphome
+}  // namespace esphome::sound_level
+
 #endif

--- a/esphome/components/speaker/automation.h
+++ b/esphome/components/speaker/automation.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace speaker {
+namespace esphome::speaker {
 
 template<typename... Ts> class PlayAction : public Action<Ts...>, public Parented<Speaker> {
  public:
@@ -84,5 +83,4 @@ template<typename... Ts> class IsStoppedCondition : public Condition<Ts...>, pub
   bool check(const Ts &...x) override { return this->parent_->is_stopped(); }
 };
 
-}  // namespace speaker
-}  // namespace esphome
+}  // namespace esphome::speaker

--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -7,8 +7,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace speaker {
+namespace esphome::speaker {
 
 static const uint32_t INITIAL_BUFFER_MS = 1000;  // Start playback after buffering this duration of the file
 
@@ -513,7 +512,6 @@ void AudioPipeline::decode_task(void *params) {
   }
 }
 
-}  // namespace speaker
-}  // namespace esphome
+}  // namespace esphome::speaker
 
 #endif

--- a/esphome/components/speaker/media_player/audio_pipeline.h
+++ b/esphome/components/speaker/media_player/audio_pipeline.h
@@ -15,8 +15,7 @@
 #include <freertos/event_groups.h>
 #include <freertos/queue.h>
 
-namespace esphome {
-namespace speaker {
+namespace esphome::speaker {
 
 // Internal sink/source buffers for reader and decoder
 static const size_t DEFAULT_TRANSFER_BUFFER_SIZE = 24 * 1024;
@@ -147,7 +146,6 @@ class AudioPipeline {
   StaticTask decode_task_;
 };
 
-}  // namespace speaker
-}  // namespace esphome
+}  // namespace esphome::speaker
 
 #endif

--- a/esphome/components/speaker/media_player/automation.h
+++ b/esphome/components/speaker/media_player/automation.h
@@ -7,8 +7,7 @@
 #include "esphome/components/audio/audio.h"
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace speaker {
+namespace esphome::speaker {
 
 template<typename... Ts> class PlayOnDeviceMediaAction : public Action<Ts...>, public Parented<SpeakerMediaPlayer> {
   TEMPLATABLE_VALUE(audio::AudioFile *, audio_file)
@@ -20,7 +19,6 @@ template<typename... Ts> class PlayOnDeviceMediaAction : public Action<Ts...>, p
   }
 };
 
-}  // namespace speaker
-}  // namespace esphome
+}  // namespace esphome::speaker
 
 #endif

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -9,8 +9,7 @@
 #include "esphome/components/ota/ota_backend.h"
 #endif
 
-namespace esphome {
-namespace speaker {
+namespace esphome::speaker {
 
 // Framework:
 //  - Media player that can handle two streams: one for media and one for announcements
@@ -622,7 +621,6 @@ void SpeakerMediaPlayer::set_volume_(float volume, bool publish) {
   this->defer([this, volume]() { this->volume_trigger_.trigger(volume); });
 }
 
-}  // namespace speaker
-}  // namespace esphome
+}  // namespace esphome::speaker
 
 #endif

--- a/esphome/components/speaker/media_player/speaker_media_player.h
+++ b/esphome/components/speaker/media_player/speaker_media_player.h
@@ -21,8 +21,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
 
-namespace esphome {
-namespace speaker {
+namespace esphome::speaker {
 
 struct MediaCallCommand {
   optional<media_player::MediaPlayerCommand> command;
@@ -167,7 +166,6 @@ class SpeakerMediaPlayer : public Component,
   Trigger<float> volume_trigger_;
 };
 
-}  // namespace speaker
-}  // namespace esphome
+}  // namespace esphome::speaker
 
 #endif

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -16,8 +16,7 @@
 #include "esphome/components/audio_dac/audio_dac.h"
 #endif
 
-namespace esphome {
-namespace speaker {
+namespace esphome::speaker {
 
 enum State : uint8_t {
   STATE_STOPPED = 0,
@@ -123,5 +122,4 @@ class Speaker {
   CallbackManager<void(uint32_t, int64_t)> audio_output_callback_{};
 };
 
-}  // namespace speaker
-}  // namespace esphome
+}  // namespace esphome::speaker

--- a/esphome/components/speed/fan/speed_fan.cpp
+++ b/esphome/components/speed/fan/speed_fan.cpp
@@ -1,8 +1,7 @@
 #include "speed_fan.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace speed {
+namespace esphome::speed {
 
 static const char *const TAG = "speed.fan";
 
@@ -47,5 +46,4 @@ void SpeedFan::write_state_() {
     this->direction_->set_state(this->direction == fan::FanDirection::REVERSE);
 }
 
-}  // namespace speed
-}  // namespace esphome
+}  // namespace esphome::speed

--- a/esphome/components/speed/fan/speed_fan.h
+++ b/esphome/components/speed/fan/speed_fan.h
@@ -5,8 +5,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/components/fan/fan.h"
 
-namespace esphome {
-namespace speed {
+namespace esphome::speed {
 
 class SpeedFan : public Component, public fan::Fan {
  public:
@@ -33,5 +32,4 @@ class SpeedFan : public Component, public fan::Fan {
   fan::FanTraits traits_;
 };
 
-}  // namespace speed
-}  // namespace esphome
+}  // namespace esphome::speed

--- a/esphome/components/spi_device/spi_device.cpp
+++ b/esphome/components/spi_device/spi_device.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace spi_device {
+namespace esphome::spi_device {
 
 static const char *const TAG = "spi_device";
 
@@ -23,5 +22,4 @@ void SPIDeviceComponent::dump_config() {
   }
 }
 
-}  // namespace spi_device
-}  // namespace esphome
+}  // namespace esphome::spi_device

--- a/esphome/components/spi_device/spi_device.h
+++ b/esphome/components/spi_device/spi_device.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace spi_device {
+namespace esphome::spi_device {
 
 class SPIDeviceComponent : public Component,
                            public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH,
@@ -16,5 +15,4 @@ class SPIDeviceComponent : public Component,
  protected:
 };
 
-}  // namespace spi_device
-}  // namespace esphome
+}  // namespace esphome::spi_device

--- a/esphome/components/spi_led_strip/spi_led_strip.cpp
+++ b/esphome/components/spi_led_strip/spi_led_strip.cpp
@@ -1,8 +1,7 @@
 #include "spi_led_strip.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace spi_led_strip {
+namespace esphome::spi_led_strip {
 
 SpiLedStrip::SpiLedStrip(uint16_t num_leds) {
   this->num_leds_ = num_leds;
@@ -65,5 +64,4 @@ light::ESPColorView SpiLedStrip::get_view_internal(int32_t index) const {
   return {this->buf_ + pos + 2,       this->buf_ + pos + 1, this->buf_ + pos + 0, nullptr,
           this->effect_data_ + index, &this->correction_};
 }
-}  // namespace spi_led_strip
-}  // namespace esphome
+}  // namespace esphome::spi_led_strip

--- a/esphome/components/spi_led_strip/spi_led_strip.h
+++ b/esphome/components/spi_led_strip/spi_led_strip.h
@@ -5,8 +5,7 @@
 #include "esphome/components/light/addressable_light.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace spi_led_strip {
+namespace esphome::spi_led_strip {
 
 static const char *const TAG = "spi_led_strip";
 class SpiLedStrip : public light::AddressableLight,
@@ -36,5 +35,4 @@ class SpiLedStrip : public light::AddressableLight,
   uint16_t num_leds_;
 };
 
-}  // namespace spi_led_strip
-}  // namespace esphome
+}  // namespace esphome::spi_led_strip

--- a/esphome/components/sps30/automation.h
+++ b/esphome/components/sps30/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "sps30.h"
 
-namespace esphome {
-namespace sps30 {
+namespace esphome::sps30 {
 
 template<typename... Ts> class StartFanAction : public Action<Ts...>, public Parented<SPS30Component> {
  public:
@@ -22,5 +21,4 @@ template<typename... Ts> class StopMeasurementAction : public Action<Ts...>, pub
   void play(const Ts &...x) override { this->parent_->stop_measurement(); }
 };
 
-}  // namespace sps30
-}  // namespace esphome
+}  // namespace esphome::sps30

--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace sps30 {
+namespace esphome::sps30 {
 
 static const char *const TAG = "sps30";
 
@@ -291,5 +290,4 @@ bool SPS30Component::start_fan_cleaning() {
   return true;
 }
 
-}  // namespace sps30
-}  // namespace esphome
+}  // namespace esphome::sps30

--- a/esphome/components/sps30/sps30.h
+++ b/esphome/components/sps30/sps30.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/sensirion_common/i2c_sensirion.h"
 
-namespace esphome {
-namespace sps30 {
+namespace esphome::sps30 {
 
 /// This class implements support for the Sensirion SPS30 i2c/UART Particulate Matter
 /// PM1.0, PM2.5, PM4, PM10 Air Quality sensors.
@@ -67,5 +66,4 @@ class SPS30Component : public PollingComponent, public sensirion_common::Sensiri
   optional<uint32_t> idle_interval_;
 };
 
-}  // namespace sps30
-}  // namespace esphome
+}  // namespace esphome::sps30

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/progmem.h"
 
-namespace esphome {
-namespace ssd1306_base {
+namespace esphome::ssd1306_base {
 
 static const char *const TAG = "ssd1306";
 
@@ -376,5 +375,4 @@ const LogString *SSD1306::model_str_() {
   return ModelStrings::get_log_str(static_cast<uint8_t>(this->model_), ModelStrings::LAST_INDEX);
 }
 
-}  // namespace ssd1306_base
-}  // namespace esphome
+}  // namespace esphome::ssd1306_base

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/display/display_buffer.h"
 
-namespace esphome {
-namespace ssd1306_base {
+namespace esphome::ssd1306_base {
 
 enum SSD1306Model {
   SSD1306_MODEL_128_32 = 0,
@@ -88,5 +87,4 @@ class SSD1306 : public display::DisplayBuffer {
   bool invert_{false};
 };
 
-}  // namespace ssd1306_base
-}  // namespace esphome
+}  // namespace esphome::ssd1306_base

--- a/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
+++ b/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
@@ -1,8 +1,7 @@
 #include "ssd1306_i2c.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ssd1306_i2c {
+namespace esphome::ssd1306_i2c {
 
 static const char *const TAG = "ssd1306_i2c";
 
@@ -76,5 +75,4 @@ void HOT I2CSSD1306::write_display_data() {
   }
 }
 
-}  // namespace ssd1306_i2c
-}  // namespace esphome
+}  // namespace esphome::ssd1306_i2c

--- a/esphome/components/ssd1306_i2c/ssd1306_i2c.h
+++ b/esphome/components/ssd1306_i2c/ssd1306_i2c.h
@@ -4,8 +4,7 @@
 #include "esphome/components/ssd1306_base/ssd1306_base.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ssd1306_i2c {
+namespace esphome::ssd1306_i2c {
 
 class I2CSSD1306 : public ssd1306_base::SSD1306, public i2c::I2CDevice {
  public:
@@ -19,5 +18,4 @@ class I2CSSD1306 : public ssd1306_base::SSD1306, public i2c::I2CDevice {
   enum ErrorCode { NONE = 0, COMMUNICATION_FAILED } error_code_{NONE};
 };
 
-}  // namespace ssd1306_i2c
-}  // namespace esphome
+}  // namespace esphome::ssd1306_i2c

--- a/esphome/components/ssd1306_spi/ssd1306_spi.cpp
+++ b/esphome/components/ssd1306_spi/ssd1306_spi.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ssd1306_spi {
+namespace esphome::ssd1306_spi {
 
 static const char *const TAG = "ssd1306_spi";
 
@@ -63,5 +62,4 @@ void HOT SPISSD1306::write_display_data() {
   }
 }
 
-}  // namespace ssd1306_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1306_spi

--- a/esphome/components/ssd1306_spi/ssd1306_spi.h
+++ b/esphome/components/ssd1306_spi/ssd1306_spi.h
@@ -4,8 +4,7 @@
 #include "esphome/components/ssd1306_base/ssd1306_base.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace ssd1306_spi {
+namespace esphome::ssd1306_spi {
 
 class SPISSD1306 : public ssd1306_base::SSD1306,
                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
@@ -25,5 +24,4 @@ class SPISSD1306 : public ssd1306_base::SSD1306,
   GPIOPin *dc_pin_;
 };
 
-}  // namespace ssd1306_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1306_spi

--- a/esphome/components/ssd1322_base/ssd1322_base.cpp
+++ b/esphome/components/ssd1322_base/ssd1322_base.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ssd1322_base {
+namespace esphome::ssd1322_base {
 
 static const char *const TAG = "ssd1322";
 
@@ -206,5 +205,4 @@ const char *SSD1322::model_str_() {
   }
 }
 
-}  // namespace ssd1322_base
-}  // namespace esphome
+}  // namespace esphome::ssd1322_base

--- a/esphome/components/ssd1322_base/ssd1322_base.h
+++ b/esphome/components/ssd1322_base/ssd1322_base.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/display/display_buffer.h"
 
-namespace esphome {
-namespace ssd1322_base {
+namespace esphome::ssd1322_base {
 
 enum SSD1322Model {
   SSD1322_MODEL_256_64 = 0,
@@ -51,5 +50,4 @@ class SSD1322 : public display::DisplayBuffer {
   float brightness_{1.0};
 };
 
-}  // namespace ssd1322_base
-}  // namespace esphome
+}  // namespace esphome::ssd1322_base

--- a/esphome/components/ssd1322_spi/ssd1322_spi.cpp
+++ b/esphome/components/ssd1322_spi/ssd1322_spi.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ssd1322_spi {
+namespace esphome::ssd1322_spi {
 
 static const char *const TAG = "ssd1322_spi";
 
@@ -68,5 +67,4 @@ void HOT SPISSD1322::write_display_data() {
   this->disable();
 }
 
-}  // namespace ssd1322_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1322_spi

--- a/esphome/components/ssd1322_spi/ssd1322_spi.h
+++ b/esphome/components/ssd1322_spi/ssd1322_spi.h
@@ -4,8 +4,7 @@
 #include "esphome/components/ssd1322_base/ssd1322_base.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace ssd1322_spi {
+namespace esphome::ssd1322_spi {
 
 class SPISSD1322 : public ssd1322_base::SSD1322,
                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
@@ -26,5 +25,4 @@ class SPISSD1322 : public ssd1322_base::SSD1322,
   GPIOPin *dc_pin_;
 };
 
-}  // namespace ssd1322_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1322_spi

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ssd1325_base {
+namespace esphome::ssd1325_base {
 
 static const char *const TAG = "ssd1325";
 
@@ -241,5 +240,4 @@ const char *SSD1325::model_str_() {
   }
 }
 
-}  // namespace ssd1325_base
-}  // namespace esphome
+}  // namespace esphome::ssd1325_base

--- a/esphome/components/ssd1325_base/ssd1325_base.h
+++ b/esphome/components/ssd1325_base/ssd1325_base.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/display/display_buffer.h"
 
-namespace esphome {
-namespace ssd1325_base {
+namespace esphome::ssd1325_base {
 
 enum SSD1325Model {
   SSD1325_MODEL_128_32 = 0,
@@ -56,5 +55,4 @@ class SSD1325 : public display::DisplayBuffer {
   float brightness_{1.0};
 };
 
-}  // namespace ssd1325_base
-}  // namespace esphome
+}  // namespace esphome::ssd1325_base

--- a/esphome/components/ssd1325_spi/ssd1325_spi.cpp
+++ b/esphome/components/ssd1325_spi/ssd1325_spi.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ssd1325_spi {
+namespace esphome::ssd1325_spi {
 
 static const char *const TAG = "ssd1325_spi";
 
@@ -56,5 +55,4 @@ void HOT SPISSD1325::write_display_data() {
   this->disable();
 }
 
-}  // namespace ssd1325_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1325_spi

--- a/esphome/components/ssd1325_spi/ssd1325_spi.h
+++ b/esphome/components/ssd1325_spi/ssd1325_spi.h
@@ -4,8 +4,7 @@
 #include "esphome/components/ssd1325_base/ssd1325_base.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace ssd1325_spi {
+namespace esphome::ssd1325_spi {
 
 class SPISSD1325 : public ssd1325_base::SSD1325,
                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
@@ -25,5 +24,4 @@ class SPISSD1325 : public ssd1325_base::SSD1325,
   GPIOPin *dc_pin_;
 };
 
-}  // namespace ssd1325_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1325_spi

--- a/esphome/components/ssd1327_base/ssd1327_base.cpp
+++ b/esphome/components/ssd1327_base/ssd1327_base.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ssd1327_base {
+namespace esphome::ssd1327_base {
 
 static const char *const TAG = "ssd1327";
 
@@ -182,5 +181,4 @@ const char *SSD1327::model_str_() {
   }
 }
 
-}  // namespace ssd1327_base
-}  // namespace esphome
+}  // namespace esphome::ssd1327_base

--- a/esphome/components/ssd1327_base/ssd1327_base.h
+++ b/esphome/components/ssd1327_base/ssd1327_base.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/display/display_buffer.h"
 
-namespace esphome {
-namespace ssd1327_base {
+namespace esphome::ssd1327_base {
 
 enum SSD1327Model {
   SSD1327_MODEL_128_128 = 0,
@@ -50,5 +49,4 @@ class SSD1327 : public display::DisplayBuffer {
   float brightness_{1.0};
 };
 
-}  // namespace ssd1327_base
-}  // namespace esphome
+}  // namespace esphome::ssd1327_base

--- a/esphome/components/ssd1327_i2c/ssd1327_i2c.cpp
+++ b/esphome/components/ssd1327_i2c/ssd1327_i2c.cpp
@@ -1,8 +1,7 @@
 #include "ssd1327_i2c.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ssd1327_i2c {
+namespace esphome::ssd1327_i2c {
 
 static const char *const TAG = "ssd1327_i2c";
 
@@ -39,5 +38,4 @@ void HOT I2CSSD1327::write_display_data() {
   }
 }
 
-}  // namespace ssd1327_i2c
-}  // namespace esphome
+}  // namespace esphome::ssd1327_i2c

--- a/esphome/components/ssd1327_i2c/ssd1327_i2c.h
+++ b/esphome/components/ssd1327_i2c/ssd1327_i2c.h
@@ -4,8 +4,7 @@
 #include "esphome/components/ssd1327_base/ssd1327_base.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ssd1327_i2c {
+namespace esphome::ssd1327_i2c {
 
 class I2CSSD1327 : public ssd1327_base::SSD1327, public i2c::I2CDevice {
  public:
@@ -19,5 +18,4 @@ class I2CSSD1327 : public ssd1327_base::SSD1327, public i2c::I2CDevice {
   enum ErrorCode { NONE = 0, COMMUNICATION_FAILED } error_code_{NONE};
 };
 
-}  // namespace ssd1327_i2c
-}  // namespace esphome
+}  // namespace esphome::ssd1327_i2c

--- a/esphome/components/ssd1327_spi/ssd1327_spi.cpp
+++ b/esphome/components/ssd1327_spi/ssd1327_spi.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ssd1327_spi {
+namespace esphome::ssd1327_spi {
 
 static const char *const TAG = "ssd1327_spi";
 
@@ -55,5 +54,4 @@ void HOT SPISSD1327::write_display_data() {
   this->disable();
 }
 
-}  // namespace ssd1327_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1327_spi

--- a/esphome/components/ssd1327_spi/ssd1327_spi.h
+++ b/esphome/components/ssd1327_spi/ssd1327_spi.h
@@ -4,8 +4,7 @@
 #include "esphome/components/ssd1327_base/ssd1327_base.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace ssd1327_spi {
+namespace esphome::ssd1327_spi {
 
 class SPISSD1327 : public ssd1327_base::SSD1327,
                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
@@ -25,5 +24,4 @@ class SPISSD1327 : public ssd1327_base::SSD1327,
   GPIOPin *dc_pin_;
 };
 
-}  // namespace ssd1327_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1327_spi

--- a/esphome/components/ssd1331_base/ssd1331_base.cpp
+++ b/esphome/components/ssd1331_base/ssd1331_base.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ssd1331_base {
+namespace esphome::ssd1331_base {
 
 static const char *const TAG = "ssd1331";
 
@@ -156,5 +155,4 @@ void SSD1331::init_reset_() {
   }
 }
 
-}  // namespace ssd1331_base
-}  // namespace esphome
+}  // namespace esphome::ssd1331_base

--- a/esphome/components/ssd1331_base/ssd1331_base.h
+++ b/esphome/components/ssd1331_base/ssd1331_base.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/display/display_buffer.h"
 
-namespace esphome {
-namespace ssd1331_base {
+namespace esphome::ssd1331_base {
 
 class SSD1331 : public display::DisplayBuffer {
  public:
@@ -43,5 +42,4 @@ class SSD1331 : public display::DisplayBuffer {
   float brightness_{1.0};
 };
 
-}  // namespace ssd1331_base
-}  // namespace esphome
+}  // namespace esphome::ssd1331_base

--- a/esphome/components/ssd1331_spi/ssd1331_spi.cpp
+++ b/esphome/components/ssd1331_spi/ssd1331_spi.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ssd1331_spi {
+namespace esphome::ssd1331_spi {
 
 static const char *const TAG = "ssd1331_spi";
 
@@ -52,5 +51,4 @@ void HOT SPISSD1331::write_display_data() {
   this->disable();
 }
 
-}  // namespace ssd1331_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1331_spi

--- a/esphome/components/ssd1331_spi/ssd1331_spi.h
+++ b/esphome/components/ssd1331_spi/ssd1331_spi.h
@@ -4,8 +4,7 @@
 #include "esphome/components/ssd1331_base/ssd1331_base.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace ssd1331_spi {
+namespace esphome::ssd1331_spi {
 
 class SPISSD1331 : public ssd1331_base::SSD1331,
                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
@@ -25,5 +24,4 @@ class SPISSD1331 : public ssd1331_base::SSD1331,
   GPIOPin *dc_pin_;
 };
 
-}  // namespace ssd1331_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1331_spi

--- a/esphome/components/ssd1351_base/ssd1351_base.cpp
+++ b/esphome/components/ssd1351_base/ssd1351_base.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ssd1351_base {
+namespace esphome::ssd1351_base {
 
 static const char *const TAG = "ssd1351";
 
@@ -198,5 +197,4 @@ const char *SSD1351::model_str_() {
   }
 }
 
-}  // namespace ssd1351_base
-}  // namespace esphome
+}  // namespace esphome::ssd1351_base

--- a/esphome/components/ssd1351_base/ssd1351_base.h
+++ b/esphome/components/ssd1351_base/ssd1351_base.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/display/display_buffer.h"
 
-namespace esphome {
-namespace ssd1351_base {
+namespace esphome::ssd1351_base {
 
 enum SSD1351Model {
   SSD1351_MODEL_128_96 = 0,
@@ -52,5 +51,4 @@ class SSD1351 : public display::DisplayBuffer {
   float brightness_{1.0};
 };
 
-}  // namespace ssd1351_base
-}  // namespace esphome
+}  // namespace esphome::ssd1351_base

--- a/esphome/components/ssd1351_spi/ssd1351_spi.cpp
+++ b/esphome/components/ssd1351_spi/ssd1351_spi.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ssd1351_spi {
+namespace esphome::ssd1351_spi {
 
 static const char *const TAG = "ssd1351_spi";
 
@@ -68,5 +67,4 @@ void HOT SPISSD1351::write_display_data() {
   this->disable();
 }
 
-}  // namespace ssd1351_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1351_spi

--- a/esphome/components/ssd1351_spi/ssd1351_spi.h
+++ b/esphome/components/ssd1351_spi/ssd1351_spi.h
@@ -4,8 +4,7 @@
 #include "esphome/components/ssd1351_base/ssd1351_base.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace ssd1351_spi {
+namespace esphome::ssd1351_spi {
 
 class SPISSD1351 : public ssd1351_base::SSD1351,
                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
@@ -26,5 +25,4 @@ class SPISSD1351 : public ssd1351_base::SSD1351,
   GPIOPin *dc_pin_;
 };
 
-}  // namespace ssd1351_spi
-}  // namespace esphome
+}  // namespace esphome::ssd1351_spi

--- a/esphome/components/st7567_base/st7567_base.cpp
+++ b/esphome/components/st7567_base/st7567_base.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace st7567_base {
+namespace esphome::st7567_base {
 
 static const char *const TAG = "st7567";
 
@@ -157,5 +156,4 @@ void ST7567::init_reset_() {
 
 const char *ST7567::model_str_() { return "ST7567 128x64"; }
 
-}  // namespace st7567_base
-}  // namespace esphome
+}  // namespace esphome::st7567_base

--- a/esphome/components/st7567_base/st7567_base.h
+++ b/esphome/components/st7567_base/st7567_base.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/display/display_buffer.h"
 
-namespace esphome {
-namespace st7567_base {
+namespace esphome::st7567_base {
 
 static const uint8_t ST7567_BOOSTER_ON = 0x2C;    // internal power supply on
 static const uint8_t ST7567_REGULATOR_ON = 0x2E;  // internal power supply on
@@ -96,5 +95,4 @@ class ST7567 : public display::DisplayBuffer {
   bool refresh_requested_{false};
 };
 
-}  // namespace st7567_base
-}  // namespace esphome
+}  // namespace esphome::st7567_base

--- a/esphome/components/st7567_i2c/st7567_i2c.cpp
+++ b/esphome/components/st7567_i2c/st7567_i2c.cpp
@@ -1,8 +1,7 @@
 #include "st7567_i2c.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace st7567_i2c {
+namespace esphome::st7567_i2c {
 
 static const char *const TAG = "st7567_i2c";
 
@@ -58,5 +57,4 @@ void HOT I2CST7567::write_display_data() {
   }
 }
 
-}  // namespace st7567_i2c
-}  // namespace esphome
+}  // namespace esphome::st7567_i2c

--- a/esphome/components/st7567_i2c/st7567_i2c.h
+++ b/esphome/components/st7567_i2c/st7567_i2c.h
@@ -4,8 +4,7 @@
 #include "esphome/components/st7567_base/st7567_base.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace st7567_i2c {
+namespace esphome::st7567_i2c {
 
 class I2CST7567 : public st7567_base::ST7567, public i2c::I2CDevice {
  public:
@@ -19,5 +18,4 @@ class I2CST7567 : public st7567_base::ST7567, public i2c::I2CDevice {
   enum ErrorCode { NONE = 0, COMMUNICATION_FAILED } error_code_{NONE};
 };
 
-}  // namespace st7567_i2c
-}  // namespace esphome
+}  // namespace esphome::st7567_i2c

--- a/esphome/components/st7567_spi/st7567_spi.cpp
+++ b/esphome/components/st7567_spi/st7567_spi.cpp
@@ -1,8 +1,7 @@
 #include "st7567_spi.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace st7567_spi {
+namespace esphome::st7567_spi {
 
 static const char *const TAG = "st7567_spi";
 
@@ -63,5 +62,4 @@ void HOT SPIST7567::write_display_data() {
   }
 }
 
-}  // namespace st7567_spi
-}  // namespace esphome
+}  // namespace esphome::st7567_spi

--- a/esphome/components/st7567_spi/st7567_spi.h
+++ b/esphome/components/st7567_spi/st7567_spi.h
@@ -4,8 +4,7 @@
 #include "esphome/components/st7567_base/st7567_base.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace st7567_spi {
+namespace esphome::st7567_spi {
 
 class SPIST7567 : public st7567_base::ST7567,
                   public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
@@ -25,5 +24,4 @@ class SPIST7567 : public st7567_base::ST7567,
   GPIOPin *dc_pin_;
 };
 
-}  // namespace st7567_spi
-}  // namespace esphome
+}  // namespace esphome::st7567_spi

--- a/esphome/components/st7735/st7735.cpp
+++ b/esphome/components/st7735/st7735.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace st7735 {
+namespace esphome::st7735 {
 
 static const uint8_t ST_CMD_DELAY = 0x80;  // special signifier for command lists
 
@@ -476,5 +475,4 @@ void ST7735::spi_master_write_addr_(uint16_t addr1, uint16_t addr2) {
   this->write_array(byte, 4);
 }
 
-}  // namespace st7735
-}  // namespace esphome
+}  // namespace esphome::st7735

--- a/esphome/components/st7735/st7735.h
+++ b/esphome/components/st7735/st7735.h
@@ -4,8 +4,7 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/display/display_buffer.h"
 
-namespace esphome {
-namespace st7735 {
+namespace esphome::st7735 {
 
 static const uint8_t ST7735_TFTWIDTH_128 = 128;   // for 1.44 and mini^M
 static const uint8_t ST7735_TFTWIDTH_80 = 80;     // for mini^M
@@ -85,5 +84,4 @@ class ST7735 : public display::DisplayBuffer,
   GPIOPin *dc_pin_{nullptr};
 };
 
-}  // namespace st7735
-}  // namespace esphome
+}  // namespace esphome::st7735

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <algorithm>
 
-namespace esphome {
-namespace st7789v {
+namespace esphome::st7789v {
 
 static const char *const TAG = "st7789v";
 #ifdef USE_ESP32
@@ -317,5 +316,4 @@ void HOT ST7789V::draw_absolute_pixel_internal(int x, int y, Color color) {
   }
 }
 
-}  // namespace st7789v
-}  // namespace esphome
+}  // namespace esphome::st7789v

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -7,8 +7,7 @@
 #include "esphome/components/power_supply/power_supply.h"
 #endif
 
-namespace esphome {
-namespace st7789v {
+namespace esphome::st7789v {
 
 static const uint8_t ST7789_NOP = 0x00;        // No Operation
 static const uint8_t ST7789_SWRESET = 0x01;    // Software Reset
@@ -168,5 +167,4 @@ class ST7789V : public display::DisplayBuffer,
   const char *model_str_;
 };
 
-}  // namespace st7789v
-}  // namespace esphome
+}  // namespace esphome::st7789v

--- a/esphome/components/st7920/st7920.cpp
+++ b/esphome/components/st7920/st7920.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace st7920 {
+namespace esphome::st7920 {
 
 static const char *const TAG = "st7920";
 
@@ -154,5 +153,4 @@ void ST7920::display_init_() {
   this->write_display_data();
 }
 
-}  // namespace st7920
-}  // namespace esphome
+}  // namespace esphome::st7920

--- a/esphome/components/st7920/st7920.h
+++ b/esphome/components/st7920/st7920.h
@@ -4,8 +4,7 @@
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/components/spi/spi.h"
 
-namespace esphome {
-namespace st7920 {
+namespace esphome::st7920 {
 
 class ST7920;
 
@@ -47,5 +46,4 @@ class ST7920 : public display::DisplayBuffer,
   st7920_writer_t writer_local_{};
 };
 
-}  // namespace st7920
-}  // namespace esphome
+}  // namespace esphome::st7920

--- a/esphome/components/statsd/statsd.cpp
+++ b/esphome/components/statsd/statsd.cpp
@@ -3,8 +3,8 @@
 #include "statsd.h"
 
 #ifdef USE_NETWORK
-namespace esphome {
-namespace statsd {
+
+namespace esphome::statsd {
 
 // send UDP packet if we reach 1Kb packed size
 // this is needed since statsD does not support fragmented UDP packets
@@ -165,6 +165,6 @@ void StatsdComponent::send_(std::string *out) {
 #endif
 }
 
-}  // namespace statsd
-}  // namespace esphome
+}  // namespace esphome::statsd
+
 #endif

--- a/esphome/components/statsd/statsd.h
+++ b/esphome/components/statsd/statsd.h
@@ -25,8 +25,7 @@
 #include "IPAddress.h"
 #endif
 
-namespace esphome {
-namespace statsd {
+namespace esphome::statsd {
 
 class StatsdComponent : public PollingComponent {
  public:
@@ -82,6 +81,6 @@ class StatsdComponent : public PollingComponent {
   void send_(std::string *out);
 };
 
-}  // namespace statsd
-}  // namespace esphome
+}  // namespace esphome::statsd
+
 #endif

--- a/esphome/components/status_led/light/status_led_light.cpp
+++ b/esphome/components/status_led/light/status_led_light.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/application.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace status_led {
+namespace esphome::status_led {
 
 static const char *const TAG = "status_led";
 
@@ -71,5 +70,4 @@ void StatusLEDLightOutput::output_state_(bool state) {
     this->output_->set_state(state);
 }
 
-}  // namespace status_led
-}  // namespace esphome
+}  // namespace esphome::status_led

--- a/esphome/components/status_led/light/status_led_light.h
+++ b/esphome/components/status_led/light/status_led_light.h
@@ -5,8 +5,7 @@
 #include "esphome/components/light/light_output.h"
 #include "esphome/components/output/binary_output.h"
 
-namespace esphome {
-namespace status_led {
+namespace esphome::status_led {
 
 class StatusLEDLightOutput : public light::LightOutput, public Component {
  public:
@@ -39,5 +38,4 @@ class StatusLEDLightOutput : public light::LightOutput, public Component {
   void output_state_(bool state);
 };
 
-}  // namespace status_led
-}  // namespace esphome
+}  // namespace esphome::status_led

--- a/esphome/components/status_led/status_led.cpp
+++ b/esphome/components/status_led/status_led.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace status_led {
+namespace esphome::status_led {
 
 static const char *const TAG = "status_led";
 
@@ -40,5 +39,4 @@ void StatusLED::loop() {
 }
 float StatusLED::get_setup_priority() const { return setup_priority::HARDWARE; }
 
-}  // namespace status_led
-}  // namespace esphome
+}  // namespace esphome::status_led

--- a/esphome/components/status_led/status_led.h
+++ b/esphome/components/status_led/status_led.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace status_led {
+namespace esphome::status_led {
 
 class StatusLED : public Component {
  public:
@@ -21,5 +20,4 @@ class StatusLED : public Component {
 
 extern StatusLED *global_status_led;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace status_led
-}  // namespace esphome
+}  // namespace esphome::status_led

--- a/esphome/components/stepper/stepper.cpp
+++ b/esphome/components/stepper/stepper.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace stepper {
+namespace esphome::stepper {
 
 static const char *const TAG = "stepper";
 
@@ -47,5 +46,4 @@ int32_t Stepper::should_step_() {
   return 0;
 }
 
-}  // namespace stepper
-}  // namespace esphome
+}  // namespace esphome::stepper

--- a/esphome/components/stepper/stepper.h
+++ b/esphome/components/stepper/stepper.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace stepper {
+namespace esphome::stepper {
 
 #define LOG_STEPPER(this) \
   ESP_LOGCONFIG(TAG, \
@@ -108,5 +107,4 @@ template<typename... Ts> class SetDecelerationAction : public Action<Ts...> {
   Stepper *parent_;
 };
 
-}  // namespace stepper
-}  // namespace esphome
+}  // namespace esphome::stepper

--- a/esphome/components/sts3x/sts3x.cpp
+++ b/esphome/components/sts3x/sts3x.cpp
@@ -1,8 +1,7 @@
 #include "sts3x.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sts3x {
+namespace esphome::sts3x {
 
 static const char *const TAG = "sts3x";
 
@@ -66,5 +65,4 @@ void STS3XComponent::update() {
   });
 }
 
-}  // namespace sts3x
-}  // namespace esphome
+}  // namespace esphome::sts3x

--- a/esphome/components/sts3x/sts3x.h
+++ b/esphome/components/sts3x/sts3x.h
@@ -6,8 +6,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace sts3x {
+namespace esphome::sts3x {
 
 /// This class implements support for the ST3x-DIS family of temperature i2c sensors.
 class STS3XComponent : public sensor::Sensor, public PollingComponent, public sensirion_common::SensirionI2CDevice {
@@ -17,5 +16,4 @@ class STS3XComponent : public sensor::Sensor, public PollingComponent, public se
   void update() override;
 };
 
-}  // namespace sts3x
-}  // namespace esphome
+}  // namespace esphome::sts3x

--- a/esphome/components/sun/sensor/sun_sensor.cpp
+++ b/esphome/components/sun/sensor/sun_sensor.cpp
@@ -1,12 +1,10 @@
 #include "sun_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sun {
+namespace esphome::sun {
 
 static const char *const TAG = "sun.sensor";
 
 void SunSensor::dump_config() { LOG_SENSOR("", "Sun Sensor", this); }
 
-}  // namespace sun
-}  // namespace esphome
+}  // namespace esphome::sun

--- a/esphome/components/sun/sensor/sun_sensor.h
+++ b/esphome/components/sun/sensor/sun_sensor.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sun/sun.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace sun {
+namespace esphome::sun {
 
 enum SensorType {
   SUN_SENSOR_ELEVATION,
@@ -37,5 +36,4 @@ class SunSensor : public sensor::Sensor, public PollingComponent {
   SensorType type_;
 };
 
-}  // namespace sun
-}  // namespace esphome
+}  // namespace esphome::sun

--- a/esphome/components/sun/sun.cpp
+++ b/esphome/components/sun/sun.cpp
@@ -12,8 +12,7 @@ like exact nutation are not included. But in some testing the accuracy appears t
 for random spots around the globe.
 */
 
-namespace esphome {
-namespace sun {
+namespace esphome::sun {
 
 using namespace esphome::sun::internal;
 
@@ -322,5 +321,4 @@ optional<ESPTime> Sun::sunset(ESPTime date, double elevation) { return this->cal
 double Sun::elevation() { return this->calc_coords_().elevation; }
 double Sun::azimuth() { return this->calc_coords_().azimuth; }
 
-}  // namespace sun
-}  // namespace esphome
+}  // namespace esphome::sun

--- a/esphome/components/sun/sun.h
+++ b/esphome/components/sun/sun.h
@@ -7,8 +7,7 @@
 
 #include "esphome/components/time/real_time_clock.h"
 
-namespace esphome {
-namespace sun {
+namespace esphome::sun {
 
 namespace internal {
 
@@ -129,5 +128,4 @@ template<typename... Ts> class SunCondition : public Condition<Ts...>, public Pa
   bool above_;
 };
 
-}  // namespace sun
-}  // namespace esphome
+}  // namespace esphome::sun

--- a/esphome/components/sun/text_sensor/sun_text_sensor.cpp
+++ b/esphome/components/sun/text_sensor/sun_text_sensor.cpp
@@ -1,12 +1,10 @@
 #include "sun_text_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sun {
+namespace esphome::sun {
 
 static const char *const TAG = "sun.text_sensor";
 
 void SunTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Sun Text Sensor", this); }
 
-}  // namespace sun
-}  // namespace esphome
+}  // namespace esphome::sun

--- a/esphome/components/sun/text_sensor/sun_text_sensor.h
+++ b/esphome/components/sun/text_sensor/sun_text_sensor.h
@@ -6,8 +6,7 @@
 #include "esphome/components/sun/sun.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
-namespace esphome {
-namespace sun {
+namespace esphome::sun {
 
 class SunTextSensor : public text_sensor::TextSensor, public PollingComponent {
  public:
@@ -44,5 +43,4 @@ class SunTextSensor : public text_sensor::TextSensor, public PollingComponent {
   bool sunrise_;
 };
 
-}  // namespace sun
-}  // namespace esphome
+}  // namespace esphome::sun

--- a/esphome/components/sun_gtil2/sun_gtil2.cpp
+++ b/esphome/components/sun_gtil2/sun_gtil2.cpp
@@ -1,8 +1,7 @@
 #include "sun_gtil2.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sun_gtil2 {
+namespace esphome::sun_gtil2 {
 
 static const char *const TAG = "sun_gtil2";
 
@@ -131,5 +130,4 @@ void SunGTIL2::dump_config() {
 #endif
 }
 
-}  // namespace sun_gtil2
-}  // namespace esphome
+}  // namespace esphome::sun_gtil2

--- a/esphome/components/sun_gtil2/sun_gtil2.h
+++ b/esphome/components/sun_gtil2/sun_gtil2.h
@@ -13,8 +13,7 @@
 #endif
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace sun_gtil2 {
+namespace esphome::sun_gtil2 {
 
 class SunGTIL2 : public Component, public uart::UARTDevice {
  public:
@@ -58,5 +57,4 @@ class SunGTIL2 : public Component, public uart::UARTDevice {
   std::vector<uint8_t> rx_message_;
 };
 
-}  // namespace sun_gtil2
-}  // namespace esphome
+}  // namespace esphome::sun_gtil2

--- a/esphome/components/sx126x/automation.h
+++ b/esphome/components/sx126x/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/sx126x/sx126x.h"
 
-namespace esphome {
-namespace sx126x {
+namespace esphome::sx126x {
 
 template<typename... Ts> class RunImageCalAction : public Action<Ts...>, public Parented<SX126x> {
  public:
@@ -65,5 +64,4 @@ template<typename... Ts> class SetModeStandbyAction : public Action<Ts...>, publ
   void play(const Ts &...x) override { this->parent_->set_mode_standby(STDBY_XOSC); }
 };
 
-}  // namespace sx126x
-}  // namespace esphome
+}  // namespace esphome::sx126x

--- a/esphome/components/sx126x/packet_transport/sx126x_transport.cpp
+++ b/esphome/components/sx126x/packet_transport/sx126x_transport.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/application.h"
 #include "sx126x_transport.h"
 
-namespace esphome {
-namespace sx126x {
+namespace esphome::sx126x {
 
 static const char *const TAG = "sx126x_transport";
 
@@ -16,5 +15,4 @@ void SX126xTransport::send_packet(const std::vector<uint8_t> &buf) const { this-
 
 void SX126xTransport::on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) { this->process_(packet); }
 
-}  // namespace sx126x
-}  // namespace esphome
+}  // namespace esphome::sx126x

--- a/esphome/components/sx126x/packet_transport/sx126x_transport.h
+++ b/esphome/components/sx126x/packet_transport/sx126x_transport.h
@@ -5,8 +5,7 @@
 #include "esphome/components/packet_transport/packet_transport.h"
 #include <vector>
 
-namespace esphome {
-namespace sx126x {
+namespace esphome::sx126x {
 
 class SX126xTransport : public packet_transport::PacketTransport, public Parented<SX126x>, public SX126xListener {
  public:
@@ -20,5 +19,4 @@ class SX126xTransport : public packet_transport::PacketTransport, public Parente
   size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
 };
 
-}  // namespace sx126x
-}  // namespace esphome
+}  // namespace esphome::sx126x

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sx126x {
+namespace esphome::sx126x {
 
 static const char *const TAG = "sx126x";
 static const uint16_t RAMP[8] = {10, 20, 40, 80, 200, 800, 1700, 3400};
@@ -547,5 +546,4 @@ void SX126x::dump_config() {
   }
 }
 
-}  // namespace sx126x
-}  // namespace esphome
+}  // namespace esphome::sx126x

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -8,8 +8,7 @@
 #include <utility>
 #include <vector>
 
-namespace esphome {
-namespace sx126x {
+namespace esphome::sx126x {
 
 enum SX126xBw : uint8_t {
   // FSK
@@ -146,5 +145,4 @@ class SX126x : public Component,
   bool rf_switch_{false};
 };
 
-}  // namespace sx126x
-}  // namespace esphome
+}  // namespace esphome::sx126x

--- a/esphome/components/sx126x/sx126x_reg.h
+++ b/esphome/components/sx126x/sx126x_reg.h
@@ -2,8 +2,7 @@
 
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace sx126x {
+namespace esphome::sx126x {
 
 static const uint32_t XTAL_FREQ = 32000000;
 
@@ -161,5 +160,4 @@ enum SX126xRampTime : uint8_t {
   PA_RAMP_3400 = 0x07,
 };
 
-}  // namespace sx126x
-}  // namespace esphome
+}  // namespace esphome::sx126x

--- a/esphome/components/sx127x/automation.h
+++ b/esphome/components/sx127x/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/sx127x/sx127x.h"
 
-namespace esphome {
-namespace sx127x {
+namespace esphome::sx127x {
 
 template<typename... Ts> class RunImageCalAction : public Action<Ts...>, public Parented<SX127x> {
  public:
@@ -64,5 +63,4 @@ template<typename... Ts> class SetModeStandbyAction : public Action<Ts...>, publ
   void play(const Ts &...x) override { this->parent_->set_mode_standby(); }
 };
 
-}  // namespace sx127x
-}  // namespace esphome
+}  // namespace esphome::sx127x

--- a/esphome/components/sx127x/packet_transport/sx127x_transport.cpp
+++ b/esphome/components/sx127x/packet_transport/sx127x_transport.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/application.h"
 #include "sx127x_transport.h"
 
-namespace esphome {
-namespace sx127x {
+namespace esphome::sx127x {
 
 static const char *const TAG = "sx127x_transport";
 
@@ -16,5 +15,4 @@ void SX127xTransport::send_packet(const std::vector<uint8_t> &buf) const { this-
 
 void SX127xTransport::on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) { this->process_(packet); }
 
-}  // namespace sx127x
-}  // namespace esphome
+}  // namespace esphome::sx127x

--- a/esphome/components/sx127x/packet_transport/sx127x_transport.h
+++ b/esphome/components/sx127x/packet_transport/sx127x_transport.h
@@ -5,8 +5,7 @@
 #include "esphome/components/packet_transport/packet_transport.h"
 #include <vector>
 
-namespace esphome {
-namespace sx127x {
+namespace esphome::sx127x {
 
 class SX127xTransport : public packet_transport::PacketTransport, public Parented<SX127x>, public SX127xListener {
  public:
@@ -20,5 +19,4 @@ class SX127xTransport : public packet_transport::PacketTransport, public Parente
   size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
 };
 
-}  // namespace sx127x
-}  // namespace esphome
+}  // namespace esphome::sx127x

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sx127x {
+namespace esphome::sx127x {
 
 static const char *const TAG = "sx127x";
 static const uint32_t FXOSC = 32000000u;
@@ -507,5 +506,4 @@ void SX127x::dump_config() {
   }
 }
 
-}  // namespace sx127x
-}  // namespace esphome
+}  // namespace esphome::sx127x

--- a/esphome/components/sx127x/sx127x.h
+++ b/esphome/components/sx127x/sx127x.h
@@ -7,8 +7,7 @@
 #include "esphome/core/hal.h"
 #include <vector>
 
-namespace esphome {
-namespace sx127x {
+namespace esphome::sx127x {
 
 enum SX127xBw : uint8_t {
   SX127X_BW_2_6,
@@ -126,5 +125,4 @@ class SX127x : public Component,
   bool rx_start_{false};
 };
 
-}  // namespace sx127x
-}  // namespace esphome
+}  // namespace esphome::sx127x

--- a/esphome/components/sx127x/sx127x_reg.h
+++ b/esphome/components/sx127x/sx127x_reg.h
@@ -2,8 +2,7 @@
 
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace sx127x {
+namespace esphome::sx127x {
 
 enum SX127xReg : uint8_t {
   // Common registers
@@ -291,5 +290,4 @@ enum SX127xModemCfg3 : uint8_t {
   MODEM_AGC_AUTO_ON = 0x04,
 };
 
-}  // namespace sx127x
-}  // namespace esphome
+}  // namespace esphome::sx127x

--- a/esphome/components/sx1509/binary_sensor/sx1509_binary_keypad_sensor.h
+++ b/esphome/components/sx1509/binary_sensor/sx1509_binary_keypad_sensor.h
@@ -3,8 +3,7 @@
 #include "esphome/components/sx1509/sx1509.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace sx1509 {
+namespace esphome::sx1509 {
 
 class SX1509BinarySensor : public sx1509::SX1509Processor, public binary_sensor::BinarySensor {
  public:
@@ -15,5 +14,4 @@ class SX1509BinarySensor : public sx1509::SX1509Processor, public binary_sensor:
   uint16_t key_{0};
 };
 
-}  // namespace sx1509
-}  // namespace esphome
+}  // namespace esphome::sx1509

--- a/esphome/components/sx1509/output/sx1509_float_output.cpp
+++ b/esphome/components/sx1509/output/sx1509_float_output.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sx1509 {
+namespace esphome::sx1509 {
 
 static const char *const TAG = "sx1509_float_channel";
 
@@ -29,5 +28,4 @@ void SX1509FloatOutputChannel::dump_config() {
   LOG_FLOAT_OUTPUT(this);
 }
 
-}  // namespace sx1509
-}  // namespace esphome
+}  // namespace esphome::sx1509

--- a/esphome/components/sx1509/output/sx1509_float_output.h
+++ b/esphome/components/sx1509/output/sx1509_float_output.h
@@ -3,8 +3,7 @@
 #include "esphome/components/sx1509/sx1509.h"
 #include "esphome/components/output/float_output.h"
 
-namespace esphome {
-namespace sx1509 {
+namespace esphome::sx1509 {
 
 class SX1509Component;
 
@@ -23,5 +22,4 @@ class SX1509FloatOutputChannel : public output::FloatOutput, public Component {
   uint8_t pin_;
 };
 
-}  // namespace sx1509
-}  // namespace esphome
+}  // namespace esphome::sx1509

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sx1509 {
+namespace esphome::sx1509 {
 
 static const char *const TAG = "sx1509";
 
@@ -313,5 +312,4 @@ void SX1509Component::set_debounce_keypad_(uint8_t time, uint8_t num_rows, uint8
     set_debounce_pin_(i + 8);
 }
 
-}  // namespace sx1509
-}  // namespace esphome
+}  // namespace esphome::sx1509

--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -10,8 +10,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace sx1509 {
+namespace esphome::sx1509 {
 
 // These are used for clock config:
 const uint8_t INTERNAL_CLOCK_2MHZ = 2;
@@ -97,5 +96,4 @@ class SX1509Component : public Component,
   void clock_(uint8_t osc_source = 2, uint8_t osc_pin_function = 1, uint8_t osc_freq_out = 0, uint8_t osc_divider = 0);
 };
 
-}  // namespace sx1509
-}  // namespace esphome
+}  // namespace esphome::sx1509

--- a/esphome/components/sx1509/sx1509_gpio_pin.cpp
+++ b/esphome/components/sx1509/sx1509_gpio_pin.cpp
@@ -3,8 +3,7 @@
 #include "sx1509.h"
 #include "sx1509_gpio_pin.h"
 
-namespace esphome {
-namespace sx1509 {
+namespace esphome::sx1509 {
 
 static const char *const TAG = "sx1509_gpio_pin";
 
@@ -16,5 +15,4 @@ size_t SX1509GPIOPin::dump_summary(char *buffer, size_t len) const {
   return buf_append_printf(buffer, len, 0, "%u via sx1509", this->pin_);
 }
 
-}  // namespace sx1509
-}  // namespace esphome
+}  // namespace esphome::sx1509

--- a/esphome/components/sx1509/sx1509_gpio_pin.h
+++ b/esphome/components/sx1509/sx1509_gpio_pin.h
@@ -2,8 +2,7 @@
 
 #include "esphome/core/gpio.h"
 
-namespace esphome {
-namespace sx1509 {
+namespace esphome::sx1509 {
 
 class SX1509Component;
 
@@ -29,5 +28,4 @@ class SX1509GPIOPin : public GPIOPin {
   gpio::Flags flags_;
 };
 
-}  // namespace sx1509
-}  // namespace esphome
+}  // namespace esphome::sx1509

--- a/esphome/components/sx1509/sx1509_registers.h
+++ b/esphome/components/sx1509/sx1509_registers.h
@@ -7,7 +7,6 @@ https://github.com/sparkfun/SparkFun_SX1509_Arduino_Library
 */
 #pragma once
 
-namespace esphome {
 /**
  Here you'll find the Arduino code used to interface with the SX1509 I2C
 16 I/O expander. There are functions to take advantage of everything the
@@ -25,7 +24,7 @@ local, and you've found our code helpful, please buy us a round!
 
 Distributed as-is; no warranty is given.
 */
-namespace sx1509 {
+namespace esphome::sx1509 {
 
 const uint8_t REG_INPUT_DISABLE_B =
     0x00;  //    RegInputDisableB Input buffer disable register _ I/O[15_8] (Bank B) 0000 0000
@@ -106,5 +105,4 @@ const uint8_t REG_RESET = 0x7D;   //    RegReset Software reset register 0000 00
 const uint8_t REG_TEST_1 = 0x7E;  //    RegTest1 Test register 0000 0000
 const uint8_t REG_TEST_2 = 0x7F;  //    RegTest2 Test register 0000 0000
 
-}  // namespace sx1509
-}  // namespace esphome
+}  // namespace esphome::sx1509


### PR DESCRIPTION
# What does this implement/fix?

Mechanical conversion of `namespace foo { namespace bar { ... } }` to `namespace foo::bar { ... }` (C++17 nested namespace concatenation), applied via `clang-tidy --fix` with `modernize-concat-nested-namespaces` temporarily re-enabled, followed by `clang-format`. **No semantic changes.**

This is **part 5 of 7** for the cleanup tracked in [esphome/backlog#114](https://github.com/esphome/backlog/issues/114), toward enabling `modernize-concat-nested-namespaces` project-wide and matching the convention already documented in `CLAUDE.md`. Splitting by component letter range to keep each PR reviewable.

The `.clang-tidy` disable line stays in place until the final PR so CI remains green throughout the rollout.

## Scope of this PR

- `esphome/components/s*/` — 227 files

## Reproduction

```bash
# remove the disable line from .clang-tidy
# then:
script/clang-tidy --fix --environment esp32-arduino-tidy --all-headers
git ls-files 'esphome/components/s*/**' | xargs clang-format -i
```

## Series

- 1/7 components a-c — #16294
- 2/7 components d-h — #16295
- 3/7 components i-m — #16297
- 4/7 components n-r — #16301
- 5/7 components s (this PR)
- 6/7 components t-z
- 7/7 tests + drop the `.clang-tidy` disable line

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/backlog#114

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

(Mechanical, no platform-specific code paths affected.)

## Example entry for `config.yaml`:

```yaml
# n/a
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
