### PR TITLE
[ci] Skip dashboard-deprecation bot on release/beta-bump PRs

### DIFF
--- a/.github/workflows/dashboard-deprecation-comment.yml
+++ b/.github/workflows/dashboard-deprecation-comment.yml
@@ -12,6 +12,12 @@ jobs:
   dashboard-deprecation-comment:
     name: Dashboard deprecation comment
     runs-on: ubuntu-latest
+    # Release-bump PRs (bump-X.Y.Z -> beta, beta -> release) inevitably
+    # roll up everything merged into dev since the last cut, which can
+    # include dashboard changes that have already been reviewed once.
+    # The bot's purpose is to warn new contributors before they invest
+    # time -- that only applies to PRs entering dev.
+    if: github.event.pull_request.base.ref == 'dev'
     steps:
       - name: Generate a token
         id: generate-token


### PR DESCRIPTION
# What does this implement/fix?

The `dashboard-deprecation-comment` workflow comments on every PR whose diff touches `esphome/dashboard/` or `tests/dashboard/`, advising contributors to port the change to [device-builder](https://github.com/esphome/device-builder) before investing more time.

That message is only actionable on PRs *entering* `dev`. Release-bump PRs (e.g. `bump-X.Y.Z -> beta`, `beta -> release`) inevitably roll up everything merged into `dev` since the last cut, which can include dashboard changes that have already been reviewed once on their original PR. The bot fires on the rollup PR and the comment is just noise -- the contributors it's trying to reach already shipped their change.

Triggered on #16411 (2026.5.0b1 release bump): https://github.com/esphome/esphome/pull/16411#issuecomment-...

## Fix

Gate the job with:

```yaml
if: github.event.pull_request.base.ref == 'dev'
```

so the workflow only runs on PRs targeting `dev`. Release/beta-bump PRs and any other non-`dev` base (e.g. cherry-picks to release branches) get skipped silently.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Followup to the bot reporting on #16411 unnecessarily.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI-only change; no firmware impact.)

## Example entry for \`config.yaml\`:

N/A -- no user-facing config changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).