### PR TITLE
[espidf] Emit -W warning flags at project scope so managed components also see them

### DIFF
--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -54,11 +54,22 @@ def get_project_cmakelists() -> str:
     variant = get_esp32_variant()
     idf_target = variant.lower().replace("-", "")
 
-    # Extract compile definitions from build flags (-DXXX -> XXX)
-    compile_defs = [flag for flag in sorted(CORE.build_flags) if flag.startswith("-D")]
+    # Project-wide compile options: -D defines and -W warning flags (skip
+    # -Wl, linker flags — those go on the src component via
+    # target_link_options below). Emitted via idf_build_set_property so the
+    # flags propagate to every IDF component (including managed ones like
+    # esphome__micro-mp3) rather than just src/. Required so suppressions
+    # like ``-Wno-error=maybe-uninitialized`` actually silence warnings in
+    # third-party components we don't author.
+    project_compile_opts = [
+        flag
+        for flag in sorted(CORE.build_flags)
+        if flag.startswith("-D")
+        or (flag.startswith("-W") and not flag.startswith("-Wl,"))
+    ]
     extra_compile_options = "\n".join(
-        f'idf_build_set_property(COMPILE_OPTIONS "{compile_def}" APPEND)'
-        for compile_def in compile_defs
+        f'idf_build_set_property(COMPILE_OPTIONS "{flag}" APPEND)'
+        for flag in project_compile_opts
     )
 
     return f"""\
@@ -107,15 +118,9 @@ def get_component_cmakelists(minimal: bool = False) -> str:
     idf_requires = [] if minimal else (get_available_components() or [])
     requires_str = " ".join(idf_requires)
 
-    # Extract compile options (-W flags, excluding linker flags)
-    compile_opts = [
-        flag
-        for flag in CORE.build_flags
-        if flag.startswith("-W") and not flag.startswith("-Wl,")
-    ]
-    compile_opts_str = "\n    ".join(sorted(compile_opts)) if compile_opts else ""
-
-    # Extract linker options (-Wl, flags)
+    # Extract linker options (-Wl, flags). Compile flags (-D, -W) are
+    # emitted project-wide via idf_build_set_property in
+    # get_project_cmakelists so they reach every component, not just src/.
     link_opts = [flag for flag in CORE.build_flags if flag.startswith("-Wl,")]
     link_opts_str = "\n    ".join(sorted(link_opts)) if link_opts else ""
 
@@ -136,11 +141,6 @@ idf_component_register(
 
 # Apply C++ standard
 target_compile_features(${{COMPONENT_LIB}} PUBLIC cxx_std_20)
-
-# ESPHome compile options
-target_compile_options(${{COMPONENT_LIB}} PUBLIC
-    {compile_opts_str}
-)
 
 # ESPHome linker options
 target_link_options(${{COMPONENT_LIB}} PUBLIC


### PR DESCRIPTION
# What does this implement/fix?

Suppressions added in `esp32/__init__.py` for the native-IDF toolchain path:

```python
cg.add_build_flag("-Wno-error=format")
cg.add_build_flag("-Wno-error=maybe-uninitialized")
cg.add_build_flag("-Wno-error=missing-field-initializers")
cg.add_build_flag("-Wno-error=reorder")
cg.add_build_flag("-Wno-error=volatile")
```

…were only reaching `src/`'s TUs because `build_gen/espidf.py:get_component_cmakelists` emitted them via `target_compile_options(${COMPONENT_LIB} PUBLIC …)`. Managed IDF components (`esphome__micro-mp3`, `espressif__esp32-camera`, …) don't depend on `src` and so kept compiling with the stock ESP-IDF warning policy, tripping `-Werror` on third-party code we can't patch:

```
managed_components/esphome__micro-mp3/.../pvmp3_mpeg2_get_scale_data.cpp:228:
    error: 'new_slen' may be used uninitialized [-Werror=maybe-uninitialized]
```

This is the third failure category from the native-IDF toolchain test (DNM #16383): #16392 added the right `-Wno-error=…` flags but they didn't propagate to managed components.

## How

Move non-linker compile flags (`-D` defines and `-W` warning flags, but **not** `-Wl,` linker flags) from per-component `target_compile_options` to project-scope `idf_build_set_property(COMPILE_OPTIONS … APPEND)` in `get_project_cmakelists`. That's the same channel `-DUSE_ARDUINO` and `-DUSE_ESP32_*` already use; ESP-IDF's build system propagates it to every component, including managed ones.

`-Wl,` linker flags still go through `target_link_options` on `src` — link flags genuinely need a target rather than a build-property.

## Verification

Ran an `audio`-component test build on the toolchain-flip branch:

```bash
script/test_build_components.py -c audio -t esp32-idf -e compile --toolchain esp-idf
```

The `audio` component adds `add_idf_component(name="esphome/micro-mp3", ref="0.2.0")`, which is exactly the managed component that was failing in CI. With this PR:

- Build succeeded (`1 passed, 0 failed`).
- Inspecting `build/compile_commands.json`, every TU — including ones in `xtensa`, `esp_lcd`, and the `esphome__micro-mp3` managed component — now carries the full `-Wno-error=format -Wno-error=maybe-uninitialized -Wno-error=missing-field-initializers -Wno-error=reorder -Wno-error=volatile` set.
- `tests/unit_tests/test_espidf_component.py`: 29 passed, 0 failed (no regressions).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Developer breaking change
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #16392 (which only addressed `src/`).
- Surfaced in DNM #16383's component-test batches that compile managed IDF components.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — internal build-flag plumbing change; user-visible YAML is unchanged.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).