### PR TITLE
[multiple] Fix -Wformat= mismatches in component .cpp sources

### DIFF
--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -161,7 +161,7 @@ void BME680BSECComponent::dump_config() {
                 "  IAQ Mode: %s\n"
                 "  Supply Voltage: %sV\n"
                 "  Sample Rate: %s\n"
-                "  State Save Interval: %ims",
+                "  State Save Interval: %" PRId32 "ms",
                 this->temperature_offset_, this->iaq_mode_ == IAQ_MODE_STATIC ? "Static" : "Mobile",
                 this->supply_voltage_ == SUPPLY_VOLTAGE_3V3 ? "3.3" : "1.8",
                 BME680_BSEC_SAMPLE_RATE_LOG(this->sample_rate_), this->state_save_interval_ms_);
@@ -461,7 +461,7 @@ int8_t BME680BSECComponent::write_bytes_wrapper(uint8_t devid, uint8_t a_registe
 }
 
 void BME680BSECComponent::delay_ms(uint32_t period) {
-  ESP_LOGV(TAG, "Delaying for %ums", period);
+  ESP_LOGV(TAG, "Delaying for %" PRIu32 "ms", period);
   delay(period);
 }
 

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -161,7 +161,7 @@ void BME680BSECComponent::dump_config() {
                 "  IAQ Mode: %s\n"
                 "  Supply Voltage: %sV\n"
                 "  Sample Rate: %s\n"
-                "  State Save Interval: %" PRId32 "ms",
+                "  State Save Interval: %" PRIu32 "ms",
                 this->temperature_offset_, this->iaq_mode_ == IAQ_MODE_STATIC ? "Static" : "Mobile",
                 this->supply_voltage_ == SUPPLY_VOLTAGE_3V3 ? "3.3" : "1.8",
                 BME680_BSEC_SAMPLE_RATE_LOG(this->sample_rate_), this->state_save_interval_ms_);

