### PR TITLE
[espidf] Partition pio_components cache by framework

### DIFF
--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -86,7 +86,10 @@ class URLSource(Source):
         self.url = url
 
     def download(self, dir_suffix: str, force: bool = False) -> Path:
-        base_dir = Path(CORE.data_dir) / DOMAIN
+        # Partition by framework: generated idf_component.yml content
+        # depends on CORE.using_arduino, so caches can't be shared.
+        framework = "arduino" if CORE.using_arduino else "idf"
+        base_dir = Path(CORE.data_dir) / DOMAIN / framework
         h = hashlib.new("sha256")
         h.update(self.url.encode())
         path = base_dir / h.hexdigest()[:8] / dir_suffix
@@ -121,11 +124,12 @@ class GitSource(Source):
         self.ref = ref
 
     def download(self, dir_suffix: str, force: bool = False) -> Path:
+        framework = "arduino" if CORE.using_arduino else "idf"
         path, _ = git.clone_or_update(
             url=self.url,
             ref=self.ref,
             refresh=git.NEVER_REFRESH if not force else None,
-            domain=DOMAIN,
+            domain=f"{DOMAIN}/{framework}",
             submodules=[],
             subpath=Path(dir_suffix),
         )


### PR DESCRIPTION
# What does this implement/fix?

`esphome/espidf/component.py` converts PlatformIO libraries into ESP-IDF managed components on the fly and caches the result under `<data_dir>/pio_components/<hash>/<lib>/`, where `<hash>` is derived from the library URL (`URLSource`) or `url@ref` (`GitSource`).

The generated `idf_component.yml` / `CMakeLists.txt` content **depends on `CORE.using_arduino`** — `_patch_component` (line 295-305) appends `espressif/arduino-esp32` to the converted library's dependency list whenever the build's framework is Arduino. But the cache key has no framework component, so whichever build runs first determines the cached manifest and subsequent builds with the opposite framework reuse it verbatim.

The early-return at `_generate_idf_component` (line 882-884) makes this stick: if both `CMakeLists.txt` and `idf_component.yml` already exist for the library, it returns without regenerating, on the assumption "already an ESP-IDF component."

## How this surfaces

In CI's component-test job (and any developer workflow that builds multiple framework targets in the same checkout), the worker compiles `esp32-ard` and `esp32-idf` sequentially under `--toolchain esp-idf`. With this bug:

1. **esp32-ard** runs first → `CORE.using_arduino=True` → `dsmr_parser/idf_component.yml` written with:
   ```yaml
   dependencies:
     espressif/arduino-esp32:
       version: 3.3.8
   ```
2. **esp32-idf** runs next → `CORE.using_arduino=False` → cache early-return reuses the poisoned manifest → IDF Component Manager follows the transitive dep → `arduino-esp32` + ~20 of its Arduino-dependency components (`esp-modbus`, `esp_diagnostics`, `esp_insights`, `esp_rcp_update`, `littlefs`, `esp-zboss-lib`, …) get installed into the esp-idf build's `managed_components/`.
3. `arduino-esp32/cores/esp32/IPAddress.h` lands on the include path; its `extern const IPAddress INADDR_NONE;` collides with lwIP's `INADDR_NONE` macro; every TU that combines lwIP sockets with anything pulled from the Arduino tree (`api_frame_helper*.cpp`, `api_connection.cpp`, …) fails to compile:

   ```
   lwip/ip4_addr.h:63:37: error: expected ')' before numeric constant
      63 | #define IPADDR_NONE         ((u32_t)0xffffffffUL)
   note: in expansion of macro 'INADDR_NONE'
     140 | extern const IPAddress INADDR_NONE;
   ```

## Fix

Insert the build framework (`arduino` or `idf`) as a subdirectory under the existing `pio_components/` cache root. Layout changes from:

```
pio_components/<hash>/<owner>/<lib>/...
```

to:

```
pio_components/arduino/<hash>/<owner>/<lib>/...
pio_components/idf/<hash>/<owner>/<lib>/...
```

Both manifests can now coexist side-by-side, and the right one is selected automatically per build. No regeneration cost, no marker file, no changes to `git.py` (the `domain` parameter already accepts a path).

## Verification

Reproduced the bug locally with a clean cache by running `esp32-ard` (`midea,dsmr`) then `esp32-idf` (39-component camera/api batch), both with `--toolchain esp-idf`:

**Before the fix:**
- After step 1: `pio_components/<hash>/esphome/dsmr_parser/idf_component.yml` contains `dependencies: [espressif/arduino-esp32]`
- Step 2 esp32-idf build's `managed_components/` ends up with 30+ Arduino components
- Step 2 fails with `INADDR_NONE` collision (exit code 2)

**After the fix:**
- `pio_components/arduino/<hash>/esphome/dsmr_parser/idf_component.yml` has `arduino-esp32` dep (correct under Arduino)
- `pio_components/idf/<hash>/esphome/dsmr_parser/idf_component.yml` has no `dependencies:` section (correct under ESP-IDF)
- esp32-idf build's `managed_components/` contains only `arduinojson`, `esp32-camera`, `esp_jpeg`, `mdns`
- Step 2 builds clean (`1 passed, 0 failed`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Developer breaking change
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during ESP32 ESP-IDF toolchain testing in DNM #16383.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

N/A — internal cache-layout change; user-visible YAML is unchanged. Existing cache directories from prior builds remain on disk as orphans (under the legacy unprefixed layout) and can be removed by hand or via \`esphome clean\`; they aren't a correctness issue, just disk usage.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).