### PR TITLE
[sendspin] Updates sendspin-cpp to v0.5.0

### DIFF
--- a/esphome/components/sendspin/__init__.py
+++ b/esphome/components/sendspin/__init__.py
@@ -206,11 +206,14 @@ async def to_code(config: ConfigType) -> None:
         )
 
     # sendspin-cpp library
-    esp32.add_idf_component(name="sendspin/sendspin-cpp", ref="0.4.0")
+    esp32.add_idf_component(name="sendspin/sendspin-cpp", ref="0.5.0")
 
     cg.add_define("USE_SENDSPIN", True)  # for MDNS
 
     data = _get_data()
+
+    # The color role is not yet wired up in ESPHome; disable it in the library for now.
+    esp32.add_idf_sdkconfig_option("CONFIG_SENDSPIN_ENABLE_COLOR", False)
 
     # Configure Sendspin roles based on requested features (ESPHome internally via USE_SENDSPIN_*)
     # and disable building unused code paths in the sendspin-cpp library (IDF SDKConfig via CONFIG_SENDSPIN_ENABLE_*).
@@ -264,7 +267,7 @@ async def to_code(config: ConfigType) -> None:
 
         # Library defaults: priority 18 (one above httpd_priority 17 so the decoder is not
         # starved by the HTTP server during the initial encoded-audio burst at stream start),
-        # interpolation/decode buffer locations PREFER_EXTERNAL.
+        # decode buffer location PREFER_EXTERNAL.
         player_struct_fields = [
             ("audio_formats", audio_format_structs),
             ("audio_buffer_capacity", player_cfg[CONF_BUFFER_SIZE]),

--- a/esphome/components/sendspin/media_source/sendspin_media_source.cpp
+++ b/esphome/components/sendspin/media_source/sendspin_media_source.cpp
@@ -188,14 +188,6 @@ void SendspinMediaSource::on_stream_end() {
   }
 }
 
-// THREAD CONTEXT: Main loop (PlayerRoleListener lifecycle callback)
-void SendspinMediaSource::on_stream_clear() {
-  if (this->get_state() != media_source::MediaSourceState::IDLE) {
-    // Only set to IDLE if we were previously in a non-IDLE state, to avoid duplicate state changes
-    this->set_state_(media_source::MediaSourceState::IDLE);
-  }
-}
-
 // THREAD CONTEXT: Main loop (PlayerRoleListener callback)
 void SendspinMediaSource::on_volume_changed(uint8_t volume) { this->request_volume_(volume / 100.0f); }
 

--- a/esphome/components/sendspin/media_source/sendspin_media_source.h
+++ b/esphome/components/sendspin/media_source/sendspin_media_source.h
@@ -49,9 +49,6 @@ class SendspinMediaSource : public SendspinChild,
   /// @brief Called when the audio stream ends (main loop thread).
   void on_stream_end() override;
 
-  /// @brief Called when the audio stream is cleared (main loop thread).
-  void on_stream_clear() override;
-
   /// @brief Called when volume changes (main loop thread).
   void on_volume_changed(uint8_t volume) override;
 

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -100,6 +100,6 @@ dependencies:
   esp32async/asynctcp:
     version: 3.4.91
   sendspin/sendspin-cpp:
-    version: 0.4.0
+    version: 0.5.0
   lvgl/lvgl:
     version: 9.5.0


### PR DESCRIPTION
# What does this implement/fix?

This PR bumps the sendspin-cpp library to v0.5.0 ([GitHub](https://github.com/sendspin/sendspin-cpp) and [Espressif Registry](https://components.espressif.com/components/sendspin/sendspin-cpp/versions/0.5.0/readme))
- Always disables color role (we don't currently expose its functionality)
- Removes `on_stream_clear` from the media_source, as that listener interface is no longer exposed

This release fixes a bug where metadata wasn't properly cleared on a stream end event.

Additionally, it optimizes a few thing that are especially beneficial on an ESP32. It removes a separate interpolation buffer and only uses the decoder output buffer. This keeps all outputs in internal memory (if the media source has ``decode_memory: psram` configured) reducing cache pressure which reduces stuttering at the start of a stream. It also allocates a ArduinoJSON internal memory arena for incoming messages. On an ESP32, this also reduces cache pressure (it used to do a fresh heap allocation in PSRAM for every message) at the start of a stream. In general, it avoids continuously allocating new working buffers on the heap.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

sendspin:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
