### PR TITLE
[espidf] Trim has_outdated_files watch list; embed IDF version in sdkconfig

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2464,8 +2464,14 @@ def _write_sdkconfig():
     )
 
     want_opts = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    # Include the resolved framework version as a Kconfig comment so a
+    # version switch that happens to leave the option set unchanged still
+    # bumps this file's content -- which is what has_outdated_files()
+    # uses to decide whether to reconfigure.
+    framework_version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
     contents = (
-        "\n".join(
+        f"# ESPHOME_IDF_VERSION={framework_version}\n"
+        + "\n".join(
             f"{name}={_format_sdkconfig_val(value)}"
             for name, value in sorted(want_opts.items())
         )

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -191,23 +191,38 @@ def run_reconfigure() -> int:
 def has_outdated_files():
     """Check if the build configuration is stale.
 
-    Returns True if required build files are missing or if external
-    configuration inputs (IDF install, sdkconfig, CMake's own build/config
-    dir) are newer than CMakeCache.txt. We deliberately don't watch the
-    top-level/src ``CMakeLists.txt`` here -- those are written by
-    ``write_project`` via ``write_file_if_changed`` (so an mtime bump
-    means our content actually changed) and ninja already tracks them as
-    configure-time deps via ``build.ninja``. Including them in this check
-    causes a perpetual reconfigure loop: the two-pass write leaves
-    CMakeLists newer than CMakeCache.txt, and CMake doesn't restamp the
-    cache when only ``idf_build_set_property`` values change, so the
-    check would trip on every subsequent build.
+    Returns True if required build files are missing or if ESPHome's
+    resolved build inputs are newer than CMakeCache.txt:
+
+    - ``sdkconfig.<name>.esphomeinternal`` -- the canonical "what state
+      did ESPHome resolve the YAML to" snapshot. Any change in build
+      flags, enabled components, framework version, or target ends up
+      rewriting it (we embed a ``# ESPHOME_IDF_VERSION=`` comment line
+      for the version case where the option set would otherwise be
+      identical).
+    - ``src/idf_component.yml`` -- the project manifest. Managed
+      component additions/removals (e.g. via ``add_idf_component``) can
+      happen without any sdkconfig impact, and ``_write_idf_component_yml``
+      already deletes ``dependencies.lock`` on a change but that signal
+      gets lost as soon as the lock is missing.
+
+    We deliberately don't watch:
+    - The top-level/src ``CMakeLists.txt`` -- ESPHome owns those, and
+      ninja already tracks them as configure-time deps. Including them
+      causes a perpetual reconfigure loop because CMake doesn't restamp
+      ``CMakeCache.txt`` when only ``idf_build_set_property`` values
+      change between configures.
+    - ``$IDF_PATH`` and CMake's ``build/config/`` -- both have mtime
+      semantics that fire after the wrong configure (or not at all in
+      common cases like in-place IDF version replacement). The sdkconfig
+      and manifest hashes subsume the meaningful signal.
     """
     cmakecache_txt_path = CORE.relative_build_path("build/CMakeCache.txt")
     build_config_path = CORE.relative_build_path("build/config")
     sdkconfig_internal_path = CORE.relative_build_path(
         f"sdkconfig.{CORE.name}.esphomeinternal"
     )
+    idf_component_yml_path = CORE.relative_build_path("src/idf_component.yml")
     dependency_lock_path = CORE.relative_build_path("dependencies.lock")
     build_ninja_path = CORE.relative_build_path("build/build.ninja")
 
@@ -225,12 +240,8 @@ def has_outdated_files():
     cmakecache_txt_mtime = os.path.getmtime(cmakecache_txt_path)
     return any(
         os.path.getmtime(f) > cmakecache_txt_mtime
-        for f in [
-            _get_idf_path(),
-            sdkconfig_internal_path,
-            build_config_path,
-        ]
-        if f and os.path.exists(f)
+        for f in [sdkconfig_internal_path, idf_component_yml_path]
+        if f.exists()
     )
 
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #16415, addressing two related gaps in \`has_outdated_files()\` for the native ESP-IDF toolchain:

### 1 — \`\$IDF_PATH\` and \`build/config/\` mtime watches are unreliable

\`has_outdated_files()\` was watching three directories for mtime drift past \`CMakeCache.txt\`. Two of them don't actually catch what they were meant to catch:

- **\`\$IDF_PATH\`** root directory mtime only bumps when its *direct entries* change — i.e. a clean install to a new directory. In-place version replacement, \`git pull\` inside a user-managed IDF tree, or switching back to a previously-installed version with an unchanged option set wouldn't trip this check.
- **\`build/config/\`** is written by CMake *during* the previous configure, so in normal flows its mtime is older than or equal to \`CMakeCache.txt\`. The only case where its mtime can be newer is an interrupted reconfigure that wrote into it without reaching the final cache write — and the existence/emptiness early-return at the top of \`has_outdated_files()\` still catches that scenario.

Drop both from the mtime watch list. The remaining existence checks (\`build/config\` dir, \`CMakeCache.txt\`, \`build.ninja\`) plus the \`dependencies.lock\` freshness check still handle their respective recovery cases.

### 2 — Make \`sdkconfig.<name>.esphomeinternal\` the canonical freshness signal

ESPHome's internal sdkconfig snapshot already serves as the "what state did we resolve the YAML to" hash — \`write_file_if_changed\` writes it only when content differs, so its mtime is a clean signal. But its content is just sorted Kconfig options, so a framework-version switch that produces an identical option set (e.g. a patch-version bump where ESPHome's emitted Kconfig names stay the same) wouldn't shift the content. Result: \`has_outdated_files()\` misses the version change.

Embed the resolved framework version as a \`# ESPHOME_IDF_VERSION=<ver>\` Kconfig comment line in the sdkconfig output. Version changes now force the file's content to differ, which forces the write, which bumps the mtime, which trips the existing check. \`#\` is a standard Kconfig comment so IDF's parser accepts it.

### 3 — Watch \`src/idf_component.yml\` for managed-component drift

Managed component additions/removals (e.g. \`add_idf_component()\` calls triggered by enabling/disabling ESPHome components) can change the manifest without any sdkconfig impact. \`_write_idf_component_yml\` already deletes \`dependencies.lock\` on a change, but that signal is asymmetric — once the lock is missing, the existing \`is_file() && newer than build.ninja\` check evaluates False (not-a-file). Add the manifest to the mtime watch list directly so manifest-only changes trip the check.

### Verified locally

Cold build: 32s (full two-pass + ninja's post-discovery re-run).
Warm rebuild (no source changes): 2.4s, zero CMake reconfigures.
Unit tests: 112/112.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #16415; closes the version-switch and manifest-change detection gaps left after that PR's CMakeLists-mtime fix.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal build-system change, no user-visible config.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# No user-facing config change.
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).