### PR TITLE
[ci] Skip native ESP-IDF compile test when no relevant files changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,7 @@ jobs:
       python-linters: ${{ steps.determine.outputs.python-linters }}
       import-time: ${{ steps.determine.outputs.import-time }}
       device-builder: ${{ steps.determine.outputs.device-builder }}
+      native-idf: ${{ steps.determine.outputs.native-idf }}
       changed-components: ${{ steps.determine.outputs.changed-components }}
       changed-components-with-tests: ${{ steps.determine.outputs.changed-components-with-tests }}
       directly-changed-components-with-tests: ${{ steps.determine.outputs.directly-changed-components-with-tests }}
@@ -297,6 +298,7 @@ jobs:
           echo "python-linters=$(echo "$output" | jq -r '.python_linters')" >> $GITHUB_OUTPUT
           echo "import-time=$(echo "$output" | jq -r '.import_time')" >> $GITHUB_OUTPUT
           echo "device-builder=$(echo "$output" | jq -r '.device_builder')" >> $GITHUB_OUTPUT
+          echo "native-idf=$(echo "$output" | jq -r '.native_idf')" >> $GITHUB_OUTPUT
           echo "changed-components=$(echo "$output" | jq -c '.changed_components')" >> $GITHUB_OUTPUT
           echo "changed-components-with-tests=$(echo "$output" | jq -c '.changed_components_with_tests')" >> $GITHUB_OUTPUT
           echo "directly-changed-components-with-tests=$(echo "$output" | jq -c '.directly_changed_components_with_tests')" >> $GITHUB_OUTPUT
@@ -823,7 +825,7 @@ jobs:
     needs:
       - common
       - determine-jobs
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && needs.determine-jobs.outputs.native-idf == 'true'
     env:
       ESPHOME_ESP_IDF_PREFIX: ~/.esphome-idf
       TEST_COMPONENTS: esp32,api,heatpumpir,bme280_i2c,bh1750,aht10,esp32_ble,esp32_ble_beacon,esp32_ble_client,esp32_ble_server,esp32_ble_tracker,ble_client,ble_presence,ble_rssi,ble_scanner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,7 @@ jobs:
       import-time: ${{ steps.determine.outputs.import-time }}
       device-builder: ${{ steps.determine.outputs.device-builder }}
       native-idf: ${{ steps.determine.outputs.native-idf }}
+      native-idf-components: ${{ steps.determine.outputs.native-idf-components }}
       changed-components: ${{ steps.determine.outputs.changed-components }}
       changed-components-with-tests: ${{ steps.determine.outputs.changed-components-with-tests }}
       directly-changed-components-with-tests: ${{ steps.determine.outputs.directly-changed-components-with-tests }}
@@ -299,6 +300,7 @@ jobs:
           echo "import-time=$(echo "$output" | jq -r '.import_time')" >> $GITHUB_OUTPUT
           echo "device-builder=$(echo "$output" | jq -r '.device_builder')" >> $GITHUB_OUTPUT
           echo "native-idf=$(echo "$output" | jq -r '.native_idf')" >> $GITHUB_OUTPUT
+          echo "native-idf-components=$(echo "$output" | jq -r '.native_idf_components')" >> $GITHUB_OUTPUT
           echo "changed-components=$(echo "$output" | jq -c '.changed_components')" >> $GITHUB_OUTPUT
           echo "changed-components-with-tests=$(echo "$output" | jq -c '.changed_components_with_tests')" >> $GITHUB_OUTPUT
           echo "directly-changed-components-with-tests=$(echo "$output" | jq -c '.directly_changed_components_with_tests')" >> $GITHUB_OUTPUT
@@ -828,7 +830,11 @@ jobs:
     if: github.event_name == 'pull_request' && needs.determine-jobs.outputs.native-idf == 'true'
     env:
       ESPHOME_ESP_IDF_PREFIX: ~/.esphome-idf
-      TEST_COMPONENTS: esp32,api,heatpumpir,bme280_i2c,bh1750,aht10,esp32_ble,esp32_ble_beacon,esp32_ble_client,esp32_ble_server,esp32_ble_tracker,ble_client,ble_presence,ble_rssi,ble_scanner
+      # Comma-joined subset of the native-IDF representative component list,
+      # computed by script/determine-jobs.py (native_idf_components_to_test).
+      # Single source of truth -- the full list lives in
+      # script/determine-jobs.py::NATIVE_IDF_TEST_COMPONENTS.
+      TEST_COMPONENTS: ${{ needs.determine-jobs.outputs.native-idf-components }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -519,19 +519,21 @@ NATIVE_IDF_TEST_COMPONENTS = frozenset(
     }
 )
 
-# Path prefixes whose changes always trigger the native ESP-IDF compile test:
-# anything under esphome/espidf/ (the native IDF runner / API / framework /
-# component generator) and esphome/build_gen/ (the espidf build generator).
-NATIVE_IDF_TRIGGER_PATH_PREFIXES = (
-    "esphome/espidf/",
-    "esphome/build_gen/",
-)
+# Path prefixes whose changes always trigger the native ESP-IDF compile
+# test: anything under esphome/espidf/ (the native IDF runner / API /
+# framework / component generator).
+NATIVE_IDF_TRIGGER_PATH_PREFIXES = ("esphome/espidf/",)
 
 # Standalone files that, when changed, also trigger the native ESP-IDF
