### PR TITLE
[clang-tidy] Concatenate nested namespaces (6/7: components t-z)

### DIFF
--- a/esphome/components/t6615/t6615.cpp
+++ b/esphome/components/t6615/t6615.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace t6615 {
+namespace esphome::t6615 {
 
 static const char *const TAG = "t6615";
 
@@ -92,5 +91,4 @@ void T6615Component::dump_config() {
   this->check_uart_settings(19200);
 }
 
-}  // namespace t6615
-}  // namespace esphome
+}  // namespace esphome::t6615

--- a/esphome/components/t6615/t6615.h
+++ b/esphome/components/t6615/t6615.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace t6615 {
+namespace esphome::t6615 {
 
 enum class T6615Command : uint8_t {
   NONE = 0,
@@ -38,5 +37,4 @@ class T6615Component : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *co2_sensor_{nullptr};
 };
 
-}  // namespace t6615
-}  // namespace esphome
+}  // namespace esphome::t6615

--- a/esphome/components/tc74/tc74.cpp
+++ b/esphome/components/tc74/tc74.cpp
@@ -3,8 +3,7 @@
 #include "tc74.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tc74 {
+namespace esphome::tc74 {
 
 static const char *const TAG = "tc74";
 
@@ -62,5 +61,4 @@ void TC74Component::read_temperature_() {
   this->status_clear_warning();
 }
 
-}  // namespace tc74
-}  // namespace esphome
+}  // namespace esphome::tc74

--- a/esphome/components/tc74/tc74.h
+++ b/esphome/components/tc74/tc74.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace tc74 {
+namespace esphome::tc74 {
 
 class TC74Component : public PollingComponent, public i2c::I2CDevice, public sensor::Sensor {
  public:
@@ -22,5 +21,4 @@ class TC74Component : public PollingComponent, public i2c::I2CDevice, public sen
   bool data_ready_ = false;
 };
 
-}  // namespace tc74
-}  // namespace esphome
+}  // namespace esphome::tc74

--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -1,8 +1,7 @@
 #include "tca9548a.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tca9548a {
+namespace esphome::tca9548a {
 
 static const char *const TAG = "tca9548a";
 
@@ -44,5 +43,4 @@ void TCA9548AComponent::disable_all_channels() {
   }
 }
 
-}  // namespace tca9548a
-}  // namespace esphome
+}  // namespace esphome::tca9548a

--- a/esphome/components/tca9548a/tca9548a.h
+++ b/esphome/components/tca9548a/tca9548a.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace tca9548a {
+namespace esphome::tca9548a {
 
 static const uint8_t TCA9548A_DISABLE_CHANNELS_COMMAND = 0x00;
 
@@ -35,5 +34,4 @@ class TCA9548AComponent : public Component, public i2c::I2CDevice {
  protected:
   friend class TCA9548AChannel;
 };
-}  // namespace tca9548a
-}  // namespace esphome
+}  // namespace esphome::tca9548a

--- a/esphome/components/tca9555/tca9555.cpp
+++ b/esphome/components/tca9555/tca9555.cpp
@@ -10,8 +10,7 @@ static const uint8_t TCA9555_POLARITY_REGISTER_1 = 0x05;
 static const uint8_t TCA9555_CONFIGURATION_PORT_0 = 0x06;
 static const uint8_t TCA9555_CONFIGURATION_PORT_1 = 0x07;
 
-namespace esphome {
-namespace tca9555 {
+namespace esphome::tca9555 {
 
 static const char *const TAG = "tca9555";
 
@@ -162,5 +161,4 @@ size_t TCA9555GPIOPin::dump_summary(char *buffer, size_t len) const {
   return buf_append_printf(buffer, len, 0, "%u via TCA9555", this->pin_);
 }
 
-}  // namespace tca9555
-}  // namespace esphome
+}  // namespace esphome::tca9555

--- a/esphome/components/tca9555/tca9555.h
+++ b/esphome/components/tca9555/tca9555.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace tca9555 {
+namespace esphome::tca9555 {
 
 class TCA9555Component : public Component,
                          public i2c::I2CDevice,
@@ -67,5 +66,4 @@ class TCA9555GPIOPin : public GPIOPin, public Parented<TCA9555Component> {
   gpio::Flags flags_;
 };
 
-}  // namespace tca9555
-}  // namespace esphome
+}  // namespace esphome::tca9555

--- a/esphome/components/tcl112/tcl112.cpp
+++ b/esphome/components/tcl112/tcl112.cpp
@@ -1,8 +1,7 @@
 #include "tcl112.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tcl112 {
+namespace esphome::tcl112 {
 
 static const char *const TAG = "tcl112.climate";
 
@@ -240,5 +239,4 @@ bool Tcl112Climate::on_receive(remote_base::RemoteReceiveData data) {
   return true;
 }
 
-}  // namespace tcl112
-}  // namespace esphome
+}  // namespace esphome::tcl112

--- a/esphome/components/tcl112/tcl112.h
+++ b/esphome/components/tcl112/tcl112.h
@@ -2,8 +2,7 @@
 
 #include "esphome/components/climate_ir/climate_ir.h"
 
-namespace esphome {
-namespace tcl112 {
+namespace esphome::tcl112 {
 
 // Temperature
 const float TCL112_TEMP_MAX = 31.0;
@@ -24,5 +23,4 @@ class Tcl112Climate : public climate_ir::ClimateIR {
   bool on_receive(remote_base::RemoteReceiveData data) override;
 };
 
-}  // namespace tcl112
-}  // namespace esphome
+}  // namespace esphome::tcl112

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include <algorithm>
 
-namespace esphome {
-namespace tcs34725 {
+namespace esphome::tcs34725 {
 
 static const char *const TAG = "tcs34725";
 
@@ -348,5 +347,4 @@ void TCS34725Component::set_glass_attenuation_factor(float ga) {
   this->glass_attenuation_ = ga;
 }
 
-}  // namespace tcs34725
-}  // namespace esphome
+}  // namespace esphome::tcs34725

--- a/esphome/components/tcs34725/tcs34725.h
+++ b/esphome/components/tcs34725/tcs34725.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace tcs34725 {
+namespace esphome::tcs34725 {
 
 enum TCS34725IntegrationTime {
   TCS34725_INTEGRATION_TIME_2_4MS = 0xFF,
@@ -85,5 +84,4 @@ class TCS34725Component : public PollingComponent, public i2c::I2CDevice {
   uint8_t gain_reg_{TCS34725_GAIN_1X};
 };
 
-}  // namespace tcs34725
-}  // namespace esphome
+}  // namespace esphome::tcs34725

--- a/esphome/components/tee501/tee501.cpp
+++ b/esphome/components/tee501/tee501.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tee501 {
+namespace esphome::tee501 {
 
 static const char *const TAG = "tee501";
 
@@ -66,5 +65,4 @@ void TEE501Component::update() {
   });
 }
 
-}  // namespace tee501
-}  // namespace esphome
+}  // namespace esphome::tee501

--- a/esphome/components/tee501/tee501.h
+++ b/esphome/components/tee501/tee501.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace tee501 {
+namespace esphome::tee501 {
 
 /// This class implements support for the tee501 of temperature i2c sensors.
 class TEE501Component : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
@@ -18,5 +17,4 @@ class TEE501Component : public sensor::Sensor, public PollingComponent, public i
   enum ErrorCode { NONE = 0, COMMUNICATION_FAILED, CRC_CHECK_FAILED } error_code_{NONE};
 };
 
-}  // namespace tee501
-}  // namespace esphome
+}  // namespace esphome::tee501

--- a/esphome/components/teleinfo/sensor/teleinfo_sensor.cpp
+++ b/esphome/components/teleinfo/sensor/teleinfo_sensor.cpp
@@ -1,7 +1,7 @@
 #include "esphome/core/log.h"
 #include "teleinfo_sensor.h"
-namespace esphome {
-namespace teleinfo {
+
+namespace esphome::teleinfo {
 
 static const char *const TAG = "teleinfo_sensor";
 TeleInfoSensor::TeleInfoSensor(const char *tag) { this->tag = std::string(tag); }
@@ -10,5 +10,4 @@ void TeleInfoSensor::publish_val(const std::string &val) {
   publish_state(newval);
 }
 void TeleInfoSensor::dump_config() { LOG_SENSOR("  ", "Teleinfo Sensor", this); }
-}  // namespace teleinfo
-}  // namespace esphome
+}  // namespace esphome::teleinfo

--- a/esphome/components/teleinfo/sensor/teleinfo_sensor.h
+++ b/esphome/components/teleinfo/sensor/teleinfo_sensor.h
@@ -2,8 +2,7 @@
 #include "esphome/components/teleinfo/teleinfo.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace teleinfo {
+namespace esphome::teleinfo {
 
 class TeleInfoSensor : public TeleInfoListener, public sensor::Sensor, public Component {
  public:
@@ -12,5 +11,4 @@ class TeleInfoSensor : public TeleInfoListener, public sensor::Sensor, public Co
   void dump_config() override;
 };
 
-}  // namespace teleinfo
-}  // namespace esphome
+}  // namespace esphome::teleinfo

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -1,8 +1,7 @@
 #include "teleinfo.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace teleinfo {
+namespace esphome::teleinfo {
 
 static const char *const TAG = "teleinfo";
 
@@ -205,5 +204,4 @@ TeleInfo::TeleInfo(bool historical_mode) {
 }
 void TeleInfo::register_teleinfo_listener(TeleInfoListener *listener) { teleinfo_listeners_.push_back(listener); }
 
-}  // namespace teleinfo
-}  // namespace esphome
+}  // namespace esphome::teleinfo

