### PR TITLE
[ci] codeowner-review-request: mint least-privilege App token

### DIFF
--- a/.github/workflows/codeowner-review-request.yml
+++ b/.github/workflows/codeowner-review-request.yml
@@ -17,9 +17,10 @@ on:
       - release
       - beta
 
+# PR/review writes (requestReviewers, issues.createComment) are performed with the App token minted below,
+# so the workflow's GITHUB_TOKEN only needs read access for checkout.
 permissions:
-  pull-requests: write
-  contents: read
+  contents: read  # actions/checkout to read CODEOWNERS and the shared codeowners.js helper
 
 jobs:
   request-codeowner-reviews:
@@ -32,9 +33,20 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          # Scope the minted App token to the minimum needed by the github-script step below.
+          permission-pull-requests: write  # pulls.listFiles, pulls.get, pulls.listReviews, pulls.requestReviewers
+          permission-issues: write         # issues.listComments and issues.createComment (PR comments use the issues API)
+
       - name: Request reviews from component codeowners
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { loadCodeowners, getEffectiveOwners } = require('./.github/scripts/codeowners.js');
 


### PR DESCRIPTION
# What does this implement/fix?

Moves the PR/review writes in `codeowner-review-request.yml` from the workflow's `GITHUB_TOKEN` to an App token minted via `actions/create-github-app-token`, scoped to the minimum set of installation permissions the github-script step actually exercises.

- **Workflow `GITHUB_TOKEN`** — dropped `pull-requests: write`; now only `contents: read` for `actions/checkout`.
- **Minted App token** — scoped to:
  - `permission-pull-requests: write` — `pulls.listFiles`, `pulls.get`, `pulls.listReviews`, `pulls.requestReviewers`
  - `permission-issues: write` — `issues.listComments` and `issues.createComment` (PR comments use the issues API)

Each permission line also gets an inline comment documenting why it is granted, matching the audit style introduced in #16349 and #16350.

Duplicate-ping detection still works: the script keys off the hidden `<!-- codeowner-review-request-bot -->` marker plus `comment.user.type === 'Bot'`, which both the previous `github-actions[bot]` comments and the new App-bot comments satisfy.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# Example config.yaml

\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).