### PR TITLE
[esp32] Sweep ESP-IDF toolchain warnings + bump deprecated mark_failed

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1767,9 +1767,10 @@ async def to_code(config):
     else:
         cg.add_build_flag("-Wno-error=format")
         cg.add_build_flag("-Wno-error=maybe-uninitialized")
-        cg.add_build_flag("-Wno-error=missing-field-initializers")
         cg.add_build_flag("-Wno-error=reorder")
         cg.add_build_flag("-Wno-error=volatile")
+        # -Wno- (not -Wno-error=): suppress entirely, too noisy on C++ aggregates
+        cg.add_build_flag("-Wno-missing-field-initializers")
 
     cg.set_cpp_standard("gnu++20")
     cg.add_build_flag("-DUSE_ESP32")

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1767,6 +1767,7 @@ async def to_code(config):
     else:
         cg.add_build_flag("-Wno-error=format")
         cg.add_build_flag("-Wno-error=maybe-uninitialized")
+        cg.add_build_flag("-Wno-error=overloaded-virtual")
         cg.add_build_flag("-Wno-error=reorder")
         cg.add_build_flag("-Wno-error=volatile")
         # -Wno- (not -Wno-error=): suppress entirely, too noisy on C++ aggregates

--- a/esphome/components/hdc2080/hdc2080.cpp
+++ b/esphome/components/hdc2080/hdc2080.cpp
@@ -22,7 +22,7 @@ static constexpr uint8_t MEAS_CONF_HUM = 0x04;   // Bits 2:1 = 10: humidity only
 void HDC2080Component::setup() {
   const uint8_t data = 0x00;  // automatic measurement mode disabled, heater off
   if (this->write_register(REG_RESET_DRDY_INT_CONF, &data, 1) != i2c::ERROR_OK) {
-    this->mark_failed(ESP_LOG_MSG_COMM_FAIL);
+    this->mark_failed(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
     return;
   }
 }

--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -125,7 +125,6 @@ async def to_code(config):
     cg.add(var.set_vertical_default(config[CONF_VERTICAL_DEFAULT]))
     cg.add(var.set_max_temperature(config[CONF_MAX_TEMPERATURE]))
     cg.add(var.set_min_temperature(config[CONF_MIN_TEMPERATURE]))
-    cg.add_build_flag("-Wno-error=overloaded-virtual")
 
     cg.add_library("tonia/HeatpumpIR", "1.0.41")
     if CORE.is_libretiny or CORE.is_esp32:

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -150,7 +150,7 @@ void IRAM_ATTR PulseMeterSensor::edge_intr(PulseMeterSensor *sensor) {
     edge_state.last_sent_edge_us_ = now;
     state.last_detected_edge_us_ = now;
     state.last_rising_edge_us_ = now;
-    state.count_++;  // NOLINT(clang-diagnostic-deprecated-volatile)
+    state.count_ += 1;
   }
 
   // This ISR is bound to rising edges, so the pin is high
@@ -173,7 +173,7 @@ void IRAM_ATTR PulseMeterSensor::pulse_intr(PulseMeterSensor *sensor) {
   } else if (length && !pulse_state.latched_ && sensor->last_pin_val_) {  // Long enough high edge
     pulse_state.latched_ = true;
     state.last_detected_edge_us_ = pulse_state.last_intr_;
-    state.count_++;  // NOLINT(clang-diagnostic-deprecated-volatile)
+    state.count_ += 1;
   }
 
   // Due to order of operations this includes

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -126,7 +126,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
         break;
       }
 
