### PR TITLE
[ci] Tighten workflow permissions to least-privilege

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -6,9 +6,10 @@ on:
   pull_request_target:
     types: [labeled, opened, reopened, synchronize, edited]
 
+# All PR/label/review writes are performed with the App token minted below,
+# so the workflow's GITHUB_TOKEN only needs read access for checkout.
 permissions:
-  pull-requests: write
-  contents: read
+  contents: read  # actions/checkout reads the workflow source
 
 env:
   SMALL_PR_THRESHOLD: 30
@@ -31,6 +32,10 @@ jobs:
         with:
           client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          # Scope the minted App token to the minimum needed by auto-label-pr/*.js.
+          permission-contents: read       # repos.getContent for CODEOWNERS and file lookups in detectors.js
+          permission-issues: write        # listLabelsOnIssue, addLabels, removeLabel, list/createComment
+          permission-pull-requests: write  # pulls.listFiles, list/create/update/dismissReview
 
       - name: Auto Label PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/ci-api-proto.yml
+++ b/.github/workflows/ci-api-proto.yml
@@ -12,8 +12,8 @@ on:
       - ".github/workflows/ci-api-proto.yml"
 
 permissions:
-  contents: read
-  pull-requests: write
+  contents: read        # actions/checkout for the PR head
+  pull-requests: write  # pulls.createReview / listReviews / dismissReview when generated proto files are stale
 
 jobs:
   check:

--- a/.github/workflows/ci-clang-tidy-hash.yml
+++ b/.github/workflows/ci-clang-tidy-hash.yml
@@ -12,8 +12,8 @@ on:
       - ".github/workflows/ci-clang-tidy-hash.yml"
 
 permissions:
-  contents: read
-  pull-requests: write
+  contents: read        # actions/checkout for the PR head
+  pull-requests: write  # pulls.createReview / listReviews / dismissReview when the clang-tidy hash is out of date
 
 jobs:
   verify-hash:

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -22,8 +22,7 @@ on:
       - "script/platformio_install_deps.py"
 
 permissions:
-  contents: read
-  packages: read
+  contents: read  # actions/checkout only; the build does not push images
 
 concurrency:
   # yamllint disable-line rule:line-length

--- a/.github/workflows/ci-memory-impact-comment.yml
+++ b/.github/workflows/ci-memory-impact-comment.yml
@@ -7,9 +7,9 @@ on:
     types: [completed]
 
 permissions:
-  contents: read
-  pull-requests: write
-  actions: read
+  contents: read        # actions/checkout of the base repo at the PR's target branch
+  pull-requests: write  # gh api to look up the PR by head SHA and post/update the memory-impact comment
+  actions: read         # gh run download for the memory-analysis artifacts produced by the CI workflow run
 
 jobs:
   memory-impact-comment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
   merge_group:
 
 permissions:
-  contents: read
+  contents: read  # actions/checkout for all jobs; individual jobs add their own scopes when they need to write
 
 env:
   DEFAULT_PYTHON: "3.11"
@@ -1147,8 +1147,8 @@ jobs:
       - memory-impact-pr-branch
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && fromJSON(needs.determine-jobs.outputs.memory_impact).should_run == 'true' && needs.memory-impact-target-branch.outputs.skip != 'true'
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read        # actions/checkout to load the comment-posting script
+      pull-requests: write  # ci_memory_impact_comment.py posts/updates the memory-impact comment on the PR
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/close-pr-from-fork-default-branch.yml
+++ b/.github/workflows/close-pr-from-fork-default-branch.yml
@@ -6,8 +6,8 @@ on:
     types: [opened, reopened]
 
 permissions:
-  pull-requests: write
-  issues: write
+  pull-requests: write  # pulls.update to close the PR opened from a fork's default branch
+  issues: write         # issues.createComment to explain to the contributor why the PR was closed
 
 jobs:
   close:

--- a/.github/workflows/codeowner-approved-label-update.yml
+++ b/.github/workflows/codeowner-approved-label-update.yml
@@ -15,9 +15,9 @@ on:
       - beta
 
 permissions:
-  issues: write
-  pull-requests: read
-  contents: read
+  issues: write       # issues.addLabels / removeLabel to manage the 'code-owner-approved' label on the PR
+  pull-requests: read  # listReviews to determine whether a codeowner has approved
+  contents: read       # actions/checkout to read CODEOWNERS and the shared codeowners.js helper
 
 jobs:
   codeowner-approved:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,9 @@ on:
   schedule:
     - cron: "30 18 * * 4"
 
+# Deny by default; the analyze job opts in to exactly what it needs.
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -26,15 +29,10 @@ jobs:
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
+      security-events: write  # upload CodeQL SARIF results to the Code Scanning API
+      packages: read          # fetch internal or private CodeQL query packs
+      actions: read           # required by codeql-action when run from a private repo
+      contents: read          # actions/checkout to scan the repository
 
     strategy:
       fail-fast: false

--- a/.github/workflows/external-component-bot.yml
+++ b/.github/workflows/external-component-bot.yml
@@ -5,9 +5,9 @@ on:
     types: [opened, synchronize]
 
 permissions:
-  contents: read       #  Needed to fetch PR details
-  issues: write        #  Needed to create and update comments (PR comments are managed via the issues REST API)
-  pull-requests: write  # also needed?
+  contents: read       # pulls.listFiles and the surrounding context for the PR head
+  issues: write        # issues.createComment / updateComment to post the external-component usage instructions on the PR
+  pull-requests: read  # pulls.listFiles to enumerate which components changed
 
 jobs:
   external-comment:

