### PR TITLE
[ci] pr-title-check: skip all bot authors, not just dependabot

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -29,10 +29,11 @@ jobs:
             } = require('./.github/scripts/detect-tags.js');
 
             const title = context.payload.pull_request.title;
-            const author = context.payload.pull_request.user.login;
+            const user = context.payload.pull_request.user;
 
-            // Skip bot PRs (e.g. dependabot) - they have their own title format
-            if (author === 'dependabot[bot]') {
+            // Skip bot PRs (e.g. dependabot, esphome[bot] device-class sync) -
+            // they have their own title formats.
+            if (user.type === 'Bot') {
               return;
             }
 


### PR DESCRIPTION
# What does this implement/fix?

#16452 (the automated device-class sync PR opened by `esphome[bot]`) is failing the **PR Title Check** because its title — `Synchronise Device Classes from Home Assistant` — doesn't start with a `[tag]` prefix. The workflow currently only short-circuits for `dependabot[bot]`.

Generalize the check to skip any PR whose author has `user.type === 'Bot'` in the event payload. That covers:

- `dependabot[bot]` (unchanged behaviour)
- `esphome[bot]` (the sync workflow, see #16452)
- any future GitHub App we install

The `type` field is set by GitHub for both classic bots and GitHub App users, so this is a single robust check rather than a per-login allowlist.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Unblocks #16452 and any future automated sync PRs.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI-only change — exercised by the workflow on the next bot PR.)

## Example entry for `config.yaml`:

```yaml
# N/A — workflow-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
