### PR TITLE
[writer] Clean ESP-IDF build artifacts in clean_build

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -490,6 +490,14 @@ def clean_build(clear_pio_cache: bool = True):
     if dependencies_lock.is_file():
         _LOGGER.info("Deleting %s", dependencies_lock)
         dependencies_lock.unlink()
+    # Native ESP-IDF toolchain artifacts: the IDF CMake/ninja build dir
+    # and the Component Manager's fetched managed components live under
+    # the project's build path, not under .pioenvs / .piolibdeps.
+    for name in ("build", "managed_components"):
+        idf_path = CORE.relative_build_path(name)
+        if idf_path.is_dir():
+            _LOGGER.info("Deleting %s", idf_path)
+            rmtree(idf_path)
 
     if not clear_pio_cache:
         return

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -443,6 +443,14 @@ def test_clean_build(
     dependencies_lock = tmp_path / "dependencies.lock"
     dependencies_lock.write_text("lock file")
 
+    # Native ESP-IDF toolchain artifacts.
+    idf_build_dir = tmp_path / "build"
+    idf_build_dir.mkdir()
+    (idf_build_dir / "CMakeCache.txt").write_text("cache")
+    managed_components_dir = tmp_path / "managed_components"
+    managed_components_dir.mkdir()
+    (managed_components_dir / "espressif__arduino-esp32").mkdir()
+
     # Create PlatformIO cache directory
     platformio_cache_dir = tmp_path / ".platformio" / ".cache"
     platformio_cache_dir.mkdir(parents=True)
@@ -454,12 +462,14 @@ def test_clean_build(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
-    mock_core.relative_build_path.return_value = dependencies_lock
+    mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify all exist before
     assert pioenvs_dir.exists()
     assert piolibdeps_dir.exists()
     assert dependencies_lock.exists()
+    assert idf_build_dir.exists()
+    assert managed_components_dir.exists()
     assert platformio_cache_dir.exists()
 
     # Mock PlatformIO's ProjectConfig cache_dir
@@ -482,6 +492,8 @@ def test_clean_build(
     assert not pioenvs_dir.exists()
     assert not piolibdeps_dir.exists()
     assert not dependencies_lock.exists()
+    assert not idf_build_dir.exists()
+    assert not managed_components_dir.exists()
     assert not platformio_cache_dir.exists()
 
     # Verify logging
@@ -489,6 +501,8 @@ def test_clean_build(
     assert ".pioenvs" in caplog.text
     assert ".piolibdeps" in caplog.text
     assert "dependencies.lock" in caplog.text
+    assert str(idf_build_dir) in caplog.text
+    assert str(managed_components_dir) in caplog.text
     assert "PlatformIO cache" in caplog.text
 
 
@@ -510,7 +524,7 @@ def test_clean_build_partial_exists(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
-    mock_core.relative_build_path.return_value = dependencies_lock
+    mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify only pioenvs exists
     assert pioenvs_dir.exists()
@@ -547,7 +561,7 @@ def test_clean_build_nothing_exists(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
-    mock_core.relative_build_path.return_value = dependencies_lock
+    mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify nothing exists
     assert not pioenvs_dir.exists()
@@ -583,7 +597,7 @@ def test_clean_build_platformio_not_available(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
-    mock_core.relative_build_path.return_value = dependencies_lock
+    mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify all exist before
     assert pioenvs_dir.exists()
@@ -621,7 +635,7 @@ def test_clean_build_empty_cache_dir(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = tmp_path / ".piolibdeps"
-    mock_core.relative_build_path.return_value = tmp_path / "dependencies.lock"
+    mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify pioenvs exists before
     assert pioenvs_dir.exists()
@@ -1349,7 +1363,7 @@ def test_clean_build_handles_readonly_files(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = tmp_path / ".piolibdeps"
-    mock_core.relative_build_path.return_value = tmp_path / "dependencies.lock"
+    mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify file is read-only
     assert not os.access(readonly_file, os.W_OK)
@@ -1413,7 +1427,7 @@ def test_clean_build_reraises_for_other_errors(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = tmp_path / ".piolibdeps"
-    mock_core.relative_build_path.return_value = tmp_path / "dependencies.lock"
+    mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     try:
         # Mock os.access in writer module to return True (writable)


### PR DESCRIPTION
# What does this implement/fix?

\`esphome clean\` was essentially a no-op for projects built with the native ESP-IDF toolchain. \`writer.clean_build\` only deletes:

- \`<build_path>/.pioenvs/<name>/\` (PIO-specific)
- \`<build_path>/.piolibdeps/\` (PIO-specific)
- \`<build_path>/dependencies.lock\`
- The PlatformIO cache directory

Under the native ESP-IDF toolchain the actual heavy artifacts live elsewhere:

- \`<build_path>/build/\` — IDF's CMake/ninja build dir (CMakeCache.txt, build.ninja, every \`.obj\`, \`firmware.bin\`, …)
- \`<build_path>/managed_components/\` — components fetched by the IDF Component Manager

Neither was touched by \`clean_build\`, so \`esphome clean\` on an IDF-toolchain project left all the heavy state in place.

Add both paths to the cleanup. \`dependencies.lock\` was already there (also an IDF artifact) so this just rounds out the set.

### Test changes

\`test_clean_build\` mocked \`CORE.relative_build_path\` with a single \`return_value\`, but the function now calls it with three different names (\`dependencies.lock\`, \`build\`, \`managed_components\`). Switched the mock to a \`side_effect\` lambda that maps name → \`tmp_path / name\`, and extended the main test to set up + assert removal of the new IDF paths.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced while exercising the native ESP-IDF toolchain (#16383 / #16406): \`esphome clean\` left a full IDF build tree in place.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal build-system change, no user-visible config.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# No user-facing config change.
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).