--- a/esphome/components/teleinfo/teleinfo.h
+++ b/esphome/components/teleinfo/teleinfo.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace teleinfo {
+namespace esphome::teleinfo {
 /*
  * 198 bytes should be enough to contain a full session in historical mode with
  * three phases. But go with 1024 just to be sure.
@@ -50,5 +49,4 @@ class TeleInfo : public PollingComponent, public uart::UARTDevice {
   bool check_crc_(const char *grp, const char *grp_end);
   void publish_value_(const std::string &tag, const std::string &val);
 };
-}  // namespace teleinfo
-}  // namespace esphome
+}  // namespace esphome::teleinfo

--- a/esphome/components/teleinfo/text_sensor/teleinfo_text_sensor.cpp
+++ b/esphome/components/teleinfo/text_sensor/teleinfo_text_sensor.cpp
@@ -1,11 +1,10 @@
 #include "esphome/core/log.h"
 #include "teleinfo_text_sensor.h"
-namespace esphome {
-namespace teleinfo {
+
+namespace esphome::teleinfo {
 
 static const char *const TAG = "teleinfo_text_sensor";
 TeleInfoTextSensor::TeleInfoTextSensor(const char *tag) { this->tag = std::string(tag); }
 void TeleInfoTextSensor::publish_val(const std::string &val) { publish_state(val); }
 void TeleInfoTextSensor::dump_config() { LOG_TEXT_SENSOR("  ", "Teleinfo Text Sensor", this); }
-}  // namespace teleinfo
-}  // namespace esphome
+}  // namespace esphome::teleinfo

--- a/esphome/components/teleinfo/text_sensor/teleinfo_text_sensor.h
+++ b/esphome/components/teleinfo/text_sensor/teleinfo_text_sensor.h
@@ -1,13 +1,12 @@
 #pragma once
 #include "esphome/components/teleinfo/teleinfo.h"
 #include "esphome/components/text_sensor/text_sensor.h"
-namespace esphome {
-namespace teleinfo {
+
+namespace esphome::teleinfo {
 class TeleInfoTextSensor : public TeleInfoListener, public text_sensor::TextSensor, public Component {
  public:
   TeleInfoTextSensor(const char *tag);
   void publish_val(const std::string &val) override;
   void dump_config() override;
 };
-}  // namespace teleinfo
-}  // namespace esphome
+}  // namespace esphome::teleinfo

--- a/esphome/components/tem3200/tem3200.cpp
+++ b/esphome/components/tem3200/tem3200.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tem3200 {
+namespace esphome::tem3200 {
 
 static const char *const TAG = "tem3200";
 
@@ -142,5 +141,4 @@ void TEM3200Component::update() {
   this->status_clear_warning();
 }
 
-}  // namespace tem3200
-}  // namespace esphome
+}  // namespace esphome::tem3200

--- a/esphome/components/tem3200/tem3200.h
+++ b/esphome/components/tem3200/tem3200.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace tem3200 {
+namespace esphome::tem3200 {
 
 /// This class implements support for the tem3200 pressure and temperature i2c sensors.
 class TEM3200Component : public PollingComponent, public i2c::I2CDevice {
@@ -25,5 +24,4 @@ class TEM3200Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *raw_pressure_sensor_{nullptr};
 };
 
-}  // namespace tem3200
-}  // namespace esphome
+}  // namespace esphome::tem3200

--- a/esphome/components/time_based/cover/time_based_cover.cpp
+++ b/esphome/components/time_based/cover/time_based_cover.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace time_based {
+namespace esphome::time_based {
 
 static const char *const TAG = "time_based.cover";
 
@@ -183,5 +182,4 @@ void TimeBasedCover::recompute_position_() {
   this->last_recompute_time_ = now;
 }
 
-}  // namespace time_based
-}  // namespace esphome
+}  // namespace esphome::time_based

--- a/esphome/components/time_based/cover/time_based_cover.h
+++ b/esphome/components/time_based/cover/time_based_cover.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/cover/cover.h"
 
-namespace esphome {
-namespace time_based {
+namespace esphome::time_based {
 
 class TimeBasedCover : public cover::Cover, public Component {
  public:
@@ -50,5 +49,4 @@ class TimeBasedCover : public cover::Cover, public Component {
   cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
 };
 
-}  // namespace time_based
-}  // namespace esphome
+}  // namespace esphome::time_based

--- a/esphome/components/tlc59208f/tlc59208f_output.cpp
+++ b/esphome/components/tlc59208f/tlc59208f_output.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tlc59208f {
+namespace esphome::tlc59208f {
 
 static const char *const TAG = "tlc59208f";
 
@@ -143,5 +142,4 @@ void TLC59208FChannel::write_state(float state) {
   this->parent_->set_channel_value_(this->channel_, duty);
 }
 
-}  // namespace tlc59208f
-}  // namespace esphome
+}  // namespace esphome::tlc59208f

--- a/esphome/components/tlc59208f/tlc59208f_output.h
+++ b/esphome/components/tlc59208f/tlc59208f_output.h
@@ -5,8 +5,7 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace tlc59208f {
+namespace esphome::tlc59208f {
 
 // 0*: Group dimming, 1: Group blinking
 inline constexpr uint8_t TLC59208F_MODE2_DMBLNK = (1 << 5);
@@ -65,5 +64,4 @@ class TLC59208FOutput : public Component, public i2c::I2CDevice {
   bool update_{true};
 };
 
-}  // namespace tlc59208f
-}  // namespace esphome
+}  // namespace esphome::tlc59208f

--- a/esphome/components/tlc5947/output/tlc5947_output.cpp
+++ b/esphome/components/tlc5947/output/tlc5947_output.cpp
@@ -1,12 +1,10 @@
 #include "tlc5947_output.h"
 
-namespace esphome {
-namespace tlc5947 {
+namespace esphome::tlc5947 {
 
 void TLC5947Channel::write_state(float state) {
   auto amount = static_cast<uint16_t>(state * 0xfff);
   this->parent_->set_channel_value(this->channel_, amount);
 }
 
-}  // namespace tlc5947
-}  // namespace esphome
+}  // namespace esphome::tlc5947

--- a/esphome/components/tlc5947/output/tlc5947_output.h
+++ b/esphome/components/tlc5947/output/tlc5947_output.h
@@ -6,8 +6,7 @@
 
 #include "../tlc5947.h"
 
-namespace esphome {
-namespace tlc5947 {
+namespace esphome::tlc5947 {
 
 class TLC5947Channel : public output::FloatOutput, public Parented<TLC5947> {
  public:
@@ -18,5 +17,4 @@ class TLC5947Channel : public output::FloatOutput, public Parented<TLC5947> {
   uint16_t channel_;
 };
 
-}  // namespace tlc5947
-}  // namespace esphome
+}  // namespace esphome::tlc5947

--- a/esphome/components/tlc5947/tlc5947.cpp
+++ b/esphome/components/tlc5947/tlc5947.cpp
@@ -1,8 +1,7 @@
 #include "tlc5947.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tlc5947 {
+namespace esphome::tlc5947 {
 
 static const char *const TAG = "tlc5947";
 
@@ -69,5 +68,4 @@ void TLC5947::set_channel_value(uint16_t channel, uint16_t value) {
   this->pwm_amounts_[channel] = value;
 }
 
-}  // namespace tlc5947
-}  // namespace esphome
+}  // namespace esphome::tlc5947

--- a/esphome/components/tlc5947/tlc5947.h
+++ b/esphome/components/tlc5947/tlc5947.h
@@ -7,8 +7,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace tlc5947 {
+namespace esphome::tlc5947 {
 
 class TLC5947 : public Component {
  public:
@@ -42,5 +41,4 @@ class TLC5947 : public Component {
   bool update_{true};
 };
 
-}  // namespace tlc5947
-}  // namespace esphome
+}  // namespace esphome::tlc5947

--- a/esphome/components/tlc5971/output/tlc5971_output.cpp
+++ b/esphome/components/tlc5971/output/tlc5971_output.cpp
@@ -1,12 +1,10 @@
 #include "tlc5971_output.h"
 
-namespace esphome {
-namespace tlc5971 {
+namespace esphome::tlc5971 {
 
 void TLC5971Channel::write_state(float state) {
   auto amount = static_cast<uint16_t>(state * 0xffff);
   this->parent_->set_channel_value(this->channel_, amount);
 }
 
-}  // namespace tlc5971
-}  // namespace esphome
+}  // namespace esphome::tlc5971

--- a/esphome/components/tlc5971/output/tlc5971_output.h
+++ b/esphome/components/tlc5971/output/tlc5971_output.h
@@ -6,8 +6,7 @@
 
 #include "../tlc5971.h"
 
-namespace esphome {
-namespace tlc5971 {
+namespace esphome::tlc5971 {
 
 class TLC5971Channel : public output::FloatOutput, public Parented<TLC5971> {
  public:
@@ -18,5 +17,4 @@ class TLC5971Channel : public output::FloatOutput, public Parented<TLC5971> {
   uint16_t channel_;
 };
 
-}  // namespace tlc5971
-}  // namespace esphome
+}  // namespace esphome::tlc5971

--- a/esphome/components/tlc5971/tlc5971.cpp
+++ b/esphome/components/tlc5971/tlc5971.cpp
@@ -1,8 +1,7 @@
 #include "tlc5971.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tlc5971 {
+namespace esphome::tlc5971 {
 
 static const char *const TAG = "tlc5971";
 
@@ -90,5 +89,4 @@ void TLC5971::set_channel_value(uint16_t channel, uint16_t value) {
   this->pwm_amounts_[channel] = value;
 }
 
-}  // namespace tlc5971
-}  // namespace esphome
+}  // namespace esphome::tlc5971

--- a/esphome/components/tlc5971/tlc5971.h
+++ b/esphome/components/tlc5971/tlc5971.h
@@ -7,8 +7,7 @@
 #include "esphome/components/output/float_output.h"
 #include <vector>
 
-namespace esphome {
-namespace tlc5971 {
+namespace esphome::tlc5971 {
 
 class TLC5971 : public Component {
  public:
@@ -39,5 +38,4 @@ class TLC5971 : public Component {
   std::vector<uint16_t> pwm_amounts_;
   bool update_{true};
 };
-}  // namespace tlc5971
-}  // namespace esphome
+}  // namespace esphome::tlc5971

--- a/esphome/components/tm1621/tm1621.cpp
+++ b/esphome/components/tm1621/tm1621.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tm1621 {
+namespace esphome::tm1621 {
 
 static const char *const TAG = "tm1621";
 
@@ -277,5 +276,4 @@ int TM1621Display::get_command_code_(char *destination, size_t destination_size,
   }
   return result;
 }
-}  // namespace tm1621
-}  // namespace esphome
+}  // namespace esphome::tm1621

--- a/esphome/components/tm1621/tm1621.h
+++ b/esphome/components/tm1621/tm1621.h
@@ -5,8 +5,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/display/display.h"
 
-namespace esphome {
-namespace tm1621 {
+namespace esphome::tm1621 {
 
 class TM1621Display;
 
@@ -71,5 +70,4 @@ class TM1621Display : public PollingComponent {
   bool kwh_;
 };
 
-}  // namespace tm1621
-}  // namespace esphome
+}  // namespace esphome::tm1621

--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tm1637 {
+namespace esphome::tm1637 {
 
 static const char *const TAG = "display.tm1637";
 const uint8_t TM1637_CMD_DATA = 0x40;  //!< Display data command
@@ -391,5 +390,4 @@ uint8_t TM1637Display::strftime(uint8_t pos, const char *format, ESPTime time) {
 }
 uint8_t TM1637Display::strftime(const char *format, ESPTime time) { return this->strftime(0, format, time); }
 
-}  // namespace tm1637
-}  // namespace esphome
+}  // namespace esphome::tm1637

--- a/esphome/components/tm1637/tm1637.h
+++ b/esphome/components/tm1637/tm1637.h
@@ -12,8 +12,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #endif
 
-namespace esphome {
-namespace tm1637 {
+namespace esphome::tm1637 {
 
 class TM1637Display;
 #ifdef USE_BINARY_SENSOR
@@ -105,5 +104,4 @@ class TM1637Key : public binary_sensor::BinarySensor {
 };
 #endif
 
-}  // namespace tm1637
-}  // namespace esphome
+}  // namespace esphome::tm1637

--- a/esphome/components/tm1638/binary_sensor/tm1638_key.cpp
+++ b/esphome/components/tm1638/binary_sensor/tm1638_key.cpp
@@ -1,7 +1,6 @@
 #include "tm1638_key.h"
 
-namespace esphome {
-namespace tm1638 {
+namespace esphome::tm1638 {
 
 void TM1638Key::keys_update(uint8_t keys) {
   bool pressed = keys & (1 << key_code_);
@@ -9,5 +8,4 @@ void TM1638Key::keys_update(uint8_t keys) {
     this->publish_state(pressed);
 }
 
-}  // namespace tm1638
-}  // namespace esphome
+}  // namespace esphome::tm1638

--- a/esphome/components/tm1638/binary_sensor/tm1638_key.h
+++ b/esphome/components/tm1638/binary_sensor/tm1638_key.h
@@ -3,8 +3,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "../tm1638.h"
 
-namespace esphome {
-namespace tm1638 {
+namespace esphome::tm1638 {
 
 class TM1638Key : public binary_sensor::BinarySensor, public KeyListener {
  public:
@@ -15,5 +14,4 @@ class TM1638Key : public binary_sensor::BinarySensor, public KeyListener {
   uint8_t key_code_{0};
 };
 
-}  // namespace tm1638
-}  // namespace esphome
+}  // namespace esphome::tm1638

--- a/esphome/components/tm1638/output/tm1638_output_led.cpp
+++ b/esphome/components/tm1638/output/tm1638_output_led.cpp
@@ -1,8 +1,7 @@
 #include "tm1638_output_led.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tm1638 {
+namespace esphome::tm1638 {
 
 static const char *const TAG = "tm1638.led";
 
@@ -13,5 +12,4 @@ void TM1638OutputLed::dump_config() {
   ESP_LOGCONFIG(TAG, "  LED: %d", led_);
 }
 
-}  // namespace tm1638
-}  // namespace esphome
+}  // namespace esphome::tm1638

--- a/esphome/components/tm1638/output/tm1638_output_led.h
+++ b/esphome/components/tm1638/output/tm1638_output_led.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/binary_output.h"
 #include "../tm1638.h"
 
-namespace esphome {
-namespace tm1638 {
+namespace esphome::tm1638 {
 
 class TM1638OutputLed : public output::BinaryOutput, public Component {
  public:
@@ -21,5 +20,4 @@ class TM1638OutputLed : public output::BinaryOutput, public Component {
   int led_;
 };
 
-}  // namespace tm1638
-}  // namespace esphome
+}  // namespace esphome::tm1638

--- a/esphome/components/tm1638/sevenseg.h
+++ b/esphome/components/tm1638/sevenseg.h
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace esphome {
-namespace tm1638 {
+namespace esphome::tm1638 {
 namespace TM1638Translation {
 
 constexpr unsigned char SEVEN_SEG[] PROGMEM = {
@@ -103,5 +102,4 @@ constexpr unsigned char SEVEN_SEG[] PROGMEM = {
 };
 
 };  // namespace TM1638Translation
-}  // namespace tm1638
-}  // namespace esphome
+}  // namespace esphome::tm1638

--- a/esphome/components/tm1638/switch/tm1638_switch_led.cpp
+++ b/esphome/components/tm1638/switch/tm1638_switch_led.cpp
@@ -1,8 +1,7 @@
 #include "tm1638_switch_led.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tm1638 {
+namespace esphome::tm1638 {
 
 static const char *const TAG = "tm1638.led";
 
@@ -16,5 +15,4 @@ void TM1638SwitchLed::dump_config() {
   ESP_LOGCONFIG(TAG, "  LED: %d", led_);
 }
 
-}  // namespace tm1638
-}  // namespace esphome
+}  // namespace esphome::tm1638

--- a/esphome/components/tm1638/switch/tm1638_switch_led.h
+++ b/esphome/components/tm1638/switch/tm1638_switch_led.h
@@ -4,8 +4,7 @@
 #include "esphome/components/switch/switch.h"
 #include "../tm1638.h"
 
-namespace esphome {
-namespace tm1638 {
+namespace esphome::tm1638 {
 
 class TM1638SwitchLed : public switch_::Switch, public Component {
  public:
@@ -19,5 +18,4 @@ class TM1638SwitchLed : public switch_::Switch, public Component {
   TM1638Component *tm1638_;
   int led_;
 };
-}  // namespace tm1638
-}  // namespace esphome
+}  // namespace esphome::tm1638

--- a/esphome/components/tm1638/tm1638.cpp
+++ b/esphome/components/tm1638/tm1638.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tm1638 {
+namespace esphome::tm1638 {
 
 static const char *const TAG = "display.tm1638";
 static const uint8_t TM1638_REGISTER_FIXEDADDRESS = 0x44;
@@ -282,5 +281,4 @@ void TM1638Component::shift_out_(uint8_t val) {
   }
 }
 
-}  // namespace tm1638
-}  // namespace esphome
+}  // namespace esphome::tm1638

--- a/esphome/components/tm1638/tm1638.h
+++ b/esphome/components/tm1638/tm1638.h
@@ -9,8 +9,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace tm1638 {
+namespace esphome::tm1638 {
 
 class KeyListener {
  public:
@@ -75,5 +74,4 @@ class TM1638Component : public PollingComponent {
   std::vector<KeyListener *> listeners_{};
 };
 
-}  // namespace tm1638
-}  // namespace esphome
+}  // namespace esphome::tm1638

--- a/esphome/components/tm1651/tm1651.cpp
+++ b/esphome/components/tm1651/tm1651.cpp
@@ -51,8 +51,7 @@
 #include "tm1651.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tm1651 {
+namespace esphome::tm1651 {
 
 static const char *const TAG = "tm1651.display";
 
@@ -256,5 +255,4 @@ void TM1651Display::delineate_transmission_(bool dio_state) {
   delayMicroseconds(QUARTER_CLOCK_CYCLE);
 }
 
-}  // namespace tm1651
-}  // namespace esphome
+}  // namespace esphome::tm1651

--- a/esphome/components/tm1651/tm1651.h
+++ b/esphome/components/tm1651/tm1651.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace tm1651 {
+namespace esphome::tm1651 {
 
 enum TM1651Brightness : uint8_t {
   TM1651_DARKEST = 1,
@@ -97,5 +96,4 @@ template<typename... Ts> class TurnOffAction : public Action<Ts...>, public Pare
   void play(const Ts &...x) override { this->parent_->turn_off(); }
 };
 
-}  // namespace tm1651
-}  // namespace esphome
+}  // namespace esphome::tm1651

--- a/esphome/components/tmp102/tmp102.cpp
+++ b/esphome/components/tmp102/tmp102.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace tmp102 {
+namespace esphome::tmp102 {
 
 static const char *const TAG = "tmp102";
 
@@ -46,5 +45,4 @@ void TMP102Component::update() {
   });
 }
 
-}  // namespace tmp102
-}  // namespace esphome
+}  // namespace esphome::tmp102

--- a/esphome/components/tmp102/tmp102.h
+++ b/esphome/components/tmp102/tmp102.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace tmp102 {
+namespace esphome::tmp102 {
 
 class TMP102Component : public PollingComponent, public i2c::I2CDevice, public sensor::Sensor {
  public:
@@ -13,5 +12,4 @@ class TMP102Component : public PollingComponent, public i2c::I2CDevice, public s
   void update() override;
 };
 
-}  // namespace tmp102
-}  // namespace esphome
+}  // namespace esphome::tmp102

--- a/esphome/components/tmp1075/tmp1075.cpp
+++ b/esphome/components/tmp1075/tmp1075.cpp
@@ -1,8 +1,7 @@
 #include "esphome/core/log.h"
 #include "tmp1075.h"
 
-namespace esphome {
-namespace tmp1075 {
+namespace esphome::tmp1075 {
 
 static const char *const TAG = "tmp1075";
 
@@ -127,5 +126,4 @@ static float regvalue2temp(const uint16_t regvalue) {
   return (signed_value >> 4) * 0.0625f;
 }
 
-}  // namespace tmp1075
-}  // namespace esphome
+}  // namespace esphome::tmp1075

--- a/esphome/components/tmp1075/tmp1075.h
+++ b/esphome/components/tmp1075/tmp1075.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace tmp1075 {
+namespace esphome::tmp1075 {
 
 struct TMP1075Config {
   union {
@@ -85,5 +84,4 @@ class TMP1075Sensor : public PollingComponent, public sensor::Sensor, public i2c
   void log_config_();
 };
 
-}  // namespace tmp1075
-}  // namespace esphome
+}  // namespace esphome::tmp1075

--- a/esphome/components/tof10120/tof10120_sensor.cpp
+++ b/esphome/components/tof10120/tof10120_sensor.cpp
@@ -5,8 +5,7 @@
 
 // Very basic support for TOF10120 distance sensor
 
-namespace esphome {
-namespace tof10120 {
+namespace esphome::tof10120 {
 
 static const char *const TAG = "tof10120";
 static const uint8_t TOF10120_READ_DISTANCE_CMD[] = {0x00};
@@ -56,5 +55,4 @@ void TOF10120Sensor::update() {
   this->status_clear_warning();
 }
 
-}  // namespace tof10120
-}  // namespace esphome
+}  // namespace esphome::tof10120

--- a/esphome/components/tof10120/tof10120_sensor.h
+++ b/esphome/components/tof10120/tof10120_sensor.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace tof10120 {
+namespace esphome::tof10120 {
 
 class TOF10120Sensor : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
  public:
@@ -14,5 +13,4 @@ class TOF10120Sensor : public sensor::Sensor, public PollingComponent, public i2
   void dump_config() override;
   void update() override;
 };
-}  // namespace tof10120
-}  // namespace esphome
+}  // namespace esphome::tof10120

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -5,8 +5,7 @@
 
 using namespace std;
 
-namespace esphome {
-namespace tormatic {
+namespace esphome::tormatic {
 
 static const char *const TAG = "tormatic.cover";
 
@@ -390,5 +389,4 @@ void Tormatic::drain_rx_(uint16_t n) {
   }
 }
 
-}  // namespace tormatic
-}  // namespace esphome
+}  // namespace esphome::tormatic

--- a/esphome/components/tormatic/tormatic_cover.h
+++ b/esphome/components/tormatic/tormatic_cover.h
@@ -5,8 +5,7 @@
 
 #include "tormatic_protocol.h"
 
-namespace esphome {
-namespace tormatic {
+namespace esphome::tormatic {
 
 using namespace esphome::cover;
 
@@ -56,5 +55,4 @@ class Tormatic : public cover::Cover, public uart::UARTDevice, public PollingCom
   optional<float> target_position_{};
 };
 
-}  // namespace tormatic
-}  // namespace esphome
+}  // namespace esphome::tormatic

--- a/esphome/components/tormatic/tormatic_protocol.h
+++ b/esphome/components/tormatic/tormatic_protocol.h
@@ -46,8 +46,7 @@
  * for this purpose.
  */
 
-namespace esphome {
-namespace tormatic {
+namespace esphome::tormatic {
 
 using namespace esphome::cover;
 
@@ -225,5 +224,4 @@ struct CommandRequestReply {
   void byteswap() { this->type = convert_big_endian(this->type); }
 } __attribute__((packed));
 
-}  // namespace tormatic
-}  // namespace esphome
+}  // namespace esphome::tormatic

--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -4,8 +4,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace toshiba {
+namespace esphome::toshiba {
 
 struct RacPt1411hwruFanSpeed {
   uint8_t code1;
@@ -1372,5 +1371,4 @@ bool ToshibaClimate::decode_(remote_base::RemoteReceiveData *data, uint8_t *mess
   return true;
 }
 
-}  // namespace toshiba
-}  // namespace esphome
+}  // namespace esphome::toshiba

--- a/esphome/components/toshiba/toshiba.h
+++ b/esphome/components/toshiba/toshiba.h
@@ -3,8 +3,7 @@
 #include "esphome/components/climate_ir/climate_ir.h"
 #include "esphome/components/remote_base/toshiba_ac_protocol.h"
 
-namespace esphome {
-namespace toshiba {
+namespace esphome::toshiba {
 
 // Simple enum to represent models.
 enum Model {
@@ -82,5 +81,4 @@ class ToshibaClimate : public climate_ir::ClimateIR {
   Model model_;
 };
 
-}  // namespace toshiba
-}  // namespace esphome
+}  // namespace esphome::toshiba

--- a/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.cpp
+++ b/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.cpp
@@ -1,7 +1,6 @@
 #include "touchscreen_binary_sensor.h"
 
-namespace esphome {
-namespace touchscreen {
+namespace esphome::touchscreen {
 
 void TouchscreenBinarySensor::setup() {
   this->parent_->register_listener(this);
@@ -30,5 +29,4 @@ void TouchscreenBinarySensor::touch(TouchPoint tp) {
 
 void TouchscreenBinarySensor::release() { this->publish_state(false); }
 
-}  // namespace touchscreen
-}  // namespace esphome
+}  // namespace esphome::touchscreen

--- a/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.h
+++ b/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.h
@@ -8,8 +8,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace touchscreen {
+namespace esphome::touchscreen {
 
 class TouchscreenBinarySensor : public binary_sensor::BinarySensor,
                                 public Component,
@@ -44,5 +43,4 @@ class TouchscreenBinarySensor : public binary_sensor::BinarySensor,
   std::vector<display::DisplayPage *> pages_{};
 };
 
-}  // namespace touchscreen
-}  // namespace esphome
+}  // namespace esphome::touchscreen

--- a/esphome/components/touchscreen/touchscreen.cpp
+++ b/esphome/components/touchscreen/touchscreen.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace touchscreen {
+namespace esphome::touchscreen {
 
 static const char *const TAG = "touchscreen";
 
@@ -162,5 +161,4 @@ int16_t Touchscreen::normalize_(int16_t val, int16_t min_val, int16_t max_val, b
   return ret;
 }
 
-}  // namespace touchscreen
-}  // namespace esphome
+}  // namespace esphome::touchscreen

--- a/esphome/components/touchscreen/touchscreen.h
+++ b/esphome/components/touchscreen/touchscreen.h
@@ -9,8 +9,7 @@
 #include <vector>
 #include <map>
 
-namespace esphome {
-namespace touchscreen {
+namespace esphome::touchscreen {
 
 static const uint8_t STATE_RELEASED = 0x00;
 static const uint8_t STATE_PRESSED = 0x01;
@@ -120,5 +119,4 @@ class Touchscreen : public PollingComponent {
   bool skip_update_{false};
 };
 
-}  // namespace touchscreen
-}  // namespace esphome
+}  // namespace esphome::touchscreen

--- a/esphome/components/tsl2561/tsl2561.cpp
+++ b/esphome/components/tsl2561/tsl2561.cpp
@@ -1,8 +1,7 @@
 #include "tsl2561.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tsl2561 {
+namespace esphome::tsl2561 {
 
 static const char *const TAG = "tsl2561";
 
@@ -165,5 +164,4 @@ bool TSL2561Sensor::tsl2561_read_byte(uint8_t a_register, uint8_t *value) {
   return this->read_byte(a_register | TSL2561_COMMAND_BIT, value);
 }
 
-}  // namespace tsl2561
-}  // namespace esphome
+}  // namespace esphome::tsl2561

