### PR TITLE
[ci] Add ci-run-all label to force full CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           . venv/bin/activate
-          output=$(python script/determine-jobs.py)
+          EXTRA_ARGS=""
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci-run-all') }}" == "true" ]]; then
+            EXTRA_ARGS="--force-all"
+            echo "::notice::ci-run-all label detected -- forcing every CI job to run"
+          fi
+          output=$(python script/determine-jobs.py $EXTRA_ARGS)
           echo "Test determination output:"
           echo "$output" | jq
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,7 @@ jobs:
       integration-test-buckets: ${{ steps.determine.outputs.integration-test-buckets }}
       clang-tidy: ${{ steps.determine.outputs.clang-tidy }}
       clang-tidy-mode: ${{ steps.determine.outputs.clang-tidy-mode }}
+      clang-tidy-full-scan: ${{ steps.determine.outputs.clang-tidy-full-scan }}
       python-linters: ${{ steps.determine.outputs.python-linters }}
       import-time: ${{ steps.determine.outputs.import-time }}
       device-builder: ${{ steps.determine.outputs.device-builder }}
@@ -301,6 +302,7 @@ jobs:
           echo "integration-test-buckets=$(echo "$output" | jq -c '.integration_test_buckets')" >> $GITHUB_OUTPUT
           echo "clang-tidy=$(echo "$output" | jq -r '.clang_tidy')" >> $GITHUB_OUTPUT
           echo "clang-tidy-mode=$(echo "$output" | jq -r '.clang_tidy_mode')" >> $GITHUB_OUTPUT
+          echo "clang-tidy-full-scan=$(echo "$output" | jq -r '.clang_tidy_full_scan')" >> $GITHUB_OUTPUT
           echo "python-linters=$(echo "$output" | jq -r '.python_linters')" >> $GITHUB_OUTPUT
           echo "import-time=$(echo "$output" | jq -r '.import_time')" >> $GITHUB_OUTPUT
           echo "device-builder=$(echo "$output" | jq -r '.device_builder')" >> $GITHUB_OUTPUT
@@ -505,7 +507,13 @@ jobs:
         id: check_full_scan
         run: |
           . venv/bin/activate
-          if python script/clang_tidy_hash.py --check; then
+          # determine-jobs.clang-tidy-full-scan is true when core C++ changed
+          # OR the ci-run-all label forced --force-all. Independent of the
+          # hash check, both must produce a full scan in the job itself.
+          if [ "${{ needs.determine-jobs.outputs.clang-tidy-full-scan }}" = "true" ]; then
+            echo "full_scan=true" >> $GITHUB_OUTPUT
+            echo "reason=determine_jobs" >> $GITHUB_OUTPUT
+          elif python script/clang_tidy_hash.py --check; then
             echo "full_scan=true" >> $GITHUB_OUTPUT
             echo "reason=hash_changed" >> $GITHUB_OUTPUT
           else
@@ -517,7 +525,7 @@ jobs:
         run: |
           . venv/bin/activate
           if [ "${{ steps.check_full_scan.outputs.full_scan }}" = "true" ]; then
-            echo "Running FULL clang-tidy scan (hash changed)"
+            echo "Running FULL clang-tidy scan (reason: ${{ steps.check_full_scan.outputs.reason }})"
             script/clang-tidy --all-headers --fix ${{ matrix.options }} ${{ matrix.ignore_errors && '|| true' || '' }}
           else
             echo "Running clang-tidy on changed files only"
@@ -577,7 +585,13 @@ jobs:
         id: check_full_scan
         run: |
           . venv/bin/activate
-          if python script/clang_tidy_hash.py --check; then
+          # determine-jobs.clang-tidy-full-scan is true when core C++ changed
+          # OR the ci-run-all label forced --force-all. Independent of the
+          # hash check, both must produce a full scan in the job itself.
+          if [ "${{ needs.determine-jobs.outputs.clang-tidy-full-scan }}" = "true" ]; then
+            echo "full_scan=true" >> $GITHUB_OUTPUT
+            echo "reason=determine_jobs" >> $GITHUB_OUTPUT
+          elif python script/clang_tidy_hash.py --check; then
             echo "full_scan=true" >> $GITHUB_OUTPUT
             echo "reason=hash_changed" >> $GITHUB_OUTPUT
           else
