### PR TITLE
[ci] sync-device-classes: drop branch-switch hack, skip no-commit-to-branch instead

### DIFF
--- a/.github/workflows/sync-device-classes.yml
+++ b/.github/workflows/sync-device-classes.yml
@@ -30,11 +30,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Create sync branch
-        # Switch off dev before pre-commit runs so the
-        # no-commit-to-branch hook passes (it blocks dev/release/beta).
-        run: git checkout -B sync/device-classes
-
       - name: Checkout Home Assistant
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -71,22 +66,26 @@ jobs:
         # which would otherwise abort the workflow before the auto-fixes
         # can flow into the sync PR.
         #
-        # pylint is skipped: this workflow only installs a subset of the
-        # runtime deps (HA + requirements*.txt), so pylint surfaces
-        # import-error / relative-beyond-top-level noise that the main CI
-        # already gates on real PRs.
+        # SKIP:
+        #   - no-commit-to-branch is a local guard against committing on
+        #     dev/release/beta; CI runs on dev by definition, and
+        #     peter-evans/create-pull-request creates the branch itself.
+        #   - pylint surfaces import-error / relative-beyond-top-level
+        #     noise here because this workflow installs only a subset of
+        #     the runtime deps (HA + requirements*.txt); main CI already
+        #     gates pylint on real PRs.
         env:
-          SKIP: pylint
+          SKIP: pylint,no-commit-to-branch
         run: python script/run-in-env.py pre-commit run --all-files || true
 
       - name: Verify pre-commit clean
         # Second pass: re-run all hooks against the now-fixed tree.
         # Auto-fixers exit 0 (nothing to change); any remaining failure
         # from a check-only hook (flake8 / yamllint / ci-custom) is a
-        # real issue and fails the workflow loudly. pylint stays skipped
-        # for the same reason as above.
+        # real issue and fails the workflow loudly. Same SKIP list as
+        # above for the same reasons.
         env:
-          SKIP: pylint
+          SKIP: pylint,no-commit-to-branch
         run: python script/run-in-env.py pre-commit run --all-files
 
       - name: Commit changes


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #16448 / #16449. The `sync-device-classes` workflow is still failing — now in the `Commit changes` step with:

```
Working base is branch 'sync/device-classes'
Error: The 'base' and 'branch' for a pull request must be different branches. Unable to continue.
```

Root cause: #16448 added a `Create sync branch` step (`git checkout -B sync/device-classes`) to dodge the local-only `no-commit-to-branch` pre-commit hook. But `peter-evans/create-pull-request` is designed to do the branching itself — it [expects the workflow to be checked out on the **base** branch and creates the head branch from the working-tree diff](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md). Manually switching to `sync/device-classes` makes base == head, and the action refuses to open a PR.

Changes:

- Remove the `Create sync branch` step entirely.
- Add `no-commit-to-branch` to the `SKIP` list on both pre-commit invocations. CI runs on `dev` by definition, and pre-commit isn't doing any `git commit` here — the `no-commit-to-branch` hook is a local guard that's irrelevant for this workflow. This mirrors the pattern used in `esphome/device-builder`.

After this lands, peter-evans takes care of creating `sync/device-classes` from the working-tree changes against the `dev` base.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #16448 and #16449.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI-only change — exercised by the workflow itself on `workflow_dispatch` once merged.)

## Example entry for `config.yaml`:

```yaml
# N/A — workflow-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