-# compile test. `test_build_components.py` is the harness the job invokes;
-# the workflow file itself is the job's definition.
+# compile test:
+#   - esphome/build_gen/espidf.py -- the native IDF build generator
+#     (other files under build_gen/ target PlatformIO and don't affect
+#     the native IDF path)
+#   - script/test_build_components.py -- the harness the job invokes
+#   - .github/workflows/ci.yml -- the job's own definition
 NATIVE_IDF_TRIGGER_FILES = frozenset(
     {
+        "esphome/build_gen/espidf.py",
         "script/test_build_components.py",
         ".github/workflows/ci.yml",
     }
@@ -562,8 +564,8 @@ def native_idf_components_to_test(branch: str | None = None) -> list[str]:
     Returns the full list (sorted) when we can't safely narrow:
 
     1. Core C++/Python files changed (``esphome/core/*``).
-    2. Native IDF infrastructure changed (``esphome/espidf/*``,
-       ``esphome/build_gen/*``).
+    2. Native IDF infrastructure changed (``esphome/espidf/*`` or
+       ``esphome/build_gen/espidf.py``).
     3. The test harness or workflow itself changed
        (``script/test_build_components.py``, ``.github/workflows/ci.yml``).
     4. ``get_changed_components()`` returned the full-scan sentinel.

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -559,7 +559,7 @@ def native_idf_components_to_test(branch: str | None = None) -> list[str]:
     component in the test list -- the regular ``component-test`` matrix
     already covers them via PlatformIO. So we narrow to the intersection
     of ``NATIVE_IDF_TEST_COMPONENTS`` and the changed-component dependency
-    closure from ``get_changed_components()``.
+    closure.
 
     Returns the full list (sorted) when we can't safely narrow:
 
@@ -568,10 +568,16 @@ def native_idf_components_to_test(branch: str | None = None) -> list[str]:
        ``esphome/build_gen/espidf.py``).
     3. The test harness or workflow itself changed
        (``script/test_build_components.py``, ``.github/workflows/ci.yml``).
-    4. ``get_changed_components()`` returned the full-scan sentinel.
 
     Otherwise returns the intersection (sorted), which may be empty -- an
     empty list signals the job should be skipped.
+
+    The dependency closure is derived from ``files`` via
+    ``get_components_with_dependencies()`` (the same primitive ``main()``
+    uses) so the result honors ``branch``. ``get_changed_components()``
+    is deliberately not used here: it re-invokes ``changed_files()`` with
+    its own default branch, which would silently ignore our ``branch``
+    argument.
 
     Args:
         branch: Branch to compare against. If None, uses default.
@@ -584,13 +590,10 @@ def native_idf_components_to_test(branch: str | None = None) -> list[str]:
     if core_changed(files) or _native_idf_path_or_file_trigger(files):
         return sorted(NATIVE_IDF_TEST_COMPONENTS)
 
-    changed_components_result = get_changed_components()
-    if changed_components_result is None:
-        # Defensive: core_changed() above already catches the documented
-        # None case (core C++ changes). Fall back to the full list.
-        return sorted(NATIVE_IDF_TEST_COMPONENTS)
+    component_files = [f for f in files if filter_component_and_test_files(f)]
+    changed = get_components_with_dependencies(component_files, True)
 
-    return sorted(NATIVE_IDF_TEST_COMPONENTS & set(changed_components_result))
+    return sorted(NATIVE_IDF_TEST_COMPONENTS & set(changed))
 
 
 def should_run_native_idf(branch: str | None = None) -> bool:

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -495,9 +495,10 @@ def should_run_device_builder(branch: str | None = None) -> bool:
     return False
 
 
-# Components tested by the native ESP-IDF compile-test job. Kept in sync with
-# the TEST_COMPONENTS env var on the `test-native-idf` job in
-# .github/workflows/ci.yml.
+# Components tested by the native ESP-IDF compile-test job. This is the
+# single source of truth: the workflow reads the comma-joined list from the
+# `native-idf-components` output of `determine-jobs` and uses it as the
+# `TEST_COMPONENTS` env on the `test-native-idf` job.
 NATIVE_IDF_TEST_COMPONENTS = frozenset(
     {
         "esp32",
@@ -537,26 +538,67 @@ NATIVE_IDF_TRIGGER_FILES = frozenset(
 )
 
 
-def should_run_native_idf(branch: str | None = None) -> bool:
-    """Determine if the `test-native-idf` compile-test job should run.
+def _native_idf_path_or_file_trigger(files: list[str]) -> bool:
+    """Whether any changed file is a native IDF infrastructure / harness trigger."""
+    for file in files:
+        if file in NATIVE_IDF_TRIGGER_FILES:
+            return True
+        if any(file.startswith(prefix) for prefix in NATIVE_IDF_TRIGGER_PATH_PREFIXES):
+            return True
+    return False
 
-    The job builds a fixed list of components with the native ESP-IDF
-    toolchain (no PlatformIO). Skipping it on unrelated Python-only PRs
-    avoids ~5 min of CI per PR (worse on cold caches). The regular
-    `component-test` matrix still exercises the same components through
-    PlatformIO when those components change.
 
-    Runs when ANY of the following is true:
+def native_idf_components_to_test(branch: str | None = None) -> list[str]:
+    """Subset of ``NATIVE_IDF_TEST_COMPONENTS`` the job needs to compile.
 
-    1. Core C++/Python files changed (``esphome/core/*``) -- core changes
-       can affect every compile path, including the native IDF one.
+    The job builds components with the native ESP-IDF toolchain (no
+    PlatformIO). When only a specific component (or something it depends
+    on) changed, there's no value in re-building every other unrelated
+    component in the test list -- the regular ``component-test`` matrix
+    already covers them via PlatformIO. So we narrow to the intersection
+    of ``NATIVE_IDF_TEST_COMPONENTS`` and the changed-component dependency
+    closure from ``get_changed_components()``.
+
+    Returns the full list (sorted) when we can't safely narrow:
+
+    1. Core C++/Python files changed (``esphome/core/*``).
     2. Native IDF infrastructure changed (``esphome/espidf/*``,
        ``esphome/build_gen/*``).
     3. The test harness or workflow itself changed
        (``script/test_build_components.py``, ``.github/workflows/ci.yml``).
-    4. One of the components in ``NATIVE_IDF_TEST_COMPONENTS`` (or any
-       component in its dependency closure as resolved by
-       ``get_changed_components()``) changed.
+    4. ``get_changed_components()`` returned the full-scan sentinel.
+
+    Otherwise returns the intersection (sorted), which may be empty -- an
+    empty list signals the job should be skipped.
+
+    Args:
+        branch: Branch to compare against. If None, uses default.
+
+    Returns:
+        Sorted list of component names to compile.
+    """
+    files = changed_files(branch)
+
+    if core_changed(files) or _native_idf_path_or_file_trigger(files):
+        return sorted(NATIVE_IDF_TEST_COMPONENTS)
+
+    changed_components_result = get_changed_components()
+    if changed_components_result is None:
+        # Defensive: core_changed() above already catches the documented
+        # None case (core C++ changes). Fall back to the full list.
+        return sorted(NATIVE_IDF_TEST_COMPONENTS)
+
+    return sorted(NATIVE_IDF_TEST_COMPONENTS & set(changed_components_result))
+
+
+def should_run_native_idf(branch: str | None = None) -> bool:
+    """Determine if the `test-native-idf` compile-test job should run.
+
+    Runs whenever ``native_idf_components_to_test()`` returns a non-empty
+    list. Skipping the job on unrelated Python-only PRs avoids ~5 min of
+    CI per PR (worse on cold caches). The regular ``component-test``
+    matrix still exercises the same components through PlatformIO when
+    those components change.
 
     Args:
         branch: Branch to compare against. If None, uses default.
@@ -564,29 +606,7 @@ def should_run_native_idf(branch: str | None = None) -> bool:
     Returns:
         True if the native ESP-IDF compile test should run, False otherwise.
     """
-    files = changed_files(branch)
-
-    if core_changed(files):
-        return True
-
-    for file in files:
-        if file in NATIVE_IDF_TRIGGER_FILES:
-            return True
-        if any(file.startswith(prefix) for prefix in NATIVE_IDF_TRIGGER_PATH_PREFIXES):
-            return True
-
-    # Check whether any of the tested components (or anything they depend on)
-    # is in the changed set. ``get_changed_components()`` already expands the
-    # dependency closure for us.
-    changed_components_result = get_changed_components()
-    if changed_components_result is None:
-        # get_changed_components() returns None only on core C++ changes,
-        # which core_changed() above already caught. Safety fallback.
-        return True
-    return any(
-        component in NATIVE_IDF_TEST_COMPONENTS
-        for component in changed_components_result
-    )
+    return bool(native_idf_components_to_test(branch))
 
 
 def determine_cpp_unit_tests(
@@ -1051,7 +1071,8 @@ def main() -> None:
     run_python_linters = should_run_python_linters(args.branch)
     run_import_time = should_run_import_time(args.branch)
     run_device_builder = should_run_device_builder(args.branch)
-    run_native_idf = should_run_native_idf(args.branch)
+    native_idf_components = native_idf_components_to_test(args.branch)
+    run_native_idf = bool(native_idf_components)
     changed_cpp_file_count = count_changed_cpp_files(args.branch)
 
     # Get changed components
@@ -1198,6 +1219,7 @@ def main() -> None:
         "import_time": run_import_time,
         "device_builder": run_device_builder,
         "native_idf": run_native_idf,
+        "native_idf_components": ",".join(native_idf_components),
         "changed_components": changed_components,
         "changed_components_with_tests": changed_components_with_tests,
         "directly_changed_components_with_tests": list(directly_changed_with_tests),

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -495,6 +495,100 @@ def should_run_device_builder(branch: str | None = None) -> bool:
     return False
 
 
+# Components tested by the native ESP-IDF compile-test job. Kept in sync with
+# the TEST_COMPONENTS env var on the `test-native-idf` job in
+# .github/workflows/ci.yml.
+NATIVE_IDF_TEST_COMPONENTS = frozenset(
+    {
+        "esp32",
+        "api",
+        "heatpumpir",
+        "bme280_i2c",
+        "bh1750",
+        "aht10",
+        "esp32_ble",
+        "esp32_ble_beacon",
+        "esp32_ble_client",
+        "esp32_ble_server",
+        "esp32_ble_tracker",
+        "ble_client",
+        "ble_presence",
+        "ble_rssi",
+        "ble_scanner",
+    }
+)
+
+# Path prefixes whose changes always trigger the native ESP-IDF compile test:
+# anything under esphome/espidf/ (the native IDF runner / API / framework /
+# component generator) and esphome/build_gen/ (the espidf build generator).
+NATIVE_IDF_TRIGGER_PATH_PREFIXES = (
+    "esphome/espidf/",
+    "esphome/build_gen/",
+)
+
+# Standalone files that, when changed, also trigger the native ESP-IDF
+# compile test. `test_build_components.py` is the harness the job invokes;
+# the workflow file itself is the job's definition.
+NATIVE_IDF_TRIGGER_FILES = frozenset(
+    {
+        "script/test_build_components.py",
+        ".github/workflows/ci.yml",
+    }
+)
+
+
+def should_run_native_idf(branch: str | None = None) -> bool:
+    """Determine if the `test-native-idf` compile-test job should run.
+
+    The job builds a fixed list of components with the native ESP-IDF
+    toolchain (no PlatformIO). Skipping it on unrelated Python-only PRs
+    avoids ~5 min of CI per PR (worse on cold caches). The regular
+    `component-test` matrix still exercises the same components through
+    PlatformIO when those components change.
+
+    Runs when ANY of the following is true:
+
+    1. Core C++/Python files changed (``esphome/core/*``) -- core changes
+       can affect every compile path, including the native IDF one.
+    2. Native IDF infrastructure changed (``esphome/espidf/*``,
+       ``esphome/build_gen/*``).
+    3. The test harness or workflow itself changed
+       (``script/test_build_components.py``, ``.github/workflows/ci.yml``).
+    4. One of the components in ``NATIVE_IDF_TEST_COMPONENTS`` (or any
+       component in its dependency closure as resolved by
+       ``get_changed_components()``) changed.
+
+    Args:
+        branch: Branch to compare against. If None, uses default.
+
+    Returns:
+        True if the native ESP-IDF compile test should run, False otherwise.
+    """
+    files = changed_files(branch)
+
+    if core_changed(files):
+        return True
+
+    for file in files:
+        if file in NATIVE_IDF_TRIGGER_FILES:
+            return True
+        if any(file.startswith(prefix) for prefix in NATIVE_IDF_TRIGGER_PATH_PREFIXES):
+            return True
+
+    # Check whether any of the tested components (or anything they depend on)
+    # is in the changed set. ``get_changed_components()`` already expands the
+    # dependency closure for us.
+    changed_components_result = get_changed_components()
+    if changed_components_result is None:
+        # get_changed_components() returns None only on core C++ changes,
+        # which core_changed() above already caught. Safety fallback.
+        return True
+    return any(
+        component in NATIVE_IDF_TEST_COMPONENTS
+        for component in changed_components_result
+    )
+
+
 def determine_cpp_unit_tests(
     branch: str | None = None,
 ) -> tuple[bool, list[str]]:
@@ -957,6 +1051,7 @@ def main() -> None:
     run_python_linters = should_run_python_linters(args.branch)
     run_import_time = should_run_import_time(args.branch)
     run_device_builder = should_run_device_builder(args.branch)
+    run_native_idf = should_run_native_idf(args.branch)
     changed_cpp_file_count = count_changed_cpp_files(args.branch)
 
     # Get changed components
@@ -1102,6 +1197,7 @@ def main() -> None:
         "python_linters": run_python_linters,
         "import_time": run_import_time,
         "device_builder": run_device_builder,
+        "native_idf": run_native_idf,
         "changed_components": changed_components,
         "changed_components_with_tests": changed_components_with_tests,
         "directly_changed_components_with_tests": list(directly_changed_with_tests),

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -873,32 +873,18 @@ def test_native_idf_components_to_test_returns_full_list_on_infrastructure(
     """Infrastructure / core / harness changes fall back to the full component list."""
     with (
         patch.object(determine_jobs, "changed_files", return_value=changed_files),
-        # get_changed_components shouldn't even be consulted; if it is, surface
-        # an obviously-wrong value so the assertion below would catch it.
-        patch.object(determine_jobs, "get_changed_components", return_value=["wifi"]),
-    ):
-        result = determine_jobs.native_idf_components_to_test()
-        assert result == sorted(determine_jobs.NATIVE_IDF_TEST_COMPONENTS)
-
-
-def test_native_idf_components_to_test_full_list_when_get_components_none() -> None:
-    """get_changed_components returning None falls back to the full list."""
-    with (
-        # Pick a non-core file so core_changed() is False; force the full-scan
-        # sentinel from get_changed_components.
+        # The dep-closure path shouldn't be consulted at all -- if it is,
+        # the obviously-wrong "wifi" sneaks in and the assertion catches it.
         patch.object(
-            determine_jobs,
-            "changed_files",
-            return_value=["esphome/components/wifi/wifi_component.cpp"],
+            determine_jobs, "get_components_with_dependencies", return_value=["wifi"]
         ),
-        patch.object(determine_jobs, "get_changed_components", return_value=None),
     ):
         result = determine_jobs.native_idf_components_to_test()
         assert result == sorted(determine_jobs.NATIVE_IDF_TEST_COMPONENTS)
 
 
 @pytest.mark.parametrize(
-    ("changed_files", "changed_components", "expected"),
+    ("changed_files", "dependency_closure", "expected"),
     [
         # Single tested component changed -- narrow to just that component.
         (
@@ -938,14 +924,16 @@ def test_native_idf_components_to_test_full_list_when_get_components_none() -> N
 )
 def test_native_idf_components_to_test_narrowing(
     changed_files: list[str],
-    changed_components: list[str],
+    dependency_closure: list[str],
     expected: list[str],
 ) -> None:
     """Component changes narrow the test list to the intersection."""
     with (
         patch.object(determine_jobs, "changed_files", return_value=changed_files),
         patch.object(
-            determine_jobs, "get_changed_components", return_value=changed_components
+            determine_jobs,
+            "get_components_with_dependencies",
+            return_value=dependency_closure,
         ),
     ):
         result = determine_jobs.native_idf_components_to_test()
@@ -953,10 +941,19 @@ def test_native_idf_components_to_test_narrowing(
 
 
 def test_native_idf_components_to_test_with_branch() -> None:
-    """native_idf_components_to_test passes branch argument through."""
+    """native_idf_components_to_test passes branch argument through.
+
+    Regression test: an earlier version called ``get_changed_components()``,
+    which silently ignored the branch argument because that helper re-runs
+    ``changed_files()`` with its own default. The current implementation
+    derives the closure from ``files = changed_files(branch)`` directly,
+    so a branch arg has to flow through ``changed_files``.
+    """
     with (
         patch.object(determine_jobs, "changed_files") as mock_changed,
-        patch.object(determine_jobs, "get_changed_components", return_value=[]),
+        patch.object(
+            determine_jobs, "get_components_with_dependencies", return_value=[]
+        ),
     ):
         mock_changed.return_value = []
         determine_jobs.native_idf_components_to_test("release")

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -71,9 +71,13 @@ def mock_should_run_device_builder() -> Generator[Mock, None, None]:
 
 
 @pytest.fixture
-def mock_should_run_native_idf() -> Generator[Mock, None, None]:
-    """Mock should_run_native_idf from determine_jobs."""
-    with patch.object(determine_jobs, "should_run_native_idf") as mock:
+def mock_native_idf_components_to_test() -> Generator[Mock, None, None]:
+    """Mock native_idf_components_to_test from determine_jobs.
+
+    main() drives both the ``native_idf`` boolean output and the
+    ``native_idf_components`` CSV from this one function.
+    """
+    with patch.object(determine_jobs, "native_idf_components_to_test") as mock:
         yield mock
 
 
@@ -114,7 +118,7 @@ def test_main_all_tests_should_run(
     mock_should_run_python_linters: Mock,
     mock_should_run_import_time: Mock,
     mock_should_run_device_builder: Mock,
-    mock_should_run_native_idf: Mock,
+    mock_native_idf_components_to_test: Mock,
     mock_changed_files: Mock,
     mock_determine_cpp_unit_tests: Mock,
     capsys: pytest.CaptureFixture[str],
@@ -130,7 +134,7 @@ def test_main_all_tests_should_run(
     mock_should_run_python_linters.return_value = True
     mock_should_run_import_time.return_value = True
     mock_should_run_device_builder.return_value = True
-    mock_should_run_native_idf.return_value = True
+    mock_native_idf_components_to_test.return_value = ["api", "esp32"]
     mock_determine_cpp_unit_tests.return_value = (False, ["wifi", "api", "sensor"])
 
     # Mock changed_files to return non-component files (to avoid memory impact)
@@ -213,6 +217,7 @@ def test_main_all_tests_should_run(
     assert output["import_time"] is True
     assert output["device_builder"] is True
     assert output["native_idf"] is True
+    assert output["native_idf_components"] == "api,esp32"
     assert output["changed_components"] == ["wifi", "api", "sensor"]
     # changed_components_with_tests will only include components that actually have test files
     assert "changed_components_with_tests" in output
@@ -246,7 +251,7 @@ def test_main_no_tests_should_run(
     mock_should_run_python_linters: Mock,
     mock_should_run_import_time: Mock,
     mock_should_run_device_builder: Mock,
-    mock_should_run_native_idf: Mock,
+    mock_native_idf_components_to_test: Mock,
     mock_changed_files: Mock,
     mock_determine_cpp_unit_tests: Mock,
     capsys: pytest.CaptureFixture[str],
@@ -262,7 +267,7 @@ def test_main_no_tests_should_run(
     mock_should_run_python_linters.return_value = False
     mock_should_run_import_time.return_value = False
     mock_should_run_device_builder.return_value = False
-    mock_should_run_native_idf.return_value = False
+    mock_native_idf_components_to_test.return_value = []
     mock_determine_cpp_unit_tests.return_value = (False, [])
 
     # Mock changed_files to return no component files
@@ -304,6 +309,7 @@ def test_main_no_tests_should_run(
     assert output["import_time"] is False
     assert output["device_builder"] is False
     assert output["native_idf"] is False
+    assert output["native_idf_components"] == ""
     assert output["changed_components"] == []
     assert output["changed_components_with_tests"] == []
     assert output["component_test_count"] == 0
@@ -326,7 +332,7 @@ def test_main_with_branch_argument(
     mock_should_run_python_linters: Mock,
     mock_should_run_import_time: Mock,
     mock_should_run_device_builder: Mock,
-    mock_should_run_native_idf: Mock,
+    mock_native_idf_components_to_test: Mock,
     mock_changed_files: Mock,
     mock_determine_cpp_unit_tests: Mock,
     capsys: pytest.CaptureFixture[str],
@@ -342,7 +348,7 @@ def test_main_with_branch_argument(
     mock_should_run_python_linters.return_value = True
     mock_should_run_import_time.return_value = True
     mock_should_run_device_builder.return_value = True
-    mock_should_run_native_idf.return_value = True
+    mock_native_idf_components_to_test.return_value = ["esp32"]
     mock_determine_cpp_unit_tests.return_value = (False, ["mqtt"])
 
     # Mock changed_files to return non-component files (to avoid memory impact)
@@ -381,7 +387,7 @@ def test_main_with_branch_argument(
     mock_should_run_python_linters.assert_called_once_with("main")
     mock_should_run_import_time.assert_called_once_with("main")
     mock_should_run_device_builder.assert_called_once_with("main")
-    mock_should_run_native_idf.assert_called_once_with("main")
+    mock_native_idf_components_to_test.assert_called_once_with("main")
 
     # Check output
     captured = capsys.readouterr()
@@ -396,6 +402,7 @@ def test_main_with_branch_argument(
     assert output["import_time"] is True
     assert output["device_builder"] is True
     assert output["native_idf"] is True
+    assert output["native_idf_components"] == "esp32"
     assert output["changed_components"] == ["mqtt"]
     # changed_components_with_tests will only include components that actually have test files
     assert "changed_components_with_tests" in output
@@ -844,63 +851,41 @@ def test_should_run_device_builder_skips_beta_release(target_branch: str) -> Non
         mock_changed.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    ("changed_files", "changed_components", "expected_result"),
-    [
-        # Core C++/Python changes trigger (caught before get_changed_components)
-        (["esphome/core/component.cpp"], [], True),
-        (["esphome/core/config.py"], [], True),
-        # Native IDF infrastructure paths trigger
-        (["esphome/espidf/framework.py"], [], True),
-        (["esphome/espidf/component.py"], [], True),
-        (["esphome/espidf/api.py"], [], True),
-        (["esphome/build_gen/espidf.py"], [], True),
-        # Workflow / harness files trigger
-        (["script/test_build_components.py"], [], True),
-        ([".github/workflows/ci.yml"], [], True),
-        # Components in the tested set trigger
-        (["esphome/components/esp32/__init__.py"], ["esp32"], True),
-        (
-            ["esphome/components/esp32_ble/ble.cpp"],
-            ["esp32_ble", "esp32_ble_tracker"],
-            True,
-        ),
-        # Dependency closure: changing api triggers because api is in the set
-        (["esphome/components/api/api_connection.cpp"], ["api"], True),
-        # Components outside the tested set don't trigger
-        (
-            ["esphome/components/wifi/wifi_component.cpp"],
-            ["wifi", "network"],
-            False,
-        ),
-        # Pure Python-only changes outside the trigger paths don't run
-        (["esphome/yaml_util.py"], [], False),
-        # Docs / unrelated files don't run
-        (["README.md"], [], False),
-        ([], [], False),
-    ],
-)
-def test_should_run_native_idf(
+_NATIVE_IDF_FULL_LIST_FILES = [
+    # Core C++/Python changes -- caught by core_changed()
+    ["esphome/core/component.cpp"],
+    ["esphome/core/config.py"],
+    # Native IDF infrastructure paths
+    ["esphome/espidf/framework.py"],
+    ["esphome/espidf/component.py"],
+    ["esphome/espidf/api.py"],
+    ["esphome/build_gen/espidf.py"],
+    # Workflow / harness files
+    ["script/test_build_components.py"],
+    [".github/workflows/ci.yml"],
+]
+
+
+@pytest.mark.parametrize("changed_files", _NATIVE_IDF_FULL_LIST_FILES)
+def test_native_idf_components_to_test_returns_full_list_on_infrastructure(
     changed_files: list[str],
-    changed_components: list[str],
-    expected_result: bool,
 ) -> None:
-    """Test should_run_native_idf function."""
+    """Infrastructure / core / harness changes fall back to the full component list."""
     with (
         patch.object(determine_jobs, "changed_files", return_value=changed_files),
-        patch.object(
-            determine_jobs, "get_changed_components", return_value=changed_components
-        ),
+        # get_changed_components shouldn't even be consulted; if it is, surface
+        # an obviously-wrong value so the assertion below would catch it.
+        patch.object(determine_jobs, "get_changed_components", return_value=["wifi"]),
     ):
-        result = determine_jobs.should_run_native_idf()
-        assert result == expected_result
+        result = determine_jobs.native_idf_components_to_test()
+        assert result == sorted(determine_jobs.NATIVE_IDF_TEST_COMPONENTS)
 
 
-def test_should_run_native_idf_core_cpp_returns_none() -> None:
-    """get_changed_components returning None (core C++ change) triggers the job."""
+def test_native_idf_components_to_test_full_list_when_get_components_none() -> None:
+    """get_changed_components returning None falls back to the full list."""
     with (
-        # Pick a file that isn't core (so core_changed() is False) but force
-        # get_changed_components to fall back to the full-scan sentinel.
+        # Pick a non-core file so core_changed() is False; force the full-scan
+        # sentinel from get_changed_components.
         patch.object(
             determine_jobs,
             "changed_files",
@@ -908,18 +893,98 @@ def test_should_run_native_idf_core_cpp_returns_none() -> None:
         ),
         patch.object(determine_jobs, "get_changed_components", return_value=None),
     ):
-        assert determine_jobs.should_run_native_idf() is True
+        result = determine_jobs.native_idf_components_to_test()
+        assert result == sorted(determine_jobs.NATIVE_IDF_TEST_COMPONENTS)
 
 
-def test_should_run_native_idf_with_branch() -> None:
-    """Test should_run_native_idf passes branch argument through."""
+@pytest.mark.parametrize(
+    ("changed_files", "changed_components", "expected"),
+    [
+        # Single tested component changed -- narrow to just that component.
+        (
+            ["esphome/components/esp32/__init__.py"],
+            ["esp32"],
+            ["esp32"],
+        ),
+        # Dependency closure: multiple BLE components in the changed set
+        # are all intersected with the test list and returned sorted.
+        (
+            ["esphome/components/esp32_ble/ble.cpp"],
+            ["esp32_ble", "esp32_ble_tracker", "ble_scanner"],
+            ["ble_scanner", "esp32_ble", "esp32_ble_tracker"],
+        ),
+        # api in the test set -- narrow to [api] even though the closure
+        # has other (unrelated to native-IDF coverage) entries.
+        (
+            ["esphome/components/api/api_connection.cpp"],
+            ["api", "logger"],
+            ["api"],
+        ),
+        # Components outside the test set return an empty list (job skipped).
+        (
+            ["esphome/components/wifi/wifi_component.cpp"],
+            ["wifi", "network"],
+            [],
+        ),
+        # Pure Python-only change outside trigger paths -> empty.
+        (["esphome/yaml_util.py"], [], []),
+        # Docs / unrelated files -> empty.
+        (["README.md"], [], []),
+        ([], [], []),
+    ],
+)
+def test_native_idf_components_to_test_narrowing(
+    changed_files: list[str],
+    changed_components: list[str],
+    expected: list[str],
+) -> None:
+    """Component changes narrow the test list to the intersection."""
+    with (
+        patch.object(determine_jobs, "changed_files", return_value=changed_files),
+        patch.object(
+            determine_jobs, "get_changed_components", return_value=changed_components
+        ),
+    ):
+        result = determine_jobs.native_idf_components_to_test()
+        assert result == expected
+
+
+def test_native_idf_components_to_test_with_branch() -> None:
+    """native_idf_components_to_test passes branch argument through."""
     with (
         patch.object(determine_jobs, "changed_files") as mock_changed,
         patch.object(determine_jobs, "get_changed_components", return_value=[]),
     ):
         mock_changed.return_value = []
-        determine_jobs.should_run_native_idf("release")
+        determine_jobs.native_idf_components_to_test("release")
         mock_changed.assert_called_once_with("release")
+
+
+@pytest.mark.parametrize(
+    ("components_to_test", "expected"),
+    [
+        ([], False),
+        (["esp32"], True),
+        (["esp32", "api"], True),
+    ],
+)
+def test_should_run_native_idf(components_to_test: list[str], expected: bool) -> None:
+    """should_run_native_idf is a thin wrapper around the component list."""
+    with patch.object(
+        determine_jobs,
+        "native_idf_components_to_test",
+        return_value=components_to_test,
+    ):
+        assert determine_jobs.should_run_native_idf() is expected
+
+
+def test_should_run_native_idf_with_branch() -> None:
+    """Test should_run_native_idf passes branch argument through."""
+    with patch.object(
+        determine_jobs, "native_idf_components_to_test", return_value=[]
+    ) as mock_inner:
+        determine_jobs.should_run_native_idf("release")
+        mock_inner.assert_called_once_with("release")
 
 
 @pytest.mark.parametrize(

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -71,6 +71,13 @@ def mock_should_run_device_builder() -> Generator[Mock, None, None]:
 
 
 @pytest.fixture
+def mock_should_run_native_idf() -> Generator[Mock, None, None]:
+    """Mock should_run_native_idf from determine_jobs."""
+    with patch.object(determine_jobs, "should_run_native_idf") as mock:
+        yield mock
+
+
+@pytest.fixture
 def mock_determine_cpp_unit_tests() -> Generator[Mock, None, None]:
     """Mock determine_cpp_unit_tests from helpers."""
     with patch.object(determine_jobs, "determine_cpp_unit_tests") as mock:
@@ -107,6 +114,7 @@ def test_main_all_tests_should_run(
     mock_should_run_python_linters: Mock,
     mock_should_run_import_time: Mock,
     mock_should_run_device_builder: Mock,
+    mock_should_run_native_idf: Mock,
     mock_changed_files: Mock,
     mock_determine_cpp_unit_tests: Mock,
     capsys: pytest.CaptureFixture[str],
@@ -122,6 +130,7 @@ def test_main_all_tests_should_run(
     mock_should_run_python_linters.return_value = True
     mock_should_run_import_time.return_value = True
     mock_should_run_device_builder.return_value = True
+    mock_should_run_native_idf.return_value = True
     mock_determine_cpp_unit_tests.return_value = (False, ["wifi", "api", "sensor"])
 
     # Mock changed_files to return non-component files (to avoid memory impact)
@@ -203,6 +212,7 @@ def test_main_all_tests_should_run(
     assert output["python_linters"] is True
     assert output["import_time"] is True
     assert output["device_builder"] is True
+    assert output["native_idf"] is True
     assert output["changed_components"] == ["wifi", "api", "sensor"]
     # changed_components_with_tests will only include components that actually have test files
     assert "changed_components_with_tests" in output
@@ -236,6 +246,7 @@ def test_main_no_tests_should_run(
     mock_should_run_python_linters: Mock,
     mock_should_run_import_time: Mock,
     mock_should_run_device_builder: Mock,
+    mock_should_run_native_idf: Mock,
     mock_changed_files: Mock,
     mock_determine_cpp_unit_tests: Mock,
     capsys: pytest.CaptureFixture[str],
@@ -251,6 +262,7 @@ def test_main_no_tests_should_run(
     mock_should_run_python_linters.return_value = False
     mock_should_run_import_time.return_value = False
     mock_should_run_device_builder.return_value = False
+    mock_should_run_native_idf.return_value = False
     mock_determine_cpp_unit_tests.return_value = (False, [])
 
     # Mock changed_files to return no component files
@@ -291,6 +303,7 @@ def test_main_no_tests_should_run(
     assert output["python_linters"] is False
     assert output["import_time"] is False
     assert output["device_builder"] is False
+    assert output["native_idf"] is False
     assert output["changed_components"] == []
     assert output["changed_components_with_tests"] == []
     assert output["component_test_count"] == 0
@@ -313,6 +326,7 @@ def test_main_with_branch_argument(
     mock_should_run_python_linters: Mock,
     mock_should_run_import_time: Mock,
     mock_should_run_device_builder: Mock,
+    mock_should_run_native_idf: Mock,
     mock_changed_files: Mock,
     mock_determine_cpp_unit_tests: Mock,
     capsys: pytest.CaptureFixture[str],
@@ -328,6 +342,7 @@ def test_main_with_branch_argument(
     mock_should_run_python_linters.return_value = True
     mock_should_run_import_time.return_value = True
     mock_should_run_device_builder.return_value = True
+    mock_should_run_native_idf.return_value = True
     mock_determine_cpp_unit_tests.return_value = (False, ["mqtt"])
 
     # Mock changed_files to return non-component files (to avoid memory impact)
@@ -366,6 +381,7 @@ def test_main_with_branch_argument(
     mock_should_run_python_linters.assert_called_once_with("main")
     mock_should_run_import_time.assert_called_once_with("main")
     mock_should_run_device_builder.assert_called_once_with("main")
+    mock_should_run_native_idf.assert_called_once_with("main")
 
     # Check output
     captured = capsys.readouterr()
@@ -379,6 +395,7 @@ def test_main_with_branch_argument(
     assert output["python_linters"] is True
     assert output["import_time"] is True
     assert output["device_builder"] is True
+    assert output["native_idf"] is True
     assert output["changed_components"] == ["mqtt"]
     # changed_components_with_tests will only include components that actually have test files
     assert "changed_components_with_tests" in output
@@ -825,6 +842,84 @@ def test_should_run_device_builder_skips_beta_release(target_branch: str) -> Non
         assert determine_jobs.should_run_device_builder() is False
         # changed_files shouldn't even be consulted -- the guard short-circuits.
         mock_changed.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("changed_files", "changed_components", "expected_result"),
+    [
+        # Core C++/Python changes trigger (caught before get_changed_components)
+        (["esphome/core/component.cpp"], [], True),
+        (["esphome/core/config.py"], [], True),
+        # Native IDF infrastructure paths trigger
+        (["esphome/espidf/framework.py"], [], True),
+        (["esphome/espidf/component.py"], [], True),
+        (["esphome/espidf/api.py"], [], True),
+        (["esphome/build_gen/espidf.py"], [], True),
+        # Workflow / harness files trigger
+        (["script/test_build_components.py"], [], True),
+        ([".github/workflows/ci.yml"], [], True),
+        # Components in the tested set trigger
+        (["esphome/components/esp32/__init__.py"], ["esp32"], True),
+        (
+            ["esphome/components/esp32_ble/ble.cpp"],
+            ["esp32_ble", "esp32_ble_tracker"],
+            True,
+        ),
+        # Dependency closure: changing api triggers because api is in the set
+        (["esphome/components/api/api_connection.cpp"], ["api"], True),
+        # Components outside the tested set don't trigger
+        (
+            ["esphome/components/wifi/wifi_component.cpp"],
+            ["wifi", "network"],
+            False,
+        ),
+        # Pure Python-only changes outside the trigger paths don't run
+        (["esphome/yaml_util.py"], [], False),
+        # Docs / unrelated files don't run
+        (["README.md"], [], False),
+        ([], [], False),
+    ],
+)
+def test_should_run_native_idf(
+    changed_files: list[str],
+    changed_components: list[str],
+    expected_result: bool,
+) -> None:
+    """Test should_run_native_idf function."""
+    with (
+        patch.object(determine_jobs, "changed_files", return_value=changed_files),
+        patch.object(
+            determine_jobs, "get_changed_components", return_value=changed_components
+        ),
+    ):
+        result = determine_jobs.should_run_native_idf()
+        assert result == expected_result
+
+
+def test_should_run_native_idf_core_cpp_returns_none() -> None:
+    """get_changed_components returning None (core C++ change) triggers the job."""
+    with (
+        # Pick a file that isn't core (so core_changed() is False) but force
+        # get_changed_components to fall back to the full-scan sentinel.
+        patch.object(
+            determine_jobs,
+            "changed_files",
+            return_value=["esphome/components/wifi/wifi_component.cpp"],
+        ),
+        patch.object(determine_jobs, "get_changed_components", return_value=None),
+    ):
+        assert determine_jobs.should_run_native_idf() is True
+
+
+def test_should_run_native_idf_with_branch() -> None:
+    """Test should_run_native_idf passes branch argument through."""
+    with (
+        patch.object(determine_jobs, "changed_files") as mock_changed,
+        patch.object(determine_jobs, "get_changed_components", return_value=[]),
+    ):
+        mock_changed.return_value = []
+        determine_jobs.should_run_native_idf("release")
+        mock_changed.assert_called_once_with("release")
 
 
 @pytest.mark.parametrize(

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -928,6 +928,9 @@ def test_native_idf_components_to_test_full_list_when_get_components_none() -> N
         ),
         # Pure Python-only change outside trigger paths -> empty.
         (["esphome/yaml_util.py"], [], []),
+        # Non-IDF files in esphome/build_gen/ do NOT trigger the full
+        # list -- only esphome/build_gen/espidf.py is a trigger.
+        (["esphome/build_gen/platformio.py"], [], []),
         # Docs / unrelated files -> empty.
         (["README.md"], [], []),
         ([], [], []),


### PR DESCRIPTION
# What does this implement/fix?

The `test-native-idf` job (added in #14678) only had `if: github.event_name == 'pull_request'`, so it ran on every PR regardless of what changed — ~5 min of CI per PR (worse on cold caches) even on Python-only edits to unrelated files like `esphome/yaml_util.py`.

Gate the job through `determine-jobs` like the other compile jobs do, and make the Python list of representative components the single source of truth for both the gate and the workflow's `TEST_COMPONENTS` env.

The job now runs only when one of the following changes:

- `esphome/core/*` (caught by `core_changed()`)
- `esphome/espidf/*` or `esphome/build_gen/espidf.py` (the native IDF code path)
- `script/test_build_components.py` (the harness the job invokes) or `.github/workflows/ci.yml` (the job's own definition)
- one of the components listed in `NATIVE_IDF_TEST_COMPONENTS`, or any component in its dependency closure as resolved by `get_changed_components()`

When only specific tested components changed (no infrastructure / core / harness changes), `TEST_COMPONENTS` is narrowed to the intersection of `NATIVE_IDF_TEST_COMPONENTS` and the changed-component dependency closure — so a touch to `ble_scanner` no longer rebuilds the full BLE + sensor + api set. Infrastructure / core / harness changes still fall back to the full list.

The component list lives in `script/determine-jobs.py::NATIVE_IDF_TEST_COMPONENTS`. The workflow consumes the comma-joined sorted form via the new `native-idf-components` output, so the list isn't duplicated.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI-only change — verified locally via the determine-jobs unit tests and by inspecting which jobs the workflow gates on.)

## Example entry for `config.yaml`:

```yaml
# n/a — CI workflow change only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).