### PR TITLE
[ms8607] Pin humidity i2c_id in test fixture

### DIFF
--- a/tests/components/ms8607/common.yaml
+++ b/tests/components/ms8607/common.yaml
@@ -4,6 +4,7 @@ sensor:
     temperature:
       name: Temperature
     humidity:
+      humidity_i2c_id: i2c_bus
       name: Humidity
     pressure:
       name: Pressure

--- a/tests/components/ms8607/common.yaml
+++ b/tests/components/ms8607/common.yaml
@@ -4,7 +4,7 @@ sensor:
     temperature:
       name: Temperature
     humidity:
-      humidity_i2c_id: i2c_bus
+      i2c_id: i2c_bus
       name: Humidity
     pressure:
       name: Pressure


### PR DESCRIPTION
# What does this implement/fix?

The `ms8607` sensor schema declares **two** I2C devices: the main temp/pressure die at the parent level, and a separate humidity die (`MS8607HumidityDevice`) nested under the `humidity:` block. The shared test fixture introduced in #16313 only pins the parent `i2c_id`; the humidity device's bus is left to auto-resolve.

Auto-resolution works when only one `i2c::I2CBus` is in scope, but fails as soon as a second one shows up (e.g. a `tca9548a` channel ID in a grouped test build), with:

```
sensor.ms8607:
  Too many candidates found for 'i2c_id' type 'i2c::I2CBus'
  Some are 'i2c_bus', 'multiplex0_chan0'.
```

Pin `i2c_id: i2c_bus` explicitly inside the `humidity:` block so the test stays valid alongside components that declare additional I2C buses.

(Per the schema in `esphome/components/ms8607/sensor.py`, the humidity block has two ID slots: `humidity_i2c_id` is the `declare_id` for the `MS8607HumidityDevice` variable, and `i2c_id` is the `use_id` for the bus — only the latter selects which bus the device sits on.)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #16313 (introduced the shared `common.yaml`).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: ms8607
    i2c_id: i2c_bus
    humidity:
      i2c_id: i2c_bus    # now exercised by the test fixture
      name: Humidity
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).