### PR TITLE
[ft5x06] Fix setting calibration values

### DIFF
--- a/esphome/components/ft5x06/touchscreen/ft5x06_touchscreen.cpp
+++ b/esphome/components/ft5x06/touchscreen/ft5x06_touchscreen.cpp
@@ -15,6 +15,16 @@ void FT5x06Touchscreen::setup() {
     this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
   }
 
+  // reading the chip registers to get max x/y does not seem to work.
+  if (this->display_ != nullptr) {
+    if (this->x_raw_max_ == this->x_raw_min_) {
+      this->x_raw_max_ = this->display_->get_native_width();
+    }
+    if (this->y_raw_max_ == this->y_raw_min_) {
+      this->y_raw_max_ = this->display_->get_native_height();
+    }
+  }
+
   // wait 200ms after reset.
   this->set_timeout(200, [this] { this->continue_setup_(); });
 }
@@ -39,15 +49,6 @@ void FT5x06Touchscreen::continue_setup_() {
       this->mark_failed();
       return;
   }
-  // reading the chip registers to get max x/y does not seem to work.
-  if (this->display_ != nullptr) {
-    if (this->x_raw_max_ == this->x_raw_min_) {
-      this->x_raw_max_ = this->display_->get_native_width();
-    }
-    if (this->y_raw_max_ == this->y_raw_min_) {
-      this->y_raw_max_ = this->display_->get_native_height();
-    }
-  }
 }
 
 void FT5x06Touchscreen::update_touches() {
@@ -71,7 +72,7 @@ void FT5x06Touchscreen::update_touches() {
     uint16_t x = encode_uint16(data[i][0] & 0x0F, data[i][1]);
     uint16_t y = encode_uint16(data[i][2] & 0xF, data[i][3]);
 
-    ESP_LOGD(TAG, "Read %X status, id: %d, pos %d/%d", status, id, x, y);
+    ESP_LOGV(TAG, "Read %X status, id: %d, pos %d/%d", status, id, x, y);
     if (status == 0 || status == 2) {
       this->add_raw_touch_position_(id, x, y);
     }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The FT5X06 component sets dimensions from the display dimensions, but this should be done during setup, before anything has a chance to set a display rotation which can change its native dimensions when hardware rotation is used.

Also change log level of read logging to reduce log spam.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1501208645231448146/1504685502907813928


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
