### PR TITLE
[sendspin] Fix client_id MAC mismatch with ethernet

### DIFF
--- a/esphome/components/sendspin/sendspin_hub.cpp
+++ b/esphome/components/sendspin/sendspin_hub.cpp
@@ -3,6 +3,9 @@
 #ifdef USE_ESP32
 
 #include "esphome/components/network/util.h"
+#ifdef USE_ETHERNET
+#include "esphome/components/ethernet/ethernet_component.h"
+#endif
 #ifdef USE_WIFI
 #include "esphome/components/wifi/wifi_component.h"
 #endif
@@ -63,7 +66,7 @@ void SendspinHub::dump_config() {
                 "Sendspin Hub:\n"
                 "  Client ID: %s\n"
                 "  Task stack in PSRAM: %s",
-                get_mac_address_pretty_into_buffer(mac_buf), YESNO(this->task_stack_in_psram_));
+                get_client_id_into_buffer_(mac_buf), YESNO(this->task_stack_in_psram_));
 }
 
 // --- Delegating methods ---
@@ -89,11 +92,23 @@ void SendspinHub::update_state(sendspin::SendspinClientState state) {
   }
 }
 
+const char *SendspinHub::get_client_id_into_buffer_(std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buf) {
+  // The server matches client_id against the L2 source MAC of the device's multicast traffic.
+  // ESP-IDF derives the ethernet MAC as base+3 by default on ESP32-S3, so we cannot use the
+  // eFuse base MAC when ethernet is the active interface.
+#ifdef USE_ETHERNET
+  if (ethernet::global_eth_component != nullptr) {
+    return ethernet::global_eth_component->get_eth_mac_address_pretty_into_buffer(buf);
+  }
+#endif
+  return get_mac_address_pretty_into_buffer(buf);
+}
+
 sendspin::SendspinClientConfig SendspinHub::build_client_config_() {
   sendspin::SendspinClientConfig config;
 
   char mac_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
-  config.client_id = get_mac_address_pretty_into_buffer(mac_buf);
+  config.client_id = this->get_client_id_into_buffer_(mac_buf);
   config.name = App.get_friendly_name();
   config.product_name = App.get_name();
   config.manufacturer = "ESPHome";

--- a/esphome/components/sendspin/sendspin_hub.cpp
+++ b/esphome/components/sendspin/sendspin_hub.cpp
@@ -66,7 +66,7 @@ void SendspinHub::dump_config() {
                 "Sendspin Hub:\n"
                 "  Client ID: %s\n"
                 "  Task stack in PSRAM: %s",
-                get_client_id_into_buffer_(mac_buf), YESNO(this->task_stack_in_psram_));
+                get_client_id_into_buffer(mac_buf), YESNO(this->task_stack_in_psram_));
 }
 
 // --- Delegating methods ---
@@ -92,7 +92,7 @@ void SendspinHub::update_state(sendspin::SendspinClientState state) {
   }
 }
 
-const char *SendspinHub::get_client_id_into_buffer_(std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buf) {
+const char *SendspinHub::get_client_id_into_buffer(std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buf) {
   // The server matches client_id against the L2 source MAC of the device's multicast traffic.
   // ESP-IDF derives the ethernet MAC as base+3 by default on ESP32-S3, so we cannot use the
   // eFuse base MAC when ethernet is the active interface.
@@ -108,7 +108,7 @@ sendspin::SendspinClientConfig SendspinHub::build_client_config_() {
   sendspin::SendspinClientConfig config;
 
   char mac_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
-  config.client_id = this->get_client_id_into_buffer_(mac_buf);
+  config.client_id = SendspinHub::get_client_id_into_buffer(mac_buf);
   config.name = App.get_friendly_name();
   config.product_name = App.get_name();
   config.manufacturer = "ESPHome";

--- a/esphome/components/sendspin/sendspin_hub.h
+++ b/esphome/components/sendspin/sendspin_hub.h
@@ -35,7 +35,9 @@ namespace esphome::sendspin_ {
 /// without each subcomponent having to pick a priority independently. Children run
 /// one step later than hub so they can assume hub's setup() has already completed.
 namespace sendspin_priority {
-inline constexpr float HUB = esphome::setup_priority::PROCESSOR;
+// AFTER_WIFI so the hub runs after the wifi/ethernet drivers are up and we can read the active
+// interface's MAC for client_id.
+inline constexpr float HUB = esphome::setup_priority::AFTER_WIFI;
 inline constexpr float CHILD = HUB - 1.0f;
 }  // namespace sendspin_priority
 
@@ -148,6 +150,10 @@ class SendspinHub final : public Component,
  protected:
   /// @brief Builds the SendspinClientConfig from ESPHome configuration and platform info.
   sendspin::SendspinClientConfig build_client_config_();
+
+  /// @brief Writes the active network interface's MAC into @p buf and returns its data pointer.
+  /// Uses the ethernet MAC if ethernet is configured, otherwise the base MAC (used by wifi).
+  static const char *get_client_id_into_buffer_(std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buf);
 
   // --- SendspinClientListener overrides ---
   void on_group_update(const sendspin::GroupUpdateObject &group) override;

--- a/esphome/components/sendspin/sendspin_hub.h
+++ b/esphome/components/sendspin/sendspin_hub.h
@@ -153,7 +153,7 @@ class SendspinHub final : public Component,
 
   /// @brief Writes the active network interface's MAC into @p buf and returns its data pointer.
   /// Uses the ethernet MAC if ethernet is configured, otherwise the base MAC (used by wifi).
-  static const char *get_client_id_into_buffer_(std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buf);
+  static const char *get_client_id_into_buffer(std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buf);
 
   // --- SendspinClientListener overrides ---
   void on_group_update(const sendspin::GroupUpdateObject &group) override;

--- a/tests/components/sendspin/test-ethernet.esp32-idf.yaml
+++ b/tests/components/sendspin/test-ethernet.esp32-idf.yaml
@@ -1,0 +1,9 @@
+ethernet:
+  type: OPENETH
+
+psram:
+  mode: quad
+
+sendspin:
+  id: sendspin_hub_id
+  task_stack_in_psram: true


### PR DESCRIPTION
# What does this implement/fix?

On ESP32-S3 with an Ethernet interface, the Sendspin component built `client_id` from the eFuse base MAC, but the ESP-IDF Ethernet driver defaults to a derived MAC (typically base+3). The Sendspin server matches `client_id` against the L2 source MAC of multicast/IGMP traffic, so the registration identity never matched the actual stream traffic, causing playback failures and "0 subscribers" symptoms.

Two changes:

1. Lower `SendspinHub`'s setup priority from `PROCESSOR` (400) to `AFTER_WIFI` (200) so the wifi/ethernet drivers are initialized before the hub queries them. This matches the priority used by `APIServer` and `MQTTClientComponent`.
2. Add `SendspinHub::get_client_id_into_buffer_()`, which returns the active ethernet interface's MAC when ethernet is configured and falls back to the base MAC otherwise. This matches the ethernet-first preference already used by `network::get_use_address()`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16329

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes. The fix is automatic for ESP32 + ethernet setups.
ethernet:
  type: W5500
  # ... existing ethernet config

sendspin:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).