--- a/esphome/components/tsl2561/tsl2561.h
+++ b/esphome/components/tsl2561/tsl2561.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace tsl2561 {
+namespace esphome::tsl2561 {
 
 /** Enum listing all conversion/integration time settings for the TSL2561
  *
@@ -82,5 +81,4 @@ class TSL2561Sensor : public sensor::Sensor, public PollingComponent, public i2c
   bool package_cs_{false};
 };
 
-}  // namespace tsl2561
-}  // namespace esphome
+}  // namespace esphome::tsl2561

--- a/esphome/components/tsl2591/tsl2591.cpp
+++ b/esphome/components/tsl2591/tsl2591.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace tsl2591 {
+namespace esphome::tsl2591 {
 
 static const char *const TAG = "tsl2591.sensor";
 
@@ -475,5 +474,4 @@ float TSL2591Component::get_actual_gain() {
   }
 }
 
-}  // namespace tsl2591
-}  // namespace esphome
+}  // namespace esphome::tsl2591

--- a/esphome/components/tsl2591/tsl2591.h
+++ b/esphome/components/tsl2591/tsl2591.h
@@ -6,8 +6,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace tsl2591 {
+namespace esphome::tsl2591 {
 
 /** Enum listing all conversion/integration time settings for the TSL2591.
  *
@@ -270,5 +269,4 @@ class TSL2591Component : public PollingComponent, public i2c::I2CDevice {
   void interval_function_for_update_();
 };
 
-}  // namespace tsl2591
-}  // namespace esphome
+}  // namespace esphome::tsl2591

--- a/esphome/components/tt21100/binary_sensor/tt21100_button.cpp
+++ b/esphome/components/tt21100/binary_sensor/tt21100_button.cpp
@@ -1,8 +1,7 @@
 #include "tt21100_button.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tt21100 {
+namespace esphome::tt21100 {
 
 static const char *const TAG = "tt21100.binary_sensor";
 
@@ -23,5 +22,4 @@ void TT21100Button::update_button(uint8_t index, uint16_t state) {
   this->publish_state(state > 0);
 }
 
-}  // namespace tt21100
-}  // namespace esphome
+}  // namespace esphome::tt21100

--- a/esphome/components/tt21100/binary_sensor/tt21100_button.h
+++ b/esphome/components/tt21100/binary_sensor/tt21100_button.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace tt21100 {
+namespace esphome::tt21100 {
 
 class TT21100Button : public binary_sensor::BinarySensor,
                       public Component,
@@ -24,5 +23,4 @@ class TT21100Button : public binary_sensor::BinarySensor,
   uint8_t index_;
 };
 
-}  // namespace tt21100
-}  // namespace esphome
+}  // namespace esphome::tt21100

--- a/esphome/components/tt21100/touchscreen/tt21100.cpp
+++ b/esphome/components/tt21100/touchscreen/tt21100.cpp
@@ -1,8 +1,7 @@
 #include "tt21100.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tt21100 {
+namespace esphome::tt21100 {
 
 static const char *const TAG = "tt21100";
 
@@ -139,5 +138,4 @@ void TT21100Touchscreen::dump_config() {
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
 }
 
-}  // namespace tt21100
-}  // namespace esphome
+}  // namespace esphome::tt21100

--- a/esphome/components/tt21100/touchscreen/tt21100.h
+++ b/esphome/components/tt21100/touchscreen/tt21100.h
@@ -7,8 +7,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace tt21100 {
+namespace esphome::tt21100 {
 
 using namespace touchscreen;
 
@@ -39,5 +38,4 @@ class TT21100Touchscreen : public Touchscreen, public i2c::I2CDevice {
   std::vector<TT21100ButtonListener *> button_listeners_;
 };
 
-}  // namespace tt21100
-}  // namespace esphome
+}  // namespace esphome::tt21100

--- a/esphome/components/ttp229_bsf/ttp229_bsf.cpp
+++ b/esphome/components/ttp229_bsf/ttp229_bsf.cpp
@@ -1,8 +1,7 @@
 #include "ttp229_bsf.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ttp229_bsf {
+namespace esphome::ttp229_bsf {
 
 static const char *const TAG = "ttp229_bsf";
 
@@ -18,5 +17,4 @@ void TTP229BSFComponent::dump_config() {
   LOG_PIN("  SDO pin: ", this->sdo_pin_);
 }
 
-}  // namespace ttp229_bsf
-}  // namespace esphome
+}  // namespace esphome::ttp229_bsf

--- a/esphome/components/ttp229_bsf/ttp229_bsf.h
+++ b/esphome/components/ttp229_bsf/ttp229_bsf.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace ttp229_bsf {
+namespace esphome::ttp229_bsf {
 
 class TTP229BSFChannel : public binary_sensor::BinarySensor {
  public:
@@ -51,5 +50,4 @@ class TTP229BSFComponent : public Component {
   std::vector<TTP229BSFChannel *> channels_{};
 };
 
-}  // namespace ttp229_bsf
-}  // namespace esphome
+}  // namespace esphome::ttp229_bsf

--- a/esphome/components/ttp229_lsf/ttp229_lsf.cpp
+++ b/esphome/components/ttp229_lsf/ttp229_lsf.cpp
@@ -1,8 +1,7 @@
 #include "ttp229_lsf.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ttp229_lsf {
+namespace esphome::ttp229_lsf {
 
 static const char *const TAG = "ttp229_lsf";
 
@@ -40,5 +39,4 @@ void TTP229LSFComponent::loop() {
   }
 }
 
-}  // namespace ttp229_lsf
-}  // namespace esphome
+}  // namespace esphome::ttp229_lsf

--- a/esphome/components/ttp229_lsf/ttp229_lsf.h
+++ b/esphome/components/ttp229_lsf/ttp229_lsf.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace ttp229_lsf {
+namespace esphome::ttp229_lsf {
 
 class TTP229Channel : public binary_sensor::BinarySensor {
  public:
@@ -33,5 +32,4 @@ class TTP229LSFComponent : public Component, public i2c::I2CDevice {
   } error_code_{NONE};
 };
 
-}  // namespace ttp229_lsf
-}  // namespace esphome
+}  // namespace esphome::ttp229_lsf

--- a/esphome/components/tuya/automation.cpp
+++ b/esphome/components/tuya/automation.cpp
@@ -4,8 +4,7 @@
 
 static const char *const TAG = "tuya.automation";
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 void check_expected_datapoint(const TuyaDatapoint &dp, TuyaDatapointType expected) {
   if (dp.type != expected) {
@@ -63,5 +62,4 @@ TuyaBitmaskDatapointUpdateTrigger::TuyaBitmaskDatapointUpdateTrigger(Tuya *paren
   });
 }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/automation.h
+++ b/esphome/components/tuya/automation.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 class TuyaDatapointUpdateTrigger : public Trigger<TuyaDatapoint> {
  public:
@@ -51,5 +50,4 @@ class TuyaBitmaskDatapointUpdateTrigger : public Trigger<uint32_t> {
   explicit TuyaBitmaskDatapointUpdateTrigger(Tuya *parent, uint8_t sensor_id);
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/binary_sensor/tuya_binary_sensor.cpp
+++ b/esphome/components/tuya/binary_sensor/tuya_binary_sensor.cpp
@@ -1,8 +1,7 @@
 #include "esphome/core/log.h"
 #include "tuya_binary_sensor.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 static const char *const TAG = "tuya.binary_sensor";
 
@@ -20,5 +19,4 @@ void TuyaBinarySensor::dump_config() {
                 this->sensor_id_);
 }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/binary_sensor/tuya_binary_sensor.h
+++ b/esphome/components/tuya/binary_sensor/tuya_binary_sensor.h
@@ -4,8 +4,7 @@
 #include "esphome/components/tuya/tuya.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 class TuyaBinarySensor : public binary_sensor::BinarySensor, public Component {
  public:
@@ -20,5 +19,4 @@ class TuyaBinarySensor : public binary_sensor::BinarySensor, public Component {
   uint8_t sensor_id_{0};
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/climate/tuya_climate.cpp
+++ b/esphome/components/tuya/climate/tuya_climate.cpp
@@ -1,8 +1,7 @@
 #include "tuya_climate.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 static const char *const TAG = "tuya.climate";
 
@@ -533,5 +532,4 @@ void TuyaClimate::switch_to_action_(climate::ClimateAction action) {
   this->action = action;
 }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/climate/tuya_climate.h
+++ b/esphome/components/tuya/climate/tuya_climate.h
@@ -4,8 +4,7 @@
 #include "esphome/components/tuya/tuya.h"
 #include "esphome/components/climate/climate.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 class TuyaClimate : public climate::Climate, public Component {
  public:
@@ -125,5 +124,4 @@ class TuyaClimate : public climate::Climate, public Component {
   bool reports_fahrenheit_{false};
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/cover/tuya_cover.cpp
+++ b/esphome/components/tuya/cover/tuya_cover.cpp
@@ -1,8 +1,7 @@
 #include "esphome/core/log.h"
 #include "tuya_cover.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 const uint8_t COMMAND_OPEN = 0x00;
 const uint8_t COMMAND_CLOSE = 0x02;
@@ -140,5 +139,4 @@ cover::CoverTraits TuyaCover::get_traits() {
   return traits;
 }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/cover/tuya_cover.h
+++ b/esphome/components/tuya/cover/tuya_cover.h
@@ -4,8 +4,7 @@
 #include "esphome/components/tuya/tuya.h"
 #include "esphome/components/cover/cover.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 enum TuyaCoverRestoreMode {
   COVER_NO_RESTORE,
@@ -46,5 +45,4 @@ class TuyaCover : public cover::Cover, public Component {
   bool invert_position_report_;
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -1,8 +1,7 @@
 #include "esphome/core/log.h"
 #include "tuya_fan.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 static const char *const TAG = "tuya.fan";
 
@@ -127,5 +126,4 @@ void TuyaFan::control(const fan::FanCall &call) {
   }
 }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/fan/tuya_fan.h
+++ b/esphome/components/tuya/fan/tuya_fan.h
@@ -4,8 +4,7 @@
 #include "esphome/components/tuya/tuya.h"
 #include "esphome/components/fan/fan.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 class TuyaFan : public Component, public fan::Fan {
  public:
@@ -32,5 +31,4 @@ class TuyaFan : public Component, public fan::Fan {
   TuyaDatapointType oscillation_type_{};
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -2,8 +2,7 @@
 #include "tuya_light.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 static const char *const TAG = "tuya.light";
 
@@ -228,5 +227,4 @@ void TuyaLight::write_state(light::LightState *state) {
   }
 }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -4,8 +4,7 @@
 #include "esphome/components/tuya/tuya.h"
 #include "esphome/components/light/light_output.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 enum TuyaColorType { RGB, HSV, RGBHSV };
 
@@ -65,5 +64,4 @@ class TuyaLight : public Component, public light::LightOutput {
   light::LightState *state_{nullptr};
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/number/tuya_number.cpp
+++ b/esphome/components/tuya/number/tuya_number.cpp
@@ -1,8 +1,7 @@
 #include "esphome/core/log.h"
 #include "tuya_number.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 static const char *const TAG = "tuya.number";
 
@@ -91,5 +90,4 @@ void TuyaNumber::dump_config() {
   ESP_LOGCONFIG(TAG, "  Restore Value: %s", YESNO(this->restore_value_));
 }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/number/tuya_number.h
+++ b/esphome/components/tuya/number/tuya_number.h
@@ -6,8 +6,7 @@
 #include "esphome/core/optional.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 class TuyaNumber : public number::Number, public Component {
  public:
@@ -34,5 +33,4 @@ class TuyaNumber : public number::Number, public Component {
   ESPPreferenceObject pref_;
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/select/tuya_select.cpp
+++ b/esphome/components/tuya/select/tuya_select.cpp
@@ -1,8 +1,7 @@
 #include "esphome/core/log.h"
 #include "tuya_select.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 static const char *const TAG = "tuya.select";
 
@@ -47,5 +46,4 @@ void TuyaSelect::dump_config() {
   }
 }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/select/tuya_select.h
+++ b/esphome/components/tuya/select/tuya_select.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 class TuyaSelect : public select::Select, public Component {
  public:
@@ -32,5 +31,4 @@ class TuyaSelect : public select::Select, public Component {
   bool is_int_ = false;
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/sensor/tuya_sensor.cpp
+++ b/esphome/components/tuya/sensor/tuya_sensor.cpp
@@ -2,8 +2,7 @@
 #include "tuya_sensor.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 static const char *const TAG = "tuya.sensor";
 
@@ -30,5 +29,4 @@ void TuyaSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "  Sensor has datapoint ID %u", this->sensor_id_);
 }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/sensor/tuya_sensor.h
+++ b/esphome/components/tuya/sensor/tuya_sensor.h
@@ -4,8 +4,7 @@
 #include "esphome/components/tuya/tuya.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 class TuyaSensor : public sensor::Sensor, public Component {
  public:
@@ -20,5 +19,4 @@ class TuyaSensor : public sensor::Sensor, public Component {
   uint8_t sensor_id_{0};
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/switch/tuya_switch.cpp
+++ b/esphome/components/tuya/switch/tuya_switch.cpp
@@ -1,8 +1,7 @@
 #include "esphome/core/log.h"
 #include "tuya_switch.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 static const char *const TAG = "tuya.switch";
 
@@ -24,5 +23,4 @@ void TuyaSwitch::dump_config() {
   ESP_LOGCONFIG(TAG, "  Switch has datapoint ID %u", this->switch_id_);
 }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/switch/tuya_switch.h
+++ b/esphome/components/tuya/switch/tuya_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/components/tuya/tuya.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 class TuyaSwitch : public switch_::Switch, public Component {
  public:
@@ -22,5 +21,4 @@ class TuyaSwitch : public switch_::Switch, public Component {
   uint8_t switch_id_{0};
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/entity_base.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 static const char *const TAG = "tuya.text_sensor";
 
@@ -43,5 +42,4 @@ void TuyaTextSensor::dump_config() {
                 this->sensor_id_);
 }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.h
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.h
@@ -4,8 +4,7 @@
 #include "esphome/components/tuya/tuya.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 class TuyaTextSensor : public text_sensor::TextSensor, public Component {
  public:
@@ -20,5 +19,4 @@ class TuyaTextSensor : public text_sensor::TextSensor, public Component {
   uint8_t sensor_id_{0};
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -13,8 +13,7 @@
 #include "esphome/components/captive_portal/captive_portal.h"
 #endif
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 static const char *const TAG = "tuya";
 static const int COMMAND_DELAY = 10;
@@ -760,5 +759,4 @@ void Tuya::register_listener(uint8_t datapoint_id, const std::function<void(Tuya
 
 TuyaInitState Tuya::get_init_state() { return this->init_state_; }
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -13,8 +13,7 @@
 #include "esphome/core/time.h"
 #endif
 
-namespace esphome {
-namespace tuya {
+namespace esphome::tuya {
 
 enum class TuyaDatapointType : uint8_t {
   RAW = 0x00,      // variable length
@@ -162,5 +161,4 @@ class Tuya : public Component, public uart::UARTDevice {
   CallbackManager<void()> initialized_callback_{};
 };
 
-}  // namespace tuya
-}  // namespace esphome
+}  // namespace esphome::tuya

--- a/esphome/components/tx20/tx20.cpp
+++ b/esphome/components/tx20/tx20.cpp
@@ -4,8 +4,7 @@
 
 #include <array>
 
-namespace esphome {
-namespace tx20 {
+namespace esphome::tx20 {
 
 static const char *const TAG = "tx20";
 static const uint8_t MAX_BUFFER_SIZE = 41;
@@ -206,5 +205,4 @@ void IRAM_ATTR Tx20ComponentStore::reset() {
   start_time = 0;
 }
 
-}  // namespace tx20
-}  // namespace esphome
+}  // namespace esphome::tx20

--- a/esphome/components/tx20/tx20.h
+++ b/esphome/components/tx20/tx20.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace tx20 {
+namespace esphome::tx20 {
 
 /// Store data in a class that doesn't use multiple-inheritance (vtables in flash)
 struct Tx20ComponentStore {
@@ -47,5 +46,4 @@ class Tx20Component : public Component {
   Tx20ComponentStore store_;
 };
 
-}  // namespace tx20
-}  // namespace esphome
+}  // namespace esphome::tx20

--- a/esphome/components/udp/automation.h
+++ b/esphome/components/udp/automation.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace udp {
+namespace esphome::udp {
 
 template<typename... Ts> class UDPWriteAction : public Action<Ts...>, public Parented<UDPComponent> {
  public:
@@ -40,6 +39,6 @@ template<typename... Ts> class UDPWriteAction : public Action<Ts...>, public Par
   } data_;
 };
 
-}  // namespace udp
-}  // namespace esphome
+}  // namespace esphome::udp
+
 #endif

--- a/esphome/components/udp/packet_transport/udp_transport.cpp
+++ b/esphome/components/udp/packet_transport/udp_transport.cpp
@@ -3,8 +3,7 @@
 #include "esphome/components/network/util.h"
 #include "udp_transport.h"
 
-namespace esphome {
-namespace udp {
+namespace esphome::udp {
 
 static const char *const TAG = "udp_transport";
 
@@ -17,5 +16,4 @@ void UDPTransport::setup() {
 }
 
 void UDPTransport::send_packet(const std::vector<uint8_t> &buf) const { this->parent_->send_packet(buf); }
-}  // namespace udp
-}  // namespace esphome
+}  // namespace esphome::udp

--- a/esphome/components/udp/packet_transport/udp_transport.h
+++ b/esphome/components/udp/packet_transport/udp_transport.h
@@ -6,8 +6,7 @@
 #include "esphome/components/packet_transport/packet_transport.h"
 #include <vector>
 
-namespace esphome {
-namespace udp {
+namespace esphome::udp {
 
 class UDPTransport : public packet_transport::PacketTransport, public Parented<UDPComponent> {
  public:
@@ -21,6 +20,6 @@ class UDPTransport : public packet_transport::PacketTransport, public Parented<U
   size_t get_max_packet_size() override { return MAX_PACKET_SIZE; }
 };
 
-}  // namespace udp
-}  // namespace esphome
+}  // namespace esphome::udp
+
 #endif

--- a/esphome/components/ufire_ec/ufire_ec.cpp
+++ b/esphome/components/ufire_ec/ufire_ec.cpp
@@ -2,8 +2,7 @@
 #include "ufire_ec.h"
 #include <cmath>
 
-namespace esphome {
-namespace ufire_ec {
+namespace esphome::ufire_ec {
 
 static const char *const TAG = "ufire_ec";
 
@@ -122,5 +121,4 @@ void UFireECComponent::dump_config() {
   LOG_SENSOR("  ", "Temperature Sensor external", this->temperature_sensor_external_);
 }
 
-}  // namespace ufire_ec
-}  // namespace esphome
+}  // namespace esphome::ufire_ec

--- a/esphome/components/ufire_ec/ufire_ec.h
+++ b/esphome/components/ufire_ec/ufire_ec.h
@@ -6,8 +6,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ufire_ec {
+namespace esphome::ufire_ec {
 
 static const uint8_t CONFIG_TEMP_COMPENSATION = 0x02;
 
@@ -83,5 +82,4 @@ template<typename... Ts> class UFireECResetAction : public Action<Ts...> {
   UFireECComponent *parent_;
 };
 
-}  // namespace ufire_ec
-}  // namespace esphome
+}  // namespace esphome::ufire_ec

--- a/esphome/components/ufire_ise/ufire_ise.cpp
+++ b/esphome/components/ufire_ise/ufire_ise.cpp
@@ -3,8 +3,7 @@
 
 #include <cmath>
 
-namespace esphome {
-namespace ufire_ise {
+namespace esphome::ufire_ise {
 
 static const char *const TAG = "ufire_ise";
 
@@ -147,5 +146,4 @@ void UFireISEComponent::dump_config() {
   LOG_SENSOR("  ", "Temperature Sensor external", this->temperature_sensor_external_);
 }
 
-}  // namespace ufire_ise
-}  // namespace esphome
+}  // namespace esphome::ufire_ise

--- a/esphome/components/ufire_ise/ufire_ise.h
+++ b/esphome/components/ufire_ise/ufire_ise.h
@@ -6,8 +6,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace ufire_ise {
+namespace esphome::ufire_ise {
 
 static const float PROBE_MV_TO_PH = 59.2;
 static const float PROBE_TMP_CORRECTION = 0.03;
@@ -91,5 +90,4 @@ template<typename... Ts> class UFireISEResetAction : public Action<Ts...> {
   UFireISEComponent *parent_;
 };
 
-}  // namespace ufire_ise
-}  // namespace esphome
+}  // namespace esphome::ufire_ise

--- a/esphome/components/update/automation.h
+++ b/esphome/components/update/automation.h
@@ -4,8 +4,7 @@
 
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace update {
+namespace esphome::update {
 
 template<typename... Ts> class PerformAction : public Action<Ts...>, public Parented<UpdateEntity> {
   TEMPLATABLE_VALUE(bool, force)
@@ -24,5 +23,4 @@ template<typename... Ts> class IsAvailableCondition : public Condition<Ts...>, p
   bool check(const Ts &...x) override { return this->parent_->state == UPDATE_STATE_AVAILABLE; }
 };
 
-}  // namespace update
-}  // namespace esphome
+}  // namespace esphome::update

--- a/esphome/components/update/update_entity.cpp
+++ b/esphome/components/update/update_entity.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/progmem.h"
 
-namespace esphome {
-namespace update {
+namespace esphome::update {
 
 static const char *const TAG = "update";
 
@@ -49,5 +48,4 @@ void UpdateEntity::publish_state() {
 #endif
 }
 
-}  // namespace update
-}  // namespace esphome
+}  // namespace esphome::update

--- a/esphome/components/update/update_entity.h
+++ b/esphome/components/update/update_entity.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/entity_base.h"
 
-namespace esphome {
-namespace update {
+namespace esphome::update {
 
 struct UpdateInfo {
   std::string latest_version;
@@ -58,5 +57,4 @@ class UpdateEntity : public EntityBase {
   std::unique_ptr<Trigger<const UpdateInfo &>> update_available_trigger_{nullptr};
 };
 
-}  // namespace update
-}  // namespace esphome
+}  // namespace esphome::update

--- a/esphome/components/uponor_smatrix/climate/uponor_smatrix_climate.cpp
+++ b/esphome/components/uponor_smatrix/climate/uponor_smatrix_climate.cpp
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace uponor_smatrix {
+namespace esphome::uponor_smatrix {
 
 static const char *const TAG = "uponor_smatrix.climate";
 
@@ -100,5 +99,4 @@ void UponorSmatrixClimate::on_device_data(const UponorSmatrixData *data, size_t 
   this->last_data_ = millis();
 }
 
-}  // namespace uponor_smatrix
-}  // namespace esphome
+}  // namespace esphome::uponor_smatrix

--- a/esphome/components/uponor_smatrix/climate/uponor_smatrix_climate.h
+++ b/esphome/components/uponor_smatrix/climate/uponor_smatrix_climate.h
@@ -4,8 +4,7 @@
 #include "esphome/components/uponor_smatrix/uponor_smatrix.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace uponor_smatrix {
+namespace esphome::uponor_smatrix {
 
 class UponorSmatrixClimate : public climate::Climate, public Component, public UponorSmatrixDevice {
  public:
@@ -24,5 +23,4 @@ class UponorSmatrixClimate : public climate::Climate, public Component, public U
   uint16_t target_temperature_raw_;
 };
 
-}  // namespace uponor_smatrix
-}  // namespace esphome
+}  // namespace esphome::uponor_smatrix

--- a/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.cpp
+++ b/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.cpp
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace uponor_smatrix {
+namespace esphome::uponor_smatrix {
 
 static const char *const TAG = "uponor_smatrix.sensor";
 
@@ -42,5 +41,4 @@ void UponorSmatrixSensor::on_device_data(const UponorSmatrixData *data, size_t d
   }
 }
 
-}  // namespace uponor_smatrix
-}  // namespace esphome
+}  // namespace esphome::uponor_smatrix

--- a/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.h
+++ b/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.h
@@ -4,8 +4,7 @@
 #include "esphome/components/uponor_smatrix/uponor_smatrix.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace uponor_smatrix {
+namespace esphome::uponor_smatrix {
 
 class UponorSmatrixSensor : public sensor::Sensor, public Component, public UponorSmatrixDevice {
   SUB_SENSOR(temperature)
@@ -20,5 +19,4 @@ class UponorSmatrixSensor : public sensor::Sensor, public Component, public Upon
   void on_device_data(const UponorSmatrixData *data, size_t data_len) override;
 };
 
-}  // namespace uponor_smatrix
-}  // namespace esphome
+}  // namespace esphome::uponor_smatrix

--- a/esphome/components/uponor_smatrix/uponor_smatrix.cpp
+++ b/esphome/components/uponor_smatrix/uponor_smatrix.cpp
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace uponor_smatrix {
+namespace esphome::uponor_smatrix {
 
 static const char *const TAG = "uponor_smatrix";
 
@@ -221,5 +220,4 @@ bool UponorSmatrixComponent::do_send_time_() {
 }
 #endif
 
-}  // namespace uponor_smatrix
-}  // namespace esphome
+}  // namespace esphome::uponor_smatrix

--- a/esphome/components/uponor_smatrix/uponor_smatrix.h
+++ b/esphome/components/uponor_smatrix/uponor_smatrix.h
@@ -15,8 +15,7 @@
 #include <set>
 #include <vector>
 
-namespace esphome {
-namespace uponor_smatrix {
+namespace esphome::uponor_smatrix {
 
 /// Date/Time Part 1 (year, month, day of week)
 static const uint8_t UPONOR_ID_DATETIME1 = 0x08;
@@ -123,5 +122,4 @@ inline uint16_t celsius_to_raw(float celsius) {
                              : static_cast<uint16_t>(lroundf(celsius_to_fahrenheit(celsius) * 10.0f));
 }
 
-}  // namespace uponor_smatrix
-}  // namespace esphome
+}  // namespace esphome::uponor_smatrix

--- a/esphome/components/valve/automation.h
+++ b/esphome/components/valve/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "valve.h"
 
-namespace esphome {
-namespace valve {
+namespace esphome::valve {
 
 template<typename... Ts> class OpenAction : public Action<Ts...> {
  public:
@@ -121,5 +120,4 @@ class ValveClosedTrigger : public Trigger<> {
   Valve *valve_;
 };
 
-}  // namespace valve
-}  // namespace esphome
+}  // namespace esphome::valve

--- a/esphome/components/valve/valve.cpp
+++ b/esphome/components/valve/valve.cpp
@@ -6,8 +6,7 @@
 
 #include <strings.h>
 
-namespace esphome {
-namespace valve {
+namespace esphome::valve {
 
 static const char *const TAG = "valve";
 
@@ -176,5 +175,4 @@ void ValveRestoreState::apply(Valve *valve) {
   valve->publish_state();
 }
 
-}  // namespace valve
-}  // namespace esphome
+}  // namespace esphome::valve

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -7,8 +7,7 @@
 #include "esphome/core/preferences.h"
 #include "valve_traits.h"
 
-namespace esphome {
-namespace valve {
+namespace esphome::valve {
 
 const extern float VALVE_OPEN;
 const extern float VALVE_CLOSED;
@@ -147,5 +146,4 @@ class Valve : public EntityBase {
   ESPPreferenceObject rtc_;
 };
 
-}  // namespace valve
-}  // namespace esphome
+}  // namespace esphome::valve

--- a/esphome/components/valve/valve_traits.h
+++ b/esphome/components/valve/valve_traits.h
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace esphome {
-namespace valve {
+namespace esphome::valve {
 
 class ValveTraits {
  public:
@@ -23,5 +22,4 @@ class ValveTraits {
   bool supports_stop_{false};
 };
 
-}  // namespace valve
-}  // namespace esphome
+}  // namespace esphome::valve

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace vbus {
+namespace esphome::vbus {
 
 static const char *const TAG = "vbus.binary_sensor";
 
@@ -199,5 +198,4 @@ void VBusCustomSubBSensor::parse_message(std::vector<uint8_t> &message) {
   this->publish_state(this->message_parser_(message));
 }
 
-}  // namespace vbus
-}  // namespace esphome
+}  // namespace esphome::vbus

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
@@ -3,8 +3,7 @@
 #include "../vbus.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace vbus {
+namespace esphome::vbus {
 
 class DeltaSolBSPlusBSensor : public VBusListener, public Component {
  public:
@@ -166,5 +165,4 @@ class VBusCustomSubBSensor : public binary_sensor::BinarySensor, public Componen
   message_parser_t message_parser_;
 };
 
-}  // namespace vbus
-}  // namespace esphome
+}  // namespace esphome::vbus

--- a/esphome/components/vbus/sensor/vbus_sensor.cpp
+++ b/esphome/components/vbus/sensor/vbus_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace vbus {
+namespace esphome::vbus {
 
 static const char *const TAG = "vbus.sensor";
 
@@ -337,5 +336,4 @@ void VBusCustomSubSensor::parse_message(std::vector<uint8_t> &message) {
   this->publish_state(this->message_parser_(message));
 }
 
-}  // namespace vbus
-}  // namespace esphome
+}  // namespace esphome::vbus

--- a/esphome/components/vbus/sensor/vbus_sensor.h
+++ b/esphome/components/vbus/sensor/vbus_sensor.h
@@ -3,8 +3,7 @@
 #include "../vbus.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace vbus {
+namespace esphome::vbus {
 
 class DeltaSolBSPlusSensor : public VBusListener, public Component {
  public:
@@ -243,5 +242,4 @@ class VBusCustomSubSensor : public sensor::Sensor, public Component {
   message_parser_t message_parser_;
 };
 
-}  // namespace vbus
-}  // namespace esphome
+}  // namespace esphome::vbus

--- a/esphome/components/vbus/vbus.cpp
+++ b/esphome/components/vbus/vbus.cpp
@@ -4,8 +4,7 @@
 #include <algorithm>
 #include <cinttypes>
 
-namespace esphome {
-namespace vbus {
+namespace esphome::vbus {
 
 static const char *const TAG = "vbus";
 
@@ -131,5 +130,4 @@ void VBusListener::on_message(uint16_t command, uint16_t source, uint16_t dest, 
   this->handle_message(message);
 }
 
-}  // namespace vbus
-}  // namespace esphome
+}  // namespace esphome::vbus

--- a/esphome/components/vbus/vbus.h
+++ b/esphome/components/vbus/vbus.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace vbus {
+namespace esphome::vbus {
 
 using message_parser_t = std::function<float(std::vector<uint8_t> &)>;
 
@@ -47,5 +46,4 @@ class VBus : public uart::UARTDevice, public Component {
   std::vector<VBusListener *> listeners_{};
 };
 
-}  // namespace vbus
-}  // namespace esphome
+}  // namespace esphome::vbus

--- a/esphome/components/veml3235/veml3235.cpp
+++ b/esphome/components/veml3235/veml3235.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace veml3235 {
+namespace esphome::veml3235 {
 
 static const char *const TAG = "veml3235.sensor";
 
@@ -225,5 +224,4 @@ void VEML3235Sensor::dump_config() {
                 digital_gain, gain, integration_time);
 }
 
-}  // namespace veml3235
-}  // namespace esphome
+}  // namespace esphome::veml3235

--- a/esphome/components/veml3235/veml3235.h
+++ b/esphome/components/veml3235/veml3235.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace veml3235 {
+namespace esphome::veml3235 {
 
 // Register IDs/locations
 //
@@ -104,5 +103,4 @@ class VEML3235Sensor : public sensor::Sensor, public PollingComponent, public i2
   VEML3235ComponentIntegrationTime integration_time_{VEML3235_INTEGRATION_TIME_50MS};
 };
 
-}  // namespace veml3235
-}  // namespace esphome
+}  // namespace esphome::veml3235

--- a/esphome/components/veml7700/veml7700.cpp
+++ b/esphome/components/veml7700/veml7700.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include <limits>
 
-namespace esphome {
-namespace veml7700 {
+namespace esphome::veml7700 {
 
 static const char *const TAG = "veml7700";
 static const size_t VEML_REG_SIZE = 2;
@@ -434,5 +433,4 @@ void VEML7700Component::publish_data_part_3_(Readings &data) {
     this->actual_integration_time_sensor_->publish_state(get_itime_ms(data.actual_time));
   }
 }
-}  // namespace veml7700
-}  // namespace esphome
+}  // namespace esphome::veml7700

--- a/esphome/components/veml7700/veml7700.h
+++ b/esphome/components/veml7700/veml7700.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace veml7700 {
+namespace esphome::veml7700 {
 
 using esphome::i2c::ErrorCode;
 
@@ -196,5 +195,4 @@ class VEML7700Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *actual_integration_time_sensor_{nullptr};  // Actual integration time for the measurement
 };
 
-}  // namespace veml7700
-}  // namespace esphome
+}  // namespace esphome::veml7700

--- a/esphome/components/vl53l0x/vl53l0x_sensor.cpp
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.cpp
@@ -12,8 +12,7 @@
  * in the vl53l0x integration directory.
  */
 
-namespace esphome {
-namespace vl53l0x {
+namespace esphome::vl53l0x {
 
 static const char *const TAG = "vl53l0x";
 
@@ -535,5 +534,4 @@ bool VL53L0XSensor::perform_single_ref_calibration_(uint8_t vhv_init_byte) {
   return true;
 }
 
-}  // namespace vl53l0x
-}  // namespace esphome
+}  // namespace esphome::vl53l0x

--- a/esphome/components/vl53l0x/vl53l0x_sensor.h
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.h
@@ -7,8 +7,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace vl53l0x {
+namespace esphome::vl53l0x {
 
 struct SequenceStepEnables {
   bool tcc, msrc, dss, pre_range, final_range;
@@ -70,5 +69,4 @@ class VL53L0XSensor : public sensor::Sensor, public PollingComponent, public i2c
   static bool enable_pin_setup_complete;           // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 };
 
-}  // namespace vl53l0x
-}  // namespace esphome
+}  // namespace esphome::vl53l0x

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -9,8 +9,7 @@
 #include <cinttypes>
 #include <cstdio>
 
-namespace esphome {
-namespace voice_assistant {
+namespace esphome::voice_assistant {
 
 static const char *const TAG = "voice_assistant";
 
@@ -1007,7 +1006,6 @@ const Configuration &VoiceAssistant::get_configuration() {
 
 VoiceAssistant *global_voice_assistant = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace voice_assistant
-}  // namespace esphome
+}  // namespace esphome::voice_assistant
 
 #endif  // USE_VOICE_ASSISTANT

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -26,8 +26,7 @@
 #include <span>
 #include <vector>
 
-namespace esphome {
-namespace voice_assistant {
+namespace esphome::voice_assistant {
 
 // Version 1: Initial version
 // Version 2: Adds raw speaker support
@@ -367,7 +366,6 @@ template<typename... Ts> class ConnectedCondition : public Condition<Ts...>, pub
 
 extern VoiceAssistant *global_voice_assistant;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace voice_assistant
-}  // namespace esphome
+}  // namespace esphome::voice_assistant
 
 #endif  // USE_VOICE_ASSISTANT

--- a/esphome/components/voltage_sampler/voltage_sampler.h
+++ b/esphome/components/voltage_sampler/voltage_sampler.h
@@ -2,8 +2,7 @@
 
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace voltage_sampler {
+namespace esphome::voltage_sampler {
 
 /// Abstract interface for components to request voltage (usually ADC readings)
 class VoltageSampler {
@@ -12,5 +11,4 @@ class VoltageSampler {
   virtual float sample() = 0;
 };
 
-}  // namespace voltage_sampler
-}  // namespace esphome
+}  // namespace esphome::voltage_sampler

--- a/esphome/components/wake_on_lan/wake_on_lan.cpp
+++ b/esphome/components/wake_on_lan/wake_on_lan.cpp
@@ -4,8 +4,7 @@
 #include "esphome/components/network/ip_address.h"
 #include "esphome/components/network/util.h"
 
-namespace esphome {
-namespace wake_on_lan {
+namespace esphome::wake_on_lan {
 
 static const char *const TAG = "wake_on_lan.button";
 static const uint8_t PREFIX[6] = {255, 255, 255, 255, 255, 255};
@@ -84,6 +83,6 @@ void WakeOnLanButton::setup() {
 #endif
 }
 
-}  // namespace wake_on_lan
-}  // namespace esphome
+}  // namespace esphome::wake_on_lan
+
 #endif

--- a/esphome/components/wake_on_lan/wake_on_lan.h
+++ b/esphome/components/wake_on_lan/wake_on_lan.h
@@ -9,8 +9,7 @@
 #include "WiFiUdp.h"
 #endif
 
-namespace esphome {
-namespace wake_on_lan {
+namespace esphome::wake_on_lan {
 
 class WakeOnLanButton : public button::Button, public Component {
  public:
@@ -31,6 +30,6 @@ class WakeOnLanButton : public button::Button, public Component {
   uint8_t macaddr_[6];
 };
 
-}  // namespace wake_on_lan
-}  // namespace esphome
+}  // namespace esphome::wake_on_lan
+
 #endif

--- a/esphome/components/watchdog/watchdog.cpp
+++ b/esphome/components/watchdog/watchdog.cpp
@@ -14,8 +14,7 @@
 #include "pico/stdlib.h"
 #endif
 
-namespace esphome {
-namespace watchdog {
+namespace esphome::watchdog {
 
 static const char *const TAG = "http_request.watchdog";
 
@@ -75,5 +74,4 @@ uint32_t WatchdogManager::get_timeout_() {
   return timeout_ms;
 }
 
-}  // namespace watchdog
-}  // namespace esphome
+}  // namespace esphome::watchdog

--- a/esphome/components/watchdog/watchdog.h
+++ b/esphome/components/watchdog/watchdog.h
@@ -4,8 +4,7 @@
 
 #include <cstdint>
 
-namespace esphome {
-namespace watchdog {
+namespace esphome::watchdog {
 
 class WatchdogManager {
  public:
@@ -20,5 +19,4 @@ class WatchdogManager {
   uint32_t timeout_ms_{0};
 };
 
-}  // namespace watchdog
-}  // namespace esphome
+}  // namespace esphome::watchdog

--- a/esphome/components/waveshare_epaper/waveshare_213v3.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_213v3.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace waveshare_epaper {
+namespace esphome::waveshare_epaper {
 
 static const char *const TAG = "waveshare_2.13v3";
 
@@ -188,5 +187,4 @@ void WaveshareEPaper2P13InV3::set_full_update_every(uint32_t full_update_every) 
   this->full_update_every_ = full_update_every;
 }
 
-}  // namespace waveshare_epaper
-}  // namespace esphome
+}  // namespace esphome::waveshare_epaper

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace waveshare_epaper {
+namespace esphome::waveshare_epaper {
 
 static const char *const TAG = "waveshare_epaper";
 
@@ -4770,5 +4769,4 @@ void WaveshareEPaper13P3InK::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace waveshare_epaper
-}  // namespace esphome
+}  // namespace esphome::waveshare_epaper

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -4,8 +4,7 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/display/display_buffer.h"
 
-namespace esphome {
-namespace waveshare_epaper {
+namespace esphome::waveshare_epaper {
 
 class WaveshareEPaperBase : public display::DisplayBuffer,
                             public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
@@ -1099,5 +1098,4 @@ class WaveshareEPaper13P3InK : public WaveshareEPaper {
   uint32_t idle_timeout_() override;
 };
 
-}  // namespace waveshare_epaper
-}  // namespace esphome
+}  // namespace esphome::waveshare_epaper

--- a/esphome/components/weikai/weikai.cpp
+++ b/esphome/components/weikai/weikai.cpp
@@ -6,8 +6,7 @@
 #include "weikai.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace weikai {
+namespace esphome::weikai {
 
 static const char *const TAG = "weikai";
 
@@ -567,5 +566,4 @@ bool WeikaiChannel::uart_receive_test_(char *message) {
 /// @}
 #endif
 
-}  // namespace weikai
-}  // namespace esphome
+}  // namespace esphome::weikai

--- a/esphome/components/weikai/weikai.h
+++ b/esphome/components/weikai/weikai.h
@@ -25,8 +25,7 @@
 /// @endcode
 // #define TEST_COMPONENT
 
-namespace esphome {
-namespace weikai {
+namespace esphome::weikai {
 
 /// @brief XFER_MAX_SIZE defines the maximum number of bytes allowed during one transfer.
 #if defined(I2C_BUFFER_LENGTH)
@@ -440,5 +439,4 @@ class WeikaiChannel : public uart::UARTComponent {
   std::string name_;         ///< name of the entity
 };
 
-}  // namespace weikai
-}  // namespace esphome
+}  // namespace esphome::weikai

--- a/esphome/components/weikai/wk_reg_def.h
+++ b/esphome/components/weikai/wk_reg_def.h
@@ -4,8 +4,7 @@
 /// @date Last Modified: 2024/02/18 15:49:18
 #pragma once
 
-namespace esphome {
-namespace weikai {
+namespace esphome::weikai {
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// Definition of the WeiKai registers
@@ -300,5 +299,4 @@ constexpr uint8_t WKREG_TFI = 0x08;
 
 /// @}
 /// @}
-}  // namespace weikai
-}  // namespace esphome
+}  // namespace esphome::weikai

--- a/esphome/components/weikai_i2c/weikai_i2c.cpp
+++ b/esphome/components/weikai_i2c/weikai_i2c.cpp
@@ -5,8 +5,7 @@
 
 #include "weikai_i2c.h"
 
-namespace esphome {
-namespace weikai_i2c {
+namespace esphome::weikai_i2c {
 static const char *const TAG = "weikai_i2c";
 
 /// @brief Display a buffer in hexadecimal format (32 hex values / line).
@@ -177,5 +176,4 @@ void WeikaiComponentI2C::dump_config() {
   }
 }
 
-}  // namespace weikai_i2c
-}  // namespace esphome
+}  // namespace esphome::weikai_i2c

--- a/esphome/components/weikai_i2c/weikai_i2c.h
+++ b/esphome/components/weikai_i2c/weikai_i2c.h
@@ -13,8 +13,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/weikai/weikai.h"
 
-namespace esphome {
-namespace weikai_i2c {
+namespace esphome::weikai_i2c {
 
 class WeikaiComponentI2C;
 
@@ -57,5 +56,4 @@ class WeikaiComponentI2C : public weikai::WeikaiComponent, public i2c::I2CDevice
   WeikaiRegisterI2C reg_i2c_{this, 0, 0};  ///< init to this component
 };
 
-}  // namespace weikai_i2c
-}  // namespace esphome
+}  // namespace esphome::weikai_i2c

--- a/esphome/components/weikai_spi/weikai_spi.cpp
+++ b/esphome/components/weikai_spi/weikai_spi.cpp
@@ -5,8 +5,7 @@
 
 #include "weikai_spi.h"
 
-namespace esphome {
-namespace weikai_spi {
+namespace esphome::weikai_spi {
 using namespace weikai;
 static const char *const TAG = "weikai_spi";
 
@@ -187,5 +186,4 @@ void WeikaiComponentSPI::dump_config() {
   }
 }
 
-}  // namespace weikai_spi
-}  // namespace esphome
+}  // namespace esphome::weikai_spi

--- a/esphome/components/weikai_spi/weikai_spi.h
+++ b/esphome/components/weikai_spi/weikai_spi.h
@@ -12,8 +12,7 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/weikai/weikai.h"
 
-namespace esphome {
-namespace weikai_spi {
+namespace esphome::weikai_spi {
 ////////////////////////////////////////////////////////////////////////////////////
 /// @brief WeikaiRegisterSPI objects acts as proxies to access remote register through an SPI Bus
 ////////////////////////////////////////////////////////////////////////////////////
@@ -49,5 +48,4 @@ class WeikaiComponentSPI : public weikai::WeikaiComponent,
   WeikaiRegisterSPI reg_spi_{this, 0, 0};  ///< init to this component
 };
 
-}  // namespace weikai_spi
-}  // namespace esphome
+}  // namespace esphome::weikai_spi

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -1,8 +1,7 @@
 #include "whirlpool.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace whirlpool {
