### PR TITLE
[espidf] Gate esp_idf_size --ng on IDF version

### DIFF
--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -3,7 +3,8 @@
 import json
 from pathlib import Path
 
-from esphome.components.esp32 import get_esp32_variant
+from esphome.components.esp32 import get_esp32_variant, idf_version
+import esphome.config_validation as cv
 from esphome.core import CORE
 from esphome.helpers import mkdir_p, write_file_if_changed
 from esphome.writer import update_storage_json
@@ -60,6 +61,11 @@ def get_project_cmakelists(minimal: bool = False) -> str:
     # Get IDF target from ESP32 variant (e.g., ESP32S3 -> esp32s3)
     variant = get_esp32_variant()
     idf_target = variant.lower().replace("-", "")
+
+    # esp_idf_size 2.x (bundled with IDF >=6.0) made NG the default and
+    # removed the --ng flag; on 1.x (IDF 5.5) --ng is required to get
+    # --format=raw because the legacy mode doesn't support it.
+    size_ng_flag = "--ng" if idf_version() < cv.Version(6, 0, 0) else ""
 
     # Project-wide compile options: -D defines and -W warning flags (skip
     # -Wl, linker flags — those go on the src component via
@@ -146,7 +152,7 @@ project({CORE.name})
 # Emit raw JSON size data for ESPHome to read post-build.
 add_custom_command(
     TARGET ${{CMAKE_PROJECT_NAME}}.elf POST_BUILD
-    COMMAND ${{PYTHON}} -m esp_idf_size --ng --format=raw
+    COMMAND ${{PYTHON}} -m esp_idf_size {size_ng_flag} --format=raw
             -o ${{CMAKE_BINARY_DIR}}/esp_idf_size.json
             ${{CMAKE_PROJECT_NAME}}.map
     WORKING_DIRECTORY ${{CMAKE_BINARY_DIR}}

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -11,10 +11,12 @@ import pytest
 from esphome.components.esp32 import (
     KEY_COMPONENTS,
     KEY_ESP32,
+    KEY_IDF_VERSION,
     KEY_PATH,
     KEY_REF,
     KEY_REPO,
 )
+import esphome.config_validation as cv
 from esphome.const import KEY_CORE
 from esphome.core import CORE
 
@@ -24,7 +26,10 @@ def _reset_core(tmp_path: Path) -> None:
     """Give each test its own CORE.build_path and a clean esp32 data slot."""
     CORE.build_path = str(tmp_path)
     CORE.data.setdefault(KEY_CORE, {})
-    CORE.data[KEY_ESP32] = {KEY_COMPONENTS: {}}
+    CORE.data[KEY_ESP32] = {
+        KEY_COMPONENTS: {},
+        KEY_IDF_VERSION: cv.Version(5, 5, 4),
+    }
 
 
 def _write_project_description(tmp_path: Path, components: dict[str, str]) -> None:


### PR DESCRIPTION
# What does this implement/fix?

[esp_idf_size 2.x](https://github.com/espressif/esp-idf-size/releases/tag/v2.0.0) (bundled with ESP-IDF >=6.0) made NG the default and **removed the `--ng` flag entirely**. On 1.x (bundled with IDF 5.5) `--ng` is required to access `--format=raw` because the legacy code path doesn't support that output format. Our post-link size dump in `esphome/build_gen/espidf.py::get_project_cmakelists` hard-codes `--ng`, so IDF 5.5 builds work and IDF 6.x builds fail with:

```
esp_idf_size: error: unrecognized arguments: --ng
ninja: build stopped: subcommand failed.
```

Fix: inspect the IDF version at CMakeLists generation time and emit `--ng` only when we're on IDF <6.0.

## Change

```python
size_ng_flag = "--ng" if idf_version() < cv.Version(6, 0, 0) else ""
```

…spliced into the `add_custom_command` template:

```cmake
COMMAND ${PYTHON} -m esp_idf_size {size_ng_flag} --format=raw
        -o ${CMAKE_BINARY_DIR}/esp_idf_size.json
        ${CMAKE_PROJECT_NAME}.map
```

A double-space when the flag is empty is harmless — CMake tokenizes the command line.

Also seeds `KEY_IDF_VERSION` in the `tests/unit_tests/build_gen/test_espidf.py` fixture so the new `idf_version()` lookup doesn't raise `KeyError` from the previously incomplete mock state. All 6 build_gen tests still pass.

## Validation

Validated on the IDF 6.0 testing branch [#14770](https://github.com/esphome/esphome/pull/14770), where this is the only change separating a red `Test components with native ESP-IDF` job (failing at the post-link size dump) from a green one.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced by the IDF 6.0 testing run on [#14770](https://github.com/esphome/esphome/pull/14770).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — internal build-generator fix, no user-facing config changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).