### PR TITLE
[esp32_hosted] Bump esp_hosted to 2.12.7

### DIFF
--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -249,7 +249,7 @@ async def to_code(config):
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.5.1")
         esp32.add_idf_component(name="espressif/wifi_remote_over_eppp", ref="0.3.2")
         esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.5")
-        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.6")
+        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.7")
     else:
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="0.13.0")
         esp32.add_idf_component(name="espressif/eppp_link", ref="0.2.0")

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -36,7 +36,7 @@ dependencies:
     rules:
       - if: "target in [esp32h2, esp32p4]"
   espressif/esp_hosted:
-    version: 2.12.6
+    version: 2.12.7
     rules:
       - if: "target in [esp32h2, esp32p4]"
   zorxx/multipart-parser:


### PR DESCRIPTION
# What does this implement/fix?

Bumps the IDF >=5.5 `espressif/esp_hosted` dependency: 2.12.6 → 2.12.7. Same two-file lockstep as the previous bump ([#16176](https://github.com/esphome/esphome/pull/16176)) — runtime pin in `esp32_hosted/__init__.py` and the static `idf_component.yml` declaration.

Other components in the chain stay at their current pins: `esp_wifi_remote` 1.5.1, `wifi_remote_over_eppp` 0.3.2, `eppp_link` 1.1.5.

## Notable upstream changes

`esp_hosted` 2.12.6 → 2.12.7 ([release page](https://components.espressif.com/components/espressif/esp_hosted/versions/2.12.7)):

- **ESP-IDF v6.x mempool build fix** — `common/mempool.c` no longer breaks when PicolibC is configured with `CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY` disabled. Relevant for the in-flight IDF 6 testing ([#14770](https://github.com/esphome/esphome/pull/14770)).
- **Windows build fix** — Unicode characters removed from a host-side cmake file that broke Windows builds.
- OpenThread RCP over dedicated UART support (new co-processor mode; ESPHome doesn't use it, but harmless).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Companion to [#16176](https://github.com/esphome/esphome/pull/16176) — same dependency stack, next dot release.
- IDF6 mempool fix is relevant to [#14770](https://github.com/esphome/esphome/pull/14770).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(esp_hosted is only used by IDF >= 5.5 builds for ESP32-H2 / ESP32-P4 co-processor configurations.)

## Example entry for `config.yaml`:

N/A — no user-facing config changes; pure dependency bump.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).