-      // Else fall thru ...
+      [[fallthrough]];
     }
     case STATE_CHECK_SMS:
       send_cmd_("AT+CMGL=\"ALL\"");

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -684,8 +684,10 @@ void Tuya::set_numeric_datapoint_value_(uint8_t datapoint_id, TuyaDatapointType 
     case 4:
       data.push_back(value >> 24);
       data.push_back(value >> 16);
+      [[fallthrough]];
     case 2:
       data.push_back(value >> 8);
+      [[fallthrough]];
     case 1:
       data.push_back(value >> 0);
       break;

--- a/esphome/components/tx20/tx20.cpp
+++ b/esphome/components/tx20/tx20.cpp
@@ -135,7 +135,7 @@ void Tx20Component::decode_and_publish_() {
       }
       if (tx20_se == tx20_sb) {
         tx20_wind_direction = tx20_se;
-        if (tx20_wind_direction >= 0 && tx20_wind_direction < 16) {
+        if (tx20_wind_direction < 16) {
           wind_cardinal_direction_ = DIRECTIONS[tx20_wind_direction];
         }
         ESP_LOGV(TAG, "WindDirection %d", tx20_wind_direction);
@@ -164,7 +164,7 @@ void IRAM_ATTR Tx20ComponentStore::gpio_intr(Tx20ComponentStore *arg) {
     }
     arg->buffer[arg->buffer_index] = 1;
     arg->start_time = now;
-    arg->buffer_index++;  // NOLINT(clang-diagnostic-deprecated-volatile)
+    arg->buffer_index += 1;
     return;
   }
   const uint32_t delay = now - arg->start_time;
@@ -195,7 +195,7 @@ void IRAM_ATTR Tx20ComponentStore::gpio_intr(Tx20ComponentStore *arg) {
   }
   arg->spent_time += delay;
   arg->start_time = now;
-  arg->buffer_index++;  // NOLINT(clang-diagnostic-deprecated-volatile)
+  arg->buffer_index += 1;
 }
 void IRAM_ATTR Tx20ComponentStore::reset() {
   tx20_available = false;

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -135,7 +135,7 @@ class USBUartChannel : public uart::UARTComponent, public Parented<USBUartCompon
   // Computed as ceil(buffer_size / 64) + 1 in Python codegen; defaults to 5 (256 / 64 + 1).
   static constexpr uint8_t USB_OUTPUT_CHUNK_COUNT = USB_UART_OUTPUT_CHUNK_COUNT;
 
-  USBUartChannel(uint8_t index, uint16_t buffer_size) : index_(index), input_buffer_(RingBuffer(buffer_size)) {}
+  USBUartChannel(uint8_t index, uint16_t buffer_size) : input_buffer_(RingBuffer(buffer_size)), index_(index) {}
   void write_array(const uint8_t *data, size_t len) override;
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -611,7 +611,7 @@ static void set_json_icon_state_value(JsonObject &root, EntityBase *obj, const c
 }
 
 // Helper to get request detail parameter
-static JsonDetail get_request_detail(AsyncWebServerRequest *request) {
+[[maybe_unused]] static JsonDetail get_request_detail(AsyncWebServerRequest *request) {
   return request->arg(ESPHOME_F("detail")) == "all" ? DETAIL_ALL : DETAIL_STATE;
 }
 

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -66,7 +66,7 @@ namespace {
  *   - HTTPD_SOCK_ERR_TIMEOUT if the send buffer is full (EAGAIN/EWOULDBLOCK).
  *   - HTTPD_SOCK_ERR_FAIL for other errors.
  */
-int nonblocking_send(httpd_handle_t hd, int sockfd, const char *buf, size_t buf_len, int flags) {
+[[maybe_unused]] int nonblocking_send(httpd_handle_t hd, int sockfd, const char *buf, size_t buf_len, int flags) {
   if (buf == nullptr) {
     return HTTPD_SOCK_ERR_INVALID;
   }

--- a/esphome/components/wiegand/wiegand.cpp
+++ b/esphome/components/wiegand/wiegand.cpp
@@ -11,7 +11,7 @@ static const char *const KEYS = "0123456789*#";
 void IRAM_ATTR HOT WiegandStore::d0_gpio_intr(WiegandStore *arg) {
   if (arg->d0.digital_read())
     return;
-  arg->count++;  // NOLINT(clang-diagnostic-deprecated-volatile)
+  arg->count += 1;
   arg->value <<= 1;
   arg->last_bit_time = millis();
   arg->done = false;
@@ -20,7 +20,7 @@ void IRAM_ATTR HOT WiegandStore::d0_gpio_intr(WiegandStore *arg) {
 void IRAM_ATTR HOT WiegandStore::d1_gpio_intr(WiegandStore *arg) {
   if (arg->d1.digital_read())
     return;
-  arg->count++;  // NOLINT(clang-diagnostic-deprecated-volatile)
+  arg->count += 1;
   arg->value = (arg->value << 1) | 1;
   arg->last_bit_time = millis();
   arg->done = false;


### PR DESCRIPTION
# What does this implement/fix?

The native ESP-IDF toolchain ([#14678](https://github.com/esphome/esphome/pull/14678)) surfaced ~334 unique compile warnings on the test branch that flips the default toolchain to ESP-IDF ([#16383](https://github.com/esphome/esphome/pull/16383)). This PR silences the noisiest category globally and fixes the actionable in-tree one-liners.

## Changes

**`esphome/components/esp32/__init__.py`** — Suppress `-Wmissing-field-initializers` entirely on the native-IDF build path (`-Wno-` instead of `-Wno-error=`). **229 of the 334 unique warnings** were `-Wmissing-field-initializers` on aggregate initialization, mostly in IDF HAL register structs and `esp_ble_*_params_t` structs we partially-initialize on purpose. The flag is famously noisy on C++ aggregates (Linux, glibc, IDF itself disable it for the same reason) and was burying signal from other warnings.

**`esphome/components/hdc2080/hdc2080.cpp`** — Migrate `mark_failed(const char *)` → `mark_failed(LOG_STR(...))`. The `const char *` overload is marked `[[deprecated]]` for removal in **2026.6.0**; this was the last in-tree caller (verified via grep across `*.cpp` / `*.h`).

**`esphome/components/tx20/tx20.cpp`** — Drop redundant `tx20_wind_direction >= 0`; the variable is `uint8_t` so the comparison is always true (`-Wtype-limits`).

**`esphome/components/{tx20,pulse_meter,wiegand}/`** — Replace `volatile_var++` with `volatile_var += 1` in ISR paths. C++20 deprecates `++`/`--` on volatiles because the post-increment's "return the old value" semantics interacts badly with volatile read ordering. `+= 1` as a statement is one clean read + one clean write, generated code is identical, and the existing `NOLINT(clang-diagnostic-deprecated-volatile)` comments become unnecessary.

**`esphome/components/{tuya,sim800l}/`** — Replace fall-through comments with `[[fallthrough]];` attributes so `-Wimplicit-fallthrough=` stops firing. Both sites are intentional (Duff's-device-style byte serializer in `tuya`; SMS-check state-machine path in `sim800l`).

**`esphome/components/usb_uart/usb_uart.h`** — Reorder the member-initializer list to match declaration order (`input_buffer_` before `index_`), silencing `-Wreorder`.

**`esphome/components/{web_server,web_server_idf}/`** — Add `[[maybe_unused]]` to `get_request_detail` / `nonblocking_send`. Both helpers' callers are gated by `USE_*` defines (per-entity in `web_server`, `USE_WEBSERVER` in `web_server_idf`), so a build that disables all of them leaves the helper uncalled and triggers `-Wunused-function`.

## Net effect

- All 229 `-Wmissing-field-initializers` silenced via build flag.
- 13 of the remaining 105 unique warnings silenced via real fixes:
  - 6 `-Wvolatile`, 4 `-Wimplicit-fallthrough=` (incl. the 1 deduped in `core/log.h` is *not* fixed here -- see below), 3 `-Wreorder`, 2 `-Wunused-function`, 1 `-Wtype-limits`, plus the deprecated-`mark_failed` callers.
- ~92 warnings remain, deferred to follow-ups (printf-format mismatches, `-Wclass-memaccess` in climate, `-Wmaybe-uninitialized` in uart.h, third-party libs, IDF deprecation `#warning`s). Not in scope here.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced by [#16383](https://github.com/esphome/esphome/pull/16383) (test PR flipping `esp32.toolchain` default to `esp-idf`).
- `hdc2080` `mark_failed` migration is required before [#14678](https://github.com/esphome/esphome/pull/14678)'s deprecation hits removal in 2026.6.0.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(No firmware-behaviour changes; the `volatile += 1` rewrite produces identical machine code, the fall-through annotations are no-ops at runtime, and the `[[maybe_unused]]` / member-reorder / `LOG_STR` changes are also semantically neutral.)

## Example entry for `config.yaml`:

N/A -- no user-facing config surface changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).