### PR TITLE
[yaml_util] Promote include-discovery helper, share it with bundle

### DIFF
--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -260,42 +260,20 @@ class ConfigBundleCreator:
     def _discover_yaml_includes(self) -> None:
         """Discover YAML files loaded during config parsing.
 
-        Deliberately uses a fresh re-parse and force-loads every deferred
-        ``IncludeFile`` to include *all* potentially-reachable includes,
-        even branches not selected by the local substitutions. Bundles are
-        meant to be compiled on another system where command-line
-        substitution overrides may choose a different branch — e.g.
-        ``!include network/${eth_model}/config.yaml`` must ship every
-        candidate so the remote build can pick any one.
-
-        Entries with unresolved substitution variables in the filename
-        path are skipped with a warning (they cannot be resolved without
-        the substitution pass).
-
-        Secrets files are tracked separately so we can filter them to
-        only include the keys this config actually references.
+        Delegates to :func:`yaml_util.discover_user_yaml_files`, which does a
+        fresh re-parse and force-loads every deferred ``IncludeFile`` so that
+        *all* potentially-reachable includes are captured (even branches not
+        selected by local substitutions). Bundles are meant to be compiled on
+        another system where command-line substitution overrides may choose a
+        different branch — e.g. ``!include network/${eth_model}/config.yaml``
+        must ship every candidate so the remote build can pick any one.
         """
-        # Must be a fresh parse: IncludeFile.load() caches its result in
-        # _content, and we discover files by listening for loader calls. On
-        # an already-parsed tree the cache is populated, .load() returns
-        # without calling the loader, the listener never fires, and the
-        # referenced files would be silently dropped from the bundle.
-        with yaml_util.track_yaml_loads() as loaded_files:
-            try:
-                data = yaml_util.load_yaml(self._config_path)
-            except EsphomeError:
-                _LOGGER.debug(
-                    "Bundle: re-loading YAML for include discovery failed, "
-                    "proceeding with partial file list"
-                )
-            else:
-                _force_load_include_files(data)
-
-        for fpath in loaded_files:
-            if fpath == self._config_path.resolve():
+        discovered = yaml_util.discover_user_yaml_files(self._config_path)
+        self._secrets_paths.update(discovered.secrets)
+        config_resolved = self._config_path.resolve()
+        for fpath in discovered.files:
+            if fpath == config_resolved:
                 continue  # Already added as config
-            if fpath.name in const.SECRETS_FILES:
-                self._secrets_paths.add(fpath)
             self._add_file(fpath)
 
     def _discover_component_files(self) -> None:
@@ -623,57 +601,6 @@ def _add_bytes_to_tar(tar: tarfile.TarFile, name: str, data: bytes) -> None:
     info.gid = 0
     info.mode = 0o644
     tar.addfile(info, io.BytesIO(data))
-
-
-def _force_load_include_files(obj: Any, _seen: set[int] | None = None) -> None:
-    """Recursively resolve any ``IncludeFile`` instances in a YAML tree.
-
-    Nested ``!include`` returns a deferred ``IncludeFile`` that is only
-    resolved during the substitution pass. During bundle discovery we need
-    the referenced files to actually load so the ``track_yaml_loads``
-    listener fires for them.
-
-    ``IncludeFile`` instances with unresolved substitution variables in the
-    filename cannot be loaded — we skip and warn about those.
-    """
-    if _seen is None:
-        _seen = set()
-
-    if isinstance(obj, yaml_util.IncludeFile):
-        if id(obj) in _seen:
-            return
-        _seen.add(id(obj))
-        if obj.has_unresolved_expressions():
-            _LOGGER.warning(
-                "Bundle: cannot resolve !include %s (referenced from %s) "
-                "with substitutions in path",
-                obj.file,
-                obj.parent_file,
-            )
-            return
-        try:
-            loaded = obj.load()
-        except EsphomeError as err:
-            _LOGGER.warning(
-                "Bundle: failed to load !include %s (referenced from %s): %s",
-                obj.file,
-                obj.parent_file,
-                err,
-            )
-            return
-        _force_load_include_files(loaded, _seen)
-    elif isinstance(obj, dict):
-        if id(obj) in _seen:
-            return
-        _seen.add(id(obj))
-        for value in obj.values():
-            _force_load_include_files(value, _seen)
-    elif isinstance(obj, (list, tuple)):
-        if id(obj) in _seen:
-            return
-        _seen.add(id(obj))
-        for item in obj:
-            _force_load_include_files(item, _seen)
 
 
 def _resolve_include_path(include_path: Any) -> Path | None:

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Generator
 from contextlib import contextmanager, suppress
