### PR TITLE
[script] Fix array-type parameters in script.execute

### DIFF
--- a/esphome/components/script/__init__.py
+++ b/esphome/components/script/__init__.py
@@ -169,6 +169,8 @@ async def script_execute_action_to_code(config, action_id, template_arg, args):
                 return value
             if type == "bool":
                 return cg.RawExpression(str(value).lower())
+            if isinstance(value, (list, tuple)):
+                return cg.ArrayInitializer(*value)
             return cg.RawExpression(str(value))
 
         return converter

--- a/tests/components/script/common.yaml
+++ b/tests/components/script/common.yaml
@@ -7,6 +7,12 @@ esphome:
           prefix: "Test"
           param2: 0
           param3: true
+      - script.execute:
+          id: my_script_with_array_params
+          ints: [42, 100]
+          floats: [1.5, 2.5]
+          bools: [true, false]
+          strings: ["a", "b"]
       - script.wait: my_script
       - script.stop: my_script
       - if:
@@ -34,6 +40,16 @@ script:
     mode: restart
     then:
       - lambda: 'ESP_LOGD("main", "Hello World!");'
+  - id: my_script_with_array_params
+    parameters:
+      ints: int[]
+      floats: float[]
+      bools: bool[]
+      strings: string[]
+    then:
+      - lambda: |-
+          ESP_LOGD("main", "ints=%d floats=%f bools=%d strings=%s",
+                   ints[0], floats[0], bools[0], strings[0].c_str());
   - id: my_script_with_params
     parameters:
       prefix: string

--- a/tests/integration/fixtures/script_array_params.yaml
+++ b/tests/integration/fixtures/script_array_params.yaml
@@ -1,0 +1,36 @@
+esphome:
+  name: test-script-array-params
+
+host:
+
+api:
+  actions:
+    - action: run_array_script
+      then:
+        - script.execute:
+            id: array_script
+            ints: [42, 100]
+            floats: [1.5, 2.5]
+            bools: [true, false]
+            strings: ["hello", "world"]
+
+logger:
+  level: DEBUG
+
+script:
+  - id: array_script
+    parameters:
+      ints: int[]
+      floats: float[]
+      bools: bool[]
+      strings: string[]
+    then:
+      - lambda: |-
+          ESP_LOGI("test", "ints size=%u [0]=%d [1]=%d",
+                   (unsigned) ints.size(), ints[0], ints[1]);
+          ESP_LOGI("test", "floats size=%u [0]=%.2f [1]=%.2f",
+                   (unsigned) floats.size(), floats[0], floats[1]);
+          ESP_LOGI("test", "bools size=%u [0]=%d [1]=%d",
+                   (unsigned) bools.size(), (int) bools[0], (int) bools[1]);
+          ESP_LOGI("test", "strings size=%u [0]=%s [1]=%s",
+                   (unsigned) strings.size(), strings[0].c_str(), strings[1].c_str());

--- a/tests/integration/test_script_array_params.py
+++ b/tests/integration/test_script_array_params.py
@@ -1,0 +1,71 @@
+"""Integration test for script array parameters (issue #16367).
+
+Verifies that script parameters of array types (`int[]`, `float[]`, `bool[]`,
+`string[]`) compile and execute correctly. Prior to the fix in
+`esphome/components/script/__init__.py`, the `script.execute` codegen emitted
+the Python `repr` of the list (e.g. `return [42, 100];`) instead of a C++
+braced initializer, causing compile failures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_script_array_params(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Execute a script with int[], float[], bool[], string[] parameters."""
+    loop = asyncio.get_running_loop()
+    seen: dict[str, str] = {}
+    done = loop.create_future()
+
+    patterns = {
+        "ints": re.compile(r"ints size=(\d+) \[0\]=(-?\d+) \[1\]=(-?\d+)"),
+        "floats": re.compile(
+            r"floats size=(\d+) \[0\]=(-?\d+\.\d+) \[1\]=(-?\d+\.\d+)"
+        ),
+        "bools": re.compile(r"bools size=(\d+) \[0\]=(\d+) \[1\]=(\d+)"),
+        "strings": re.compile(r"strings size=(\d+) \[0\]=(\w+) \[1\]=(\w+)"),
+    }
+
+    def check_output(line: str) -> None:
+        for key, pat in patterns.items():
+            if (m := pat.search(line)) and key not in seen:
+                seen[key] = m.group(0)
+        if len(seen) == len(patterns) and not done.done():
+            done.set_result(True)
+
+    async with (
+        run_compiled(yaml_config, line_callback=check_output),
+        api_client_connected() as client,
+    ):
+        _, services = await client.list_entities_services()
+        service = next((s for s in services if s.name == "run_array_script"), None)
+        assert service is not None, "run_array_script service not found"
+        await client.execute_service(service, {})
+
+        try:
+            await asyncio.wait_for(done, timeout=5.0)
+        except TimeoutError:
+            pytest.fail(f"Did not receive all expected log lines. Saw: {seen}")
+
+        assert (m := patterns["ints"].search(seen["ints"]))
+        assert m.group(1) == "2" and m.group(2) == "42" and m.group(3) == "100"
+
+        assert (m := patterns["floats"].search(seen["floats"]))
+        assert m.group(1) == "2" and m.group(2) == "1.50" and m.group(3) == "2.50"
+
+        assert (m := patterns["bools"].search(seen["bools"]))
+        assert m.group(1) == "2" and m.group(2) == "1" and m.group(3) == "0"
+
+        assert (m := patterns["strings"].search(seen["strings"]))
+        assert m.group(1) == "2" and m.group(2) == "hello" and m.group(3) == "world"


### PR DESCRIPTION
# What does this implement/fix?

Script parameters declared with an array type (e.g. `int[]`, `float[]`, `bool[]`, `string[]`) caused C++ compile errors because the `script.execute` codegen emitted the Python `repr` of the list (e.g. `return [42, 100];`) instead of a C++ braced initializer.

Teach the converter inside `script_execute_action_to_code` to wrap list/tuple values in `cg.ArrayInitializer`. The generated lambda now returns `{42, 100}`, which list-initializes the script parameter's `std::vector`:

```cpp
script_scriptexecuteaction_id->set_args([]() -> std::vector<int> {
    return {42, 100};
  }, []() -> std::vector<float> {
    return {1.5f, 2.5f};
  }, []() -> std::vector<bool> {
    return {true, false};
  }, []() -> std::vector<std::string> {
    return {"hello", "world"};
});
```

This was broken since #4627 (June 2023), when the `convert` helper introduced a `cg.RawExpression(str(value))` fallback that does not handle Python lists.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16367

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Host integration test also runs.)

## Example entry for `config.yaml`:

```yaml
script:
  - id: test_array
    parameters:
      arr: int[]
    then:
      - lambda: |-
          ESP_LOGI("test", "arr[0]=%d", arr[0]);

binary_sensor:
  - platform: gpio
    id: test
    pin: GPIO0
    on_press:
      - script.execute:
          id: test_array
          arr: [42, 100]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).