### PR TITLE
[ci] Use larger app partition for esp32-s3-idf component test grouping

### DIFF
--- a/tests/test_build_components/build_components_base.esp32-s3-idf.yaml
+++ b/tests/test_build_components/build_components_base.esp32-s3-idf.yaml
@@ -7,6 +7,9 @@ esp32:
   variant: ESP32S3
   framework:
     type: esp-idf
+  # Use custom partition table with larger app partition (3MB)
+  # Default IDF partitions only allow 1.75MB which is too small for grouped tests
+  partitions: ../partitions_testing.csv
 
 logger:
   level: VERY_VERBOSE


### PR DESCRIPTION
# What does this implement/fix?

The `tests/test_build_components/build_components_base.esp32-s3-idf.yaml` base config was missing the `partitions: ../partitions_testing.csv` override that the `esp32-idf`, `esp32-c2-idf`, and `esp32-c3-idf` base configs already use.

Without that override, ESP-IDF falls back to its default partition table where the factory app partition is capped at 1.75 MB. When `test_build_components` groups many component tests into a single esp32-s3-idf build, the resulting binary can exceed that limit and the build fails with:

```
RAM:   [===       ]  27.1% (used 88776 bytes from 327680 bytes)
Flash: [==========]  102.5% (used 1880787 bytes from 1835008 bytes)
Error: The program size (1880787 bytes) is greater than maximum allowed (1835008 bytes)
```

Reported in Discord; reproducible on `dev` (no local changes) with:

```
script/test_build_components.py -c bluetooth_proxy,esp32_rmt_led_strip,esp32_touch,hub75,micro_wake_word,mipi_rgb,mixer,online_image,psram,resampler,rpi_dpi_rgb,sound_level,st7701s,usb_host,usb_uart -t esp32-s3-idf -e compile
```

The `esp32s3box` board used in this base config has 16 MB of flash, so the ~4 MB `partitions_testing.csv` layout (3 MB factory app + coredump etc.) fits easily.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A (Discord report of grouped-build flash overflow on `esp32-s3-idf`)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# CI-only change; no user-facing config.
# Affects only tests/test_build_components/build_components_base.esp32-s3-idf.yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).