### PR TITLE
[script] Preserve source order of enum options in language schema

### DIFF
--- a/script/build_language_schema.py
+++ b/script/build_language_schema.py
@@ -119,7 +119,15 @@ from esphome.util import Registry  # noqa: E402
 
 def sort_obj(obj):
     if isinstance(obj, dict):
-        return {k: sort_obj(v) for k, v in sorted(obj.items(), key=lambda x: str(x[0]))}
+        is_enum = obj.get(S_TYPE) == "enum"
+        result = {}
+        for k, v in sorted(obj.items(), key=lambda x: str(x[0])):
+            if is_enum and k == "values" and isinstance(v, dict):
+                # Preserve source order of enum options
+                result[k] = {vk: sort_obj(vv) for vk, vv in v.items()}
+            else:
+                result[k] = sort_obj(v)
+        return result
     if isinstance(obj, list):
         return [sort_obj(item) for item in obj]
     return obj

--- a/tests/script/test_build_language_schema.py
+++ b/tests/script/test_build_language_schema.py
@@ -1,0 +1,98 @@
+"""Unit tests for script/build_language_schema.py."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "script"
+    / "build_language_schema.py"
+)
+
+
+def _extract_sort_obj():
+    # build_language_schema.py runs argparse, loads every component, and
+    # calls build_schema() at import time, so a plain import isn't viable
+    # in a unit test. Pull just the pure helper out via AST instead.
+    tree = ast.parse(SCRIPT_PATH.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "sort_obj":
+            namespace: dict = {"S_TYPE": "type"}
+            module = ast.Module(body=[node], type_ignores=[])
+            exec(compile(module, str(SCRIPT_PATH), "exec"), namespace)
+            return namespace["sort_obj"]
+    raise AssertionError("sort_obj not found in build_language_schema.py")
+
+
+sort_obj = _extract_sort_obj()
+
+
+def test_sort_obj_sorts_dict_keys() -> None:
+    result = sort_obj({"b": 1, "a": 2, "c": 3})
+    assert list(result.keys()) == ["a", "b", "c"]
+
+
+def test_sort_obj_sorts_nested_dicts() -> None:
+    result = sort_obj({"outer": {"z": 1, "a": 2}})
+    assert list(result["outer"].keys()) == ["a", "z"]
+
+
+def test_sort_obj_preserves_enum_values_order() -> None:
+    config = {
+        "type": "enum",
+        "values": {
+            "2MB": None,
+            "4MB": None,
+            "8MB": None,
+            "16MB": None,
+            "32MB": None,
+        },
+    }
+    result = sort_obj(config)
+    assert list(result["values"].keys()) == ["2MB", "4MB", "8MB", "16MB", "32MB"]
+
+
+def test_sort_obj_sorts_non_enum_values_key() -> None:
+    config = {"type": "schema", "values": {"z": 1, "a": 2}}
+    result = sort_obj(config)
+    assert list(result["values"].keys()) == ["a", "z"]
+
+
+def test_sort_obj_sorts_other_keys_in_enum() -> None:
+    config = {
+        "type": "enum",
+        "default": "4MB",
+        "key": "Optional",
+        "values": {"2MB": None, "4MB": None},
+    }
+    result = sort_obj(config)
+    assert list(result.keys()) == ["default", "key", "type", "values"]
+    assert list(result["values"].keys()) == ["2MB", "4MB"]
+
+
+def test_sort_obj_recurses_into_enum_value_entries() -> None:
+    config = {
+        "type": "enum",
+        "values": {
+            "esp32": {"name": "ESP32", "docs": "Original"},
+            "esp32-c3": {"name": "ESP32-C3", "docs": "RISC-V"},
+        },
+    }
+    result = sort_obj(config)
+    assert list(result["values"].keys()) == ["esp32", "esp32-c3"]
+    assert list(result["values"]["esp32"].keys()) == ["docs", "name"]
+
+
+def test_sort_obj_handles_lists() -> None:
+    result = sort_obj([{"b": 1, "a": 2}, {"d": 3, "c": 4}])
+    assert list(result[0].keys()) == ["a", "b"]
+    assert list(result[1].keys()) == ["c", "d"]
+
+
+def test_sort_obj_passes_through_scalars() -> None:
+    assert sort_obj("hello") == "hello"
+    assert sort_obj(42) == 42
+    assert sort_obj(None) is None
+    assert sort_obj(True) is True


### PR DESCRIPTION
# What does this implement/fix?

`script/build_language_schema.py` recursively alphabetises every dict key on output, which also re-orders the `values` dict of `type: enum` config vars (`cv.enum` and `cv.one_of`). Their key order in the source schema is meaningful (e.g. `flash_size` going 2MB → 4MB → 8MB → 16MB → 32MB, not the alphabetical 16MB, 2MB, 32MB, 4MB, 8MB).

`sort_obj` now skips sorting the `values` dict when the enclosing object has `type: "enum"` — keys retain their source-dict order while everything else in the schema still gets sorted, so the diff against the existing dumps stays minimal.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).