@@ -589,7 +603,7 @@ jobs:
         run: |
           . venv/bin/activate
           if [ "${{ steps.check_full_scan.outputs.full_scan }}" = "true" ]; then
-            echo "Running FULL clang-tidy scan (hash changed)"
+            echo "Running FULL clang-tidy scan (reason: ${{ steps.check_full_scan.outputs.reason }})"
             script/clang-tidy --all-headers --fix --environment esp32-arduino-tidy
           else
             echo "Running clang-tidy on changed files only"
@@ -666,7 +680,13 @@ jobs:
         id: check_full_scan
         run: |
           . venv/bin/activate
-          if python script/clang_tidy_hash.py --check; then
+          # determine-jobs.clang-tidy-full-scan is true when core C++ changed
+          # OR the ci-run-all label forced --force-all. Independent of the
+          # hash check, both must produce a full scan in the job itself.
+          if [ "${{ needs.determine-jobs.outputs.clang-tidy-full-scan }}" = "true" ]; then
+            echo "full_scan=true" >> $GITHUB_OUTPUT
+            echo "reason=determine_jobs" >> $GITHUB_OUTPUT
+          elif python script/clang_tidy_hash.py --check; then
             echo "full_scan=true" >> $GITHUB_OUTPUT
             echo "reason=hash_changed" >> $GITHUB_OUTPUT
           else
@@ -678,7 +698,7 @@ jobs:
         run: |
           . venv/bin/activate
           if [ "${{ steps.check_full_scan.outputs.full_scan }}" = "true" ]; then
-            echo "Running FULL clang-tidy scan (hash changed)"
+            echo "Running FULL clang-tidy scan (reason: ${{ steps.check_full_scan.outputs.reason }})"
             script/clang-tidy --all-headers --fix ${{ matrix.options }}
           else
             echo "Running clang-tidy on changed files only"

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -1062,22 +1062,42 @@ def main() -> None:
     parser.add_argument(
         "-b", "--branch", help="Branch to compare changed files against"
     )
+    parser.add_argument(
+        "--force-all",
+        action="store_true",
+        help=(
+            "Force every job to run regardless of what changed. Used by CI "
+            "when the ci-run-all label is applied to a PR (escape hatch for "
+            "changes that need full-matrix validation but don't touch enough "
+            "files to trigger it organically)."
+        ),
+    )
     args = parser.parse_args()
 
     # Determine what should run
-    integration_run_all, integration_test_files = determine_integration_tests(
-        args.branch
-    )
+    if args.force_all:
+        integration_run_all, integration_test_files = True, []
+        run_clang_tidy = True
+        run_clang_format = True
+        run_python_linters = True
+        run_import_time = True
+        run_device_builder = True
+        native_idf_components = sorted(NATIVE_IDF_TEST_COMPONENTS)
+        run_native_idf = True
+    else:
+        integration_run_all, integration_test_files = determine_integration_tests(
+            args.branch
+        )
+        run_clang_tidy = should_run_clang_tidy(args.branch)
+        run_clang_format = should_run_clang_format(args.branch)
+        run_python_linters = should_run_python_linters(args.branch)
+        run_import_time = should_run_import_time(args.branch)
+        run_device_builder = should_run_device_builder(args.branch)
+        native_idf_components = native_idf_components_to_test(args.branch)
+        run_native_idf = bool(native_idf_components)
     run_integration, integration_test_buckets = _compute_integration_test_buckets(
         integration_run_all, integration_test_files
     )
-    run_clang_tidy = should_run_clang_tidy(args.branch)
-    run_clang_format = should_run_clang_format(args.branch)
-    run_python_linters = should_run_python_linters(args.branch)
-    run_import_time = should_run_import_time(args.branch)
-    run_device_builder = should_run_device_builder(args.branch)
-    native_idf_components = native_idf_components_to_test(args.branch)
-    run_native_idf = bool(native_idf_components)
     changed_cpp_file_count = count_changed_cpp_files(args.branch)
 
     # Get changed components
@@ -1106,11 +1126,27 @@ def main() -> None:
         changed_components = changed_components_result
         is_core_change = False
 