--- a/.github/workflows/external-component-bot.yml
+++ b/.github/workflows/external-component-bot.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize]
 
 permissions:
-  contents: read       # pulls.listFiles and the surrounding context for the PR head
   issues: write        # issues.createComment / updateComment to post the external-component usage instructions on the PR
   pull-requests: read  # pulls.listFiles to enumerate which components changed
 

--- a/.github/workflows/issue-codeowner-notify.yml
+++ b/.github/workflows/issue-codeowner-notify.yml
@@ -9,8 +9,8 @@ on:
     types: [labeled]
 
 permissions:
-  issues: write
-  contents: read
+  issues: write   # issues.createComment to mention component codeowners on the newly labelled issue
+  contents: read  # repos.getContent to fetch CODEOWNERS from the default branch
 
 jobs:
   notify-codeowners:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,6 +6,12 @@ on:
     - cron: "30 0 * * *"  # Run daily at 00:30 UTC
   workflow_dispatch:
 
+# Deny by default; the lock job opts in to exactly what the reusable workflow needs.
+permissions: {}
+
 jobs:
   lock:
+    permissions:
+      issues: write         # issues.lock on closed issues
+      pull-requests: write  # issues.lock on closed pull requests
     uses: esphome/workflows/.github/workflows/lock.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -8,8 +8,8 @@ on:
       - beta
 
 permissions:
-  contents: read
-  pull-requests: read
+  contents: read       # actions/checkout to load detect-tags.js
+  pull-requests: read  # pulls.listFiles to map changed files to component/core/dashboard/ci tags
 
 jobs:
   check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
     - cron: "0 2 * * *"
 
 permissions:
-  contents: read
+  contents: read  # actions/checkout for all jobs; deploy jobs add their own scopes when they need to write
 
 jobs:
   init:
@@ -57,8 +57,8 @@ jobs:
     if: github.repository == 'esphome/esphome' && github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write
+      contents: read   # actions/checkout to build the sdist/wheel
+      id-token: write  # OIDC token for PyPI Trusted Publishing (pypa/gh-action-pypi-publish)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
@@ -78,8 +78,8 @@ jobs:
     name: Build ESPHome ${{ matrix.platform.arch }}
     if: github.repository == 'esphome/esphome'
     permissions:
-      contents: read
-      packages: write
+      contents: read   # actions/checkout to load Dockerfile and build context
+      packages: write  # docker/login-action + build-push-action push image digests to ghcr.io
     runs-on: ${{ matrix.platform.os }}
     needs: [init]
     strategy:
@@ -152,8 +152,8 @@ jobs:
       - deploy-docker
     if: github.repository == 'esphome/esphome'
     permissions:
-      contents: read
-      packages: write
+      contents: read   # actions/checkout to load Dockerfile and build context
+      packages: write  # docker/login-action + build-push-action push image digests to ghcr.io
     strategy:
       fail-fast: false
       matrix:
@@ -227,6 +227,7 @@ jobs:
           private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
           owner: esphome
           repositories: home-assistant-addon
+          permission-actions: write  # actions.createWorkflowDispatch on the target repo (only API call made with this token)
 
       - name: Trigger Workflow
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -262,6 +263,7 @@ jobs:
           private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
           owner: esphome
           repositories: esphome-schema
+          permission-actions: write  # actions.createWorkflowDispatch on the target repo (only API call made with this token)
 
       - name: Trigger Workflow
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -293,6 +295,7 @@ jobs:
           private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
           owner: esphome
           repositories: version-notifier
+          permission-actions: write  # actions.createWorkflowDispatch on the target repo (only API call made with this token)
 
       - name: Trigger Workflow
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  issues: write
-  pull-requests: write
+  issues: write         # actions/stale labels, comments on, and closes stale issues
+  pull-requests: write  # actions/stale labels, comments on, and closes stale pull requests
 
 concurrency:
   group: lock

--- a/.github/workflows/status-check-labels.yml
+++ b/.github/workflows/status-check-labels.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, synchronize]
 
+permissions:
+  pull-requests: read  # issues.listLabelsOnIssue to detect blocking labels (needs-docs, merge-after-release, chained-pr)
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
# What does this implement/fix?

Audits every GitHub Actions workflow in this repo and every App token minted via `actions/create-github-app-token`, scoping each one down to the specific API calls the workflow actually makes. Adds an inline comment on every permission line documenting *why* it is granted so drift is easy to catch in review.

Summary of substantive changes (every other workflow only gained comments):

- **`auto-label-pr.yml`** — dropped the workflow's top-level `pull-requests: write`; all writes use the App token, so `GITHUB_TOKEN` is now `contents: read` only. The minted App token is scoped to `contents: read`, `issues: write`, `pull-requests: write`.
- **`ci-docker.yml`** — dropped unused `packages: read` (this workflow only builds locally, it never pushes or pulls authenticated images).
- **`codeql.yml`** — added top-level `permissions: {}` (was relying on the repo default); the analyze job already self-scopes.
- **`external-component-bot.yml`** — downgraded `pull-requests: write` → `read` (the workflow only reads PR files; comment writes go through the issues API).
- **`lock.yml`** — added top-level `permissions: {}` and job-level `issues: write` + `pull-requests: write` (was relying on the repo default).
- **`release.yml`** — three `deploy-*` jobs that mint an App token only to call `actions.createWorkflowDispatch` now mint with `permission-actions: write` (instead of inheriting every installation scope of the GitHub App).
- **`status-check-labels.yml`** — added `pull-requests: read` (was relying on the repo default).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# Example config.yaml

\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).