### PR TITLE
[esp32] Relax -Werror=reorder and -Werror=maybe-uninitialized on native ESP-IDF

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1754,7 +1754,9 @@ async def to_code(config):
             )
     else:
         cg.add_build_flag("-Wno-error=format")
+        cg.add_build_flag("-Wno-error=maybe-uninitialized")
         cg.add_build_flag("-Wno-error=missing-field-initializers")
+        cg.add_build_flag("-Wno-error=reorder")
         cg.add_build_flag("-Wno-error=volatile")
 
     cg.set_cpp_standard("gnu++20")


### PR DESCRIPTION
# What does this implement/fix?

The native ESP-IDF toolchain path in `esp32/__init__.py` already disables three `-Werror=...` levels that PlatformIO doesn't enable (`format`, `missing-field-initializers`, `volatile`). Add two more to the same block:

```python
else:  # native ESP-IDF toolchain
    cg.add_build_flag("-Wno-error=format")
    cg.add_build_flag("-Wno-error=maybe-uninitialized")        # new
    cg.add_build_flag("-Wno-error=missing-field-initializers")
    cg.add_build_flag("-Wno-error=reorder")                    # new
    cg.add_build_flag("-Wno-error=volatile")
```

Surfaced while exercising the native ESP-IDF toolchain across the full component matrix in DNM #16383:

- **`-Werror=reorder`** fires when a constructor's initializer list doesn't match the field declaration order. C++ always runs initializers in declaration order regardless of init-list order, so the diagnostic is cosmetic and produces no runtime difference. Hit by `zigbee` and `usb_uart` on this branch.
- **`-Werror=maybe-uninitialized`** fires on third-party managed components we don't control (e.g. the OpenCORE MP3 decoder vendored as `esphome__micro-mp3`). We can't patch the third-party sources from this repo, so the warning should not block our build.

Both warnings remain enabled (just not promoted to errors), so they still show up in build output for anyone watching.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Native ESP-IDF toolchain testing (DNM #16383).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — internal build-flag change; user-visible YAML is unchanged.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).