### PR TITLE
[wifi] Accept lowercase variant in variant_has_wifi

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -76,11 +76,17 @@ def variant_has_wifi(variant: str) -> bool:
     Variants without a native PHY (ESP32-H2, ESP32-P4) need the
     ``esp32_hosted`` co-processor to use ``wifi:``.
 
+    Case-insensitive on *variant* so external callers can pass either
+    the upstream uppercase form (e.g. ``"ESP32H2"`` from
+    ``const.VARIANT_ESP32H2``) or a lowercase form their own enum
+    surfaces (e.g. ``"esp32h2"`` from device-builder's
+    ``Esp32Variant``). Both classify identically.
+
     Used by device-builder (esphome/device-builder) to decide whether
     its basic-setup wizard emits a ``wifi:`` block — please keep the
     signature stable.
     """
-    return variant not in NO_WIFI_VARIANTS
+    return variant.upper() not in NO_WIFI_VARIANTS
 
 
 _WIFI_FIRST_PLATFORMS: frozenset[str] = frozenset(

--- a/tests/unit_tests/components/test_wifi.py
+++ b/tests/unit_tests/components/test_wifi.py
@@ -10,27 +10,44 @@ from esphome.const import Platform
 @pytest.mark.parametrize(
     "variant",
     [
+        # Upstream's canonical uppercase form.
         const.VARIANT_ESP32,
         const.VARIANT_ESP32S2,
         const.VARIANT_ESP32S3,
         const.VARIANT_ESP32C3,
         const.VARIANT_ESP32C6,
+        # Lowercase form external callers (e.g. device-builder's
+        # ``Esp32Variant`` StrEnum) surface.
+        "esp32",
+        "esp32s3",
+        "esp32c3",
+        # Mixed-case — defence in depth against future callers that
+        # pull the value off some other serialisation.
+        "Esp32",
     ],
 )
 def test_variant_has_wifi_for_native_phy_variants(variant: str) -> None:
-    """Variants with a native WiFi PHY → True."""
+    """Variants with a native WiFi PHY → True, case-insensitive."""
     assert variant_has_wifi(variant) is True
 
 
 @pytest.mark.parametrize(
     "variant",
     [
+        # Upstream's canonical uppercase form.
         const.VARIANT_ESP32H2,
         const.VARIANT_ESP32P4,
+        # Lowercase form external callers (e.g. device-builder's
+        # ``Esp32Variant`` StrEnum) surface.
+        "esp32h2",
+        "esp32p4",
+        # Mixed-case — defence in depth against future callers that
+        # pull the value off some other serialisation.
+        "Esp32H2",
     ],
 )
 def test_variant_has_wifi_for_no_phy_variants(variant: str) -> None:
-    """Variants that need ``esp32_hosted`` → False."""
+    """Variants that need ``esp32_hosted`` → False, case-insensitive."""
     assert variant_has_wifi(variant) is False
 
 
@@ -42,6 +59,18 @@ def test_has_native_wifi_dispatches_esp32_to_variant_check() -> None:
     assert (
         has_native_wifi(platform=Platform.ESP32, variant=const.VARIANT_ESP32H2) is False
     )
+
+
+def test_has_native_wifi_esp32_variant_case_insensitive() -> None:
+    """has_native_wifi accepts lowercase variant input.
+
+    External callers (device-builder's wizard, etc.) may surface
+    variant strings from their own enums that don't match upstream's
+    uppercase convention. The dispatcher should classify them
+    identically.
+    """
+    assert has_native_wifi(platform=Platform.ESP32, variant="esp32h2") is False
+    assert has_native_wifi(platform=Platform.ESP32, variant="esp32c3") is True
 
 
 def test_has_native_wifi_dispatches_rp2040_to_board_check() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Make `esphome.components.wifi.variant_has_wifi` case-insensitive on its `variant` argument so external tooling doesn't silently mis-classify ESP32-H2 / ESP32-P4 as Wi-Fi-capable when the variant string arrives in a case that differs from `const.VARIANT_*`.

The helper was added in d143df3c49 (#16300) and compares `variant` against `NO_WIFI_VARIANTS` (`["ESP32H2", "ESP32P4"]`) by literal equality. The `const.VARIANT_*` constants are uppercase, but external callers (notably device-builder's `Esp32Variant` StrEnum, which surfaces `"esp32h2"`) may legitimately pass the lowercase form. The mismatch made the dispatcher report H2 / P4 as Wi-Fi-capable, so the wizard emitted `wifi:` / `api:` / `ota:` blocks that the downstream compile rejected.

The function's docstring explicitly invites external callers and asks future maintainers to keep the signature stable, so centralising the normalisation here is preferable to pushing the case convention into every external caller's memory.

Worked around downstream in esphome/device-builder#561 by uppercasing at the call site; that workaround can be dropped once a new esphome dep floor includes this fix.

Internal callers pass `const.VARIANT_*` values (uppercase by definition), so behaviour for in-tree usage is unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# N/A — internal Python helper used by external tooling (device-builder).
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).