--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -92,7 +92,7 @@ void Esp32HostedUpdate::setup() {
   if (esp_hosted_get_coprocessor_fwversion(&ver_info) == ESP_OK) {
     // 16 bytes: "255.255.255" (11 chars) + null + safety margin
     char buf[16];
-    snprintf(buf, sizeof(buf), "%d.%d.%d", ver_info.major1, ver_info.minor1, ver_info.patch1);
+    snprintf(buf, sizeof(buf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32, ver_info.major1, ver_info.minor1, ver_info.patch1);
     this->update_info_.current_version = buf;
   } else {
     this->update_info_.current_version = "unknown";
@@ -120,8 +120,8 @@ void Esp32HostedUpdate::setup() {
         this->state_ = update::UPDATE_STATE_NO_UPDATE;
       }
     } else {
-      ESP_LOGW(TAG, "Invalid app description magic word: 0x%08x (expected 0x%08x)", app_desc->magic_word,
-               ESP_APP_DESC_MAGIC_WORD);
+      ESP_LOGW(TAG, "Invalid app description magic word: 0x%08" PRIx32 " (expected 0x%08" PRIx32 ")",
+               app_desc->magic_word, ESP_APP_DESC_MAGIC_WORD);
       this->state_ = update::UPDATE_STATE_NO_UPDATE;
     }
   } else {

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -108,8 +108,8 @@ void ESPHomeOTAComponent::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "  Partition access allowed\n"
                 "  Running app:\n"
-                "    Partition address: 0x%X\n"
-                "    Used size: %zu bytes (0x%X)",
+                "    Partition address: 0x%" PRIX32 "\n"
+                "    Used size: %zu bytes (0x%zX)",
                 this->running_app_offset_, this->running_app_size_, this->running_app_size_);
 
 #ifdef USE_ESP32
@@ -378,7 +378,7 @@ void ESPHomeOTAComponent::handle_data_() {
   }
   ota_size = (static_cast<size_t>(buf[0]) << 24) | (static_cast<size_t>(buf[1]) << 16) |
              (static_cast<size_t>(buf[2]) << 8) | buf[3];
-  ESP_LOGV(TAG, "Size is %u bytes", ota_size);
+  ESP_LOGV(TAG, "Size is %zu bytes", ota_size);
 
 #ifndef USE_OTA_PARTITIONS
   if (ota_type != ota::OTA_TYPE_UPDATE_APP) {
@@ -749,7 +749,7 @@ bool ESPHomeOTAComponent::handle_auth_send_() {
     this->auth_buf_[0] = this->auth_type_;
     hasher.get_hex(buf);
 
-    ESP_LOGV(TAG, "Auth: Nonce is %.*s", hex_size, buf);
+    ESP_LOGV(TAG, "Auth: Nonce is %.*s", (int) hex_size, buf);
   }
 
   // Try to write auth_type + nonce
@@ -809,13 +809,13 @@ bool ESPHomeOTAComponent::handle_auth_read_() {
   hasher.add(nonce, hex_size * 2);  // Add both nonce and cnonce (contiguous in buffer)
   hasher.calculate();
 
-  ESP_LOGV(TAG, "Auth: CNonce is %.*s", hex_size, cnonce);
+  ESP_LOGV(TAG, "Auth: CNonce is %.*s", (int) hex_size, cnonce);
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   char computed_hash[SHA256_HEX_SIZE + 1];  // Buffer for hex-encoded hash (max expected length + null terminator)
   hasher.get_hex(computed_hash);
-  ESP_LOGV(TAG, "Auth: Result is %.*s", hex_size, computed_hash);
+  ESP_LOGV(TAG, "Auth: Result is %.*s", (int) hex_size, computed_hash);
 #endif
-  ESP_LOGV(TAG, "Auth: Response is %.*s", hex_size, response);
+  ESP_LOGV(TAG, "Auth: Response is %.*s", (int) hex_size, response);
 
   // Compare response
   bool matches = hasher.equals_hex(response);

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -19,7 +19,7 @@ void FastLEDLightOutput::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "FastLED light:\n"
                 "  Num LEDs: %u\n"
-                "  Max refresh rate: %u",
+                "  Max refresh rate: %" PRIu32,
                 this->num_leds_, this->max_refresh_rate_.value_or(0));
 }
 void FastLEDLightOutput::write_state(light::LightState *state) {

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -319,7 +319,7 @@ void Inkplate::fill(Color color) {
     memset(this->partial_buffer_, fill, this->get_buffer_length_());
   }
 
-  ESP_LOGV(TAG, "Fill finished (%ums)", millis() - start_time);
+  ESP_LOGV(TAG, "Fill finished (%" PRIu32 "ms)", millis() - start_time);
 }
 
 void Inkplate::display() {

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -130,8 +130,8 @@ ClimateTraits AirConditioner::traits() {
 void AirConditioner::dump_config() {
   ESP_LOGCONFIG(Constants::TAG,
                 "MideaDongle:\n"
-                "  [x] Period: %dms\n"
-                "  [x] Response timeout: %dms\n"
+                "  [x] Period: %" PRIu32 "ms\n"
+                "  [x] Response timeout: %" PRIu32 "ms\n"
                 "  [x] Request attempts: %d",
                 this->base_.getPeriod(), this->base_.getTimeout(), this->base_.getNumAttempts());
 #ifdef USE_REMOTE_TRANSMITTER

--- a/esphome/components/ota/ota_partitions_esp_idf.cpp
+++ b/esphome/components/ota/ota_partitions_esp_idf.cpp
@@ -210,7 +210,7 @@ OTAResponseTypes IDFOTABackend::update_partition_table() {
       ESP_LOGE(TAG, "Cannot resolve running app partition at address 0x%" PRIX32, running_app_offset);
       return OTA_RESPONSE_ERROR_PARTITION_TABLE_UPDATE;
     }
-    ESP_LOGD(TAG, "Copying running app from 0x%X to 0x%X (size: 0x%X)", running_app_part->address,
+    ESP_LOGD(TAG, "Copying running app from 0x%" PRIX32 " to 0x%" PRIX32 " (size: 0x%zX)", running_app_part->address,
              plan.copy_dest_part->address, running_app_size);
     err = esp_partition_copy(plan.copy_dest_part, 0, running_app_part, 0, running_app_size);
     if (err != ESP_OK) {
@@ -261,7 +261,7 @@ OTAResponseTypes IDFOTABackend::update_partition_table() {
     ESP_LOGE(TAG, "Selected app partition not found after partition table update");
     return OTA_RESPONSE_ERROR_PARTITION_TABLE_UPDATE;
   }
-  ESP_LOGD(TAG, "Setting next boot partition to 0x%X", new_boot_partition->address);
+  ESP_LOGD(TAG, "Setting next boot partition to 0x%" PRIX32, new_boot_partition->address);
   err = esp_ota_set_boot_partition(new_boot_partition);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "esp_ota_set_boot_partition failed (err=0x%X)", err);

--- a/esphome/components/remote_receiver/remote_receiver.cpp
+++ b/esphome/components/remote_receiver/remote_receiver.cpp
@@ -78,10 +78,10 @@ void RemoteReceiverComponent::setup() {
 void RemoteReceiverComponent::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Remote Receiver:\n"
-                "  Buffer Size: %u\n"
-                "  Tolerance: %u%s\n"
-                "  Filter out pulses shorter than: %u us\n"
-                "  Signal is done after %u us of no changes",
+                "  Buffer Size: %" PRIu32 "\n"
+                "  Tolerance: %" PRIu32 "%s\n"
+                "  Filter out pulses shorter than: %" PRIu32 " us\n"
+                "  Signal is done after %" PRIu32 " us of no changes",
                 this->buffer_size_, this->tolerance_,
                 (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%", this->filter_us_,
                 this->idle_us_);

--- a/esphome/components/sendspin/sendspin_hub.cpp
+++ b/esphome/components/sendspin/sendspin_hub.cpp
@@ -153,7 +153,7 @@ bool SendspinHub::save_last_server_hash(uint32_t hash) {
   LastPlayedServerPref pref{.server_id_hash = hash};
   bool ok = this->last_played_server_pref_.save(&pref);
   if (ok) {
-    ESP_LOGD(TAG, "Persisted last played server hash: 0x%08X", hash);
+    ESP_LOGD(TAG, "Persisted last played server hash: 0x%08" PRIX32, hash);
   } else {
     ESP_LOGW(TAG, "Failed to persist last played server hash");
   }
@@ -164,7 +164,7 @@ bool SendspinHub::save_last_server_hash(uint32_t hash) {
 std::optional<uint32_t> SendspinHub::load_last_server_hash() {
   LastPlayedServerPref pref{};
   if (this->last_played_server_pref_.load(&pref)) {
-    ESP_LOGI(TAG, "Loaded last played server hash: 0x%08X", pref.server_id_hash);
+    ESP_LOGI(TAG, "Loaded last played server hash: 0x%08" PRIX32, pref.server_id_hash);
     return pref.server_id_hash;
   }
   return std::nullopt;

--- a/esphome/components/total_daily_energy/total_daily_energy.cpp
+++ b/esphome/components/total_daily_energy/total_daily_energy.cpp
@@ -72,7 +72,7 @@ void TotalDailyEnergy::schedule_midnight_reset_() {
     timeout_seconds = seconds_until_midnight + 1;
   }
 
-  ESP_LOGD(TAG, "Scheduling midnight check in %us", timeout_seconds);
+  ESP_LOGD(TAG, "Scheduling midnight check in %" PRIu32 "s", timeout_seconds);
   this->set_timeout(TIMEOUT_ID_MIDNIGHT, timeout_seconds * MILLIS_PER_SECOND,
                     [this]() { this->schedule_midnight_reset_(); });
 }


### PR DESCRIPTION
# What does this implement/fix?

The native ESP-IDF toolchain ([#14678](https://github.com/esphome/esphome/pull/14678)) surfaced 24 unique `-Wformat=` warnings spread across 10 components. All are real signedness / size-type mismatches (`uint32_t` / `size_t` / `esp_partition_t::address` formatted with `%d` / `%u` / `%X` / `%.*s`).

None changed runtime behaviour on ESP32: on 32-bit xtensa/riscv the varargs ABI is identical for `unsigned int` vs `unsigned long`, and `int` vs `int32_t`. The bits land in the right registers either way. But the diagnostic noise the new toolchain generates is real and was burying signal from other warnings on PR #16383, so this fixes them properly using `PRI*` macros and `%zu` / `%zX`.

## What changed

| component | warning | fix |
|---|---|---|
| `bme680_bsec` | `%i` / `%u` for `state_save_interval_ms_` / delay-ms `period` (`uint32_t`) | `PRId32` / `PRIu32` |
| `esp32_hosted/update` | `%d.%d.%d` for `ver_info.{major1,minor1,patch1}` (`uint32_t`); `0x%08x` for magic word + expected (`uint32_t`) | `PRIu32` / `PRIx32` |
| `esphome/ota/ota_esphome` | `0x%X` for `running_app_offset_` (`uint32_t`) and `running_app_size_` (`size_t`); `%u` for `ota_size` (`size_t`); four `%.*s` precisions with `hex_size` (`size_t`) | `PRIX32` / `%zX` / `%zu` / `(int)` cast |
| `fastled_base` | `%u` for `max_refresh_rate_.value_or(0)` (`uint32_t`) | `PRIu32` |
| `inkplate` | `%u` for `millis()` return (`uint32_t`) | `PRIu32` |
| `midea/air_conditioner` | `%d` for `getPeriod` / `getTimeout` (`uint32_t`, signedness slip) | `PRIu32` |
| `ota/ota_partitions_esp_idf` | `0x%X` for `esp_partition_t::address` (`uint32_t`) in two `ESP_LOGD`s; `size_t` arg in the same log | `PRIX32` / `%zX` |
| `remote_receiver` | `%u` for `buffer_size_` / `tolerance_` / `filter_us_` / `idle_us_` (all `uint32_t`) | `PRIu32` |
| `sendspin/sendspin_hub` | `0x%08X` for server-id hashes (`uint32_t`) | `PRIX32` |
| `total_daily_energy` | `%u` for `timeout_seconds` (`uint32_t`) | `PRIu32` |

All target files already include `esphome/core/log.h` which pulls in `<inttypes.h>`, so no additional includes are needed.

This is the first of three follow-ups to address `-Wformat=` from the IDF toolchain test PR ([#16383](https://github.com/esphome/esphome/pull/16383)). The remaining ~22 sites come from core codegen and from lambdas in test fixtures and will land in separate PRs to keep the diffs focused.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced by [#16383](https://github.com/esphome/esphome/pull/16383) (test PR flipping `esp32.toolchain` default to `esp-idf`).
- Companion to [#16432](https://github.com/esphome/esphome/pull/16432) (the broader IDF toolchain warning sweep).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(No firmware-behaviour changes; varargs ABI for `unsigned int` vs `unsigned long` is identical on 32-bit ESP targets.)

## Example entry for `config.yaml`:

N/A -- no user-facing config surface changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).