### PR TITLE
[ci] Comment on PRs that touch the legacy dashboard

### DIFF
--- a/.github/workflows/dashboard-deprecation-comment.yml
+++ b/.github/workflows/dashboard-deprecation-comment.yml
@@ -1,0 +1,113 @@
+name: Add Dashboard Deprecation Comment
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+# All API calls (pulls.listFiles + issues.{list,create,update}Comment) are performed with
+# the App token minted below, so the workflow's GITHUB_TOKEN does not need any scopes.
+permissions: {}
+
+jobs:
+  dashboard-deprecation-comment:
+    name: Dashboard deprecation comment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          # pulls.listFiles + issues.{list,create,update}Comment on PRs. For PR resources
+          # the issues.*Comment APIs require the pull-requests scope, not issues.
+          permission-pull-requests: write
+
+      - name: Add dashboard deprecation comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const commentMarker = "<!-- This comment was generated automatically by the dashboard-deprecation-comment workflow. -->";
+
+            const commentBody = `Thanks for opening this PR!
+
+            Heads up: the legacy ESPHome dashboard (\`esphome/dashboard/\` and \`tests/dashboard/\`) is **deprecated** and is being replaced by [ESPHome Device Builder](https://github.com/esphome/device-builder). We are not adding new features to the legacy dashboard and it will eventually be removed from this repository.
+
+            What this means for your PR:
+
+            - **New features / enhancements**: please port the change to [esphome/device-builder](https://github.com/esphome/device-builder) instead. We are unlikely to review or merge new dashboard features here.
+            - **Bug fixes**: small fixes may still be considered, but please check first whether the same issue exists in Device Builder, where the fix will have a longer life.
+            - **Security issues**: please do not file a public PR. Report privately via [GitHub security advisories](https://github.com/esphome/esphome/security/advisories/new) so we can coordinate a fix.
+
+            We appreciate the contribution and apologize for the friction; flagging this early so your time isn't spent on a change that may not land.
+
+            ---
+            (Added by the PR bot)
+
+            ${commentMarker}`;
+
+            async function getDashboardChanges(github, owner, repo, prNumber) {
+                const changedFiles = await github.paginate(
+                    github.rest.pulls.listFiles,
+                    {
+                        owner: owner,
+                        repo: repo,
+                        pull_number: prNumber,
+                        per_page: 100,
+                    }
+                );
+
+                return changedFiles.filter(file =>
+                    file.filename.startsWith('esphome/dashboard/') ||
+                    file.filename.startsWith('tests/dashboard/')
+                );
+            }
+
+            async function findBotComment(github, owner, repo, prNumber) {
+                const comments = await github.paginate(
+                    github.rest.issues.listComments,
+                    {
+                        owner: owner,
+                        repo: repo,
+                        issue_number: prNumber,
+                        per_page: 100,
+                    }
+                );
+
+                return comments.find(comment =>
+                    comment.body.includes(commentMarker) && comment.user.type === "Bot"
+                );
+            }
+
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+
+            const dashboardChanges = await getDashboardChanges(github, owner, repo, prNumber);
+            const existingComment = await findBotComment(github, owner, repo, prNumber);
+
+            if (dashboardChanges.length === 0) {
+                // PR doesn't (or no longer) touches the legacy dashboard. If we previously
+                // commented (e.g. files were removed in a later push), leave the comment in
+                // place for history rather than thrash on edit/delete.
+                return;
+            }
+
+            if (existingComment) {
+                if (existingComment.body === commentBody) {
+                    return;
+                }
+                await github.rest.issues.updateComment({
+                    owner: owner,
+                    repo: repo,
+                    comment_id: existingComment.id,
+                    body: commentBody,
+                });
+            } else {
+                await github.rest.issues.createComment({
+                    owner: owner,
+                    repo: repo,
+                    issue_number: prNumber,
+                    body: commentBody,
+                });
+            }


### PR DESCRIPTION
# What does this implement/fix?

Adds a GitHub Actions workflow that posts a single (updating) comment on any pull request that touches `esphome/dashboard/` or `tests/dashboard/`. The comment lets contributors know early that the legacy dashboard is deprecated in favor of [esphome/device-builder](https://github.com/esphome/device-builder), and asks for security issues to be reported privately via GitHub security advisories rather than as public PRs.

Today, contributors only find out their dashboard PR will not be reviewed after the fact (see for example [#15485](https://github.com/esphome/esphome/pull/15485)). This wastes their time and ours. A bot comment on PR open / synchronize surfaces the situation immediately, in friendly language, with a clear pointer to where to send the work instead.

The workflow is closely modeled on `.github/workflows/external-component-bot.yml`: same `pull_request_target` trigger, same GitHub App token pattern, single self-updating comment keyed off an HTML marker, no token scopes on the workflow itself.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A (process / contributor experience improvement)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

CI-only change; no device firmware is affected.

## Example entry for `config.yaml`:

```yaml
# N/A - this PR only adds a CI workflow.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).