+namespace esphome::whirlpool {
 
 static const char *const TAG = "whirlpool.climate";
 
@@ -307,5 +306,4 @@ bool WhirlpoolClimate::on_receive(remote_base::RemoteReceiveData data) {
   return true;
 }
 
-}  // namespace whirlpool
-}  // namespace esphome
+}  // namespace esphome::whirlpool

--- a/esphome/components/whirlpool/whirlpool.h
+++ b/esphome/components/whirlpool/whirlpool.h
@@ -2,8 +2,7 @@
 
 #include "esphome/components/climate_ir/climate_ir.h"
 
-namespace esphome {
-namespace whirlpool {
+namespace esphome::whirlpool {
 
 /// Simple enum to represent models.
 enum Model {
@@ -61,5 +60,4 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
   }
 };
 
-}  // namespace whirlpool
-}  // namespace esphome
+}  // namespace esphome::whirlpool

--- a/esphome/components/whynter/whynter.cpp
+++ b/esphome/components/whynter/whynter.cpp
@@ -1,8 +1,7 @@
 #include "whynter.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace whynter {
+namespace esphome::whynter {
 
 static const char *const TAG = "climate.whynter";
 
@@ -177,5 +176,4 @@ void Whynter::transmit_(uint32_t value) {
   transmit.perform();
 }
 
-}  // namespace whynter
-}  // namespace esphome
+}  // namespace esphome::whynter