-    # Filter to only components that have test files
-    # Components without tests shouldn't generate CI test jobs
-    changed_components_with_tests = [
-        component for component in changed_components if _component_has_tests(component)
-    ]
+    if args.force_all:
+        # Force every component with tests into the CI matrix. Each disk entry
+        # under tests/components/<name> is treated as a component; filtered
+        # below by _component_has_tests so components without YAML tests are
+        # still excluded.
+        tests_root = Path(root_path) / ESPHOME_TESTS_COMPONENTS_PATH
+        all_components = sorted(d.name for d in tests_root.iterdir() if d.is_dir())
+        changed_components_with_tests = [
+            component for component in all_components if _component_has_tests(component)
+        ]
+        # Treat as a core change so downstream logic (clang-tidy full scan,
+        # dep expansion) sees the same world as when esphome/core/ changes.
+        is_core_change = True
+    else:
+        # Filter to only components that have test files
+        # Components without tests shouldn't generate CI test jobs
+        changed_components_with_tests = [
+            component
+            for component in changed_components
+            if _component_has_tests(component)
+        ]
 
     # Get directly changed components with tests (for isolated testing)
     # These will be tested WITHOUT --testing-mode in CI to enable full validation
@@ -1177,10 +1213,12 @@ def main() -> None:
 
     # Build output
     # Determine which C++ unit tests to run
-    cpp_run_all, cpp_components = determine_cpp_unit_tests(args.branch)
-
-    # Determine if benchmarks should run
-    run_benchmarks = should_run_benchmarks(args.branch)
+    if args.force_all:
+        cpp_run_all, cpp_components = True, []
+        run_benchmarks = True
+    else:
+        cpp_run_all, cpp_components = determine_cpp_unit_tests(args.branch)
+        run_benchmarks = should_run_benchmarks(args.branch)
 
     # Split components into batches for CI testing
     # This intelligently groups components with similar bus configurations

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -1179,8 +1179,10 @@ def main() -> None:
     memory_impact = detect_memory_impact_config(args.branch)
 
     # Determine clang-tidy mode based on actual files that will be checked
+    is_full_scan = False
     if run_clang_tidy:
         # Full scan needed if: hash changed OR core files changed
+        # (is_core_change is forced True under --force-all)
         is_full_scan = _is_clang_tidy_full_scan() or is_core_change
 
         if is_full_scan:
@@ -1257,6 +1259,7 @@ def main() -> None:
         "integration_test_buckets": integration_test_buckets,
         "clang_tidy": run_clang_tidy,
         "clang_tidy_mode": clang_tidy_mode,
