### PR TITLE
[writer] Mark storage_should_clean as public API for device-builder

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -87,6 +87,21 @@ def replace_file_content(text, pattern, repl):
 
 
 def storage_should_clean(old: StorageJSON | None, new: StorageJSON) -> bool:
+    """Return True when the build tree must be wiped before reuse.
+
+    Predicate is True when *old* is missing (first build),
+    ``src_version`` differs, ``build_path`` differs, or a previously
+    loaded integration was removed in *new*. Adding integrations or
+    changing unrelated fields (friendly name, esphome version, etc.)
+    does not trigger a clean.
+
+    Used by esphome-device-builder (esphome/device-builder) to gate
+    its remote-build artifact materialiser so a local → remote → local
+    cycle preserves PlatformIO's local object cache instead of wiping
+    it on every cycle. The signature, semantics, and ``None`` handling
+    for *old* are part of the public contract; keep them stable so the
+    offloader's wipe decision tracks core's.
+    """
     if old is None:
         return True
 


### PR DESCRIPTION
# What does this implement/fix?

Document `esphome.writer.storage_should_clean` as a stable, public predicate so `esphome-device-builder` can reuse it as the wipe gate in its remote-build artifact materialiser.

Background: device-builder's offloader path keeps a local `<data_dir>/build/<name>/.pioenvs/<name>/` object cache and was unconditionally wiping it before every receiver tarball extract. A `local → remote → local` cycle therefore lost PlatformIO's incremental cache on every flip and triggered a cold rebuild. esphome/device-builder#874 rewires the materialiser to call `storage_should_clean(prior_storage, new_storage)` so the wipe only fires on the same conditions core already uses (no prior sidecar, `src_version` change, `build_path` change, integrations removed). To do that safely the offloader needs a public-API guarantee that the signature and semantics will not drift.

This PR adds the docstring that records that contract; behavior is unchanged. Mirrors the approach used in #16290 (`write_file`) and #16300 (`variant_has_wifi` / `has_native_wifi`).

Coverage is already thorough; `tests/unit_tests/test_writer.py` exercises every branch of `storage_should_clean` (None old, `src_version` diff, `build_path` diff, single + multiple component removal, no-op equality, additions-only, unrelated-field changes, empty↔non-empty integration sets). No new tests needed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <none; coordinated with esphome/device-builder#874>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<n/a; docstring-only change in a Python helper, no user-facing docs>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Docstring-only change in `esphome/writer.py`; no platform-specific code paths affected.)

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# n/a — internal helper; no YAML surface.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).