--- a/esphome/components/whynter/whynter.h
+++ b/esphome/components/whynter/whynter.h
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace whynter {
+namespace esphome::whynter {
 
 // Temperature
 const uint8_t TEMP_MIN_C = 16;  // Celsius
@@ -49,5 +48,4 @@ class Whynter : public climate_ir::ClimateIR {
   climate::ClimateMode mode_before_{climate::CLIMATE_MODE_OFF};
 };
 
-}  // namespace whynter
-}  // namespace esphome
+}  // namespace esphome::whynter

--- a/esphome/components/wiegand/wiegand.cpp
+++ b/esphome/components/wiegand/wiegand.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace wiegand {
+namespace esphome::wiegand {
 
 static const char *const TAG = "wiegand";
 static const char *const KEYS = "0123456789*#";
@@ -127,5 +126,4 @@ void Wiegand::dump_config() {
   LOG_PIN("  D1 pin: ", this->d1_pin_);
 }
 
-}  // namespace wiegand
-}  // namespace esphome
+}  // namespace esphome::wiegand

--- a/esphome/components/wiegand/wiegand.h
+++ b/esphome/components/wiegand/wiegand.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace wiegand {
+namespace esphome::wiegand {
 
 class Wiegand;
 
@@ -50,5 +49,4 @@ class Wiegand : public key_provider::KeyProvider, public Component {
   std::vector<WiegandKeyTrigger *> key_triggers_;
 };
 
-}  // namespace wiegand
-}  // namespace esphome
+}  // namespace esphome::wiegand

