### PR TITLE
[core] Add stable esphome.upload_targets module for port classification

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -64,6 +64,7 @@ from esphome.enum import StrEnum
 from esphome.helpers import get_bool_env, indent, is_ip_address
 from esphome.log import AnsiFore, color, setup_log
 from esphome.types import ConfigType
+from esphome.upload_targets import PortType, get_port_type
 from esphome.util import (
     PICOTOOL_PACKAGE,
     FlashImage,
@@ -193,14 +194,6 @@ def choose_prompt(options, purpose: str = None):
 class Purpose(StrEnum):
     UPLOADING = "uploading"
     LOGGING = "logging"
-
-
-class PortType(StrEnum):
-    SERIAL = "SERIAL"
-    NETWORK = "NETWORK"
-    MQTT = "MQTT"
-    MQTTIP = "MQTTIP"
-    BOOTSEL = "BOOTSEL"
 
 
 # Magic MQTT port types that require special handling
@@ -596,27 +589,6 @@ def _resolve_network_devices(
             network_devices.append(device)
 
     return network_devices
-
-
-def get_port_type(port: str) -> PortType:
-    """Determine the type of port/device identifier.
-
-    Returns:
-        PortType.SERIAL for serial ports (/dev/ttyUSB0, COM1, etc.)
-        PortType.BOOTSEL for RP2040 BOOTSEL upload via picotool
-        PortType.MQTT for MQTT logging
-        PortType.MQTTIP for MQTT IP lookup
-        PortType.NETWORK for IP addresses, hostnames, or mDNS names
-    """
-    if port == "BOOTSEL":
-        return PortType.BOOTSEL
-    if port.startswith("/") or port.startswith("COM"):
-        return PortType.SERIAL
-    if port == "MQTT":
-        return PortType.MQTT
-    if port == "MQTTIP":
-        return PortType.MQTTIP
-    return PortType.NETWORK
 
 
 def run_miniterm(config: ConfigType, port: str, args) -> int:

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -405,11 +405,12 @@ def _upload_using_platformio(
 
 
 def upload_program(config: ConfigType, args, host: str) -> bool:
-    from esphome.__main__ import check_permissions, get_port_type
+    from esphome.__main__ import check_permissions
+    from esphome.upload_targets import PortType, get_port_type
 
     mcumgr_device: str | None = None
 
-    if get_port_type(host) == "SERIAL":
+    if get_port_type(host) == PortType.SERIAL:
         check_permissions(host)
         if zephyr_data()[KEY_BOOTLOADER] == BOOTLOADER_MCUBOOT:
             mcumgr_device = host

--- a/esphome/upload_targets.py
+++ b/esphome/upload_targets.py
@@ -1,0 +1,66 @@
+"""Stable classification of ``--device`` / port strings.
+
+External tooling (the device-builder dashboard at
+esphome/device-builder, and other consumers) needs to decide whether
+a user-supplied port string names a local serial device, an OTA
+network target, an MQTT magic string, or an RP2040 BOOTSEL upload.
+
+This module is the single stable home for that classification. The
+upstream CLI (``esphome.__main__``) re-exports ``PortType`` and
+``get_port_type`` from here for its own use; external callers should
+import directly from ``esphome.upload_targets`` so the surface stays
+stable across releases (``esphome/__main__`` is a CLI entrypoint and
+not a stable import path).
+
+Please keep ``PortType`` member names / values and the
+``get_port_type`` signature stable — see the docstrings on each for
+the contract.
+"""
+
+from __future__ import annotations
+
+from esphome.enum import StrEnum
+
+
+class PortType(StrEnum):
+    """Port classification returned by :func:`get_port_type`.
+
+    Used by device-builder (esphome/device-builder) and other
+    external tooling to route a user-supplied ``--device`` value to
+    the right upload / log path. Member names and string values are
+    part of the stable surface — adding new members is fine, but
+    existing names / values must not be renamed or changed.
+    """
+
+    SERIAL = "SERIAL"
+    NETWORK = "NETWORK"
+    MQTT = "MQTT"
+    MQTTIP = "MQTTIP"
+    BOOTSEL = "BOOTSEL"
+
+
+def get_port_type(port: str) -> PortType:
+    """Determine the type of port/device identifier.
+
+    Used by device-builder (esphome/device-builder)'s dashboard to
+    decide whether a user-supplied ``--device`` value names a local
+    serial port (must build / flash locally), an OTA network target
+    (eligible for remote builds), an MQTT magic string, or an RP2040
+    BOOTSEL upload. Please keep the signature stable.
+
+    Returns:
+        PortType.SERIAL for serial ports (/dev/ttyUSB0, COM1, etc.)
+        PortType.BOOTSEL for RP2040 BOOTSEL upload via picotool
+        PortType.MQTT for MQTT logging
+        PortType.MQTTIP for MQTT IP lookup
+        PortType.NETWORK for IP addresses, hostnames, or mDNS names
+    """
+    if port == "BOOTSEL":
+        return PortType.BOOTSEL
+    if port.startswith("/") or port.startswith("COM"):
+        return PortType.SERIAL
+    if port == "MQTT":
+        return PortType.MQTT
+    if port == "MQTTIP":
+        return PortType.MQTTIP
+    return PortType.NETWORK

--- a/tests/unit_tests/test_upload_targets.py
+++ b/tests/unit_tests/test_upload_targets.py
@@ -1,0 +1,81 @@
+"""Tests for the stable upload-targets classification helpers."""
+
+import pytest
+
+from esphome.upload_targets import PortType, get_port_type
+
+
+@pytest.mark.parametrize(
+    "port",
+    [
+        "/dev/ttyUSB0",
+        "/dev/ttyACM0",
+        "/dev/cu.usbserial-1410",
+        "/dev/tty.usbmodem1101",
+        "COM1",
+        "COM23",
+    ],
+)
+def test_get_port_type_serial(port: str) -> None:
+    """Local serial devices classify as SERIAL."""
+    assert get_port_type(port) is PortType.SERIAL
+
+
+def test_get_port_type_bootsel() -> None:
+    """``BOOTSEL`` magic string classifies as BOOTSEL."""
+    assert get_port_type("BOOTSEL") is PortType.BOOTSEL
+
+
+def test_get_port_type_mqtt() -> None:
+    """``MQTT`` magic string classifies as MQTT."""
+    assert get_port_type("MQTT") is PortType.MQTT
+
+
+def test_get_port_type_mqttip() -> None:
+    """``MQTTIP`` magic string classifies as MQTTIP."""
+    assert get_port_type("MQTTIP") is PortType.MQTTIP
+
+
+@pytest.mark.parametrize(
+    "port",
+    [
+        "192.168.1.10",
+        "fe80::1",
+        "device.local",
+        "my-esp.example.com",
+    ],
+)
+def test_get_port_type_network(port: str) -> None:
+    """IP addresses, mDNS, and hostnames classify as NETWORK."""
+    assert get_port_type(port) is PortType.NETWORK
+
+
+def test_port_type_values_are_stable() -> None:
+    """Member values are part of the stable surface.
+
+    External tooling (device-builder, etc.) may compare against the
+    string values directly. Renaming or changing these breaks
+    downstream consumers — guard against accidental edits.
+    """
+    assert PortType.SERIAL.value == "SERIAL"
+    assert PortType.NETWORK.value == "NETWORK"
+    assert PortType.MQTT.value == "MQTT"
+    assert PortType.MQTTIP.value == "MQTTIP"
+    assert PortType.BOOTSEL.value == "BOOTSEL"
+
+
+def test_main_re_exports_for_backwards_compat() -> None:
+    """``esphome.__main__`` re-exports the stable surface.
+
+    The CLI entry point pre-dated the stable module and existing
+    internal callers (and any third-party code that snuck in via
+    ``__main__``) still import from there. The re-export must
+    resolve to the same objects.
+    """
+    from esphome.__main__ import (
+        PortType as MainPortType,
+        get_port_type as main_get_port_type,
+    )
+
+    assert MainPortType is PortType
+    assert main_get_port_type is get_port_type


### PR DESCRIPTION
# What does this implement/fix?

Move `PortType` and `get_port_type` out of `esphome.__main__` and into a new `esphome.upload_targets` module so external tooling (device-builder, etc.) has a stable import path. `esphome.__main__` is a CLI entrypoint and was never a stable surface for third-party imports — its contents shift between releases without semver consideration. The classification logic itself is small and pure, so moving it to a dedicated module is mechanical.

Pattern follows #16300 ([wifi][rp2040] Add stable wifi-capability helpers for device-builder): a small, well-documented surface lives in a stable module, the docstring explicitly calls out the device-builder consumer and asks future maintainers to keep the signature stable.

`esphome.__main__` re-exports `PortType` and `get_port_type` from the new module, so the existing in-tree callers (and any external code that snuck in through `__main__`) keep working unchanged. The in-tree `nrf52` caller is updated to import from `esphome.upload_targets` directly and compare against `PortType.SERIAL` rather than the bare `\"SERIAL\"` string (which worked because `PortType` is a `StrEnum`, but the enum form is cleaner).

Once a new esphome dep floor is set in device-builder that includes this, the dashboard's `_is_serial_port` helper can be dropped and replaced with a direct call to `get_port_type(...) == PortType.SERIAL`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- closes esphome/device-builder#562

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# Example config.yaml
# N/A — internal Python module for tooling integrations.
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).