### PR TITLE
[espidf] Stop perpetual reconfigure loop on native ESP-IDF builds

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2509,7 +2509,12 @@ def _write_idf_component_yml():
 
         stubs_dir = CORE.relative_build_path("component_stubs")
         stubs_dir.mkdir(exist_ok=True)
-        for component_name in components_to_stub:
+        # Sort so the dict insertion order (and thus the generated
+        # src/idf_component.yml) is deterministic across runs; otherwise
+        # the manifest content shuffles every build, write_file_if_changed
+        # always writes, and ninja keeps triggering CMake re-runs on
+        # otherwise-cached rebuilds.
+        for component_name in sorted(components_to_stub):
             # Create stub directory with minimal CMakeLists.txt
             stub_path = stubs_dir / _idf_component_stub_name(component_name)
             stub_path.mkdir(exist_ok=True)

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -191,13 +191,19 @@ def run_reconfigure() -> int:
 def has_outdated_files():
     """Check if the build configuration is stale.
 
-    Returns True if required build files are missing or if configuration inputs
-    are newer than the generated CMake/Ninja build artifacts.
+    Returns True if required build files are missing or if external
+    configuration inputs (IDF install, sdkconfig, CMake's own build/config
+    dir) are newer than CMakeCache.txt. We deliberately don't watch the
+    top-level/src ``CMakeLists.txt`` here -- those are written by
+    ``write_project`` via ``write_file_if_changed`` (so an mtime bump
+    means our content actually changed) and ninja already tracks them as
+    configure-time deps via ``build.ninja``. Including them in this check
+    causes a perpetual reconfigure loop: the two-pass write leaves
+    CMakeLists newer than CMakeCache.txt, and CMake doesn't restamp the
+    cache when only ``idf_build_set_property`` values change, so the
+    check would trip on every subsequent build.
     """
     cmakecache_txt_path = CORE.relative_build_path("build/CMakeCache.txt")
-
-    cmakelists_txt_build_path = CORE.relative_build_path("CMakeLists.txt")
-    cmakelists_txt_src_path = CORE.relative_src_path("CMakeLists.txt")
     build_config_path = CORE.relative_build_path("build/config")
     sdkconfig_internal_path = CORE.relative_build_path(
         f"sdkconfig.{CORE.name}.esphomeinternal"
@@ -221,8 +227,6 @@ def has_outdated_files():
         os.path.getmtime(f) > cmakecache_txt_mtime
         for f in [
             _get_idf_path(),
-            cmakelists_txt_build_path,
-            cmakelists_txt_src_path,
             sdkconfig_internal_path,
             build_config_path,
         ]
@@ -302,21 +306,13 @@ def run_compile(config, verbose: bool) -> int:
             return rc
         _LOGGER.info("Regenerating CMakeLists.txt with discovered components...")
         write_project(minimal=False)
-        # The post-discovery rewrite leaves CMakeLists newer than
-        # CMakeCache.txt. CMake won't re-touch CMakeCache.txt on a
-        # configure that only changes idf_build_set_property values
-        # (those aren't cache variables), so has_outdated_files() would
-        # return True on every subsequent build, perpetually retriggering
-        # the two-pass. Touch CMakeCache.txt now so its mtime stays past
-        # the rewritten CMakeLists.
-        cmakecache = CORE.relative_build_path("build/CMakeCache.txt")
-        if cmakecache.is_file():
-            os.utime(cmakecache)
         if CORE.testing_mode:
             # Reconfigure again so cmake is up to date with the full
             # component list before the build's idf.py invocation runs --
             # idf.py build would otherwise re-run cmake and regenerate
             # memory.ld, wiping the DRAM/IRAM patches applied below.
+            # Outside testing mode ninja's own configure-time dep on
+            # CMakeLists.txt handles the re-run as part of the build step.
             rc = run_reconfigure()
             if rc != 0:
                 _LOGGER.error("Reconfigure with discovered components failed")


### PR DESCRIPTION
# What does this implement/fix?

After PR #16406 landed, every subsequent \`esphome compile\` on a native ESP-IDF project re-runs the full two-pass CMake discovery dance even when nothing changed. The root cause is a self-perpetuating mtime drift between \`CMakeLists.txt\` and \`CMakeCache.txt\`.

### Layer 1 — \`has_outdated_files\` watches a file we own

\`has_outdated_files()\` checks whether the top-level / src \`CMakeLists.txt\` is newer than \`build/CMakeCache.txt\` to decide whether to reconfigure. But:

- ESPHome is the only writer of those CMakeLists files, and \`write_file_if_changed\` only bumps mtime when **content actually changed**. So checking mtime is redundant with content tracking — if we wrote, content changed; if we didn't write, mtime is stable.
- Ninja already tracks both files as configure-time dependencies via \`build.ninja\`. When CMakeLists changes, ninja re-invokes CMake automatically as part of the next build invocation. The \`has_outdated_files\` check duplicates a mechanism ninja already handles correctly.
- The duplicate check creates a loop. The post-discovery write in the two-pass leaves \`CMakeLists.txt\` newer than \`CMakeCache.txt\`. CMake doesn't restamp \`CMakeCache.txt\`'s mtime on a reconfigure that only mutates \`idf_build_set_property\` values (those aren't cache variables), so \`CMakeLists > CMakeCache\` holds across builds — \`has_outdated_files()\` trips on every subsequent build, retriggering the two-pass forever. The previous workaround (\`os.utime(build/CMakeCache.txt)\` after the two-pass, added in #16406) was specifically compensating for this duplicate check; with the check removed, the touch becomes unnecessary and can go.

This PR drops the CMakeLists entries from \`has_outdated_files\`'s watch list and removes the \`os.utime\` workaround. The remaining checks (\`IDF_PATH\`, \`sdkconfig.<name>.esphomeinternal\`, \`build/config\`) all watch genuinely external state ESPHome doesn't directly write.

### Layer 2 — Non-deterministic \`src/idf_component.yml\`

Even with the layer-1 fix, ninja was still re-running CMake on every build. Reason: \`_write_idf_component_yml\` iterates \`components_to_stub\` (a Python \`set\`, whose iteration order is hash-randomized) when building the project manifest, so the resulting YAML had keys in a different order each run. \`write_file_if_changed\` wrote a "new" file every time, which bumped \`src/idf_component.yml\`'s mtime, which ninja tracks as a configure dep, which forced a CMake re-run. Sorting \`components_to_stub\` before the iteration fixes this — the manifest content is now stable across runs.

### Result

Verified locally with \`script/test_build_components --toolchain esp-idf\`:

| Build | Configures | Wall time |
| --- | ---: | ---: |
| Cold (no build dir) | 3 (two-pass + ninja's post-discovery rerun) | ~44 s |
| Warm (no source changes) | **0** | 2.4 s |

Project switch within same \`(IDF version, target)\`: handled by ninja's auto-rerun when our generated \`CMakeLists.txt\` content changes (one CMake reconfigure, no two-pass). Real external changes (sdkconfig edits, IDF upgrade) still trip \`has_outdated_files\` through the remaining watched files.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #16406; replaces the temporary \`os.utime(CMakeCache.txt)\` introduced there.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal build-system change, no user-visible config.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# No user-facing config change.
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).