### PR TITLE
[zigbee] Fix init-order and missing-field warnings on native ESP-IDF

### DIFF
--- a/esphome/components/zigbee/zigbee_attribute_esp32.cpp
+++ b/esphome/components/zigbee/zigbee_attribute_esp32.cpp
@@ -32,10 +32,9 @@ void ZigbeeAttribute::report_(bool has_lock) {
     return;
   }
   if (has_lock or esp_zb_lock_acquire(10 / portTICK_PERIOD_MS)) {
-    esp_zb_zcl_report_attr_cmd_t cmd = {
-        .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
-        .direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI,
-    };
+    esp_zb_zcl_report_attr_cmd_t cmd = {};
+    cmd.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
+    cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
     cmd.zcl_basic_cmd.dst_addr_u.addr_short = 0x0000;
     cmd.zcl_basic_cmd.dst_endpoint = 1;
     cmd.zcl_basic_cmd.src_endpoint = this->endpoint_id_;
@@ -50,14 +49,13 @@ void ZigbeeAttribute::report_(bool has_lock) {
 }
 
 esp_zb_zcl_reporting_info_t ZigbeeAttribute::get_reporting_info() {
-  esp_zb_zcl_reporting_info_t reporting_info = {
-      .direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_SRV,
-      .ep = this->endpoint_id_,
-      .cluster_id = this->cluster_id_,
-      .cluster_role = this->role_,
-      .attr_id = this->attr_id_,
-      .manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC,
-  };
+  esp_zb_zcl_reporting_info_t reporting_info = {};
+  reporting_info.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_SRV;
+  reporting_info.ep = this->endpoint_id_;
+  reporting_info.cluster_id = this->cluster_id_;
+  reporting_info.cluster_role = this->role_;
+  reporting_info.attr_id = this->attr_id_;
+  reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.u.send_info.min_interval = 10;     /*!< Actual minimum reporting interval */
   reporting_info.u.send_info.max_interval = 0;      /*!< Actual maximum reporting interval */

--- a/esphome/components/zigbee/zigbee_attribute_esp32.h
+++ b/esphome/components/zigbee/zigbee_attribute_esp32.h
@@ -37,8 +37,8 @@ class ZigbeeAttribute : public Component {
         role_(role),
         attr_id_(attr_id),
         attr_type_(attr_type),
-        scale_(scale),
-        max_size_(max_size) {}
+        max_size_(max_size),
+        scale_(scale) {}
   void loop() override;
   template<typename T> void add_attr(T value);
   esp_zb_zcl_reporting_info_t get_reporting_info();

--- a/esphome/components/zigbee/zigbee_esp32.cpp
+++ b/esphome/components/zigbee/zigbee_esp32.cpp
@@ -204,10 +204,9 @@ static void esp_zb_task_(void *pvParameters) {
 
 void ZigbeeComponent::setup() {
   global_zigbee = this;
-  esp_zb_platform_config_t config = {
-      .radio_config = ESP_ZB_DEFAULT_RADIO_CONFIG(),
-      .host_config = ESP_ZB_DEFAULT_HOST_CONFIG(),
-  };
+  esp_zb_platform_config_t config = {};
+  config.radio_config = ESP_ZB_DEFAULT_RADIO_CONFIG();
+  config.host_config = ESP_ZB_DEFAULT_HOST_CONFIG();
 #ifdef USE_WIFI
   if (esp_coex_wifi_i154_enable() != ESP_OK) {
     this->mark_failed();


### PR DESCRIPTION
# What does this implement/fix?

Two latent C++ issues in the `zigbee` component that PlatformIO masks (via ESPHome's per-framework `-Wno-error=...` flags, see `esp32/__init__.py:1756-1759`) but native ESP-IDF builds catch with `-Werror=reorder` and `-Werror=missing-field-initializers`.

## 1. `-Werror=reorder` in `ZigbeeAttribute`

Fields are declared in this order:
```cpp
uint8_t attr_type_;
uint8_t max_size_;
float scale_;
```

…but the constructor initialized them as `attr_type_, scale_, max_size_`. C++ runs initializers in declaration order regardless of init-list order, so g++ flags this. Fix: swap the two entries in the init list so they match declaration order. Semantics unchanged.

## 2. `-Werror=missing-field-initializers` in three POD-struct compound literals

`zigbee_attribute_esp32.cpp:35`, `:53`, and `zigbee_esp32.cpp:207` use designated initializers that touch some — but not all — members of `esp_zb_zcl_report_attr_cmd_t`, `esp_zb_zcl_reporting_info_t`, and `esp_zb_platform_config_t`. With `-Werror=missing-field-initializers` enabled, that's an error.

Fix: value-init the struct first (`= {}`), then assign the populated fields explicitly. Every byte gets zeroed without listing every member name, so the warning doesn't fire and behavior matches the original code (since the unmentioned members were already implicitly zero-initialized by C++'s designated-initializer rules).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced while testing native ESP-IDF toolchain builds (DNM #16383).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — internal C++ fix; user-visible YAML is unchanged.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).