### PR TITLE
[tinyusb] Reject `tinyusb:` configured without a USB class companion

### DIFF
--- a/esphome/components/tinyusb/__init__.py
+++ b/esphome/components/tinyusb/__init__.py
@@ -1,3 +1,4 @@
+from esphome import final_validate as fv
 import esphome.codegen as cg
 from esphome.components import esp32
 from esphome.components.esp32 import (
@@ -20,6 +21,13 @@ CONF_USB_PRODUCT_STR = "usb_product_str"
 CONF_USB_SERIAL_STR = "usb_serial_str"
 CONF_USB_VENDOR_ID = "usb_vendor_id"
 
+# Components that provide a USB device class (CDC, HID, MSC, ...) on top of
+# tinyusb. Configuring `tinyusb:` without any of these triggers a 5s hang in
+# esp_tinyusb's driver install (descriptors_set fails with no class and no
+# user-provided full_speed_config), which trips the task watchdog before
+# loop() ever runs.
+_USB_CLASS_COMPONENTS = ("usb_cdc_acm",)
+
 tinyusb_ns = cg.esphome_ns.namespace("tinyusb")
 TinyUSB = tinyusb_ns.class_("TinyUSB", cg.Component)
 
@@ -39,6 +47,18 @@ CONFIG_SCHEMA = cv.All(
         supported=[VARIANT_ESP32P4, VARIANT_ESP32S2, VARIANT_ESP32S3],
     ),
 )
+
+
+def _final_validate(config):
+    full_config = fv.full_config.get()
+    if not any(name in full_config for name in _USB_CLASS_COMPONENTS):
+        raise cv.Invalid(
+            "The 'tinyusb' component requires at least one USB class component"
+        )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 
 async def to_code(config):

--- a/esphome/components/tinyusb/tinyusb_component.cpp
+++ b/esphome/components/tinyusb/tinyusb_component.cpp
@@ -26,6 +26,21 @@ void TinyUSB::setup() {
       .string_count = SIZE,
   };
 
+  // Defense-in-depth: esp_tinyusb's tinyusb_descriptors_set() fails with
+  // ESP_ERR_INVALID_ARG when no configuration descriptor is provided and
+  // no class that has a built-in default (CDC/MSC/NCM) is compiled in. In
+  // that case the internal task exits without notifying us, and
+  // tinyusb_driver_install() blocks 5s on the notify-take -- long enough
+  // to trip the task watchdog. Bail early so the rest of the device can
+  // still boot.
+#if !(CFG_TUD_CDC > 0 || CFG_TUD_MSC > 0 || CFG_TUD_NCM > 0)
+  if (this->tusb_cfg_.descriptor.full_speed_config == nullptr) {
+    ESP_LOGE(TAG, "No USB class configured");
+    this->mark_failed();
+    return;
+  }
+#endif
+
   esp_err_t result = tinyusb_driver_install(&this->tusb_cfg_);
   if (result != ESP_OK) {
     ESP_LOGE(TAG, "tinyusb_driver_install failed: %s", esp_err_to_name(result));

--- a/tests/components/tinyusb/common.yaml
+++ b/tests/components/tinyusb/common.yaml
@@ -6,3 +6,8 @@ tinyusb:
   usb_product_str: ESPHomeTestProduct
   usb_serial_str: ESPHomeTestSerialNumber
   usb_vendor_id: 0x2345
+
+# tinyusb requires at least one USB class companion; usb_cdc_acm satisfies that.
+usb_cdc_acm:
+  interfaces:
+    - id: tinyusb_test_cdc


### PR DESCRIPTION
# What does this implement/fix?

Fixes a boot-time hang / watchdog reboot loop when `tinyusb:` is configured without any USB device class component alongside it (e.g. no `usb_cdc_acm:`).

Root cause in [esp_tinyusb 2.1.1](https://components.espressif.com/components/espressif/esp_tinyusb/versions/2.1.1):

1. `TinyUSB::setup()` calls `tinyusb_driver_install()` without setting `tusb_cfg_.descriptor.full_speed_config` — that's intentional, the class component provides it.
2. When no class is configured, `CONFIG_TINYUSB_CDC_ENABLED` / `MSC` / `NCM` are all unset, so `CFG_TUD_CDC == CFG_TUD_MSC == CFG_TUD_NCM == 0`.
3. `tinyusb_descriptors_set()` then fails with `ESP_ERR_INVALID_ARG` (no descriptor provided, no class with a built-in default).
4. The internal `tinyusb_device_task` exits without `xTaskNotifyGive()`-ing the parent.
5. `tinyusb_task_start()` blocks 5 s on `ulTaskNotifyTake()`, longer than the 5 s task watchdog → reboot loop.

This PR adds two layers of protection:

**Config-time validation** — a `FINAL_VALIDATE_SCHEMA` in `tinyusb/__init__.py` that errors out when no known USB class component is configured. Today that's just `usb_cdc_acm`; future class components (e.g. `usb_uart_bridge`, `tinyusb_keyboard` from #16079) just need to be appended to the `_USB_CLASS_COMPONENTS` tuple.

**Runtime guard** — a defense-in-depth check in `TinyUSB::setup()` that mirrors esp_tinyusb's exact failure condition (`!(CFG_TUD_CDC|MSC|NCM > 0) && full_speed_config == nullptr`) and calls `mark_failed()` instead of letting the device hang. This protects against external components or future configurations that bypass the Python validation.

The standalone `tests/components/tinyusb/` fixture was exercising the now-invalid `tinyusb:`-alone config, so it's been paired with a minimal `usb_cdc_acm:` to keep it valid while still exercising tinyusb's options.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16184

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Tested on ESP32-S3 with IDF. Previously reproduced the 5 s hang + watchdog reboot loop with `tinyusb:` alone; after this PR the same config errors at `esphome config` time with a clear message.

## Example entry for `config.yaml`:

Before this PR, the following config would reboot-loop the device at boot:

```yaml
esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

tinyusb:
```

After this PR, the same config fails fast at validation:

```
The 'tinyusb' component requires at least one USB class component
```

A correct configuration pairs `tinyusb:` with a USB class component:

```yaml
esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

tinyusb:
  usb_manufacturer_str: ExampleCo
  usb_product_str: ExampleDevice

usb_cdc_acm:
  interfaces:
    - id: cdc0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).