### PR TITLE
[ci] sync-device-classes: use uv for installs and skip pylint

### DIFF
--- a/.github/workflows/sync-device-classes.yml
+++ b/.github/workflows/sync-device-classes.yml
@@ -46,13 +46,22 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Set up uv
+        # An order of magnitude faster than pip on cold boots, with its
+        # own wheel cache. ``--system`` (below) installs into the
+        # setup-python interpreter so subsequent ``pre-commit`` /
+        # ``script/run-in-env.py`` steps find the deps without a
+        # ``uv run`` prefix.
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
       - name: Install Home Assistant
         run: |
-          python -m pip install --upgrade pip
-          pip install -e lib/home-assistant
+          uv pip install --system -e lib/home-assistant
           # Project requirements are needed so pylint can resolve runtime
           # imports (e.g. smpclient in esphome/components/nrf52/ota.py).
-          pip install -r requirements.txt -r requirements_test.txt pre-commit
+          uv pip install --system -r requirements.txt -r requirements_test.txt pre-commit
 
       - name: Sync
         run: |

--- a/.github/workflows/sync-device-classes.yml
+++ b/.github/workflows/sync-device-classes.yml
@@ -59,8 +59,6 @@ jobs:
       - name: Install Home Assistant
         run: |
           uv pip install --system -e lib/home-assistant
-          # Project requirements are needed so pylint can resolve runtime
-          # imports (e.g. smpclient in esphome/components/nrf52/ota.py).
           uv pip install --system -r requirements.txt -r requirements_test.txt pre-commit
 
       - name: Sync
@@ -72,13 +70,23 @@ jobs:
         # files. pre-commit exits non-zero whenever a hook touches anything,
         # which would otherwise abort the workflow before the auto-fixes
         # can flow into the sync PR.
+        #
+        # pylint is skipped: this workflow only installs a subset of the
+        # runtime deps (HA + requirements*.txt), so pylint surfaces
+        # import-error / relative-beyond-top-level noise that the main CI
+        # already gates on real PRs.
+        env:
+          SKIP: pylint
         run: python script/run-in-env.py pre-commit run --all-files || true
 
       - name: Verify pre-commit clean
         # Second pass: re-run all hooks against the now-fixed tree.
         # Auto-fixers exit 0 (nothing to change); any remaining failure
-        # from a check-only hook (pylint / flake8 / yamllint / ci-custom)
-        # is a real issue and fails the workflow loudly.
+        # from a check-only hook (flake8 / yamllint / ci-custom) is a
+        # real issue and fails the workflow loudly. pylint stays skipped
+        # for the same reason as above.
+        env:
+          SKIP: pylint
         run: python script/run-in-env.py pre-commit run --all-files
 
       - name: Commit changes


### PR DESCRIPTION
# What does this implement/fix?

Two follow-ups to #16448 on the `sync-device-classes` workflow:

1. **Use `uv` for the install step.** Mirrors the install pattern in `esphome/device-builder` — roughly an order of magnitude faster on cold boots, with a persistent wheel cache across the daily runs.
   - Adds `astral-sh/setup-uv@v8.1.0` (SHA-pinned) with `enable-cache: true`.
   - Replaces both `pip install` calls with `uv pip install --system …`. `--system` keeps installs in the `actions/setup-python` interpreter so `pre-commit` and `script/run-in-env.py` continue to find the deps without a `uv run` prefix.
   - Drops the `pip install --upgrade pip` line — uv handles its own resolver.

2. **Skip the `pylint` pre-commit hook.** The workflow only installs HA + `requirements*.txt`, not the full dev set, so pylint surfaces import-error / relative-beyond-top-level noise (e.g. `mipi_rgb/models/waveshare.py: E0402`) that's already gated on real PRs by the main CI. Adds `SKIP: pylint` to both pre-commit invocations so the auto-fix and verify passes don't fail on this.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #16448 which restored the workflow to a working state.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI-only change — exercised by `workflow_dispatch` on the workflow itself / next scheduled run.)

## Example entry for `config.yaml`:

```yaml
# N/A — workflow-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