--- a/esphome/components/wk2132_i2c/wk2132_i2c.cpp
+++ b/esphome/components/wk2132_i2c/wk2132_i2c.cpp
@@ -1,4 +1,2 @@
 /* compiling with esp-idf framework requires a .cpp file for some reason ? */
-namespace esphome {
-namespace wk2132_i2c {}
-}  // namespace esphome
+namespace esphome::wk2132_i2c {}  // namespace esphome::wk2132_i2c

--- a/esphome/components/wl_134/wl_134.cpp
+++ b/esphome/components/wl_134/wl_134.cpp
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace wl_134 {
+namespace esphome::wl_134 {
 
 static const char *const TAG = "wl_134.sensor";
 static const uint8_t ASCII_CR = 0x0D;
@@ -114,5 +113,4 @@ void Wl134Component::dump_config() {
   // As specified in the sensor's data sheet
   this->check_uart_settings(9600, 1, esphome::uart::UART_CONFIG_PARITY_NONE, 8);
 }
-}  // namespace wl_134
-}  // namespace esphome
+}  // namespace esphome::wl_134

--- a/esphome/components/wl_134/wl_134.h
+++ b/esphome/components/wl_134/wl_134.h
@@ -6,8 +6,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace wl_134 {
+namespace esphome::wl_134 {
 
 class Wl134Component : public text_sensor::TextSensor, public Component, public uart::UARTDevice {
  public:
@@ -59,5 +58,4 @@ class Wl134Component : public text_sensor::TextSensor, public Component, public 
   uint64_t hex_lsb_ascii_to_uint64_(const uint8_t *text, uint8_t text_size);
 };
 
-}  // namespace wl_134
-}  // namespace esphome
+}  // namespace esphome::wl_134

--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -17,8 +17,7 @@
 #include <WiFiUdp.h>
 #endif
 
-namespace esphome {
-namespace wled {
+namespace esphome::wled {
 
 // Description of protocols:
 // https://github.com/Aircoookie/WLED/wiki/UDP-Realtime-Control
@@ -284,7 +283,6 @@ bool WLEDLightEffect::parse_dnrgb_frame_(light::AddressableLight &it, const uint
   return true;
 }
 
-}  // namespace wled
-}  // namespace esphome
+}  // namespace esphome::wled
 
 #endif  // USE_ARDUINO

--- a/esphome/components/wled/wled_light_effect.h
+++ b/esphome/components/wled/wled_light_effect.h
@@ -10,8 +10,7 @@
 
 class UDP;
 
-namespace esphome {
-namespace wled {
+namespace esphome::wled {
 
 class WLEDLightEffect : public light::AddressableLightEffect {
  public:
@@ -42,7 +41,6 @@ class WLEDLightEffect : public light::AddressableLightEffect {
   bool blank_on_start_{true};
 };
 
-}  // namespace wled
-}  // namespace esphome
+}  // namespace esphome::wled
 
 #endif  // USE_ARDUINO

--- a/esphome/components/wts01/wts01.cpp
+++ b/esphome/components/wts01/wts01.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <cmath>
 
-namespace esphome {
-namespace wts01 {
+namespace esphome::wts01 {
 
 constexpr uint8_t HEADER_1 = 0x55;
 constexpr uint8_t HEADER_2 = 0x01;
@@ -90,5 +89,4 @@ void WTS01Sensor::process_packet_() {
   this->publish_state(temperature);
 }
 
-}  // namespace wts01
-}  // namespace esphome
+}  // namespace esphome::wts01

--- a/esphome/components/wts01/wts01.h
+++ b/esphome/components/wts01/wts01.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace wts01 {
+namespace esphome::wts01 {
 
 constexpr uint8_t PACKET_SIZE = 9;
 
@@ -22,5 +21,4 @@ class WTS01Sensor : public sensor::Sensor, public uart::UARTDevice, public Compo
   void process_packet_();
 };
 
-}  // namespace wts01
-}  // namespace esphome
+}  // namespace esphome::wts01

--- a/esphome/components/x9c/x9c.cpp
+++ b/esphome/components/x9c/x9c.cpp
@@ -1,8 +1,7 @@
 #include "x9c.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace x9c {
+namespace esphome::x9c {
 
 static const char *const TAG = "x9c.output";
 
@@ -73,5 +72,4 @@ void X9cOutput::dump_config() {
   LOG_FLOAT_OUTPUT(this);
 }
 
-}  // namespace x9c
-}  // namespace esphome
+}  // namespace esphome::x9c

--- a/esphome/components/x9c/x9c.h
+++ b/esphome/components/x9c/x9c.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/output/float_output.h"
 
-namespace esphome {
-namespace x9c {
+namespace esphome::x9c {
 
 class X9cOutput : public output::FloatOutput, public Component {
  public:
@@ -30,5 +29,4 @@ class X9cOutput : public output::FloatOutput, public Component {
   int step_delay_{0};
 };
 
-}  // namespace x9c
-}  // namespace esphome
+}  // namespace esphome::x9c

--- a/esphome/components/xgzp68xx/xgzp68xx.cpp
+++ b/esphome/components/xgzp68xx/xgzp68xx.cpp
@@ -6,8 +6,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace xgzp68xx {
+namespace esphome::xgzp68xx {
 
 static const char *const TAG = "xgzp68xx.sensor";
 
@@ -118,5 +117,4 @@ void XGZP68XXComponent::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace xgzp68xx
-}  // namespace esphome
+}  // namespace esphome::xgzp68xx

--- a/esphome/components/xgzp68xx/xgzp68xx.h
+++ b/esphome/components/xgzp68xx/xgzp68xx.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace xgzp68xx {
+namespace esphome::xgzp68xx {
 
 /// Enum listing all oversampling options for the XGZP68XX.
 enum XGZP68XXOversampling : uint8_t {
@@ -43,5 +42,4 @@ class XGZP68XXComponent : public PollingComponent, public sensor::Sensor, public
   XGZP68XXOversampling last_pressure_oversampling_{XGZP68XX_OVERSAMPLING_UNKNOWN};
 };
 
-}  // namespace xgzp68xx
-}  // namespace esphome
+}  // namespace esphome::xgzp68xx

--- a/esphome/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.cpp
@@ -12,8 +12,7 @@
 #include "mbedtls/ccm.h"
 #endif
 
-namespace esphome {
-namespace xiaomi_ble {
+namespace esphome::xiaomi_ble {
 
 static const char *const TAG = "xiaomi_ble";
 
@@ -460,7 +459,6 @@ bool XiaomiListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   return false;  // with true it's not showing device scans
 }
 
-}  // namespace xiaomi_ble
-}  // namespace esphome
+}  // namespace esphome::xiaomi_ble
 
 #endif

--- a/esphome/components/xiaomi_ble/xiaomi_ble.h
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_ble {
+namespace esphome::xiaomi_ble {
 
 struct XiaomiParseResult {
   enum {
@@ -78,7 +77,6 @@ class XiaomiListener : public esp32_ble_tracker::ESPBTDeviceListener {
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 };
 
-}  // namespace xiaomi_ble
-}  // namespace esphome
+}  // namespace esphome::xiaomi_ble
 
 #endif

--- a/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
+++ b/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_cgd1 {
+namespace esphome::xiaomi_cgd1 {
 
 static const char *const TAG = "xiaomi_cgd1";
 
@@ -65,7 +64,6 @@ bool XiaomiCGD1::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
 
 void XiaomiCGD1::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
-}  // namespace xiaomi_cgd1
-}  // namespace esphome
+}  // namespace esphome::xiaomi_cgd1
 
 #endif

--- a/esphome/components/xiaomi_cgd1/xiaomi_cgd1.h
+++ b/esphome/components/xiaomi_cgd1/xiaomi_cgd1.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_cgd1 {
+namespace esphome::xiaomi_cgd1 {
 
 class XiaomiCGD1 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -29,7 +28,6 @@ class XiaomiCGD1 : public Component, public esp32_ble_tracker::ESPBTDeviceListen
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_cgd1
-}  // namespace esphome
+}  // namespace esphome::xiaomi_cgd1
 
 #endif

--- a/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
+++ b/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_cgdk2 {
+namespace esphome::xiaomi_cgdk2 {
 
 static const char *const TAG = "xiaomi_cgdk2";
 
@@ -65,7 +64,6 @@ bool XiaomiCGDK2::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
 
 void XiaomiCGDK2::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
-}  // namespace xiaomi_cgdk2
-}  // namespace esphome
+}  // namespace esphome::xiaomi_cgdk2
 
 #endif

--- a/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.h
+++ b/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_cgdk2 {
+namespace esphome::xiaomi_cgdk2 {
 
 class XiaomiCGDK2 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -29,7 +28,6 @@ class XiaomiCGDK2 : public Component, public esp32_ble_tracker::ESPBTDeviceListe
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_cgdk2
-}  // namespace esphome
+}  // namespace esphome::xiaomi_cgdk2
 
 #endif

