### PR TITLE
[ci] Fix external-component-bot 403 on PR comments

### DIFF
--- a/.github/workflows/external-component-bot.yml
+++ b/.github/workflows/external-component-bot.yml
@@ -5,8 +5,10 @@ on:
     types: [opened, synchronize]
 
 permissions:
-  issues: write        # issues.createComment / updateComment to post the external-component usage instructions on the PR
-  pull-requests: read  # pulls.listFiles to enumerate which components changed
+  # pull-requests: write covers pulls.listFiles and creating/updating PR comments via the
+  # issues.*Comment APIs. For PR resources, GitHub Actions requires the pull-requests scope
+  # for comment writes -- issues: write is only sufficient for comments on real issues.
+  pull-requests: write
 
 jobs:
   external-comment:

--- a/.github/workflows/external-component-bot.yml
+++ b/.github/workflows/external-component-bot.yml
@@ -4,21 +4,29 @@ on:
   pull_request_target:
     types: [opened, synchronize]
 
-permissions:
-  # pull-requests: write covers pulls.listFiles and creating/updating PR comments via the
-  # issues.*Comment APIs. For PR resources, GitHub Actions requires the pull-requests scope
-  # for comment writes -- issues: write is only sufficient for comments on real issues.
-  pull-requests: write
+# All API calls (pulls.listFiles + issues.{list,create,update}Comment) are performed with
+# the App token minted below, so the workflow's GITHUB_TOKEN does not need any scopes.
+permissions: {}
 
 jobs:
   external-comment:
     name: External component comment
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          # pulls.listFiles + issues.{list,create,update}Comment on PRs. For PR resources
+          # the issues.*Comment APIs require the pull-requests scope, not issues.
+          permission-pull-requests: write
+
       - name: Add external component comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             // Generate external component usage instructions
             function generateExternalComponentInstructions(prNumber, componentNames, owner, repo) {


### PR DESCRIPTION
# What does this implement/fix?

After #16349 the external-component-bot workflow has been failing on PR comment writes (run [25653776409 on #16353](https://github.com/esphome/esphome/actions/runs/25653776409/job/75297451128?pr=16353)).

The token in that run was granted exactly what the previous PR set:

```
Issues: write
PullRequests: read
```

and the comment POST 403'd:

```
POST /repos/esphome/esphome/issues/16353/comments - 403
RequestError [HttpError]: Resource not accessible by integration
```

Even though the REST endpoint URL is in the `/issues/` namespace, when the resource is a **pull request** the GitHub Actions `GITHUB_TOKEN` requires the `pull-requests` scope for comment writes — `issues: write` is only sufficient for comments on real issues. This is the inverse of label *reads* on PRs, which accept either scope.

Two commits land in this PR:

1. **Fix the 403** by restoring `pull-requests: write` (covers both `pulls.listFiles` and the `issues.{create,update}Comment` calls the script makes).
2. **Migrate the workflow to a minted App token**, matching the pattern used by `auto-label-pr`, `codeowner-review-request`, `sync-device-classes`, and the three `release.yml` deploy jobs. The minted token is scoped to `pull-requests: write` only; the workflow's `GITHUB_TOKEN` drops to `permissions: {}`. Inline comments on every permission line document which API call requires it and call out the issues-vs-pull-requests gotcha so the next least-privilege pass doesn't repeat the regression.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# Example config.yaml

\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).