### PR TITLE
[ci] Fix sync-device-classes workflow (failing daily for weeks)

### DIFF
--- a/.github/workflows/sync-device-classes.yml
+++ b/.github/workflows/sync-device-classes.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Create sync branch
+        # Switch off dev before pre-commit runs so the
+        # no-commit-to-branch hook passes (it blocks dev/release/beta).
+        run: git checkout -B sync/device-classes
+
       - name: Checkout Home Assistant
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -45,15 +50,27 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e lib/home-assistant
-          pip install -r requirements_test.txt pre-commit
+          # Project requirements are needed so pylint can resolve runtime
+          # imports (e.g. smpclient in esphome/components/nrf52/ota.py).
+          pip install -r requirements.txt -r requirements_test.txt pre-commit
 
       - name: Sync
         run: |
           python ./script/sync-device_class.py
 
-      - name: Run pre-commit hooks
-        run: |
-          python script/run-in-env.py pre-commit run --all-files
+      - name: Apply pre-commit auto-fixes
+        # First pass: let formatters (ruff, end-of-file-fixer, etc.) modify
+        # files. pre-commit exits non-zero whenever a hook touches anything,
+        # which would otherwise abort the workflow before the auto-fixes
+        # can flow into the sync PR.
+        run: python script/run-in-env.py pre-commit run --all-files || true
+
+      - name: Verify pre-commit clean
+        # Second pass: re-run all hooks against the now-fixed tree.
+        # Auto-fixers exit 0 (nothing to change); any remaining failure
+        # from a check-only hook (pylint / flake8 / yamllint / ci-custom)
+        # is a real issue and fails the workflow loudly.
+        run: python script/run-in-env.py pre-commit run --all-files
 
       - name: Commit changes
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1


### PR DESCRIPTION
# What does this implement/fix?

The Synchronise Device Classes from Home Assistant workflow has been failing on every scheduled run since at least early May (see [run history](https://github.com/esphome/esphome/actions/workflows/sync-device-classes.yml)). The failure mode is the `Run pre-commit hooks` step, with three concurrent issues:

1. **`no-commit-to-branch` hook blocks dev** — `.pre-commit-config.yaml` configures the hook with `--branch=dev --branch=release --branch=beta`. The workflow's HEAD is on `dev` when `pre-commit run --all-files` runs, so the hook unconditionally fails.

2. **`pylint` can't resolve `smpclient` imports** — `esphome/components/nrf52/ota.py` imports `smp.exceptions`, `smpclient`, `smpclient.generics`, `smpclient.mcuboot`, `smpclient.requests.image_management`, and `smpclient.requests.os_management`. The workflow only installs `requirements_test.txt + pre-commit`, **not** `requirements.txt`, so pylint sees the imports as unresolvable and emits 6 `E0401`s.

3. **`ruff (legacy alias)` exits non-zero on auto-fix** — `Found 2 errors (2 fixed, 0 remaining).` pre-commit always exits 1 when a hook **modifies** files (so a real developer re-stages and re-commits), which aborts the workflow before `peter-evans/create-pull-request` can run.

## Fixes

Three corresponding changes in `.github/workflows/sync-device-classes.yml`:

- **New `Create sync branch` step** before pre-commit runs:
  ```yaml
  - name: Create sync branch
    run: git checkout -B sync/device-classes
  ```
  Switches HEAD off `dev` so the `no-commit-to-branch` hook passes naturally. The downstream `peter-evans/create-pull-request` step already targets `sync/device-classes`, so it just continues committing on top of the branch we already checked out.

- **Install `requirements.txt` too** in the existing Install step:
  ```yaml
  pip install -r requirements.txt -r requirements_test.txt pre-commit
  ```
  Now pylint can resolve `smpclient` and other runtime-only imports.

- **Two-pass pre-commit** instead of one:
  ```yaml
  - name: Apply pre-commit auto-fixes
    run: python script/run-in-env.py pre-commit run --all-files || true

  - name: Verify pre-commit clean
    run: python script/run-in-env.py pre-commit run --all-files
  ```
  First pass with `|| true` lets formatters (`ruff`, `ruff format`, `end-of-file-fixer`, `trim trailing whitespace`, `pyupgrade`, `clang-format`) modify files. Second pass re-runs all hooks against the now-fixed tree — auto-fixers exit 0 (nothing to change), and any remaining failure from a check-only hook (`pylint`, `flake8`, `yamllint`, `ci-custom`) is genuine and fails the workflow loudly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- The workflow has been silently failing on daily schedule fires for weeks.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI / sync-bot workflow change; no firmware impact.)

## Example entry for `config.yaml`:

N/A -- no user-facing config changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).