### PR TITLE
[audio] Bump microMP3 to v0.2.1

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -395,7 +395,7 @@ async def to_code(config):
         )
     if data.mp3_support:
         cg.add_define("USE_AUDIO_MP3_SUPPORT")
-        add_idf_component(name="esphome/micro-mp3", ref="0.2.0")
+        add_idf_component(name="esphome/micro-mp3", ref="0.2.1")
         _emit_memory_pair(
             data.mp3.buffer_memory,
             "CONFIG_MP3_DECODER_PREFER_PSRAM",

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -10,7 +10,7 @@ dependencies:
   esphome/micro-flac:
     version: 0.2.0
   esphome/micro-mp3:
-    version: 0.2.0
+    version: 0.2.1
   esphome/micro-opus:
     version: 0.4.1
   esphome/micro-wav:


### PR DESCRIPTION
# What does this implement/fix?

Bumps microMP3 ([GitHub](https://github.com/esphome-libs/micro-mp3) and [Espressif Registry](https://components.espressif.com/components/esphome/micro-mp3/versions/0.2.1/readme)) to v0.2.1. This fixes a bug where a file with only 1 MP3 packet would never play (originally raised by Copilot in the initial PR: https://github.com/esphome/esphome/pull/16236#pullrequestreview-4222993677). While this type of file is extremely rare in practice, it was still technically a bug. 

microMP3 now no longer consumes the first packet when probing the stream information (no audio is decoded at this stage), so the AudioDecoder class no longer assumes the end of stream because the entire packet/file was consumed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

media_player:
  - platform: speaker
    name: None
    id: speaker_media_player
    announcement_pipeline:
      speaker: box_speaker
      format: MP3
      sample_rate: 48000
      num_channels: 2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
