### PR TITLE
[esp32] Print PlatformIO-format RAM/Flash summary after native ESP-IDF builds

### DIFF
--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -89,6 +89,16 @@ include($ENV{{IDF_PATH}}/tools/cmake/project.cmake)
 {extra_compile_options}
 
 project({CORE.name})
+
+# Emit raw JSON size data for ESPHome to read post-build.
+add_custom_command(
+    TARGET ${{CMAKE_PROJECT_NAME}}.elf POST_BUILD
+    COMMAND ${{PYTHON}} -m esp_idf_size --ng --format=raw
+            -o ${{CMAKE_BINARY_DIR}}/esp_idf_size.json
+            ${{CMAKE_PROJECT_NAME}}.map
+    WORKING_DIRECTORY ${{CMAKE_BINARY_DIR}}
+    VERBATIM
+)
 """
 
 

--- a/esphome/espidf/runner.py
+++ b/esphome/espidf/runner.py
@@ -57,6 +57,15 @@ FILTER_IDF_LINES: list[str] = [
     # line, so a NOTICE often arrives prefixed with ".NOTICE:" or
     # "...........NOTICE:".
     r"\.*NOTICE: ",
+    # ``idf.py size`` prefaces its table with a centered banner; the
+    # per-region table below already makes the structure obvious.
+    r"\s*Memory Type Usage Summary",
+    # Prefix match for esp-idf-size's trailing "Note:" paragraph (no
+    # upstream flag suppresses it).
+    r"Note: The reported total sizes may be smaller than those in the",
+    # Drop the blank line rich emits after the note so the build log
+    # doesn't end with an orphan gap before ESPHome's own status lines.
+    r"\s*$",
 ]
 
 

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -44,32 +44,24 @@ def _parse_size(token: str) -> int:
 
 
 def _find_app_partition_size(partitions_csv: Path) -> int:
-    """Return the size of the partition the firmware lands in.
+    """Return the size of the firmware's app partition.
 
-    Prefers ``app + ota_0`` (PlatformIO's
-    ``platforms/espressif32/builder/main.py::_set_default_size`` rule);
-    accepts ``app + factory`` for non-OTA single-image layouts. Raises
-    ``ValueError`` if neither is present so callers don't silently misreport
-    the Flash budget against the wrong partition.
+    OTA-capable layouts must allocate equal-sized slots (``ota_0``,
+    ``ota_1``, ...) so any slot can become the active image; non-OTA
+    layouts use a single ``factory`` partition. Either way the first
+    ``app``-type row captures the constraint the firmware must fit
+    within. Raises ``ValueError`` if no app partition is present.
     """
     if not partitions_csv.is_file():
         raise ValueError(f"partitions.csv not found at {partitions_csv}")
-    factory_size: int | None = None
     for row in csv.reader(partitions_csv.read_text().splitlines()):
         cells = [c.strip() for c in row]
         if not cells or cells[0].startswith("#") or len(cells) < 5:
             continue