+from dataclasses import dataclass, field
 import functools
 import inspect
 from io import BytesIO, TextIOBase, TextIOWrapper
@@ -299,6 +300,7 @@ def force_load_include_files(
             )
 
 
+@dataclass(slots=True)
 class DiscoveredYamlFiles:
     """Result of :func:`discover_user_yaml_files`.
 
@@ -309,11 +311,8 @@ class DiscoveredYamlFiles:
     flagged as secrets).
     """
 
-    __slots__ = ("files", "secrets")
-
-    def __init__(self, files: list[Path], secrets: set[Path]) -> None:
-        self.files = files
-        self.secrets = secrets
+    files: list[Path] = field(default_factory=list)
+    secrets: set[Path] = field(default_factory=set)
 
 
 def discover_user_yaml_files(config_path: Path) -> DiscoveredYamlFiles:

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -233,6 +233,132 @@ class IncludeFile:
         return has_substitution_or_expression(str(self.file))
 
 
+def force_load_include_files(
+    obj: Any,
+    *,
+    warn_on_unresolved: bool = True,
+    _seen: set[int] | None = None,
+) -> None:
+    """Recursively resolve any deferred ``IncludeFile`` instances in a YAML tree.
+
+    Nested ``!include`` returns a deferred ``IncludeFile`` that is only resolved
+    later (substitution / packages pass). Callers that need every referenced
+    file to actually load — bundle discovery, on-device YAML recovery — invoke
+    this while a :func:`track_yaml_loads` listener is active so the underlying
+    loader fires and records every reachable file.
+
+    ``IncludeFile`` instances whose path contains unresolved substitution
+    variables cannot be loaded. By default a warning is logged for each one;
+    pass ``warn_on_unresolved=False`` (used by discovery paths that run on a
+    fresh re-parse where substitutions haven't been applied yet) to demote it
+    to a debug log.
+    """
+    if _seen is None:
+        _seen = set()
+
+    if isinstance(obj, IncludeFile):
+        if id(obj) in _seen:
+            return
+        _seen.add(id(obj))
+        if obj.has_unresolved_expressions():
+            log = _LOGGER.warning if warn_on_unresolved else _LOGGER.debug
+            log(
+                "Cannot resolve !include %s (referenced from %s) with substitutions in path",
+                obj.file,
+                obj.parent_file,
+            )
+            return
+        try:
+            loaded = obj.load()
+        except EsphomeError as err:
+            _LOGGER.warning(
+                "Failed to load !include %s (referenced from %s): %s",
+                obj.file,
+                obj.parent_file,
+                err,
+            )
+            return
+        force_load_include_files(
+            loaded, warn_on_unresolved=warn_on_unresolved, _seen=_seen
+        )
+    elif isinstance(obj, dict):
+        if id(obj) in _seen:
+            return
+        _seen.add(id(obj))
+        for value in obj.values():
+            force_load_include_files(
+                value, warn_on_unresolved=warn_on_unresolved, _seen=_seen
+            )
+    elif isinstance(obj, (list, tuple)):
+        if id(obj) in _seen:
+            return
+        _seen.add(id(obj))
+        for item in obj:
+            force_load_include_files(
+                item, warn_on_unresolved=warn_on_unresolved, _seen=_seen
+            )
+
+
+class DiscoveredYamlFiles:
+    """Result of :func:`discover_user_yaml_files`.
+
+    ``files`` contains every resolved path the YAML loader touched while we
+    were re-parsing the user's config; ``secrets`` is the subset whose
+    *un-resolved* filename matched :data:`esphome.const.SECRETS_FILES` (so
+    a ``secrets.yaml`` symlinked to a differently-named target is still
+    flagged as secrets).
+    """
+
+    __slots__ = ("files", "secrets")
+
+    def __init__(self, files: list[Path], secrets: set[Path]) -> None:
+        self.files = files
+        self.secrets = secrets
+
+
+def discover_user_yaml_files(config_path: Path) -> DiscoveredYamlFiles:
+    """Fresh-re-parse ``config_path`` and report every file the YAML loader
+    pulled in, plus which of them came in under a secrets filename.
+
+    Does NOT run schema validation, substitutions, or package resolution — so
+    component-internal YAML loaded by validators (LVGL helpers, dashboard
+    imports, etc.) is *not* captured. Deferred ``!include`` references whose
+    paths don't depend on substitutions are force-loaded here so they're
+    captured too.
+
+    Must run on a fresh parse because :meth:`IncludeFile.load` caches its
+    result; on an already-resolved tree :meth:`load` returns without invoking
+    the loader and the listener would not fire for the referenced files.
+    """
+    from esphome.const import SECRETS_FILES
+
+    secrets: set[Path] = set()
+
+    def _capture_secret(fname: Path) -> None:
+        if Path(fname).name in SECRETS_FILES:
+            secrets.add(Path(fname).resolve())
+
+    with track_yaml_loads() as loaded:
+        _load_listeners.append(_capture_secret)
+        try:
+            try:
+                data = load_yaml(config_path)
+            except EsphomeError:
+                return DiscoveredYamlFiles(list(loaded), secrets)
+            force_load_include_files(data, warn_on_unresolved=False)
+        finally:
+            _load_listeners.remove(_capture_secret)
+
+    # Deduplicate while preserving first-seen order.
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for path in loaded:
+        if path not in seen:
+            seen.add(path)
+            unique.append(path)
+    return DiscoveredYamlFiles(unique, secrets)
+
+
 def _add_data_ref(fn):
     @functools.wraps(fn)
     def wrapped(loader, node):

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -22,13 +22,13 @@ from esphome.bundle import (
     _add_bytes_to_tar,
     _default_target_dir,
     _find_used_secret_keys,
-    _force_load_include_files,
     extract_bundle,
     is_bundle_path,
     prepare_bundle_for_compile,
     read_bundle_manifest,
 )
 from esphome.core import CORE, EsphomeError
