### PR TITLE
[helpers] Re-enable ProgressBar under --dashboard mode

### DIFF
--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -618,10 +618,19 @@ class ProgressBar:
     """A simple terminal progress bar for upload operations."""
 
     def __init__(self, header: str, stream: TextIO | None = None) -> None:
+        # Local import to avoid a top-level cycle with esphome.core.
+        from esphome.core import CORE
+
         self.header = header
         self.stream = stream or sys.stderr
         self.last_progress: int | None = None
-        self.enabled = hasattr(self.stream, "isatty") and self.stream.isatty()
+        # Enable when writing to an interactive TTY *or* when running under
+        # ``--dashboard``. The dashboard captures our stderr via
+        # ``stdout=PIPE, stderr=STDOUT`` and parses the ``\rUploading: NN%``
+        # frames to drive its own progress UI -- gating purely on ``isatty()``
+        # silently disables every dashboard-side flash-progress indicator.
+        is_tty = hasattr(self.stream, "isatty") and self.stream.isatty()
+        self.enabled = is_tty or CORE.dashboard
 
     def update(self, progress: float) -> None:
         if not self.enabled:

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -1,9 +1,10 @@
+import io
 import logging
 import os
 from pathlib import Path
 import socket
 import stat
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from aioesphomeapi.host_resolver import AddrInfo, IPv4Sockaddr, IPv6Sockaddr
 from hypothesis import given
@@ -12,7 +13,8 @@ import pytest
 
 from esphome import helpers
 from esphome.address_cache import AddressCache
