### PR TITLE
[tests] Fix -Wformat= mismatches in test YAML lambdas/logger.log

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -511,7 +511,7 @@ def validate_printf(value):
     (?:[-+0 #]{0,5})                   # optional flags
     (?:\d+|\*)?                        # width
     (?:\.(?:\d+|\*))?                  # precision
-    (?:h|l|ll|w|I|I32|I64)?            # size
+    (?:hh|h|ll|l|j|z|t|L|w|I|I32|I64)?  # size
     [cCdiouxXeEfgGaAnpsSZ]             # type
     )
     """  # noqa

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -506,13 +506,13 @@ async def _late_logger_init(config: ConfigType) -> None:
 def validate_printf(value):
     # https://stackoverflow.com/questions/30011379/how-can-i-parse-a-c-format-string-in-python
     cfmt = r"""
-    (                                  # start of capture group 1
-    %                                  # literal "%"
-    (?:[-+0 #]{0,5})                   # optional flags
-    (?:\d+|\*)?                        # width
-    (?:\.(?:\d+|\*))?                  # precision
+    (                                   # start of capture group 1
+    %                                   # literal "%"
+    (?:[-+0 #]{0,5})                    # optional flags
+    (?:\d+|\*)?                         # width
+    (?:\.(?:\d+|\*))?                   # precision
     (?:hh|h|ll|l|j|z|t|L|w|I|I32|I64)?  # size
-    [cCdiouxXeEfgGaAnpsSZ]             # type
+    [cCdiouxXeEfgGaAnpsSZ]              # type
     )
     """  # noqa
     matches = re.findall(cfmt, value[CONF_FORMAT], flags=re.VERBOSE)

--- a/esphome/components/lvgl/helpers.py
+++ b/esphome/components/lvgl/helpers.py
@@ -14,7 +14,7 @@ f_regex = re.compile(
     [-+0 #]{0,5}                   # optional flags
     (?:\d+|\*)?                        # width
     (?:\.(?:\d+|\*))?                  # precision
-    (?:h|l|ll|w|I|I32|I64)?            # size
+    (?:hh|h|ll|l|j|z|t|L|w|I|I32|I64)?  # size
     f                                  # type
     )
     """,
@@ -28,7 +28,7 @@ c_regex = re.compile(
     [-+0 #]{0,5}                   # optional flags
     (?:\d+|\*)?                        # width
     (?:\.(?:\d+|\*))?                  # precision
-    (?:h|l|ll|w|I|I32|I64)?            # size
+    (?:hh|h|ll|l|j|z|t|L|w|I|I32|I64)?  # size
     [cCdiouxXeEfgGaAnpsSZ]             # type
     )
     """,

--- a/esphome/components/lvgl/helpers.py
+++ b/esphome/components/lvgl/helpers.py
@@ -9,13 +9,13 @@ CONF_IF_NAN = "if_nan"
 # noqa
 f_regex = re.compile(
     r"""
-    (                                  # start of capture group 1
-    %                                  # literal "%"
-    [-+0 #]{0,5}                   # optional flags
-    (?:\d+|\*)?                        # width
-    (?:\.(?:\d+|\*))?                  # precision
+    (                                   # start of capture group 1
+    %                                   # literal "%"
+    [-+0 #]{0,5}                        # optional flags
+    (?:\d+|\*)?                         # width
+    (?:\.(?:\d+|\*))?                   # precision
     (?:hh|h|ll|l|j|z|t|L|w|I|I32|I64)?  # size
-    f                                  # type
+    f                                   # type
     )
     """,
     flags=re.VERBOSE,
@@ -23,13 +23,13 @@ f_regex = re.compile(
 # noqa
 c_regex = re.compile(
     r"""
-    (                                  # start of capture group 1
-    %                                  # literal "%"
-    [-+0 #]{0,5}                   # optional flags
-    (?:\d+|\*)?                        # width
-    (?:\.(?:\d+|\*))?                  # precision
+    (                                   # start of capture group 1
+    %                                   # literal "%"
+    [-+0 #]{0,5}                        # optional flags
+    (?:\d+|\*)?                         # width
+    (?:\.(?:\d+|\*))?                   # precision
     (?:hh|h|ll|l|j|z|t|L|w|I|I32|I64)?  # size
-    [cCdiouxXeEfgGaAnpsSZ]             # type
+    [cCdiouxXeEfgGaAnpsSZ]              # type
     )
     """,
     flags=re.VERBOSE,

--- a/tests/components/esp32_ble_tracker/common.yaml
+++ b/tests/components/esp32_ble_tracker/common.yaml
@@ -29,12 +29,12 @@ esp32_ble_tracker:
     - service_uuid: ABCD
       then:
         - lambda: !lambda |-
-            ESP_LOGD("main", "Length of service data is %i", x.size());
+            ESP_LOGD("main", "Length of service data is %zu", x.size());
   on_ble_manufacturer_data_advertise:
     - manufacturer_id: ABCD
       then:
         - lambda: !lambda |-
-            ESP_LOGD("main", "Length of manufacturer data is %i", x.size());
+            ESP_LOGD("main", "Length of manufacturer data is %zu", x.size());
   on_scan_end:
     - then:
         - lambda: |-

--- a/tests/components/ld2412/common.yaml
+++ b/tests/components/ld2412/common.yaml
@@ -123,7 +123,7 @@ select:
         - lambda: |-
             id(uart_bus).flush();
             uint32_t new_baud_rate = stoi(x);
-            ESP_LOGD("change_baud_rate", "Changing baud rate from %i to %i",id(uart_bus).get_baud_rate(), new_baud_rate);
+            ESP_LOGD("change_baud_rate", "Changing baud rate from %" PRIu32 " to %" PRIu32, id(uart_bus).get_baud_rate(), new_baud_rate);
             if (id(uart_bus).get_baud_rate() != new_baud_rate) {
               id(uart_bus).set_baud_rate(new_baud_rate);
             #if defined(USE_ESP8266) || defined(USE_ESP32)

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -660,13 +660,13 @@ lvgl:
             on_release:
               logger.log:
                 format: Button released at %d/%d
-                args: [point.x, point.y]
+                args: ['(int) point.x', '(int) point.y']
             on_long_press_repeat:
               logger.log: Button clicked
             on_pressing:
               logger.log:
                 format: Button pressing at %d/%d
-                args: [point.x, point.y]
+                args: ['(int) point.x', '(int) point.y']
             on_press_lost:
               logger.log: Button press lost
             on_single_click:
@@ -944,7 +944,7 @@ lvgl:
             on_release:
               logger.log:
                 format: Slider released at %d/%d with value %.0f
-                args: [point.x, point.y, x]
+                args: ['(int) point.x', '(int) point.y', x]
         - button:
             styles: spin_button
             id: spin_up

--- a/tests/components/modbus_server/common.yaml
+++ b/tests/components/modbus_server/common.yaml
@@ -21,7 +21,7 @@ modbus_server:
         read_lambda: |-
           return 31;
         write_lambda: |-
-          printf("address=%d, value=%d", x);
+          printf("address=%d, value=%" PRId32 "\n", (int) address, x);
           return true;
   - id: modbus_server4
     modbus_id: mod_bus2

--- a/tests/components/mqtt/common.yaml
+++ b/tests/components/mqtt/common.yaml
@@ -64,7 +64,7 @@ mqtt:
         topic: some/topic
         payload: Good-bye
     - lambda: |-
-        ESP_LOGD("MQTT", "Disconnect reason %d", reason);
+        ESP_LOGD("MQTT", "Disconnect reason %d", (int) reason);
   publish_nan_as_none: false
 
 binary_sensor:

--- a/tests/components/nextion/common.yaml
+++ b/tests/components/nextion/common.yaml
@@ -299,7 +299,7 @@ display:
         - lambda: |-
             // key: StringRef, value: int32_t
             if (key == "temperature_raw") {
-              ESP_LOGD("nextion.custom", "%s=%d", key.c_str(), value);
+              ESP_LOGD("nextion.custom", "%s=%" PRId32, key.c_str(), value);
             }
     on_custom_binary_sensor:
       then:

--- a/tests/components/remote_receiver/common-actions.yaml
+++ b/tests/components/remote_receiver/common-actions.yaml
@@ -12,7 +12,7 @@ on_brennenstuhl:
   then:
     - logger.log:
         format: "on_brennenstuhl: %u"
-        args: ["x.code"]
+        args: ["(unsigned) x.code"]
 on_aeha:
   then:
     - logger.log:

--- a/tests/components/script/common.yaml
+++ b/tests/components/script/common.yaml
@@ -49,7 +49,7 @@ script:
     then:
       - lambda: |-
           ESP_LOGD("main", "ints=%d floats=%f bools=%d strings=%s",
-                   ints[0], floats[0], bools[0], strings[0].c_str());
+                   ints[0], floats[0], (int) bools[0], strings[0].c_str());
   - id: my_script_with_params
     parameters:
       prefix: string

--- a/tests/components/udp/common.yaml
+++ b/tests/components/udp/common.yaml
@@ -11,7 +11,7 @@ udp:
     - "10.0.0.255"
   on_receive:
     - logger.log:
-        format: "Received %d bytes"
+        format: "Received %zu bytes"
         args: [data.size()]
     - udp.write:
         id: my_udp

--- a/tests/components/udp/test.host.yaml
+++ b/tests/components/udp/test.host.yaml
@@ -4,7 +4,7 @@ udp:
   addresses: ["239.0.60.53"]
   on_receive:
     - logger.log:
-        format: "Received %d bytes"
+        format: "Received %zu bytes"
         args: [data.size()]
     - udp.write:
         id: my_udp


### PR DESCRIPTION
# What does this implement/fix?

The native ESP-IDF toolchain ([#14678](https://github.com/esphome/esphome/pull/14678)) surfaced 22 `-Wformat=` warnings emitted from test-fixture `lambda:` bodies and `logger.log:` actions. None affect runtime behaviour on ESP32 (varargs ABI is the same for `unsigned int` vs `unsigned long` on 32-bit xtensa/riscv), but they're diagnostic noise that was burying actionable signal on PR [#16383](https://github.com/esphome/esphome/pull/16383).

Companion to [#16433](https://github.com/esphome/esphome/pull/16433) (which fixed the 24 sites in component `.cpp` sources). Between the two, all 46 `-Wformat=` warnings on the IDF toolchain test PR are resolved.

## Fix patterns

Two shapes depending on context:

- **`logger.log:` format strings (YAML literal):** when the spec change can be expressed in pure format-spec characters (`%zu` for `size_t`), edit the format. When the spec needs a `PRI*` macro, cast the *arg* in the YAML expression instead — the macros can't be spliced into a YAML literal cleanly.
- **`!lambda` bodies (full C++):** use `PRI*` macros inline via adjacent-string concatenation, which works naturally.

## Sites fixed

| test fixture | warning | source | fix |
|---|---|---|---|
| `esp32_ble_tracker/common.yaml:32,37` | `%i` with `x.size()` (`size_t`) | inline | `%zu` |
| `ld2412/common.yaml:126` | `%i %i` with `uart get_baud_rate()` / `new_baud_rate` (`uint32_t`) | inline | `PRIu32` — this is the source of the `merged_camera_camera_encoder_esp32_camera_plus_33:1552` warnings (×2 args at one site) |
| `lvgl/lvgl-package.yaml:662,668,946` | `%d` with `point.x` / `point.y` (`lv_coord_t = int32_t`) | inline | cast args to `(int)` (×3 sites, ×6 args) |
| `modbus_server/common.yaml:24` | `printf("address=%d, value=%d", x)` — 2 specifiers, 1 arg (real format-count bug) | inline | use both lambda params `(address, x)` + `PRId32` for the `int32_t` value |
| `mqtt/common.yaml:67` | `%d` with `reason` (`MQTTClientDisconnectReason` enum) | inline | cast to `(int)` — source of the `merged_event_factory_reset_feedback:1189` warning |
| `nextion/common.yaml:302` | `%d` with `value` (`int32_t` per inline comment) | inline | `PRId32` |
| `remote_receiver/common-actions.yaml:14` | `%u` with `x.code` (`uint32_t = long unsigned int`) | inline | cast to `(unsigned)` — source of the `main.cpp:1114` family across 4 chip variants |
| `script/common.yaml:51` | `%d` with `bools[0]` (`std::vector<bool>::reference` proxy from `bool[]` action variables) | inline | cast to `(int)` — source of the `std::vector<bool>::reference` warnings across 3 merged builds (ntc/opentherm, nrf52 power_supply×2) |
| `udp/common.yaml:14`, `test.host.yaml:7` | `%d` with `data.size()` (`size_t`) | inline | `%zu` |

The merged-build warnings (`merged_*.yaml`) referenced in the IDF toolchain test were red herrings — the line numbers point at the merged file, but the actual offending lambdas live in single-component test YAMLs (`script`, `mqtt`, `ld2412`, `remote_receiver`). Fixing the source removes the warning across every batch the fixture is merged into.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced by [#16383](https://github.com/esphome/esphome/pull/16383) (test PR flipping `esp32.toolchain` default to `esp-idf`).
- Companion to [#16433](https://github.com/esphome/esphome/pull/16433) (the `-Wformat=` cleanup in component `.cpp` sources).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(No firmware-behaviour changes; varargs ABI is identical on 32-bit ESP targets, and the `modbus_server` format-count bug only affected a test-only `printf` log line.)

## Example entry for `config.yaml`:

N/A -- only test fixtures changed.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).