### PR TITLE
[ci] sync-device-classes: mint least-privilege App token

### DIFF
--- a/.github/workflows/sync-device-classes.yml
+++ b/.github/workflows/sync-device-classes.yml
@@ -6,12 +6,27 @@ on:
   schedule:
     - cron: "45 6 * * *"
 
+# Repo writes (branch push, PR open) happen via the App token minted below,
+# so the workflow's GITHUB_TOKEN does not need any write scopes.
+permissions:
+  contents: read  # actions/checkout for this repo and home-assistant/core
+
 jobs:
   sync:
     name: Sync Device Classes
     runs-on: ubuntu-latest
     if: github.repository == 'esphome/esphome'
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          # Scope the minted App token to the minimum needed by peter-evans/create-pull-request.
+          permission-contents: write       # git.createCommit + refs.create/update to push the sync/device-classes branch
+          permission-pull-requests: write  # pulls.create / pulls.update to open or refresh the sync PR
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -50,4 +65,4 @@ jobs:
           delete-branch: true
           title: "Synchronise Device Classes from Home Assistant"
           body-path: .github/PULL_REQUEST_TEMPLATE.md
-          token: ${{ secrets.DEVICE_CLASS_SYNC_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
# What does this implement/fix?

Replace the long-lived \`DEVICE_CLASS_SYNC_TOKEN\` PAT used by \`.github/workflows/sync-device-classes.yml\` with a short-lived token minted on each run via \`actions/create-github-app-token\` (same \`ESPHOME_GITHUB_APP_CLIENT_ID\` / \`ESPHOME_GITHUB_APP_PRIVATE_KEY\` pair already used by \`auto-label-pr.yml\` and \`release.yml\`).

The minted token is scoped to the minimum surface \`peter-evans/create-pull-request\` needs:

- \`permission-contents: write\` — push the \`sync/device-classes\` branch
- \`permission-pull-requests: write\` — open / refresh the sync PR

Everything else the installation could grant is dropped from the issued token. The workflow's own \`GITHUB_TOKEN\` is also locked down to \`contents: read\` (only \`actions/checkout\` needs it). Comment style matches #16349.

Once this lands, the \`DEVICE_CLASS_SYNC_TOKEN\` repository secret can be deleted.

> Requires the ESPHome GitHub App installation on \`esphome/esphome\` to already have **Contents: write** and **Pull requests: write** — \`permission-*\` inputs can only narrow what the installation has, not expand it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# Example config.yaml

\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).