-from esphome.core import EsphomeError
+from esphome.core import CORE, EsphomeError
+from esphome.helpers import ProgressBar
 
 
 @pytest.mark.parametrize(
@@ -1024,3 +1026,39 @@ def test_resolve_ip_address_mixed_cached_uncached() -> None:
         assert "192.168.1.10" in addresses  # Direct IP
         assert "192.168.1.50" in addresses  # From cache
         assert "192.168.1.100" in addresses  # From resolver
+
+
+def test_progressbar_enabled_on_tty(monkeypatch) -> None:
+    """Interactive TTY: progress writes through (pre-existing behaviour)."""
+    stream = MagicMock(spec=io.TextIOWrapper)
+    stream.isatty.return_value = True
+    monkeypatch.setattr(CORE, "dashboard", False)
+
+    bar = ProgressBar("Uploading", stream=stream)
+    assert bar.enabled is True
+
+
+def test_progressbar_disabled_on_pipe_without_dashboard(monkeypatch) -> None:
+    """Piped output without --dashboard: progress suppressed."""
+    stream = MagicMock(spec=io.TextIOWrapper)
+    stream.isatty.return_value = False
+    monkeypatch.setattr(CORE, "dashboard", False)
+
+    bar = ProgressBar("Uploading", stream=stream)
+    assert bar.enabled is False
+
+
+def test_progressbar_enabled_on_pipe_with_dashboard(monkeypatch) -> None:
+    r"""Piped output under --dashboard: progress writes through.
+
+    The dashboard captures stderr through a pipe (so ``isatty()`` is False)
+    and parses ``\rUploading: NN%`` frames to drive its progress UI.
+    Gating purely on ``isatty()`` silently disables every dashboard-side
+    flash-progress indicator.
+    """
+    stream = MagicMock(spec=io.TextIOWrapper)
+    stream.isatty.return_value = False
+    monkeypatch.setattr(CORE, "dashboard", True)
+
+    bar = ProgressBar("Uploading", stream=stream)
+    assert bar.enabled is True


### PR DESCRIPTION
# What does this implement/fix?

Re-enables `ProgressBar` (in `esphome/helpers.py`) when ESPHome is invoked with `--dashboard`, even though its stderr is a pipe rather than a TTY.

`esphome upload` / `esphome run` are spawned by both the legacy `esphome.dashboard` and the new [`esphome/device-builder`](https://github.com/esphome/device-builder) dashboard with `stdout=PIPE, stderr=STDOUT`. The dashboard then parses the `\rUploading: NN% ` frames out of that pipe to drive its own firmware-tasks progress UI.

### Where it regressed

The `isatty()` gate on `ProgressBar.enabled` was introduced in #14678 ([core] Native idf full support) — commit `e9cc10fedc` on `esphome/helpers.py`:

```python
self.enabled = hasattr(self.stream, "isatty") and self.stream.isatty()
```

Before #14678, `ProgressBar` wrote unconditionally and the dashboard saw every frame. After #14678 the dashboard's stderr-pipe child has `isatty()` False, `enabled` is `False`, every `update()` early-returns, and `iter_lines_with_progress` on the dashboard side never sees a `\rUploading:` chunk. The firmware-tasks progress bar has stayed frozen at 0% during the upload phase of every dashboard-driven OTA since.

The #14678 gate intent is reasonable in isolation — `esphome upload yaml > log.txt` shouldn't fill a log file with `\r`-overwrites — but it collides with `--dashboard`, where the consumer is specifically tooling that *wants* those overwrites.

### Empirical reproduction

Captured inside the device-builder HA add-on container, before this fix:

```
$ esphome --dashboard upload /config/esphome/<dev>.yaml \
    --device <ip> --file <staged.bin> 2>&1 | cat -A
^[[32mINFO Connecting to <ip> port 3232...^[[0m$
^[[32mINFO Connected to <ip>^[[0m$
^[[32mINFO Uploading /tmp/.../firmware.bin (789312 bytes)^[[0m$
^[[32mINFO Upload took 4.54 seconds, waiting for result...^[[0m$
^[[32mINFO OTA successful^[[0m$
^[[32mINFO Successfully uploaded program.^[[0m$
```

Note the missing `^MUploading: [============] NN% ` frames that should appear between `Connected` and `Upload took`. The same command in an interactive terminal does emit them.

### Fix

Extend `ProgressBar.enabled` to also fire under `CORE.dashboard`:

```python
is_tty = hasattr(self.stream, "isatty") and self.stream.isatty()
self.enabled = is_tty or CORE.dashboard
```

`CORE.dashboard` is the canonical "I'm running under tooling that consumes my piped output" signal. The local `from esphome.core import CORE` mirrors the pattern already used elsewhere in `helpers.py` (e.g. `docs_url`) to avoid a top-level import cycle.

Compatibility matrix:

- **Interactive `esphome upload` / `esphome run`**: unchanged. `is_tty` True, `enabled` True.
- **Non-interactive piped invocation without `--dashboard`** (`esphome upload yaml > log.txt`, CI scripts): unchanged. `is_tty` False, `CORE.dashboard` False, output still suppressed — the #14678 intent is preserved.
- **`--dashboard` invocation** (legacy dashboard, `esphome/device-builder`, any future external tool that sets `--dashboard`): now enabled. Output flows to the consuming pipe.

### Downstream coordination

No changes needed on the dashboard side. Both [`esphome/dashboard`](https://github.com/esphome/dashboard) and [`esphome/device-builder`](https://github.com/esphome/device-builder) already have an `iter_lines_with_progress`-style reader; once this lands, they pick the `\rUploading: NN%` frames up automatically and their firmware-tasks progress bars start animating again during the upload phase.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- regression introduced in #14678

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — `--dashboard` is `argparse.SUPPRESS`-hidden and not user-facing; no docs change needed.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Fix is platform-independent — lives in the Python host-side `helpers.py`. Tested against an OTA target via the device-builder dashboard pipe.)

## Example entry for `config.yaml`:

```yaml
# No config change required — host-side fix only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

Three regression tests added to `tests/unit_tests/test_helpers.py` pin all three cases:

- `test_progressbar_enabled_on_tty` — interactive TTY still emits progress.
- `test_progressbar_disabled_on_pipe_without_dashboard` — piped invocation without `--dashboard` still suppresses (the #14678 intent).
- `test_progressbar_enabled_on_pipe_with_dashboard` — piped invocation under `--dashboard` now emits progress. This one fails without the fix.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).