+from esphome.yaml_util import force_load_include_files
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -947,7 +947,7 @@ def test_discover_files_nested_include_load_failure(
     paths = [f.path for f in files]
     assert "test.yaml" in paths
     assert any(
-        "failed to load !include" in r.message and "missing.yaml" in r.message
+        "failed to load !include" in r.message.lower() and "missing.yaml" in r.message
         for r in caplog.records
     )
 
@@ -974,8 +974,8 @@ def test_force_load_skips_duplicate_include_file() -> None:
     # Same instance appears twice — second visit must hit the _seen guard.
     tree = {"a": stub, "b": [stub]}
 
-    with patch("esphome.bundle.yaml_util.IncludeFile", _StubInclude):
-        _force_load_include_files(tree)
+    with patch("esphome.yaml_util.IncludeFile", _StubInclude):
+        force_load_include_files(tree)
 
     assert stub.load_calls == 1
 
@@ -989,8 +989,8 @@ def test_force_load_handles_cyclic_containers() -> None:
     cyclic_list.append(cyclic_list)
 
     # Should return without recursing forever
-    _force_load_include_files(cyclic_dict)
-    _force_load_include_files(cyclic_list)
+    force_load_include_files(cyclic_dict)
+    force_load_include_files(cyclic_list)
 
 
 def test_discover_files_yaml_reload_failure(

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -12,11 +12,15 @@ import esphome.config_validation as cv
 from esphome.core import DocumentLocation, DocumentRange, EsphomeError
 from esphome.util import OrderedDict
 from esphome.yaml_util import (
+    DiscoveredYamlFiles,
     ESPHomeDataBase,
     ESPLiteralValue,
+    discover_user_yaml_files,
+    force_load_include_files,
     format_path,
     make_data_base,
     make_literal,
+    track_yaml_loads,
 )
 
 
@@ -966,3 +970,224 @@ def test_make_literal_blocks_substitution() -> None:
     # undefined in the context.
     assert result == {"pin": "${PIN}"}
     assert isinstance(result, ESPLiteralValue)
+
+
+# ---------------------------------------------------------------------------
+# force_load_include_files / discover_user_yaml_files
+# ---------------------------------------------------------------------------
+
+
+class _StubInclude:
+    """Stand-in for `IncludeFile` that records how `load()` was called.
+
+    Patched in via `esphome.yaml_util.IncludeFile` so the recursion in
+    `force_load_include_files` treats instances as deferred includes without
+    needing an actual on-disk file.
+    """
+
+    def __init__(
+        self,
+        file: str = "stub.yaml",
+        parent_file: Path | None = None,
+        *,
+        unresolved: bool = False,
+        load_result: object = None,
+        raise_on_load: EsphomeError | None = None,
+    ) -> None:
+        self.file = Path(file)
+        self.parent_file = parent_file or Path("/tmp/parent.yaml")
+        self._unresolved = unresolved
+        self._load_result = load_result if load_result is not None else {}
+        self._raise = raise_on_load
+        self.load_calls = 0
+
+    def has_unresolved_expressions(self) -> bool:
+        return self._unresolved
+
+    def load(self) -> object:
+        self.load_calls += 1
+        if self._raise is not None:
+            raise self._raise
+        return self._load_result
+
+
+def test_force_load_include_files_resolves_nested_includes() -> None:
+    """A tree of dict/list/IncludeFile is walked and every IncludeFile is loaded."""
+    inner = _StubInclude("inner.yaml")
+    outer = _StubInclude("outer.yaml", load_result={"nested": inner})
+    tree = [{"a": outer}, "scalar"]
+    with patch("esphome.yaml_util.IncludeFile", _StubInclude):
+        force_load_include_files(tree)
+    assert outer.load_calls == 1
+    assert inner.load_calls == 1
+
+
+def test_force_load_include_files_seen_guard_prevents_double_load() -> None:
+    """The same IncludeFile referenced from two branches loads once."""
+    stub = _StubInclude("once.yaml")
+    tree = {"a": stub, "b": [stub]}
+    with patch("esphome.yaml_util.IncludeFile", _StubInclude):
+        force_load_include_files(tree)
+    assert stub.load_calls == 1
+
+
+def test_force_load_include_files_handles_cyclic_containers() -> None:
+    """Cyclic dict/list references don't trigger infinite recursion."""
+    cyclic_dict: dict[str, object] = {}
+    cyclic_dict["self"] = cyclic_dict
+    cyclic_list: list[object] = []
+    cyclic_list.append(cyclic_list)
+    # Both calls must return without recursing forever.
+    force_load_include_files(cyclic_dict)
+    force_load_include_files(cyclic_list)
+
+
+def test_force_load_include_files_warns_on_unresolved_by_default(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Substitution-templated include paths surface as warnings by default."""
+    stub = _StubInclude("${var}.yaml", unresolved=True)
+    with (
+        caplog.at_level("DEBUG", logger="esphome.yaml_util"),
+        patch("esphome.yaml_util.IncludeFile", _StubInclude),
+    ):
+        force_load_include_files({"k": stub})
+    assert stub.load_calls == 0
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("Cannot resolve !include" in r.message for r in warnings)
+
+
+def test_force_load_include_files_demotes_unresolved_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`warn_on_unresolved=False` keeps the same skip but logs at DEBUG."""
+    stub = _StubInclude("${var}.yaml", unresolved=True)
+    with (
+        caplog.at_level("DEBUG", logger="esphome.yaml_util"),
+        patch("esphome.yaml_util.IncludeFile", _StubInclude),
+    ):
+        force_load_include_files({"k": stub}, warn_on_unresolved=False)
+    assert stub.load_calls == 0
+    levels = {r.levelname for r in caplog.records if "Cannot resolve" in r.message}
+    assert "WARNING" not in levels
+    assert "DEBUG" in levels
+
+
+def test_force_load_include_files_warns_on_load_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An `EsphomeError` raised by `load()` is caught and logged, not propagated."""
+    stub = _StubInclude("missing.yaml", raise_on_load=EsphomeError("boom"))
+    with (
+        caplog.at_level("WARNING", logger="esphome.yaml_util"),
+        patch("esphome.yaml_util.IncludeFile", _StubInclude),
+    ):
+        force_load_include_files({"k": stub})
+    assert any(
+        "Failed to load !include" in r.message and "missing.yaml" in r.message
+        for r in caplog.records
+    )
+
+
+def test_discovered_yaml_files_holds_files_and_secrets() -> None:
+    """`DiscoveredYamlFiles` is a small data carrier; both fields are mandatory."""
+    files = [Path("/tmp/a.yaml")]
+    secrets = {Path("/tmp/a.yaml")}
+    discovered = DiscoveredYamlFiles(files, secrets)
+    assert discovered.files is files
+    assert discovered.secrets is secrets
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    path = tmp_path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+def test_discover_user_yaml_files_captures_includes(tmp_path: Path) -> None:
+    """A `!include` in the entry yaml is force-loaded so the listener fires."""
+    _write(tmp_path, "wifi.yaml", "ssid: my_ssid\npassword: my_pw\n")
+    entry = _write(
+        tmp_path,
+        "entry.yaml",
+        "esphome:\n  name: test\nwifi: !include wifi.yaml\n",
+    )
+    discovered = discover_user_yaml_files(entry)
+    names = {p.name for p in discovered.files}
+    assert names == {"entry.yaml", "wifi.yaml"}
+    assert discovered.secrets == set()
+
+
+def test_discover_user_yaml_files_flags_secrets_yaml(tmp_path: Path) -> None:
+    """`secrets.yaml` referenced via `!include` is captured under `.secrets`."""
+    _write(tmp_path, "secrets.yaml", "api_key: redacted_in_test\n")
+    entry = _write(
+        tmp_path,
+        "entry.yaml",
+        "esphome:\n  name: test\nwifi: !include secrets.yaml\n",
+    )
+    discovered = discover_user_yaml_files(entry)
+    assert (tmp_path / "secrets.yaml").resolve() in discovered.secrets
+
+
+def test_discover_user_yaml_files_flags_secrets_yml_extension(
+    tmp_path: Path,
+) -> None:
+    """`secrets.yml` (yml extension) is treated the same as `secrets.yaml`."""
+    _write(tmp_path, "secrets.yml", "key: value\n")
+    entry = _write(
+        tmp_path,
+        "entry.yaml",
+        "esphome:\n  name: test\nwifi: !include secrets.yml\n",
+    )
+    discovered = discover_user_yaml_files(entry)
+    assert (tmp_path / "secrets.yml").resolve() in discovered.secrets
+
+
+def test_discover_user_yaml_files_flags_secrets_symlink(tmp_path: Path) -> None:
+    """`secrets.yaml` symlinked to a non-secrets-named target is still flagged
+    because the un-resolved basename is what gets recorded."""
+    target = _write(tmp_path, "real_creds.yaml", "key: value\n")
+    link = tmp_path / "secrets.yaml"
+    link.symlink_to(target)
+    entry = _write(
+        tmp_path,
+        "entry.yaml",
+        "esphome:\n  name: test\nwifi: !include secrets.yaml\n",
+    )
+    discovered = discover_user_yaml_files(entry)
+    # The recorded "secret path" is the resolved target — even though its
+    # basename is `real_creds.yaml`, it's still in `.secrets`.
+    assert target.resolve() in discovered.secrets
+
+
+def test_discover_user_yaml_files_swallows_parse_errors(tmp_path: Path) -> None:
+    """A YAML parse failure returns whatever was tracked so far without raising."""
+    entry = _write(tmp_path, "entry.yaml", "esphome: [unterminated\n")
+    discovered = discover_user_yaml_files(entry)
+    assert isinstance(discovered, DiscoveredYamlFiles)
+
+
+def test_discover_user_yaml_files_deduplicates(tmp_path: Path) -> None:
+    """The same file referenced twice appears once in `.files`."""
+    _write(tmp_path, "wifi.yaml", "ssid: a\n")
+    entry = _write(
+        tmp_path,
+        "entry.yaml",
+        "esphome:\n  name: test\nwifi: !include wifi.yaml\nfoo: !include wifi.yaml\n",
+    )
+    discovered = discover_user_yaml_files(entry)
+    wifi_resolved = (tmp_path / "wifi.yaml").resolve()
+    assert discovered.files.count(wifi_resolved) == 1
+
+
+def test_track_yaml_loads_records_resolved_paths(tmp_path: Path) -> None:
+    """`track_yaml_loads` is the building block — sanity-check it resolves
+    symlinks so callers can dedupe by identity."""
+    target = _write(tmp_path, "actual.yaml", "esphome:\n  name: t\n")
+    link = tmp_path / "alias.yaml"
+    link.symlink_to(target)
+    with track_yaml_loads() as loaded:
+        yaml_util.load_yaml(link)
+    assert target.resolve() in loaded

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -1011,23 +1011,31 @@ class _StubInclude:
         return self._load_result
 
 
-def test_force_load_include_files_resolves_nested_includes() -> None:
+@pytest.fixture
+def patch_include_file():
+    """Replace `IncludeFile` with `_StubInclude` so isinstance checks in
+    `force_load_include_files` match the stubs constructed by tests."""
+    with patch("esphome.yaml_util.IncludeFile", _StubInclude):
+        yield
+
+
+def test_force_load_include_files_resolves_nested_includes(
+    patch_include_file: None,
+) -> None:
     """A tree of dict/list/IncludeFile is walked and every IncludeFile is loaded."""
     inner = _StubInclude("inner.yaml")
     outer = _StubInclude("outer.yaml", load_result={"nested": inner})
-    tree = [{"a": outer}, "scalar"]
-    with patch("esphome.yaml_util.IncludeFile", _StubInclude):
-        force_load_include_files(tree)
+    force_load_include_files([{"a": outer}, "scalar"])
     assert outer.load_calls == 1
     assert inner.load_calls == 1
 
 
-def test_force_load_include_files_seen_guard_prevents_double_load() -> None:
+def test_force_load_include_files_seen_guard_prevents_double_load(
+    patch_include_file: None,
+) -> None:
     """The same IncludeFile referenced from two branches loads once."""
     stub = _StubInclude("once.yaml")
-    tree = {"a": stub, "b": [stub]}
-    with patch("esphome.yaml_util.IncludeFile", _StubInclude):
-        force_load_include_files(tree)
+    force_load_include_files({"a": stub, "b": [stub]})
     assert stub.load_calls == 1
 
 
@@ -1042,46 +1050,38 @@ def test_force_load_include_files_handles_cyclic_containers() -> None:
     force_load_include_files(cyclic_list)
 
 
-def test_force_load_include_files_warns_on_unresolved_by_default(
+@pytest.mark.parametrize(
+    ("warn_on_unresolved", "expect_level"),
+    [
+        pytest.param(True, "WARNING", id="default-warns"),
+        pytest.param(False, "DEBUG", id="opt-in-demotes"),
+    ],
+)
+def test_force_load_include_files_unresolved_log_level(
+    patch_include_file: None,
     caplog: pytest.LogCaptureFixture,
+    warn_on_unresolved: bool,
+    expect_level: str,
 ) -> None:
-    """Substitution-templated include paths surface as warnings by default."""
+    """Substitution-templated include paths skip the load and log at the
+    level chosen by `warn_on_unresolved`."""
     stub = _StubInclude("${var}.yaml", unresolved=True)
-    with (
-        caplog.at_level("DEBUG", logger="esphome.yaml_util"),
-        patch("esphome.yaml_util.IncludeFile", _StubInclude),
-    ):
-        force_load_include_files({"k": stub})
+    with caplog.at_level("DEBUG", logger="esphome.yaml_util"):
+        force_load_include_files({"k": stub}, warn_on_unresolved=warn_on_unresolved)
     assert stub.load_calls == 0
-    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-    assert any("Cannot resolve !include" in r.message for r in warnings)
-
-
-def test_force_load_include_files_demotes_unresolved_warning(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """`warn_on_unresolved=False` keeps the same skip but logs at DEBUG."""
-    stub = _StubInclude("${var}.yaml", unresolved=True)
-    with (
-        caplog.at_level("DEBUG", logger="esphome.yaml_util"),
-        patch("esphome.yaml_util.IncludeFile", _StubInclude),
-    ):
-        force_load_include_files({"k": stub}, warn_on_unresolved=False)
-    assert stub.load_calls == 0
-    levels = {r.levelname for r in caplog.records if "Cannot resolve" in r.message}
-    assert "WARNING" not in levels
-    assert "DEBUG" in levels
+    matching = [
+        r.levelname for r in caplog.records if "Cannot resolve !include" in r.message
+    ]
+    assert matching == [expect_level]
 
 
 def test_force_load_include_files_warns_on_load_failure(
+    patch_include_file: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """An `EsphomeError` raised by `load()` is caught and logged, not propagated."""
     stub = _StubInclude("missing.yaml", raise_on_load=EsphomeError("boom"))
-    with (
-        caplog.at_level("WARNING", logger="esphome.yaml_util"),
-        patch("esphome.yaml_util.IncludeFile", _StubInclude),
-    ):
+    with caplog.at_level("WARNING", logger="esphome.yaml_util"):
         force_load_include_files({"k": stub})
     assert any(
         "Failed to load !include" in r.message and "missing.yaml" in r.message
@@ -1099,64 +1099,55 @@ def test_discovered_yaml_files_holds_files_and_secrets() -> None:
 
 
 def _write(tmp_path: Path, name: str, content: str) -> Path:
+    """Write `content` to `tmp_path/name`, creating parent dirs as needed."""
     path = tmp_path / name
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
     return path
 
 
+def _write_entry_including(tmp_path: Path, included_name: str) -> Path:
+    """Write a minimal entry yaml that `!include`s `included_name`."""
+    return _write(
+        tmp_path,
+        "entry.yaml",
+        f"esphome:\n  name: test\nwifi: !include {included_name}\n",
+    )
+
+
 def test_discover_user_yaml_files_captures_includes(tmp_path: Path) -> None:
     """A `!include` in the entry yaml is force-loaded so the listener fires."""
     _write(tmp_path, "wifi.yaml", "ssid: my_ssid\npassword: my_pw\n")
-    entry = _write(
-        tmp_path,
-        "entry.yaml",
-        "esphome:\n  name: test\nwifi: !include wifi.yaml\n",
-    )
-    discovered = discover_user_yaml_files(entry)
+    discovered = discover_user_yaml_files(_write_entry_including(tmp_path, "wifi.yaml"))
     names = {p.name for p in discovered.files}
     assert names == {"entry.yaml", "wifi.yaml"}
     assert discovered.secrets == set()
 
 
-def test_discover_user_yaml_files_flags_secrets_yaml(tmp_path: Path) -> None:
-    """`secrets.yaml` referenced via `!include` is captured under `.secrets`."""
-    _write(tmp_path, "secrets.yaml", "api_key: redacted_in_test\n")
-    entry = _write(
-        tmp_path,
-        "entry.yaml",
-        "esphome:\n  name: test\nwifi: !include secrets.yaml\n",
-    )
-    discovered = discover_user_yaml_files(entry)
-    assert (tmp_path / "secrets.yaml").resolve() in discovered.secrets
-
-
-def test_discover_user_yaml_files_flags_secrets_yml_extension(
-    tmp_path: Path,
+@pytest.mark.parametrize(
+    "secret_name",
+    [
+        pytest.param("secrets.yaml", id="yaml"),
+        pytest.param("secrets.yml", id="yml"),
+    ],
+)
+def test_discover_user_yaml_files_flags_secrets_filename(
+    tmp_path: Path, secret_name: str
 ) -> None:
-    """`secrets.yml` (yml extension) is treated the same as `secrets.yaml`."""
-    _write(tmp_path, "secrets.yml", "key: value\n")
-    entry = _write(
-        tmp_path,
-        "entry.yaml",
-        "esphome:\n  name: test\nwifi: !include secrets.yml\n",
-    )
-    discovered = discover_user_yaml_files(entry)
-    assert (tmp_path / "secrets.yml").resolve() in discovered.secrets
+    """Both `secrets.yaml` and `secrets.yml` get flagged in `.secrets`."""
+    _write(tmp_path, secret_name, "key: value\n")
+    discovered = discover_user_yaml_files(_write_entry_including(tmp_path, secret_name))
+    assert (tmp_path / secret_name).resolve() in discovered.secrets
 
 
 def test_discover_user_yaml_files_flags_secrets_symlink(tmp_path: Path) -> None:
     """`secrets.yaml` symlinked to a non-secrets-named target is still flagged
     because the un-resolved basename is what gets recorded."""
     target = _write(tmp_path, "real_creds.yaml", "key: value\n")
-    link = tmp_path / "secrets.yaml"
-    link.symlink_to(target)
-    entry = _write(
-        tmp_path,
-        "entry.yaml",
-        "esphome:\n  name: test\nwifi: !include secrets.yaml\n",
+    (tmp_path / "secrets.yaml").symlink_to(target)
+    discovered = discover_user_yaml_files(
+        _write_entry_including(tmp_path, "secrets.yaml")
     )
-    discovered = discover_user_yaml_files(entry)
     # The recorded "secret path" is the resolved target — even though its
     # basename is `real_creds.yaml`, it's still in `.secrets`.
     assert target.resolve() in discovered.secrets


### PR DESCRIPTION
# What does this implement/fix?

Lifts `bundle.py`'s private `_force_load_include_files` into `esphome.yaml_util` as the public `force_load_include_files`, and adds a matching `discover_user_yaml_files(config_path)` helper that does a fresh re-parse with a load listener active and reports:

- every resolved file path the YAML loader touched, and
- the subset whose *un-resolved* basename matched `SECRETS_FILES` (so a `secrets.yaml` symlinked to a non-secrets-named target is still flagged correctly).

`force_load_include_files` now also takes `warn_on_unresolved` (default `True`, preserving bundle's current behaviour) so discovery paths that run before substitution can quietly skip substitution-templated `!include` paths instead of logging warnings for valid configs.

`bundle.py:_discover_yaml_includes` now delegates to the shared helper — its observable behaviour is unchanged (the manifest still lists every reachable include and tracks secrets paths). Existing bundle unit tests pass against the new shape.

This is split out ahead of esphome/esphome#16445 (which adds a `store_yaml` component that uses the same discovery helper to embed the user's YAML in firmware for recovery). Landing the helper independently keeps `store_yaml`'s PR focused on the component itself and the API plumbing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- prerequisite for esphome/esphome#16445

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal helper, no user-visible API

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

This is a pure-Python refactor with no compiled code changes; behaviour is unchanged on every platform. `pytest tests/unit_tests/test_bundle.py` (88 tests) passes; `pre-commit` (ruff, ruff-format, flake8, pylint, ci-custom) clean.

## Example entry for `config.yaml`:

```yaml
# No YAML schema changes — this PR only extracts a shared Python helper.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).