+        "clang_tidy_full_scan": is_full_scan,
         "clang_format": run_clang_format,
         "python_linters": run_python_linters,
         "import_time": run_import_time,

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -2602,3 +2602,141 @@ def test_main_validate_only_excludes_transitive_components(
     # Only foo (directly changed, validate-only). bar is a transitive dep
     # and still needs compile despite no source change of its own.
     assert output["validate_only_components"] == ["foo"]
+
+
+def test_main_force_all_overrides_detection(
+    mock_determine_integration_tests: Mock,
+    mock_should_run_clang_tidy: Mock,
+    mock_should_run_clang_format: Mock,
+    mock_should_run_python_linters: Mock,
+    mock_should_run_import_time: Mock,
+    mock_should_run_device_builder: Mock,
+    mock_native_idf_components_to_test: Mock,
+    mock_determine_cpp_unit_tests: Mock,
+    mock_changed_files: Mock,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--force-all bypasses per-feature detection and runs every job.
+
+    Detection mocks all return False/empty (which would normally skip
+    everything) -- the flag must override them. Also verifies clang-tidy
+    goes to ``split`` (full scan) and the component-test matrix is
+    populated from disk rather than from changed-files.
+    """
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+
+    mock_determine_integration_tests.return_value = (False, [])
+    mock_should_run_clang_tidy.return_value = False
+    mock_should_run_clang_format.return_value = False
+    mock_should_run_python_linters.return_value = False
+    mock_should_run_import_time.return_value = False
+    mock_should_run_device_builder.return_value = False
+    mock_native_idf_components_to_test.return_value = []
+    mock_determine_cpp_unit_tests.return_value = (False, [])
+    mock_changed_files.return_value = []
+
+    with (
+        patch("sys.argv", ["determine-jobs.py", "--force-all"]),
+        patch.object(determine_jobs, "get_changed_components", return_value=[]),
+        patch.object(
+            determine_jobs, "filter_component_and_test_files", return_value=False
+        ),
+        patch.object(
+            determine_jobs, "get_components_with_dependencies", return_value=[]
+        ),
+        patch.object(
+            determine_jobs,
+            "detect_memory_impact_config",
+            return_value={"should_run": "false"},
+        ),
+        patch.object(determine_jobs, "should_run_benchmarks", return_value=False),
+    ):
+        determine_jobs.main()
+
+    output = json.loads(capsys.readouterr().out)
+
+    assert output["integration_tests"] is True
+    assert output["clang_tidy"] is True
+    assert output["clang_tidy_mode"] == "split"
+    assert output["clang_format"] is True
+    assert output["python_linters"] is True
+    assert output["import_time"] is True
+    assert output["device_builder"] is True
+    assert output["native_idf"] is True
+    # native_idf_components is a CSV of NATIVE_IDF_TEST_COMPONENTS
+    assert "esp32" in output["native_idf_components"].split(",")
+    assert output["cpp_unit_tests_run_all"] is True
+    assert output["cpp_unit_tests_components"] == []
+    assert output["benchmarks"] is True
+    # Detection helpers must not be consulted when --force-all is set
+    mock_determine_integration_tests.assert_not_called()
+    mock_should_run_clang_tidy.assert_not_called()
+    mock_should_run_clang_format.assert_not_called()
+    mock_should_run_python_linters.assert_not_called()
+    mock_should_run_import_time.assert_not_called()
+    mock_should_run_device_builder.assert_not_called()
+    mock_native_idf_components_to_test.assert_not_called()
+    mock_determine_cpp_unit_tests.assert_not_called()
+    # Component matrix is populated from disk (tests/components/ in the repo)
+    assert output["component_test_count"] > 0
+    assert len(output["component_test_batches"]) > 0
+
+
+def test_main_force_all_off_uses_detection(
+    mock_determine_integration_tests: Mock,
+    mock_should_run_clang_tidy: Mock,
+    mock_should_run_clang_format: Mock,
+    mock_should_run_python_linters: Mock,
+    mock_should_run_import_time: Mock,
+    mock_should_run_device_builder: Mock,
+    mock_native_idf_components_to_test: Mock,
+    mock_determine_cpp_unit_tests: Mock,
+    mock_changed_files: Mock,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without --force-all, detection helpers drive the decision (regression guard)."""
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+
+    mock_determine_integration_tests.return_value = (False, [])
+    mock_should_run_clang_tidy.return_value = False
+    mock_should_run_clang_format.return_value = False
+    mock_should_run_python_linters.return_value = False
+    mock_should_run_import_time.return_value = False
+    mock_should_run_device_builder.return_value = False
+    mock_native_idf_components_to_test.return_value = []
+    mock_determine_cpp_unit_tests.return_value = (False, [])
+    mock_changed_files.return_value = []
+
+    with (
+        patch("sys.argv", ["determine-jobs.py"]),
+        patch.object(determine_jobs, "get_changed_components", return_value=[]),
+        patch.object(
+            determine_jobs, "filter_component_and_test_files", return_value=False
+        ),
+        patch.object(
+            determine_jobs, "get_components_with_dependencies", return_value=[]
+        ),
+        patch.object(
+            determine_jobs,
+            "detect_memory_impact_config",
+            return_value={"should_run": "false"},
+        ),
+        patch.object(
+            determine_jobs, "create_intelligent_batches", return_value=([], {})
+        ),
+        patch.object(determine_jobs, "should_run_benchmarks", return_value=False),
+    ):
+        determine_jobs.main()
+
+    output = json.loads(capsys.readouterr().out)
+
+    assert output["integration_tests"] is False
+    assert output["clang_tidy"] is False
+    assert output["clang_format"] is False
+    assert output["python_linters"] is False
+    assert output["native_idf"] is False
+    assert output["component_test_count"] == 0
+    mock_determine_integration_tests.assert_called_once()
+    mock_should_run_clang_tidy.assert_called_once()

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -2659,6 +2659,7 @@ def test_main_force_all_overrides_detection(
     assert output["integration_tests"] is True
     assert output["clang_tidy"] is True
     assert output["clang_tidy_mode"] == "split"
+    assert output["clang_tidy_full_scan"] is True
     assert output["clang_format"] is True
     assert output["python_linters"] is True
     assert output["import_time"] is True


### PR DESCRIPTION
# What does this implement/fix?

Adds a `--force-all` flag to `script/determine-jobs.py` and wires `.github/workflows/ci.yml` to pass it whenever the **`ci-run-all`** label is applied to a PR. When set, every job runs regardless of which files changed:

- Integration tests (all buckets)
- Clang-tidy -- forced to `split` mode **and** forced to do a full scan (not `--changed`) in every clang-tidy job
- Clang-format
- Python linters (ruff, flake8, pylint, pyupgrade)
- `import esphome.__main__` time check
- Downstream `esphome/device-builder` tests
- Native ESP-IDF compile test (full `NATIVE_IDF_TEST_COMPONENTS` set)
- C++ unit tests (`run_all=true`)
- Component-test matrix populated from disk (every component under `tests/components/` that has test YAML)
- C++ benchmarks

Detection helpers (`should_run_integration_tests`, `should_run_clang_tidy`, etc.) are bypassed entirely. Memory-impact analysis is intentionally left as `should_run=false` -- forcing all ~600 components into a single merged build is exactly the case `MEMORY_IMPACT_MAX_COMPONENTS` guards against.

**Clang-tidy plumbing.** `determine-jobs.py` already computed whether a full scan was needed (`is_full_scan = hash_changed OR core_change`), but each of the three clang-tidy jobs (`clang-tidy-single`, `clang-tidy-nosplit`, `clang-tidy-split`) re-decided that independently via `clang_tidy_hash.py --check`. Under `--force-all` the hash hadn't changed, so `clang_tidy_mode == 'split'` fanned the ESP32-Arduino job out 4x but each replica still ran `--changed` against an empty diff. This PR exposes a new `clang_tidy_full_scan` output, threads it through the workflow as `clang-tidy-full-scan`, and ORs it into each job's `check_full_scan` step so they all honor the determine-jobs decision.

**Why this is useful:**

Most PRs only touch a few components and the existing change-based detection (correctly) skips the bulk of CI. There are however a handful of scenarios where we want the *entire* matrix to run even though the diff is small:

- **Prerelease testing** -- before cutting a beta/release, smoke-test the full surface on the candidate branch without having to fabricate file changes.
- **New framework / toolchain versions** -- bumping ESP-IDF, Arduino, LibreTiny, Zephyr SDK, etc. typically touches one or two files but can break arbitrary components at compile time. The full matrix is the only way to catch that.
- **Disruption changes** -- e.g. the in-flight ESP32 ESP-IDF toolchain default switch (#16383), where the surface area being affected is enormous but the diff is tiny. That branch has been rebased to use this PR's `ci-run-all` label in place of the ad-hoc `.clang-tidy.hash` / `determine-jobs.py` hacks it originally carried.

**Note on label-driven runs.** PR-event triggers (`labeled` / `unlabeled`) are deliberately *not* added to the `pull_request:` event filter so that stalebot's label churn doesn't re-trigger CI. To pick up the label's effect on an existing PR, push a new commit (or close + reopen).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Used by #16383 (ESP32 ESP-IDF toolchain default switch) in place of the manual hacks it originally carried.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI-only change; no firmware impact.)

## Example entry for `config.yaml`:

N/A -- no user-facing config changes. Usage from a maintainer's perspective:

1. Open / find a PR you want to fully validate.
2. Apply the `ci-run-all` label.
3. Push a new commit (or close + reopen) so the workflow runs with the label visible. CI then enables every job. Removing the label and pushing again reverts to normal change-based detection.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

Local verification of `script/determine-jobs.py --force-all` on this branch:

```
integration_tests: True
integration_test_buckets: <3 buckets>
clang_tidy: True
clang_tidy_mode: split
clang_tidy_full_scan: True
clang_format: True
python_linters: True
import_time: True
device_builder: True
native_idf: True
native_idf_components: aht10,api,bh1750,ble_client,...,heatpumpir
cpp_unit_tests_run_all: True
component_test_count: 616
component_test_batches: 23
memory_impact: {'should_run': 'false'}
benchmarks: True
```

`tests/script/test_determine_jobs.py` adds two cases:
- `test_main_force_all_overrides_detection` -- with detection mocks all returning False/empty, `--force-all` still produces a full-matrix output, asserts `clang_tidy_full_scan` is true, and verifies the detection helpers are not called.
- `test_main_force_all_off_uses_detection` -- regression guard that the default code path still consults the detection helpers.

All 209 tests pass.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).