### PR TITLE
[ci] Run fastled / neopixelbus component tests as solo batches

### DIFF
--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -1243,14 +1243,31 @@ def main() -> None:
             # Normal PR: only directly changed components are isolated
             batch_directly_changed = directly_changed_with_tests
 
+        # Components that must run in their own batch (known to fail,
+        # should not take down other components)
+        solo_batch_components = {
+            "fastled_clockless",
+            "fastled_spi",
+            "neopixelbus",
+        }
+        solo_components = [
+            c for c in changed_components_with_tests if c in solo_batch_components
+        ]
+        remaining_components = [
+            c for c in changed_components_with_tests if c not in solo_batch_components
+        ]
+
         batches, _ = create_intelligent_batches(
-            components=changed_components_with_tests,
+            components=remaining_components,
             tests_dir=tests_dir,
             batch_size=COMPONENT_TEST_BATCH_SIZE,
             directly_changed=batch_directly_changed,
         )
         # Convert batches to space-separated strings for CI matrix
         component_test_batches = [" ".join(batch) for batch in batches]
+        # Add solo components as individual batches
+        for comp in solo_components:
+            component_test_batches.append(comp)
     else:
         component_test_batches = []
 


### PR DESCRIPTION
# What does this implement/fix?

`fastled_clockless`, `fastled_spi`, and `neopixelbus` have known build issues on the new ESP-IDF toolchain (and are pinned to PIO libraries that we don't yet have clean replacements for — see the [ESP-IDF 6.0 testing PR #14770](https://github.com/esphome/esphome/pull/14770) and the upstream FastLED [#2200](https://github.com/FastLED/FastLED/issues/2200) thread for the long-running discussion).

When they're folded into a shared batch with other components by `create_intelligent_batches`, a failure on any of them takes down the whole batch and masks the other components' real status. The intelligent-batch grouping is a CI speedup that assumes components succeed; for components we know don't, it's actively misleading.

This PR pulls those three components out of the grouping and emits each as its own single-component matrix entry, so a failure stays contained and the rest of the matrix keeps reporting accurate pass/fail.

## Change

`script/determine-jobs.py::main()` — after the intelligent-batches call, split `changed_components_with_tests` into `solo_components` (the known-flaky set) and `remaining_components`, run `create_intelligent_batches` only on the remaining set, then append each solo component as its own batch:

```python
solo_batch_components = {
    "fastled_clockless",
    "fastled_spi",
    "neopixelbus",
}
solo_components = [c for c in changed_components_with_tests if c in solo_batch_components]
remaining_components = [c for c in changed_components_with_tests if c not in solo_batch_components]

batches, _ = create_intelligent_batches(
    components=remaining_components,
    ...
)
component_test_batches = [" ".join(batch) for batch in batches]
for comp in solo_components:
    component_test_batches.append(comp)
```

No workflow changes — the existing `test-build-components-split` matrix consumes whatever `component-test-batches` outputs, single-component entries included.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Extracted from #14770 (ESP-IDF 6.0 testing branch).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI-only change; no firmware impact.)

## Example entry for `config.yaml`:

N/A -- no user-facing config changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

The existing 209 tests in `tests/script/test_determine_jobs.py` still pass.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).