### PR TITLE
[ci] Skip needs-docs for new components without CONFIG_SCHEMA

### DIFF
--- a/.github/scripts/auto-label-pr/detectors.js
+++ b/.github/scripts/auto-label-pr/detectors.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const { DOCS_PR_PATTERNS } = require('./constants');
 const {
   COMPONENT_REGEX,
@@ -13,6 +12,26 @@ const { loadCodeowners, getEffectiveOwners } = require('../codeowners');
 // Ruff/Black enforce exactly one space around `=` and no space before `:`,
 // so we can match strictly: `CONFIG_SCHEMA ` or `CONFIG_SCHEMA:`.
 const CONFIG_SCHEMA_REGEX = /^CONFIG_SCHEMA[ :]/m;
+
+// Fetch a file's contents from the PR head SHA via the GitHub API.
+// The auto-label workflow runs on `pull_request_target`, which checks out the
+// base branch — files added by the PR don't exist in the workspace, so we have
+// to fetch them from the head SHA. Returns null if the file can't be fetched.
+async function fetchPrFileContent(github, context, path) {
+  try {
+    const { owner, repo } = context.repo;
+    const { data } = await github.rest.repos.getContent({
+      owner,
+      repo,
+      path,
+      ref: context.payload.pull_request.head.sha,
+    });
+    return Buffer.from(data.content, 'base64').toString('utf8');
+  } catch (error) {
+    console.log(`Failed to fetch ${path} from PR head:`, error.message);
+    return null;
+  }
+}
 
 // Strategy: Merge branch detection
 async function detectMergeBranch(context) {
@@ -50,7 +69,7 @@ async function detectComponentPlatforms(changedFiles, apiData) {
 }
 
 // Strategy: New component detection
-async function detectNewComponents(prFiles) {
+async function detectNewComponents(github, context, prFiles) {
   const labels = new Set();
   let hasYamlLoadable = false;
   const addedFiles = prFiles.filter(file => file.status === 'added').map(file => file.filename);
@@ -59,30 +78,26 @@ async function detectNewComponents(prFiles) {
     const componentMatch = file.match(/^esphome\/components\/([^\/]+)\/__init__\.py$/);
     if (!componentMatch) continue;
 
-    let content = null;
-    try {
-      content = fs.readFileSync(file, 'utf8');
-    } catch (error) {
-      console.log(`Failed to read content of ${file}:`, error.message);
-      // Safe default: assume YAML-loadable so needs-docs behaviour is unchanged on read failure
+    labels.add('new-component');
+    const content = await fetchPrFileContent(github, context, file);
+    if (content === null) {
+      // Safe default: assume YAML-loadable so needs-docs behaviour is unchanged on fetch failure
+      hasYamlLoadable = true;
+      continue;
+    }
+    if (content.includes('IS_TARGET_PLATFORM = True')) {
+      labels.add('new-target-platform');
+    }
+    if (CONFIG_SCHEMA_REGEX.test(content)) {
       hasYamlLoadable = true;
     }
-    if (content !== null) {
-      if (content.includes('IS_TARGET_PLATFORM = True')) {
-        labels.add('new-target-platform');
-      }
-      if (CONFIG_SCHEMA_REGEX.test(content)) {
-        hasYamlLoadable = true;
-      }
-    }
-    labels.add('new-component');
   }
 
   return { labels, hasYamlLoadable };
 }
 
 // Strategy: New platform detection
-async function detectNewPlatforms(prFiles, apiData) {
+async function detectNewPlatforms(github, context, prFiles, apiData) {
   const labels = new Set();
   let hasYamlLoadable = false;
   const addedFiles = prFiles.filter(file => file.status === 'added').map(file => file.filename);
@@ -100,14 +115,11 @@ async function detectNewPlatforms(prFiles, apiData) {
       if (!apiData.platformComponents.includes(platform)) break;
 
       labels.add('new-platform');
-      try {
-        const content = fs.readFileSync(file, 'utf8');
-        if (CONFIG_SCHEMA_REGEX.test(content)) {
-          hasYamlLoadable = true;
-        }
-      } catch (error) {
-        console.log(`Failed to read content of ${file}:`, error.message);
-        // Safe default: assume YAML-loadable so needs-docs behaviour is unchanged on read failure
+      const content = await fetchPrFileContent(github, context, file);
+      if (content === null) {
+        // Safe default: assume YAML-loadable so needs-docs behaviour is unchanged on fetch failure
+        hasYamlLoadable = true;
+      } else if (CONFIG_SCHEMA_REGEX.test(content)) {
         hasYamlLoadable = true;
       }
       break;

--- a/.github/scripts/auto-label-pr/detectors.js
+++ b/.github/scripts/auto-label-pr/detectors.js
@@ -9,6 +9,11 @@ const {
 } = require('../detect-tags');
 const { loadCodeowners, getEffectiveOwners } = require('../codeowners');
 
+// Top-level `CONFIG_SCHEMA = ...` (assignment) or `CONFIG_SCHEMA: ConfigType = ...` (annotation).
+// Ruff/Black enforce exactly one space around `=` and no space before `:`,
+// so we can match strictly: `CONFIG_SCHEMA ` or `CONFIG_SCHEMA:`.
+const CONFIG_SCHEMA_REGEX = /^CONFIG_SCHEMA[ :]/m;
+
 // Strategy: Merge branch detection
 async function detectMergeBranch(context) {
   const labels = new Set();
@@ -47,50 +52,69 @@ async function detectComponentPlatforms(changedFiles, apiData) {
 // Strategy: New component detection
 async function detectNewComponents(prFiles) {
   const labels = new Set();
+  let hasYamlLoadable = false;
   const addedFiles = prFiles.filter(file => file.status === 'added').map(file => file.filename);
 
   for (const file of addedFiles) {
     const componentMatch = file.match(/^esphome\/components\/([^\/]+)\/__init__\.py$/);
-    if (componentMatch) {
-      try {
-        const content = fs.readFileSync(file, 'utf8');
-        if (content.includes('IS_TARGET_PLATFORM = True')) {
-          labels.add('new-target-platform');
-        }
-      } catch (error) {
-        console.log(`Failed to read content of ${file}:`, error.message);
-      }
-      labels.add('new-component');
+    if (!componentMatch) continue;
+
+    let content = null;
+    try {
+      content = fs.readFileSync(file, 'utf8');
+    } catch (error) {
+      console.log(`Failed to read content of ${file}:`, error.message);
+      // Safe default: assume YAML-loadable so needs-docs behaviour is unchanged on read failure
+      hasYamlLoadable = true;
     }
+    if (content !== null) {
+      if (content.includes('IS_TARGET_PLATFORM = True')) {
+        labels.add('new-target-platform');
+      }
+      if (CONFIG_SCHEMA_REGEX.test(content)) {
+        hasYamlLoadable = true;
+      }
+    }
+    labels.add('new-component');
   }
 
-  return labels;
+  return { labels, hasYamlLoadable };
 }
 
 // Strategy: New platform detection
 async function detectNewPlatforms(prFiles, apiData) {
   const labels = new Set();
+  let hasYamlLoadable = false;
   const addedFiles = prFiles.filter(file => file.status === 'added').map(file => file.filename);
 
-  for (const file of addedFiles) {
-    const platformFileMatch = file.match(/^esphome\/components\/([^\/]+)\/([^\/]+)\.py$/);
-    if (platformFileMatch) {
-      const [, component, platform] = platformFileMatch;
-      if (apiData.platformComponents.includes(platform)) {
-        labels.add('new-platform');
-      }
-    }
+  const platformPathPatterns = [
+    /^esphome\/components\/([^\/]+)\/([^\/]+)\.py$/,
+    /^esphome\/components\/([^\/]+)\/([^\/]+)\/__init__\.py$/,
+  ];
 
-    const platformDirMatch = file.match(/^esphome\/components\/([^\/]+)\/([^\/]+)\/__init__\.py$/);
-    if (platformDirMatch) {
-      const [, component, platform] = platformDirMatch;
-      if (apiData.platformComponents.includes(platform)) {
-        labels.add('new-platform');
+  for (const file of addedFiles) {
+    for (const re of platformPathPatterns) {
+      const match = file.match(re);
+      if (!match) continue;
+      const platform = match[2];
+      if (!apiData.platformComponents.includes(platform)) break;
+
+      labels.add('new-platform');
+      try {
+        const content = fs.readFileSync(file, 'utf8');
+        if (CONFIG_SCHEMA_REGEX.test(content)) {
+          hasYamlLoadable = true;
+        }
+      } catch (error) {
+        console.log(`Failed to read content of ${file}:`, error.message);
+        // Safe default: assume YAML-loadable so needs-docs behaviour is unchanged on read failure
+        hasYamlLoadable = true;
       }
+      break;
     }
   }
 
-  return labels;
+  return { labels, hasYamlLoadable };
 }
 
 // Strategy: Core files detection
@@ -300,7 +324,7 @@ function detectMaintainerAccess(context) {
 }
 
 // Strategy: Requirements detection
-async function detectRequirements(allLabels, prFiles, context) {
+async function detectRequirements(allLabels, prFiles, context, hasYamlLoadable) {
   const labels = new Set();
 
   // Check for missing tests
@@ -308,8 +332,15 @@ async function detectRequirements(allLabels, prFiles, context) {
     labels.add('needs-tests');
   }
 
-  // Check for missing docs
-  if (allLabels.has('new-component') || allLabels.has('new-platform') || allLabels.has('new-feature')) {
+  // Check for missing docs.
+  // `new-feature` (PR-body checkbox) always counts. `new-component` / `new-platform`
+  // only count when at least one newly added file defines a top-level CONFIG_SCHEMA,
+  // i.e. the new component/platform is actually loadable from YAML.
+  const docsEligible =
+    allLabels.has('new-feature') ||
+    ((allLabels.has('new-component') || allLabels.has('new-platform')) && hasYamlLoadable);
+
+  if (docsEligible) {
     const prBody = context.payload.pull_request.body || '';
     const hasDocsLink = DOCS_PR_PATTERNS.some(pattern => pattern.test(prBody));
 

--- a/.github/scripts/auto-label-pr/index.js
+++ b/.github/scripts/auto-label-pr/index.js
@@ -106,8 +106,8 @@ module.exports = async ({ github, context }) => {
   const [
     branchLabels,
     componentLabels,
-    newComponentLabels,
-    newPlatformLabels,
+    newComponentResult,
+    newPlatformResult,
     coreLabels,
     sizeLabels,
     dashboardLabels,
@@ -133,6 +133,13 @@ module.exports = async ({ github, context }) => {
     detectMaintainerAccess(context)
   ]);
 
+  // Extract new-component / new-platform results
+  const newComponentLabels = newComponentResult.labels;
+  const newPlatformLabels = newPlatformResult.labels;
+  // Eligible for needs-docs only if any newly added component or platform file
+  // defines a top-level CONFIG_SCHEMA (i.e. is actually loadable from YAML).
+  const hasYamlLoadable = newComponentResult.hasYamlLoadable || newPlatformResult.hasYamlLoadable;
+
   // Extract deprecated component info
   const deprecatedLabels = deprecatedResult.labels;
   const deprecatedInfo = deprecatedResult.deprecatedInfo;
@@ -154,7 +161,7 @@ module.exports = async ({ github, context }) => {
   ]);
 
   // Detect requirements based on all other labels
-  const requirementLabels = await detectRequirements(allLabels, prFiles, context);
+  const requirementLabels = await detectRequirements(allLabels, prFiles, context, hasYamlLoadable);
   for (const label of requirementLabels) {
     allLabels.add(label);
   }

--- a/.github/scripts/auto-label-pr/index.js
+++ b/.github/scripts/auto-label-pr/index.js
@@ -120,8 +120,8 @@ module.exports = async ({ github, context }) => {
   ] = await Promise.all([
     detectMergeBranch(context),
     detectComponentPlatforms(changedFiles, apiData),
-    detectNewComponents(prFiles),
-    detectNewPlatforms(prFiles, apiData),
+    detectNewComponents(github, context, prFiles),
+    detectNewPlatforms(github, context, prFiles, apiData),
     detectCoreChanges(changedFiles),
     detectPRSize(prFiles, totalAdditions, totalDeletions, totalChanges, isMegaPR, SMALL_PR_THRESHOLD, MEDIUM_PR_THRESHOLD, TOO_BIG_THRESHOLD),
     detectDashboardChanges(changedFiles),


### PR DESCRIPTION
# What does this implement/fix?

The auto-labeller currently adds the `needs-docs` label to any PR that introduces a new `esphome/components/<x>/__init__.py` (or matching platform file). The trigger is purely path-based, so it false-positives when the new code is not loadable from YAML — for example pure C++ libraries / shared base modules used only as dependencies of other components.

This change gates `needs-docs` on whether at least one newly added file (component `__init__.py` or any platform file) actually defines a top-level `CONFIG_SCHEMA`. If none of the new files do, the new code is not directly YAML-loadable and the docs label is skipped. The `new-component` / `new-platform` labels themselves are unchanged. The eligibility check looks across **all** newly added files so the common shape (e.g. `aht10/__init__.py` without schema + `aht10/sensor.py` with schema) still correctly triggers `needs-docs`.

`new-feature` (which comes from a PR-body checkbox, not file analysis) keeps unconditional behaviour. The docs-link short-circuit (`esphome/esphome-docs#NNNN` in the body) also still wins as before.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# Example config.yaml

\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).