### PR TITLE
[docker] Install libusb-1.0 so ESP-IDF tools can validate openocd

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,12 +13,16 @@ RUN git config --system --add safe.directory "*" \
     && git config --system advice.detachedHead false
 
 # Install build tools for Python packages that require compilation
-# (e.g., ruamel.yaml.clibz used by ESP-IDF's idf-component-manager)
+# (e.g., ruamel.yaml.clibz used by ESP-IDF's idf-component-manager).
+# Also install libusb-1.0 at runtime so the ESP-IDF tools installer can
+# validate openocd-esp32 (it dynamically links libusb-1.0.so.0); without
+# it idf_tools.py rejects the openocd install with exit 127 and aborts
+# the whole framework setup.
 RUN if command -v apk > /dev/null; then \
-        apk add --no-cache build-base; \
+        apk add --no-cache build-base libusb; \
     else \
         apt-get update \
-        && apt-get install -y --no-install-recommends build-essential \
+        && apt-get install -y --no-install-recommends build-essential libusb-1.0-0 \
         && rm -rf /var/lib/apt/lists/*; \
     fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN git config --system --add safe.directory "*" \
     && git config --system advice.detachedHead false
 
 # Install build tools for Python packages that require compilation
-# (e.g., ruamel.yaml.clibz used by ESP-IDF's idf-component-manager).
+# (e.g., ruamel.yaml.clib used by ESP-IDF's idf-component-manager).
 # Also install libusb-1.0 at runtime so the ESP-IDF tools installer can
 # validate openocd-esp32 (it dynamically links libusb-1.0.so.0); without
 # it idf_tools.py rejects the openocd install with exit 127 and aborts


### PR DESCRIPTION
# What does this implement/fix?

When the native ESP-IDF toolchain installs its tools via `idf_tools.py`, it runs each binary as a post-install sanity check. `openocd-esp32` dynamically links `libusb-1.0.so.0`. The Debian and Alpine base images used by `docker/Dockerfile` don't ship that library, so the binary exits 127 ("error while loading shared libraries: libusb-1.0.so.0"), `idf_tools.py` removes the just-extracted tool directory, and the whole ESP-IDF framework install is reported as failed:

```
Installing openocd-esp32@v0.12.0-esp32-20251215
ERROR: tool openocd-esp32 version v0.12.0-esp32-20251215 is installed, but
       getting error: non-zero exit code (127) with message:
       openocd: error while loading shared libraries: libusb-1.0.so.0:
       cannot open shared object file: No such file or directory
ERROR ESP-IDF 5.5.4 framework installation - failed (returncode=1)
RuntimeError: ESP-IDF 5.5.4 framework installation failure
```

Add `libusb-1.0-0` (Debian) and `libusb` (Alpine) alongside the existing `build-essential` / `build-base` install so the validation step passes.

## Reproduction and verification

Repro on the published image:

```bash
docker run --rm -v $PWD:/config -w /config ghcr.io/esphome/esphome:dev compile test.yaml
```

with a minimal `test.yaml`:

```yaml
esphome:
  name: libusb-repro
esp32:
  board: esp32dev
  toolchain: esp-idf
  framework:
    type: esp-idf
logger:
```

Fails at the openocd validation step as shown above. Rebuilding the image with this PR's Dockerfile change and running the same compile completes successfully (`INFO Successfully compiled program.`).

## Affected images

Both the regular `esphome/esphome` image and the `esphome/esphome-hassio` Home Assistant add-on resolve to a Debian base in `.github/actions/build-image/action.yaml` (`base_os` defaults to `debian` and is not overridden by the release workflow), so the Debian package (`libusb-1.0-0`) fixes both. The Alpine package is added to keep the CI sanity-build (`docker/build.py`, which uses the Dockerfile default `BUILD_OS=alpine`) consistent.

## Reported by

Multiple users in the #esphome-dev "ESPHome without Platformio" thread, hitting it on the HA ESPHome Beta App / new builder and on Docker-on-Windows running `dev`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Docker image change; ESP32 listed because it's the toolchain path that exercises the failing tool.)

## Example entry for `config.yaml`:

N/A -- no user-facing config changes. The fix becomes effective once `:dev` (and later `:beta`/release) ships with the updated image.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).