### PR TITLE
Fix casing of custom fan modes

### DIFF
--- a/esphome/components/midea/ac_adapter.cpp
+++ b/esphome/components/midea/ac_adapter.cpp
@@ -6,9 +6,9 @@
 namespace esphome::midea::ac {
 
 const char *const Constants::TAG = "midea";
-const char *const Constants::FREEZE_PROTECTION = "freeze protection";
-const char *const Constants::SILENT = "silent";
-const char *const Constants::TURBO = "turbo";
+const char *const Constants::FREEZE_PROTECTION = "Freeze Protection";
+const char *const Constants::SILENT = "Silent";
+const char *const Constants::TURBO = "Turbo";
 
 ClimateMode Converters::to_climate_mode(MideaMode mode) {
   switch (mode) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes the casing of the custom fan (and freeze protection) modes.

### Before
<img width="129" height="258" alt="Before" src="https://github.com/user-attachments/assets/00c5997a-90d9-430b-b150-ae9b476f2791" />

### After
<img width="125" height="257" alt="After" src="https://github.com/user-attachments/assets/d704f27f-78a1-426f-a6c0-5eeb6e632246" />

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Test Environment

- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
climate:
  - platform: midea
    name: Air Conditioner
    autoconf: true
    custom_fan_modes:
      - SILENT
      - TURBO
    custom_presets:
      - FREEZE_PROTECTION
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
