### PR TITLE
[tests] Cover top-level !include failure path in track_yaml_loads

### DIFF
--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -393,14 +393,7 @@ def test_track_yaml_loads_cleanup_on_exception(tmp_path: Path) -> None:
 def test_track_yaml_loads_no_duplicate_load_on_top_level_include_failure(
     tmp_path: Path,
 ) -> None:
-    """A failing top-level !include must not cause the same file to be loaded twice.
-
-    Loaders driven by a request/response protocol (e.g. the VS Code loader, which
-    asks the editor for file content over stdin) cannot tolerate the same path
-    being requested more than once for a single load. ``track_yaml_loads`` is the
-    public hook for observing those requests, so this also locks in that
-    invariant for any future caller that aggregates by load count.
-    """
+    """A failed top-level !include must not record any file twice in track_yaml_loads."""
     main = tmp_path / "main.yaml"
     main.write_text("!include missing.yaml\n")
 

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -390,6 +390,28 @@ def test_track_yaml_loads_cleanup_on_exception(tmp_path: Path) -> None:
     assert len(yaml_util._load_listeners) == before
 
 
+def test_track_yaml_loads_no_duplicate_load_on_top_level_include_failure(
+    tmp_path: Path,
+) -> None:
+    """A failing top-level !include must not cause the same file to be loaded twice.
+
+    Loaders driven by a request/response protocol (e.g. the VS Code loader, which
+    asks the editor for file content over stdin) cannot tolerate the same path
+    being requested more than once for a single load. ``track_yaml_loads`` is the
+    public hook for observing those requests, so this also locks in that
+    invariant for any future caller that aggregates by load count.
+    """
+    main = tmp_path / "main.yaml"
+    main.write_text("!include missing.yaml\n")
+
+    with yaml_util.track_yaml_loads() as loaded, pytest.raises(EsphomeError):
+        yaml_util.load_yaml(main)
+
+    assert len(loaded) == len(set(loaded)), (
+        f"Files loaded more than once during a failed top-level include: {loaded}"
+    )
+
+
 @pytest.mark.parametrize(
     "data",
     [


### PR DESCRIPTION
# What does this implement/fix?

Adds a unit test for a previously uncovered branch in `track_yaml_loads`: a top-level `!include` whose outer file parses cleanly but whose included file fails to open. The test asserts that no path is recorded in the listener more than once.

There was no existing coverage for the load-listener behavior on this error path.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No user-visible config changes; tests-only PR.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).