### PR TITLE
[ci] Prohibit curly braces in PR titles for MDX safety

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -68,14 +68,15 @@ jobs:
               return;
             }
 
-            // Check for angle brackets not wrapped in backticks.
-            // Astro docs MDX treats bare < as JSX component opening tags.
+            // Check for MDX syntax characters not wrapped in backticks.
+            // Astro docs MDX treats bare `<` as JSX component opening tags and
+            // bare `{` as JS expressions, so both must be escaped in changelog entries.
             const stripped = title.replace(/`[^`]*`/g, '');
-            if (/[<>]/.test(stripped)) {
+            if (/[<>{}]/.test(stripped)) {
               core.setFailed(
-                'PR title contains `<` or `>` not wrapped in backticks.\n' +
-                'Astro docs MDX interprets bare `<` as JSX components.\n' +
-                'Please wrap angle brackets with backticks, e.g.: [component] Add `<feature>` support'
+                'PR title contains `<`, `>`, `{`, or `}` not wrapped in backticks.\n' +
+                'Astro docs MDX interprets bare `<` as JSX components and bare `{` as JS expressions.\n' +
+                'Please wrap these characters with backticks, e.g.: [component] Add `<feature>` support'
               );
               return;
             }


### PR DESCRIPTION
# What does this implement/fix?

Extends the existing PR title check to also flag bare `{` and `}` characters (in addition to the already-blocked `<` and `>`).

The release-notes changelog is rendered through Astro MDX, which treats both bare `<` (JSX component opening tags) and bare `{` (JS expressions) as syntax. An unescaped occurrence of either character in a changelog line breaks page rendering.

A real example just surfaced in [esphome/esphome-docs#6619 commit `3be3922`](https://github.com/esphome/esphome-docs/pull/6619/commits/3be3922ccad11da3852b9d5cbe216f8f39aa9605), where the changelog entry had to be hand-patched from:

```
- [core] Split wake.{h,cpp} into per-platform files
```

to:

```
- [core] Split wake.\{h,cpp\} into per-platform files
```

Catching this at PR-title time avoids the manual patch on release.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# n/a — CI workflow change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).