--- a/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
+++ b/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_cgg1 {
+namespace esphome::xiaomi_cgg1 {
 
 static const char *const TAG = "xiaomi_cgg1";
 
@@ -65,7 +64,6 @@ bool XiaomiCGG1::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
 
 void XiaomiCGG1::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
-}  // namespace xiaomi_cgg1
-}  // namespace esphome
+}  // namespace esphome::xiaomi_cgg1
 
 #endif

--- a/esphome/components/xiaomi_cgg1/xiaomi_cgg1.h
+++ b/esphome/components/xiaomi_cgg1/xiaomi_cgg1.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_cgg1 {
+namespace esphome::xiaomi_cgg1 {
 
 class XiaomiCGG1 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -30,7 +29,6 @@ class XiaomiCGG1 : public Component, public esp32_ble_tracker::ESPBTDeviceListen
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_cgg1
-}  // namespace esphome
+}  // namespace esphome::xiaomi_cgg1
 
 #endif

--- a/esphome/components/xiaomi_cgpr1/xiaomi_cgpr1.cpp
+++ b/esphome/components/xiaomi_cgpr1/xiaomi_cgpr1.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_cgpr1 {
+namespace esphome::xiaomi_cgpr1 {
 
 static const char *const TAG = "xiaomi_cgpr1";
 
@@ -62,7 +61,6 @@ bool XiaomiCGPR1::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
 
 void XiaomiCGPR1::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
-}  // namespace xiaomi_cgpr1
-}  // namespace esphome
+}  // namespace esphome::xiaomi_cgpr1
 
 #endif

--- a/esphome/components/xiaomi_cgpr1/xiaomi_cgpr1.h
+++ b/esphome/components/xiaomi_cgpr1/xiaomi_cgpr1.h
@@ -8,8 +8,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_cgpr1 {
+namespace esphome::xiaomi_cgpr1 {
 
 class XiaomiCGPR1 : public Component,
                     public binary_sensor::BinarySensorInitiallyOff,
@@ -33,7 +32,6 @@ class XiaomiCGPR1 : public Component,
   sensor::Sensor *illuminance_{nullptr};
 };
 
-}  // namespace xiaomi_cgpr1
-}  // namespace esphome
+}  // namespace esphome::xiaomi_cgpr1
 
 #endif

--- a/esphome/components/xiaomi_gcls002/xiaomi_gcls002.cpp
+++ b/esphome/components/xiaomi_gcls002/xiaomi_gcls002.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_gcls002 {
+namespace esphome::xiaomi_gcls002 {
 
 static const char *const TAG = "xiaomi_gcls002";
 
@@ -58,7 +57,6 @@ bool XiaomiGCLS002::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return success;
 }
 
-}  // namespace xiaomi_gcls002
-}  // namespace esphome
+}  // namespace esphome::xiaomi_gcls002
 
 #endif

--- a/esphome/components/xiaomi_gcls002/xiaomi_gcls002.h
+++ b/esphome/components/xiaomi_gcls002/xiaomi_gcls002.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_gcls002 {
+namespace esphome::xiaomi_gcls002 {
 
 class XiaomiGCLS002 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -30,7 +29,6 @@ class XiaomiGCLS002 : public Component, public esp32_ble_tracker::ESPBTDeviceLis
   sensor::Sensor *illuminance_{nullptr};
 };
 
-}  // namespace xiaomi_gcls002
-}  // namespace esphome
+}  // namespace esphome::xiaomi_gcls002
 
 #endif

--- a/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.cpp
+++ b/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_hhccjcy01 {
+namespace esphome::xiaomi_hhccjcy01 {
 
 static const char *const TAG = "xiaomi_hhccjcy01";
 
@@ -61,7 +60,6 @@ bool XiaomiHHCCJCY01::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
   return success;
 }
 
-}  // namespace xiaomi_hhccjcy01
-}  // namespace esphome
+}  // namespace esphome::xiaomi_hhccjcy01
 
 #endif

--- a/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.h
+++ b/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_hhccjcy01 {
+namespace esphome::xiaomi_hhccjcy01 {
 
 class XiaomiHHCCJCY01 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -32,7 +31,6 @@ class XiaomiHHCCJCY01 : public Component, public esp32_ble_tracker::ESPBTDeviceL
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_hhccjcy01
-}  // namespace esphome
+}  // namespace esphome::xiaomi_hhccjcy01
 
 #endif

--- a/esphome/components/xiaomi_hhccjcy10/xiaomi_hhccjcy10.cpp
+++ b/esphome/components/xiaomi_hhccjcy10/xiaomi_hhccjcy10.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_hhccjcy10 {
+namespace esphome::xiaomi_hhccjcy10 {
 
 static const char *const TAG = "xiaomi_hhccjcy10";
 
@@ -63,7 +62,6 @@ bool XiaomiHHCCJCY10::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
   return success;
 }
 
-}  // namespace xiaomi_hhccjcy10
-}  // namespace esphome
+}  // namespace esphome::xiaomi_hhccjcy10
 
 #endif

--- a/esphome/components/xiaomi_hhccjcy10/xiaomi_hhccjcy10.h
+++ b/esphome/components/xiaomi_hhccjcy10/xiaomi_hhccjcy10.h
@@ -6,8 +6,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_hhccjcy10 {
+namespace esphome::xiaomi_hhccjcy10 {
 
 class XiaomiHHCCJCY10 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -31,7 +30,6 @@ class XiaomiHHCCJCY10 : public Component, public esp32_ble_tracker::ESPBTDeviceL
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_hhccjcy10
-}  // namespace esphome
+}  // namespace esphome::xiaomi_hhccjcy10
 
 #endif

--- a/esphome/components/xiaomi_hhccpot002/xiaomi_hhccpot002.cpp
+++ b/esphome/components/xiaomi_hhccpot002/xiaomi_hhccpot002.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_hhccpot002 {
+namespace esphome::xiaomi_hhccpot002 {
 
 static const char *const TAG = "xiaomi_hhccpot002";
 
@@ -52,7 +51,6 @@ bool XiaomiHHCCPOT002::parse_device(const esp32_ble_tracker::ESPBTDevice &device
   return success;
 }
 
-}  // namespace xiaomi_hhccpot002
-}  // namespace esphome
+}  // namespace esphome::xiaomi_hhccpot002
 
 #endif

--- a/esphome/components/xiaomi_hhccpot002/xiaomi_hhccpot002.h
+++ b/esphome/components/xiaomi_hhccpot002/xiaomi_hhccpot002.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_hhccpot002 {
+namespace esphome::xiaomi_hhccpot002 {
 
 class XiaomiHHCCPOT002 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -26,7 +25,6 @@ class XiaomiHHCCPOT002 : public Component, public esp32_ble_tracker::ESPBTDevice
   sensor::Sensor *conductivity_{nullptr};
 };
 
-}  // namespace xiaomi_hhccpot002
-}  // namespace esphome
+}  // namespace esphome::xiaomi_hhccpot002
 
 #endif

--- a/esphome/components/xiaomi_jqjcy01ym/xiaomi_jqjcy01ym.cpp
+++ b/esphome/components/xiaomi_jqjcy01ym/xiaomi_jqjcy01ym.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_jqjcy01ym {
+namespace esphome::xiaomi_jqjcy01ym {
 
 static const char *const TAG = "xiaomi_jqjcy01ym";
 
@@ -58,7 +57,6 @@ bool XiaomiJQJCY01YM::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
   return success;
 }
 
-}  // namespace xiaomi_jqjcy01ym
-}  // namespace esphome
+}  // namespace esphome::xiaomi_jqjcy01ym
 
 #endif

--- a/esphome/components/xiaomi_jqjcy01ym/xiaomi_jqjcy01ym.h
+++ b/esphome/components/xiaomi_jqjcy01ym/xiaomi_jqjcy01ym.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_jqjcy01ym {
+namespace esphome::xiaomi_jqjcy01ym {
 
 class XiaomiJQJCY01YM : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -30,7 +29,6 @@ class XiaomiJQJCY01YM : public Component, public esp32_ble_tracker::ESPBTDeviceL
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_jqjcy01ym
-}  // namespace esphome
+}  // namespace esphome::xiaomi_jqjcy01ym
 
 #endif

--- a/esphome/components/xiaomi_lywsd02/xiaomi_lywsd02.cpp
+++ b/esphome/components/xiaomi_lywsd02/xiaomi_lywsd02.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_lywsd02 {
+namespace esphome::xiaomi_lywsd02 {
 
 static const char *const TAG = "xiaomi_lywsd02";
 
@@ -55,7 +54,6 @@ bool XiaomiLYWSD02::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return success;
 }
 
-}  // namespace xiaomi_lywsd02
-}  // namespace esphome
+}  // namespace esphome::xiaomi_lywsd02
 
 #endif

--- a/esphome/components/xiaomi_lywsd02/xiaomi_lywsd02.h
+++ b/esphome/components/xiaomi_lywsd02/xiaomi_lywsd02.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_lywsd02 {
+namespace esphome::xiaomi_lywsd02 {
 
 class XiaomiLYWSD02 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -28,7 +27,6 @@ class XiaomiLYWSD02 : public Component, public esp32_ble_tracker::ESPBTDeviceLis
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_lywsd02
-}  // namespace esphome
+}  // namespace esphome::xiaomi_lywsd02
 
 #endif

--- a/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
+++ b/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_lywsd02mmc {
+namespace esphome::xiaomi_lywsd02mmc {
 
 static const char *const TAG = "xiaomi_lywsd02mmc";
 
@@ -65,7 +64,6 @@ bool XiaomiLYWSD02MMC::parse_device(const esp32_ble_tracker::ESPBTDevice &device
 
 void XiaomiLYWSD02MMC::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
-}  // namespace xiaomi_lywsd02mmc
-}  // namespace esphome
+}  // namespace esphome::xiaomi_lywsd02mmc
 
 #endif

--- a/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.h
+++ b/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_lywsd02mmc {
+namespace esphome::xiaomi_lywsd02mmc {
 
 class XiaomiLYWSD02MMC : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -30,7 +29,6 @@ class XiaomiLYWSD02MMC : public Component, public esp32_ble_tracker::ESPBTDevice
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_lywsd02mmc
-}  // namespace esphome
+}  // namespace esphome::xiaomi_lywsd02mmc
 
 #endif

--- a/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
+++ b/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_lywsd03mmc {
+namespace esphome::xiaomi_lywsd03mmc {
 
 static const char *const TAG = "xiaomi_lywsd03mmc";
 
@@ -69,7 +68,6 @@ bool XiaomiLYWSD03MMC::parse_device(const esp32_ble_tracker::ESPBTDevice &device
 
 void XiaomiLYWSD03MMC::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
-}  // namespace xiaomi_lywsd03mmc
-}  // namespace esphome
+}  // namespace esphome::xiaomi_lywsd03mmc
 
 #endif

--- a/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.h
+++ b/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_lywsd03mmc {
+namespace esphome::xiaomi_lywsd03mmc {
 
 class XiaomiLYWSD03MMC : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -29,7 +28,6 @@ class XiaomiLYWSD03MMC : public Component, public esp32_ble_tracker::ESPBTDevice
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_lywsd03mmc
-}  // namespace esphome
+}  // namespace esphome::xiaomi_lywsd03mmc
 
 #endif

--- a/esphome/components/xiaomi_lywsdcgq/xiaomi_lywsdcgq.cpp
+++ b/esphome/components/xiaomi_lywsdcgq/xiaomi_lywsdcgq.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_lywsdcgq {
+namespace esphome::xiaomi_lywsdcgq {
 
 static const char *const TAG = "xiaomi_lywsdcgq";
 
@@ -55,7 +54,6 @@ bool XiaomiLYWSDCGQ::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   return success;
 }
 
-}  // namespace xiaomi_lywsdcgq
-}  // namespace esphome
+}  // namespace esphome::xiaomi_lywsdcgq
 
 #endif

--- a/esphome/components/xiaomi_lywsdcgq/xiaomi_lywsdcgq.h
+++ b/esphome/components/xiaomi_lywsdcgq/xiaomi_lywsdcgq.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_lywsdcgq {
+namespace esphome::xiaomi_lywsdcgq {
 
 class XiaomiLYWSDCGQ : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -28,7 +27,6 @@ class XiaomiLYWSDCGQ : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_lywsdcgq
-}  // namespace esphome
+}  // namespace esphome::xiaomi_lywsdcgq
 
 #endif

--- a/esphome/components/xiaomi_mhoc303/xiaomi_mhoc303.cpp
+++ b/esphome/components/xiaomi_mhoc303/xiaomi_mhoc303.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_mhoc303 {
+namespace esphome::xiaomi_mhoc303 {
 
 static const char *const TAG = "xiaomi_mhoc303";
 
@@ -55,7 +54,6 @@ bool XiaomiMHOC303::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return success;
 }
 
-}  // namespace xiaomi_mhoc303
-}  // namespace esphome
+}  // namespace esphome::xiaomi_mhoc303
 
 #endif

--- a/esphome/components/xiaomi_mhoc303/xiaomi_mhoc303.h
+++ b/esphome/components/xiaomi_mhoc303/xiaomi_mhoc303.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_mhoc303 {
+namespace esphome::xiaomi_mhoc303 {
 
 class XiaomiMHOC303 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -28,7 +27,6 @@ class XiaomiMHOC303 : public Component, public esp32_ble_tracker::ESPBTDeviceLis
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_mhoc303
-}  // namespace esphome
+}  // namespace esphome::xiaomi_mhoc303
 
 #endif

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_mhoc401 {
+namespace esphome::xiaomi_mhoc401 {
 
 static const char *const TAG = "xiaomi_mhoc401";
 
@@ -69,7 +68,6 @@ bool XiaomiMHOC401::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
 
 void XiaomiMHOC401::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
-}  // namespace xiaomi_mhoc401
-}  // namespace esphome
+}  // namespace esphome::xiaomi_mhoc401
 
 #endif

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.h
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_mhoc401 {
+namespace esphome::xiaomi_mhoc401 {
 
 class XiaomiMHOC401 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -29,7 +28,6 @@ class XiaomiMHOC401 : public Component, public esp32_ble_tracker::ESPBTDeviceLis
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_mhoc401
-}  // namespace esphome
+}  // namespace esphome::xiaomi_mhoc401
 
 #endif

--- a/esphome/components/xiaomi_miscale/xiaomi_miscale.cpp
+++ b/esphome/components/xiaomi_miscale/xiaomi_miscale.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_miscale {
+namespace esphome::xiaomi_miscale {
 
 static const char *const TAG = "xiaomi_miscale";
 
@@ -167,7 +166,6 @@ bool XiaomiMiscale::report_results_(const optional<ParseResult> &result, const c
   return true;
 }
 
-}  // namespace xiaomi_miscale
-}  // namespace esphome
+}  // namespace esphome::xiaomi_miscale
 
 #endif

--- a/esphome/components/xiaomi_miscale/xiaomi_miscale.h
+++ b/esphome/components/xiaomi_miscale/xiaomi_miscale.h
@@ -8,8 +8,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_miscale {
+namespace esphome::xiaomi_miscale {
 
 struct ParseResult {
   int version;
@@ -40,7 +39,6 @@ class XiaomiMiscale : public Component, public esp32_ble_tracker::ESPBTDeviceLis
   bool report_results_(const optional<ParseResult> &result, const char *address);
 };
 
-}  // namespace xiaomi_miscale
-}  // namespace esphome
+}  // namespace esphome::xiaomi_miscale
 
 #endif

