### PR TITLE
[audio] Document ring buffer source thread safety

### DIFF
--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -220,6 +220,10 @@ class ConstAudioSourceBuffer : public AudioReadableBuffer {
 /// source transparently stitches frames that straddle the ring buffer's wrap boundary by buffering the
 /// trailing partial frame from one chunk and joining it with the head of the next chunk in a small
 /// internal splice buffer, so callers always see frame-aligned data.
+///
+/// Not thread-safe. The underlying ring_buffer::RingBuffer supports one producer and one consumer
+/// running concurrently, but a given RingBufferAudioSource (its acquired item, splice buffer, and
+/// queued region) must be used by only one thread, and that thread is the ring buffer's consumer.
 class RingBufferAudioSource : public AudioReadableBuffer {
  public:
   /// Maximum supported alignment. Sized to cover 32-bit samples across up to 2 channels (8 bytes).

--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -246,6 +246,8 @@ class RingBufferAudioSource : public AudioReadableBuffer {
   size_t available() const override { return this->current_available_; }
   void consume(size_t bytes) override;
   bool has_buffered_data() const override;
+  /// pre_shift is ignored: there is no intermediate transfer buffer to compact, so an unconsumed
+  /// exposure stays in place and fill() returns 0 until it is fully consumed.
   size_t fill(TickType_t ticks_to_wait, bool pre_shift) override;
 
   /// @brief Returns a mutable pointer to the currently exposed audio data.


### PR DESCRIPTION
# What does this implement/fix?

Quick follow up to #16314 per @bdraco's feedback on the PR. Documents the class's thread safety and adds a quick note that the `pre_shift` parameter is ignored. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not Applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
