### PR TITLE
[tinyusb] Reject `logger.hardware_uart: USB_CDC`

### DIFF
--- a/esphome/components/tinyusb/__init__.py
+++ b/esphome/components/tinyusb/__init__.py
@@ -64,7 +64,8 @@ def _final_validate(config):
             "'tinyusb' cannot be used with 'logger.hardware_uart: USB_CDC' "
             "because both share the USB OTG peripheral. Set "
             "'logger.hardware_uart' to a hardware UART (e.g. UART0), or to "
-            "USB_SERIAL_JTAG on variants that support it (ESP32-S3, ESP32-P4)."
+            "USB_SERIAL_JTAG on variants that support it (ESP32-S3, ESP32-P4)"
+        )
     return config
 
 

--- a/esphome/components/tinyusb/__init__.py
+++ b/esphome/components/tinyusb/__init__.py
@@ -1,3 +1,4 @@
+from esphome import final_validate as fv
 import esphome.codegen as cg
 from esphome.components import esp32
 from esphome.components.esp32 import (
@@ -8,7 +9,7 @@ from esphome.components.esp32 import (
     add_idf_sdkconfig_option,
 )
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import CONF_HARDWARE_UART, CONF_ID
 
 CODEOWNERS = ["@kbx81"]
 CONFLICTS_WITH = ["usb_host"]
@@ -39,6 +40,25 @@ CONFIG_SCHEMA = cv.All(
         supported=[VARIANT_ESP32P4, VARIANT_ESP32S2, VARIANT_ESP32S3],
     ),
 )
+
+
+def _final_validate(config):
+    full_config = fv.full_config.get()
+    # tinyusb owns the USB OTG peripheral. The logger's USB_CDC backend routes
+    # the ROM console through that same peripheral, so the two cannot coexist.
+    # (USB_SERIAL_JTAG is a separate peripheral and is fine alongside tinyusb.)
+    logger_config = full_config.get("logger")
+    if logger_config and logger_config.get(CONF_HARDWARE_UART) == "USB_CDC":
+        raise cv.Invalid(
+            "'tinyusb' cannot be used with 'logger.hardware_uart: USB_CDC' "
+            "because both share the USB OTG peripheral. Set "
+            "'logger.hardware_uart' to a hardware UART (e.g. UART0), or to "
+            "USB_SERIAL_JTAG on variants that support it (ESP32-S3, ESP32-P4)."
+        )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 
 async def to_code(config):

--- a/tests/components/tinyusb/test.esp32-s2-idf.yaml
+++ b/tests/components/tinyusb/test.esp32-s2-idf.yaml
@@ -1,1 +1,6 @@
 <<: !include common.yaml
+
+# S2 defaults logger to USB_CDC, which conflicts with tinyusb on the shared
+# USB OTG peripheral; route the logger to UART0 so the fixture builds.
+logger:
+  hardware_uart: UART0

--- a/tests/components/usb_cdc_acm/test.esp32-s2-idf.yaml
+++ b/tests/components/usb_cdc_acm/test.esp32-s2-idf.yaml
@@ -1,5 +1,10 @@
 <<: !include tinyusb_common.yaml
 
+# S2 defaults logger to USB_CDC, which conflicts with tinyusb on the shared
+# USB OTG peripheral; route the logger to UART0 so the fixture builds.
+logger:
+  hardware_uart: UART0
+
 usb_cdc_acm:
   interfaces:
     - id: usb_cdc_acm1


### PR DESCRIPTION
# What does this implement/fix?

Surfaces a config-time error when `tinyusb:` is configured alongside `logger.hardware_uart: USB_CDC`. The two cannot coexist because the logger's `USB_CDC` backend routes the ROM console through the same USB OTG peripheral that tinyusb wants to own — attempts to enable both manifest as a boot-time hang or flaky enumeration.

This affects every tinyusb-supported variant, just via different paths:

| Variant | Logger `USB_CDC` reached via | Default `hardware_uart` |
|---|---|---|
| **S2** | the default | `USB_CDC` |
| **S3** | explicit user opt-in | `USB_SERIAL_JTAG` (separate peripheral, fine) |
| **P4** | explicit user opt-in | `USB_SERIAL_JTAG` (separate peripheral, fine) |

S2 is where users hit this most often (Merikei's report on #16184 is the canonical example), but an S3/P4 user who explicitly sets `logger.hardware_uart: USB_CDC` would hit the same boot hang — so the check is variant-agnostic. `USB_SERIAL_JTAG` is a separate hardware peripheral on S3/P4 and is unaffected.

The validation is a `FINAL_VALIDATE_SCHEMA` on `tinyusb`, deliberately structured to mirror #16413 (same imports, helper name, hook name) so the two merge cleanly: when both PRs land, the resolution is to combine the two checks into the same `_final_validate` body.

The S2 test fixtures for `tinyusb` and `usb_cdc_acm` are updated to set `logger: hardware_uart: UART0` so they keep building under the new check. S3/P4 fixtures take `USB_SERIAL_JTAG` by default and need no change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/esphome/issues/16184

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Tested locally:

- S2 + default logger (resolves to `USB_CDC`) → fails validation with the new message.
- S2 + `hardware_uart: UART0` → passes.
- S3 + explicit `hardware_uart: USB_CDC` → fails validation (the variant-agnostic scope).
- S3 + default logger (`USB_SERIAL_JTAG`) → passes.
- P4 + explicit `hardware_uart: USB_CDC` → fails validation.
- `script/test_build_components -e config -c tinyusb` → 3/3 pass.
- `script/test_build_components -e config -c usb_cdc_acm` → 3/3 pass.

## Example entry for `config.yaml`:

Before this PR, the following config would boot-loop on an S2 (and the S3/P4 equivalent with an explicit `USB_CDC` logger):

```yaml
esp32:
  board: lolin_s2_mini
  framework:
    type: esp-idf

# logger defaults to hardware_uart: USB_CDC on S2

tinyusb:

usb_cdc_acm:
  interfaces:
    - id: cdc0
```

After this PR, the same config fails fast at validation:

```
'tinyusb' cannot be used with 'logger.hardware_uart: USB_CDC' because
both share the USB OTG peripheral. Set 'logger.hardware_uart' to a
hardware UART (e.g. UART0), or to USB_SERIAL_JTAG on variants that
support it (ESP32-S3, ESP32-P4).
```

The correct configuration routes the logger off USB OTG — to a UART on any variant, or to `USB_SERIAL_JTAG` on S3/P4:

```yaml
esp32:
  board: lolin_s2_mini
  framework:
    type: esp-idf

logger:
  hardware_uart: UART0

tinyusb:

usb_cdc_acm:
  interfaces:
    - id: cdc0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).