### PR TITLE
[openthread] add coroutine-with-priority COMMUNICATION

### DIFF
--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -21,7 +21,12 @@ from esphome.const import (
     CONF_USE_ADDRESS,
     PLATFORM_ESP32,
 )
-from esphome.core import CORE, TimePeriodMilliseconds
+from esphome.core import (
+    CORE,
+    CoroPriority,
+    TimePeriodMilliseconds,
+    coroutine_with_priority,
+)
 import esphome.final_validate as fv
 from esphome.types import ConfigType
 
@@ -223,6 +228,7 @@ def _final_validate(_):
 FINAL_VALIDATE_SCHEMA = _final_validate
 
 
+@coroutine_with_priority(CoroPriority.COMMUNICATION)
 async def to_code(config):
     # Re-enable openthread IDF component (excluded by default)
     include_builtin_idf_component("openthread")


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Adds `@coroutine_with_priority(CoroPriority.COMMUNICATION)` above `to_code` in `__init__.py so that openthread` is moved above `safe_mode` and will still be available when Safe Mode is Active.  Behavior before this fix was a bootloop failure in OTA do to esp_netif_init not having been called prior to OTA setup().

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No change, tested with simple configuration using openthread component
```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
This needs an integration test, but I don't know how to write it.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
