### PR TITLE
[ci] Use uv for pip installs across CI workflows

### DIFF
--- a/.github/actions/restore-python/action.yml
+++ b/.github/actions/restore-python/action.yml
@@ -27,6 +27,14 @@ runs:
         path: venv
         # yamllint disable-line rule:line-length
         key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ inputs.cache-key }}
+    - name: Set up uv
+      # Only needed on cache miss to populate the venv. ``uv pip install``
+      # detects the activated venv via ``VIRTUAL_ENV`` so the venv layout
+      # downstream jobs rely on is preserved.
+      if: steps.cache-venv.outputs.cache-hit != 'true'
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        enable-cache: true
     - name: Create Python virtual environment
       if: steps.cache-venv.outputs.cache-hit != 'true' && runner.os != 'Windows'
       shell: bash
@@ -34,8 +42,8 @@ runs:
         python -m venv venv
         source venv/bin/activate
         python --version
-        pip install -r requirements.txt -r requirements_test.txt
-        pip install -e .
+        uv pip install -r requirements.txt -r requirements_test.txt
+        uv pip install -e .
     - name: Create Python virtual environment
       if: steps.cache-venv.outputs.cache-hit != 'true' && runner.os == 'Windows'
       shell: bash
@@ -43,5 +51,5 @@ runs:
         python -m venv venv
         source ./venv/Scripts/activate
         python --version
-        pip install -r requirements.txt -r requirements_test.txt
-        pip install -e .
+        uv pip install -r requirements.txt -r requirements_test.txt
+        uv pip install -e .

--- a/.github/workflows/ci-api-proto.yml
+++ b/.github/workflows/ci-api-proto.yml
@@ -26,6 +26,12 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
+      - name: Set up uv
+        # ``--system`` (below) installs into the setup-python interpreter;
+        # no venv is created or restored by this workflow.
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
 
       - name: Install apt dependencies
         run: |
@@ -34,7 +40,7 @@ jobs:
           sudo apt install -y protobuf-compiler
           protoc --version
       - name: Install python dependencies
-        run: pip install aioesphomeapi -c requirements.txt -r requirements_dev.txt
+        run: uv pip install --system aioesphomeapi -c requirements.txt -r requirements_dev.txt
       - name: Generate files
         run: script/api_protobuf/api_protobuf.py
       - name: Check for changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,22 @@ jobs:
           path: venv
           # yamllint disable-line rule:line-length
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ steps.cache-key.outputs.key }}
+      - name: Set up uv
+        # Only needed on cache miss to populate the venv. ``uv pip install``
+        # detects the activated venv via ``VIRTUAL_ENV`` so downstream jobs
+        # that ``. venv/bin/activate`` see an identical layout.
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           python -m venv venv
           . venv/bin/activate
           python --version
-          pip install -r requirements.txt -r requirements_dev.txt -r requirements_test.txt pre-commit
-          pip install -e .
+          uv pip install -r requirements.txt -r requirements_dev.txt -r requirements_test.txt pre-commit
+          uv pip install -e .
 
   pylint:
     name: Check pylint
@@ -351,14 +359,20 @@ jobs:
         with:
           path: venv
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ needs.common.outputs.cache-key }}
+      - name: Set up uv
+        # Only needed on cache miss to populate the venv.
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           python -m venv venv
           . venv/bin/activate
           python --version
-          pip install -r requirements.txt -r requirements_test.txt
-          pip install -e .
+          uv pip install -r requirements.txt -r requirements_test.txt
+          uv pip install -e .
       - name: Register matcher
         run: echo "::add-matcher::.github/workflows/matchers/pytest.json"
       - name: Run integration tests


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #16449 / #16448, extending the `uv` install switch from the daily `sync-device-classes` workflow to the workflows that actually dominate CI cost (every push + every PR).

In `ci.yml` the only spot already on `uv` was the `device-builder` downstream job — every other Python install (`common`, `integration-tests`, every job that goes through `.github/actions/restore-python`, plus `ci-api-proto`) was still calling raw `pip install`. This PR aligns them all on the same `astral-sh/setup-uv@v8.1.0` install pattern (SHA-pinned, `enable-cache: true`).

Changes:

- **`.github/actions/restore-python`** — composite action invoked by almost every downstream CI job as the venv cache-miss fallback. Adds `setup-uv` (only on cache miss, to keep cache-hit jobs untouched) and switches both the Linux/macOS and Windows venv-create paths from `pip install` to `uv pip install`. No `--system` flag: the activate step sets `VIRTUAL_ENV`, so `uv pip install` lands in the venv that downstream jobs expect to `. venv/bin/activate`.
- **`.github/workflows/ci.yml` `common` job** — the canonical venv builder whose cache feeds the rest of the workflow. Same pattern: `setup-uv` on cache miss, `uv pip install` into the activated venv.
- **`.github/workflows/ci.yml` `integration-tests` job** — has its own venv-create path on cache miss for the 3.13 matrix entry. Same pattern.
- **`.github/workflows/ci-api-proto.yml`** — single-step workflow with no venv. Uses `uv pip install --system` (matches the `sync-device-classes` / device-builder install shape).

Cache-hit paths are unchanged — `setup-uv` is gated on `cache-hit != 'true'` everywhere a venv is restored, so steady-state behavior is identical to today. The speed-up shows up on cache misses (requirements / pre-commit config change, new Python version, etc.) and on workflows without a venv cache (`ci-api-proto`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #16449 and #16448.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI-only change — exercised by the workflows themselves on this PR. Cache-miss validation: #16454 salts the cache key and confirms `uv pip install` runs on every Linux/macOS/Windows × 3.11/3.13/3.14 combo.)

## Example entry for `config.yaml`:

```yaml
# N/A — workflow-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