-        ptype, psubtype, psize = cells[1], cells[2], cells[4]
-        if ptype not in ("app", "0"):
-            continue
-        size = _parse_size(psize)
-        if psubtype == "ota_0":
-            return size
-        if psubtype == "factory":
-            factory_size = size
-    if factory_size is not None:
-        return factory_size
-    raise ValueError(f"No app+ota_0 or app+factory partition in {partitions_csv}")
+        ptype, psize = cells[1], cells[4]
+        if ptype in ("app", "0"):
+            return _parse_size(psize)
+    raise ValueError(f"No app partition in {partitions_csv}")
 
 
 def _format_bar(used: int, total: int) -> str:

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -1,0 +1,106 @@
+"""PlatformIO-format RAM/Flash one-liners after a native ESP-IDF build.
+
+``idf.py size`` (chained onto ``idf.py build`` in
+``toolchain.run_compile``) prints the per-region table inline as part
+of the build. This module adds two summary lines underneath,
+byte-identical to PlatformIO's output:
+
+    RAM:   [====      ]  26.5% (used 47932 bytes from 180736 bytes)
+    Flash: [===       ]  48.4% (used 888511 bytes from 1835008 bytes)
+
+The format matches ``script/ci_memory_impact_extract.py`` so CI memory
+analysis works unchanged on native ESP-IDF builds. RAM total is the
+DRAM region size from the linker map; Flash total is the ``app+ota_0``
+partition size from ``partitions.csv``, mirroring PlatformIO's
+``platforms/espressif32/builder/main.py::_set_default_size`` rule.
+
+Structured size data is produced at link time by a CMake POST_BUILD
+custom command (see ``build_gen/espidf.py``) which writes
+``esphome_size.json`` next to the ELF. We read that file here rather
+than re-running ``esp_idf_size`` from Python.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from pathlib import Path
+
+_LOGGER = logging.getLogger(__name__)
+_SIZE_SUFFIXES = {"K": 1024, "M": 1024 * 1024}
+
+
+def _parse_size(token: str) -> int:
+    token = token.strip()
+    if not token:
+        return 0
+    if token.startswith(("0x", "0X")):
+        return int(token, 16)
+    suffix = token[-1].upper()
+    if suffix in _SIZE_SUFFIXES:
+        return int(token[:-1]) * _SIZE_SUFFIXES[suffix]
+    return int(token)
+
+
+def _find_app_partition_size(partitions_csv: Path) -> int | None:
+    """Mirror PlatformIO: prefer ``app + ota_0``, else first ``app`` row."""
+    if not partitions_csv.is_file():
+        return None
+    primary: int | None = None
+    first: int | None = None
+    for row in csv.reader(partitions_csv.read_text().splitlines()):
+        cells = [c.strip() for c in row]
+        if not cells or cells[0].startswith("#") or len(cells) < 5:
+            continue
+        ptype, psubtype, psize = cells[1], cells[2], cells[4]
+        if ptype not in ("app", "0"):
+            continue
+        size = _parse_size(psize)
+        if first is None:
+            first = size
+        if psubtype == "ota_0":
+            primary = size
+            break
+    return primary if primary is not None else first
+
+
+def _format_bar(used: int, total: int) -> str:
+    """Match PlatformIO's ``_format_availale_bytes`` (pioupload.py) exactly."""
+    pct_raw = used / total if total else 0
+    blocks = 10
+    filled = min(int(round(blocks * pct_raw)), blocks)
+    progress = "=" * filled
+    return (
+        f"[{progress:<{blocks}}] {pct_raw: 6.1%} "
+        f"(used {used:d} bytes from {total:d} bytes)"
+    )
+
+
+def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
+    """Print PlatformIO-shaped RAM and Flash one-liners.
+
+    Failures are non-fatal: the build has already succeeded, we just couldn't
+    summarize. Logs the cause at debug level.
+    """
+    if not size_json.is_file():
+        _LOGGER.debug("Skipping size summary: %s not found", size_json)
+        return
+    try:
+        data = json.loads(size_json.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        _LOGGER.debug("Skipping size summary: %s", e)
+        return
+
+    dram = data.get("memory_types", {}).get("DRAM") or {}
+    ram_used = dram.get("used")
+    ram_total = dram.get("size")
+    if ram_total and ram_used is not None:
+        print(f"RAM:   {_format_bar(ram_used, ram_total)}")
+
+    image_size = data.get("image_size")
+    if image_size is None or partitions_csv is None:
+        return
+    app_size = _find_app_partition_size(partitions_csv)
+    if app_size:
+        print(f"Flash: {_format_bar(image_size, app_size)}")

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -43,12 +43,18 @@ def _parse_size(token: str) -> int:
     return int(token)
 
 
-def _find_app_partition_size(partitions_csv: Path) -> int | None:
-    """Mirror PlatformIO: prefer ``app + ota_0``, else first ``app`` row."""
+def _find_app_partition_size(partitions_csv: Path) -> int:
+    """Return the size of the partition the firmware lands in.
+
+    Prefers ``app + ota_0`` (PlatformIO's
+    ``platforms/espressif32/builder/main.py::_set_default_size`` rule);
+    accepts ``app + factory`` for non-OTA single-image layouts. Raises
+    ``ValueError`` if neither is present so callers don't silently misreport
+    the Flash budget against the wrong partition.
+    """
     if not partitions_csv.is_file():
-        return None
-    primary: int | None = None
-    first: int | None = None
+        raise ValueError(f"partitions.csv not found at {partitions_csv}")
+    factory_size: int | None = None
     for row in csv.reader(partitions_csv.read_text().splitlines()):
         cells = [c.strip() for c in row]
         if not cells or cells[0].startswith("#") or len(cells) < 5:
@@ -57,12 +63,13 @@ def _find_app_partition_size(partitions_csv: Path) -> int | None:
         if ptype not in ("app", "0"):
             continue
         size = _parse_size(psize)
-        if first is None:
-            first = size
         if psubtype == "ota_0":
-            primary = size
-            break
-    return primary if primary is not None else first
+            return size
+        if psubtype == "factory":
+            factory_size = size
+    if factory_size is not None:
+        return factory_size
+    raise ValueError(f"No app+ota_0 or app+factory partition in {partitions_csv}")
 
 
 def _format_bar(used: int, total: int) -> str:
@@ -101,6 +108,9 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
     image_size = data.get("image_size")
     if image_size is None or partitions_csv is None:
         return
-    app_size = _find_app_partition_size(partitions_csv)
-    if app_size:
-        print(f"Flash: {_format_bar(image_size, app_size)}")
+    try:
+        app_size = _find_app_partition_size(partitions_csv)
+    except ValueError as e:
+        _LOGGER.debug("Skipping Flash summary: %s", e)
+        return
+    print(f"Flash: {_format_bar(image_size, app_size)}")

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -16,7 +16,7 @@ partition size from ``partitions.csv``, mirroring PlatformIO's
 
 Structured size data is produced at link time by a CMake POST_BUILD
 custom command (see ``build_gen/espidf.py``) which writes
-``esphome_size.json`` next to the ELF. We read that file here rather
+``esp_idf_size.json`` next to the ELF. We read that file here rather
 than re-running ``esp_idf_size`` from Python.
 """
 

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -10,10 +10,10 @@ byte-identical to PlatformIO's output:
 
 The format matches ``script/ci_memory_impact_extract.py`` so CI memory
 analysis works unchanged on native ESP-IDF builds. RAM total is the
-DRAM region size from the linker map; Flash total is the first
-``app``-type partition's size from ``partitions.csv`` (OTA slots are
-required to be equal-sized, and ``factory`` is the only alternative,
-so the first row captures the constraint).
+DRAM region size from the linker map; Flash total is taken from
+``partitions.csv`` using PlatformIO's rule (first app partition whose
+subtype is ``factory`` or ``ota_0``; see
+``platform-espressif32/builder/main.py::_update_max_upload_size``).
 
 Structured size data is produced at link time by a CMake POST_BUILD
 custom command (see ``build_gen/espidf.py``) which writes
@@ -47,11 +47,13 @@ def _parse_size(token: str) -> int:
 def _find_app_partition_size(partitions_csv: Path) -> int:
     """Return the size of the firmware's app partition.
 
-    OTA-capable layouts must allocate equal-sized slots (``ota_0``,
-    ``ota_1``, ...) so any slot can become the active image; non-OTA
-    layouts use a single ``factory`` partition. Either way the first
-    ``app``-type row captures the constraint the firmware must fit
-    within. Raises ``ValueError`` if no app partition is present.
+    Mirrors PlatformIO's ``platform-espressif32/builder/main.py::
+    _update_max_upload_size``: take the first ``app``-type partition
+    whose subtype is ``factory`` or ``ota_0``. Order matters because
+    layouts like Adafruit's ``partitions-4MB-tinyuf2.csv`` repurpose
+    ``factory`` for a UF2 bootloader before the real OTA slot, so a
+    naive "prefer factory" rule would pick the wrong row. Raises
+    ``ValueError`` if no qualifying partition is present.
     """
     if not partitions_csv.is_file():
         raise ValueError(f"partitions.csv not found at {partitions_csv}")
@@ -59,10 +61,10 @@ def _find_app_partition_size(partitions_csv: Path) -> int:
         cells = [c.strip() for c in row]
         if not cells or cells[0].startswith("#") or len(cells) < 5:
             continue
-        ptype, psize = cells[1], cells[4]
-        if ptype in ("app", "0"):
+        ptype, psubtype, psize = cells[1], cells[2], cells[4]
+        if ptype in ("app", "0") and psubtype in ("factory", "ota_0"):
             return _parse_size(psize)
-    raise ValueError(f"No app partition in {partitions_csv}")
+    raise ValueError(f"No app+factory or app+ota_0 partition in {partitions_csv}")
 
 
 def _format_bar(used: int, total: int) -> str:

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -10,9 +10,10 @@ byte-identical to PlatformIO's output:
 
 The format matches ``script/ci_memory_impact_extract.py`` so CI memory
 analysis works unchanged on native ESP-IDF builds. RAM total is the
-DRAM region size from the linker map; Flash total is the ``app+ota_0``
-partition size from ``partitions.csv``, mirroring PlatformIO's
-``platforms/espressif32/builder/main.py::_set_default_size`` rule.
+DRAM region size from the linker map; Flash total is the first
+``app``-type partition's size from ``partitions.csv`` (OTA slots are
+required to be equal-sized, and ``factory`` is the only alternative,
+so the first row captures the constraint).
 
 Structured size data is produced at link time by a CMake POST_BUILD
 custom command (see ``build_gen/espidf.py``) which writes

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -12,6 +12,7 @@ import subprocess
 from esphome.components.esp32.const import KEY_ESP32, KEY_FLASH_SIZE, KEY_IDF_VERSION
 from esphome.core import CORE, EsphomeError
 from esphome.espidf.framework import check_esp_idf_install, get_framework_env
+from esphome.espidf.size_summary import print_summary
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -341,8 +342,14 @@ def run_compile(config, verbose: bool) -> int:
 
     args.extend(_get_sdkconfig_args())
     args.append("build")
+    args.append("size")
 
-    return run_idf_py(*args)
+    rc = run_idf_py(*args)
+    if rc == 0:
+        size_json = CORE.relative_build_path("build", "esp_idf_size.json")
+        partitions = CORE.relative_build_path("partitions.csv")
+        print_summary(size_json, partitions if partitions.is_file() else None)
+    return rc
 
 
 def get_firmware_path() -> Path:


### PR DESCRIPTION
# What does this implement/fix?

Native ESP-IDF builds (toolchain: esp-idf) don't emit the familiar PlatformIO summary lines, so users — and `script/ci_memory_impact_extract.py` — have no compact per-build memory comparison line. This PR adds two:

```
RAM:   [====      ]  26.5% (used 47932 bytes from 180736 bytes)
Flash: [=====     ]  48.4% (used 888511 bytes from 1835008 bytes)
```

Byte-identical to PlatformIO's [`pioupload.py::_format_availale_bytes`](https://github.com/platformio/platformio-core/blob/develop/platformio/builder/tools/pioupload.py). The existing CI memory-impact script parses them unchanged.

## Example output

End of a real native ESP-IDF build with this PR applied:

```
┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Memory Type/Section   ┃ Used [bytes] ┃ Used [%] ┃ Remain [bytes] ┃ Total [bytes] ┃
┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ Flash Code            │       671756 │          │                │               │
│    .text              │       671756 │          │                │               │
│ Flash Data            │       119464 │          │                │               │
│    .rodata            │       119208 │          │                │               │
│    .appdesc           │          256 │          │                │               │
│ IRAM                  │        80351 │     61.3 │          50721 │        131072 │
│    .text              │        79323 │    60.52 │                │               │
│    .vectors           │         1028 │     0.78 │                │               │
│ DRAM                  │        47932 │    26.52 │         132804 │        180736 │
│    .bss               │        31024 │    17.17 │                │               │
│    .data              │        16908 │     9.36 │                │               │
│ RTC SLOW              │           56 │     0.68 │           8136 │          8192 │
│    .force_slow        │           32 │     0.39 │                │               │
│    .rtc_slow_reserved │           24 │     0.29 │                │               │
└───────────────────────┴──────────────┴──────────┴────────────────┴───────────────┘
Total image size: 888511 bytes (.bin may be padded larger)
RAM:   [===       ]  26.5% (used 47932 bytes from 180736 bytes)
Flash: [=====     ]  48.4% (used 888511 bytes from 1835008 bytes)
```

The table and `Total image size:` line come straight from `idf.py size`; the last two lines are added by this PR.

## How

1. **Chain `idf.py size`** onto the existing `idf.py build` call so `esp-idf-size`'s per-region table prints inline as part of the build output (no separate Python subprocess). Its centered `Memory Type Usage Summary` banner and trailing yellow `Note: ...` paragraph are dropped via `FILTER_IDF_LINES` in `runner.py`.

2. **POST_BUILD CMake custom command** in the generated top-level `CMakeLists.txt` writes `esp_idf_size.json` (raw-format JSON containing `image_size` + per-region `size`/`used`) next to the ELF after each successful link. Fires only on relink, so no-op rebuilds stay quiet.

3. **Post-build helper** (`esphome/espidf/size_summary.py`) reads that JSON and `partitions.csv`, then prints the two PlatformIO-format lines. RAM total = DRAM region from the linker map; Flash total = `app+ota_0` partition size, mirroring PlatformIO's [`platforms/espressif32/builder/main.py::_set_default_size`](https://github.com/platformio/platform-espressif32/blob/develop/builder/main.py) rule (prefer `app+ota_0`, fall back to first `app` row, honor `build.app_partition_name` override).

Note on Flash totals: we deliberately don't pass `--use-flash-size` to esp-idf-size. That flag reports the linker's whole-flash address space (3–4 MB per region), which isn't meaningful for ESPHome's OTA layouts — the real budget is the app partition size, which we look up ourselves.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Surfaced while testing the native ESP-IDF toolchain in DNM #16383 — the memory-impact CI job was failing because the extractor couldn't find PlatformIO-format size lines in native IDF output. This PR makes the extractor work unchanged.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — no user-visible configuration changes; the new output appears automatically at the end of every native ESP-IDF build.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).