--- a/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.cpp
+++ b/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_mjyd02yla {
+namespace esphome::xiaomi_mjyd02yla {
 
 static const char *const TAG = "xiaomi_mjyd02yla";
 
@@ -65,7 +64,6 @@ bool XiaomiMJYD02YLA::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
 
 void XiaomiMJYD02YLA::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
-}  // namespace xiaomi_mjyd02yla
-}  // namespace esphome
+}  // namespace esphome::xiaomi_mjyd02yla
 
 #endif

--- a/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.h
+++ b/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.h
@@ -8,8 +8,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_mjyd02yla {
+namespace esphome::xiaomi_mjyd02yla {
 
 class XiaomiMJYD02YLA : public Component,
                         public binary_sensor::BinarySensorInitiallyOff,
@@ -35,7 +34,6 @@ class XiaomiMJYD02YLA : public Component,
   binary_sensor::BinarySensor *is_light_{nullptr};
 };
 
-}  // namespace xiaomi_mjyd02yla
-}  // namespace esphome
+}  // namespace esphome::xiaomi_mjyd02yla
 
 #endif

--- a/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.cpp
+++ b/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_mue4094rt {
+namespace esphome::xiaomi_mue4094rt {
 
 static const char *const TAG = "xiaomi_mue4094rt";
 
@@ -51,7 +50,6 @@ bool XiaomiMUE4094RT::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
   return success;
 }
 
-}  // namespace xiaomi_mue4094rt
-}  // namespace esphome
+}  // namespace esphome::xiaomi_mue4094rt
 
 #endif

--- a/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.h
+++ b/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_mue4094rt {
+namespace esphome::xiaomi_mue4094rt {
 
 class XiaomiMUE4094RT : public Component,
                         public binary_sensor::BinarySensorInitiallyOff,
@@ -26,7 +25,6 @@ class XiaomiMUE4094RT : public Component,
   uint16_t timeout_;
 };
 
-}  // namespace xiaomi_mue4094rt
-}  // namespace esphome
+}  // namespace esphome::xiaomi_mue4094rt
 
 #endif

--- a/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.cpp
+++ b/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_rtcgq02lm {
+namespace esphome::xiaomi_rtcgq02lm {
 
 static const char *const TAG = "xiaomi_rtcgq02lm";
 
@@ -79,7 +78,6 @@ bool XiaomiRTCGQ02LM::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
 
 void XiaomiRTCGQ02LM::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
-}  // namespace xiaomi_rtcgq02lm
-}  // namespace esphome
+}  // namespace esphome::xiaomi_rtcgq02lm
 
 #endif

--- a/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.h
+++ b/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.h
@@ -13,8 +13,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_rtcgq02lm {
+namespace esphome::xiaomi_rtcgq02lm {
 
 class XiaomiRTCGQ02LM : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -54,7 +53,6 @@ class XiaomiRTCGQ02LM : public Component, public esp32_ble_tracker::ESPBTDeviceL
 #endif
 };
 
-}  // namespace xiaomi_rtcgq02lm
-}  // namespace esphome
+}  // namespace esphome::xiaomi_rtcgq02lm
 
 #endif

--- a/esphome/components/xiaomi_wx08zm/xiaomi_wx08zm.cpp
+++ b/esphome/components/xiaomi_wx08zm/xiaomi_wx08zm.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_wx08zm {
+namespace esphome::xiaomi_wx08zm {
 
 static const char *const TAG = "xiaomi_wx08zm";
 
@@ -56,7 +55,6 @@ bool XiaomiWX08ZM::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return success;
 }
 
-}  // namespace xiaomi_wx08zm
-}  // namespace esphome
+}  // namespace esphome::xiaomi_wx08zm
 
 #endif

--- a/esphome/components/xiaomi_wx08zm/xiaomi_wx08zm.h
+++ b/esphome/components/xiaomi_wx08zm/xiaomi_wx08zm.h
@@ -8,8 +8,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_wx08zm {
+namespace esphome::xiaomi_wx08zm {
 
 class XiaomiWX08ZM : public Component,
                      public binary_sensor::BinarySensorInitiallyOff,
@@ -29,7 +28,6 @@ class XiaomiWX08ZM : public Component,
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_wx08zm
-}  // namespace esphome
+}  // namespace esphome::xiaomi_wx08zm
 
 #endif

--- a/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.cpp
+++ b/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_xmwsdj04mmc {
+namespace esphome::xiaomi_xmwsdj04mmc {
 
 static const char *const TAG = "xiaomi_xmwsdj04mmc";
 
@@ -69,7 +68,6 @@ bool XiaomiXMWSDJ04MMC::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
 
 void XiaomiXMWSDJ04MMC::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
-}  // namespace xiaomi_xmwsdj04mmc
-}  // namespace esphome
+}  // namespace esphome::xiaomi_xmwsdj04mmc
 
 #endif

--- a/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.h
+++ b/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_xmwsdj04mmc {
+namespace esphome::xiaomi_xmwsdj04mmc {
 
 class XiaomiXMWSDJ04MMC : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -30,7 +29,6 @@ class XiaomiXMWSDJ04MMC : public Component, public esp32_ble_tracker::ESPBTDevic
   sensor::Sensor *battery_level_{nullptr};
 };
 
-}  // namespace xiaomi_xmwsdj04mmc
-}  // namespace esphome
+}  // namespace esphome::xiaomi_xmwsdj04mmc
 
 #endif

--- a/esphome/components/xl9535/xl9535.cpp
+++ b/esphome/components/xl9535/xl9535.cpp
@@ -1,8 +1,7 @@
 #include "xl9535.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace xl9535 {
+namespace esphome::xl9535 {
 
 static const char *const TAG = "xl9535";
 
@@ -118,5 +117,4 @@ void XL9535GPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this->
 bool XL9535GPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
 void XL9535GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
 
-}  // namespace xl9535
-}  // namespace esphome
+}  // namespace esphome::xl9535

--- a/esphome/components/xl9535/xl9535.h
+++ b/esphome/components/xl9535/xl9535.h
@@ -4,8 +4,7 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace xl9535 {
+namespace esphome::xl9535 {
 
 enum {
   XL9535_INPUT_PORT_0_REGISTER = 0x00,
@@ -52,5 +51,4 @@ class XL9535GPIOPin : public GPIOPin {
   gpio::Flags flags_;
 };
 
-}  // namespace xl9535
-}  // namespace esphome
+}  // namespace esphome::xl9535

--- a/esphome/components/xpt2046/touchscreen/xpt2046.cpp
+++ b/esphome/components/xpt2046/touchscreen/xpt2046.cpp
@@ -4,8 +4,7 @@
 
 #include <algorithm>
 
-namespace esphome {
-namespace xpt2046 {
+namespace esphome::xpt2046 {
 
 static const char *const TAG = "xpt2046";
 
@@ -107,5 +106,4 @@ int16_t XPT2046Component::read_adc_(uint8_t ctrl) {  // NOLINT
   return ((data[0] << 8) | data[1]) >> 3;
 }
 
-}  // namespace xpt2046
-}  // namespace esphome
+}  // namespace esphome::xpt2046

--- a/esphome/components/xpt2046/touchscreen/xpt2046.h
+++ b/esphome/components/xpt2046/touchscreen/xpt2046.h
@@ -7,8 +7,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace xpt2046 {
+namespace esphome::xpt2046 {
 
 using namespace touchscreen;
 
@@ -37,5 +36,4 @@ class XPT2046Component : public Touchscreen,
   InternalGPIOPin *irq_pin_{nullptr};
 };
 
-}  // namespace xpt2046
-}  // namespace esphome
+}  // namespace esphome::xpt2046

--- a/esphome/components/xxtea/xxtea.cpp
+++ b/esphome/components/xxtea/xxtea.cpp
@@ -1,7 +1,6 @@
 #include "xxtea.h"
 
-namespace esphome {
-namespace xxtea {
+namespace esphome::xxtea {
 
 static const uint32_t DELTA = 0x9e3779b9;
 #define MX ((((z >> 5) ^ (y << 2)) + ((y >> 3) ^ (z << 4))) ^ ((sum ^ y) + (k[(p ^ e) & 7] ^ z)))
@@ -46,5 +45,4 @@ void decrypt(uint32_t *v, size_t n, const uint32_t *k) {
   }
 }
 
-}  // namespace xxtea
-}  // namespace esphome
+}  // namespace esphome::xxtea

--- a/esphome/components/xxtea/xxtea.h
+++ b/esphome/components/xxtea/xxtea.h
@@ -3,8 +3,7 @@
 #include <cstdint>
 #include <cstddef>
 
-namespace esphome {
-namespace xxtea {
+namespace esphome::xxtea {
 
 /**
  * Encrypt a block of data in-place using XXTEA algorithm with 256-bit key
@@ -22,5 +21,4 @@ void encrypt(uint32_t *v, size_t n, const uint32_t *k);
  */
 void decrypt(uint32_t *v, size_t n, const uint32_t *k);
 
-}  // namespace xxtea
-}  // namespace esphome
+}  // namespace esphome::xxtea

--- a/esphome/components/yashima/yashima.cpp
+++ b/esphome/components/yashima/yashima.cpp
@@ -1,8 +1,7 @@
 #include "yashima.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace yashima {
+namespace esphome::yashima {
 
 static const char *const TAG = "yashima.climate";
 
@@ -197,5 +196,4 @@ void YashimaClimate::transmit_state_() {
   transmit.perform();
 }
 
-}  // namespace yashima
-}  // namespace esphome
+}  // namespace esphome::yashima

--- a/esphome/components/yashima/yashima.h
+++ b/esphome/components/yashima/yashima.h
@@ -7,8 +7,7 @@
 #include "esphome/components/remote_transmitter/remote_transmitter.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace yashima {
+namespace esphome::yashima {
 
 class YashimaClimate : public climate::Climate, public Component {
  public:
@@ -36,5 +35,4 @@ class YashimaClimate : public climate::Climate, public Component {
   sensor::Sensor *sensor_{nullptr};
 };
 
-}  // namespace yashima
-}  // namespace esphome
+}  // namespace esphome::yashima

--- a/esphome/components/zhlt01/zhlt01.cpp
+++ b/esphome/components/zhlt01/zhlt01.cpp
@@ -1,8 +1,7 @@
 #include "zhlt01.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace zhlt01 {
+namespace esphome::zhlt01 {
 
 static const char *const TAG = "zhlt01.climate";
 
@@ -234,5 +233,4 @@ bool ZHLT01Climate::on_receive(remote_base::RemoteReceiveData data) {
   return true;
 }
 
-}  // namespace zhlt01
-}  // namespace esphome
+}  // namespace esphome::zhlt01

--- a/esphome/components/zhlt01/zhlt01.h
+++ b/esphome/components/zhlt01/zhlt01.h
@@ -82,8 +82,7 @@
  *
  ***********************************************************************************/
 
-namespace esphome {
-namespace zhlt01 {
+namespace esphome::zhlt01 {
 
 /********************************************************************************
  *  TIMINGS
@@ -163,5 +162,4 @@ class ZHLT01Climate : public climate_ir::ClimateIR {
   bool on_receive(remote_base::RemoteReceiveData data) override;
 };
 
-}  // namespace zhlt01
-}  // namespace esphome
+}  // namespace esphome::zhlt01

--- a/esphome/components/zio_ultrasonic/zio_ultrasonic.cpp
+++ b/esphome/components/zio_ultrasonic/zio_ultrasonic.cpp
@@ -3,8 +3,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace zio_ultrasonic {
+namespace esphome::zio_ultrasonic {
 
 static const char *const TAG = "zio_ultrasonic";
 
@@ -27,5 +26,4 @@ void ZioUltrasonicComponent::update() {
   }
 }
 
-}  // namespace zio_ultrasonic
-}  // namespace esphome
+}  // namespace esphome::zio_ultrasonic

--- a/esphome/components/zio_ultrasonic/zio_ultrasonic.h
+++ b/esphome/components/zio_ultrasonic/zio_ultrasonic.h
@@ -6,8 +6,7 @@
 
 static const char *const TAG = "Zio Ultrasonic";
 
-namespace esphome {
-namespace zio_ultrasonic {
+namespace esphome::zio_ultrasonic {
 
 class ZioUltrasonicComponent : public i2c::I2CDevice, public PollingComponent, public sensor::Sensor {
  public:
@@ -16,5 +15,4 @@ class ZioUltrasonicComponent : public i2c::I2CDevice, public PollingComponent, p
   void update() override;
 };
 
-}  // namespace zio_ultrasonic
-}  // namespace esphome
+}  // namespace esphome::zio_ultrasonic

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -1,8 +1,7 @@
 #include "zyaura.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace zyaura {
+namespace esphome::zyaura {
 
 static const char *const TAG = "zyaura";
 
@@ -121,5 +120,4 @@ void ZyAuraSensor::update() {
   }
 }
 
-}  // namespace zyaura
-}  // namespace esphome
+}  // namespace esphome::zyaura

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace zyaura {
+namespace esphome::zyaura {
 
 static const uint8_t ZA_MAX_MS = 2;
 static const uint8_t ZA_MSG_LEN = 5;
@@ -81,5 +80,4 @@ class ZyAuraSensor : public PollingComponent {
   bool publish_state_(ZaDataType data_type, sensor::Sensor *sensor, uint16_t *data_value);
 };
 
-}  // namespace zyaura
-}  // namespace esphome
+}  // namespace esphome::zyaura


### PR DESCRIPTION
# What does this implement/fix?

Mechanical conversion of `namespace foo { namespace bar { ... } }` to `namespace foo::bar { ... }` (C++17 nested namespace concatenation), applied via `clang-tidy --fix` with `modernize-concat-nested-namespaces` temporarily re-enabled, followed by `clang-format`. **No semantic changes.**

This is **part 6 of 7** for the cleanup tracked in [esphome/backlog#114](https://github.com/esphome/backlog/issues/114), toward enabling `modernize-concat-nested-namespaces` project-wide and matching the convention already documented in `CLAUDE.md`. Splitting by component letter range to keep each PR reviewable.

The `.clang-tidy` disable line stays in place until the final PR so CI remains green throughout the rollout.

## Scope of this PR

- `esphome/components/[t-z]*/` — 226 files

## Note on wk2132_i2c.cpp

`esphome/components/wk2132_i2c/wk2132_i2c.cpp` had an empty `namespace esphome { namespace wk2132_i2c {} }` placeholder whose only purpose was to satisfy `script/ci-custom.py`'s namespace lint rule (the `.cpp` exists only because the ESP-IDF framework requires one). The auto-fix collapsed the placeholder; restored as `namespace esphome::wk2132_i2c {}` (the concatenated form the lint rule explicitly accepts). Same situation as `lvgl_proxy.h` in #16297.

## Reproduction

```bash
# remove the disable line from .clang-tidy
# then:
script/clang-tidy --fix --environment esp32-arduino-tidy --all-headers
git ls-files 'esphome/components/[t-z]*/**' | xargs clang-format -i
```

## Series

- 1/7 components a-c — #16294
- 2/7 components d-h — #16295
- 3/7 components i-m — #16297
- 4/7 components n-r — #16301
- 5/7 components s — #16302
- 6/7 components t-z (this PR)
- 7/7 tests + drop the `.clang-tidy` disable line

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/backlog#114

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

(Mechanical, no platform-specific code paths affected.)

## Example entry for `config.yaml`:

```yaml
# n/a
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
