### PR TITLE
[ci] PROBE: validate #16451 by busting venv cache (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Generate cache-key
         id: cache-key
-        run: echo key="${{ hashFiles('requirements.txt', 'requirements_dev.txt', 'requirements_test.txt', '.pre-commit-config.yaml') }}" >> $GITHUB_OUTPUT
+        # PROBE: salt prefix forces every venv-cache restore in this
+        # workflow run to miss so the uv install path from #16451 is
+        # actually exercised across Linux/macOS/Windows x 3.11/3.13/3.14.
+        # DO NOT MERGE -- remove this salt before landing.
+        run: echo key="uvprobe-${{ hashFiles('requirements.txt', 'requirements_dev.txt', 'requirements_test.txt', '.pre-commit-config.yaml') }}" >> $GITHUB_OUTPUT
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
# What does this implement/fix?

**Probe only — do not merge.** Chained off #16451.

The CI run for #16451 cache-hit on every job (`Linux-/macOS-/Windows-3.11/3.13/3.14-venv-<requirements-hash>` were all already populated from `dev`), so the new `uv pip install` lines never actually ran. This branch salts the cache key in the `common` job so every downstream venv restore misses, which forces:

- `common` job — `uv pip install` into the Linux/3.11 venv
- `.github/actions/restore-python` (Linux/macOS branch) — used by `ci-custom`, `pylint`, `determine-jobs`, `pytest` matrix, etc.
- `.github/actions/restore-python` (Windows branch) — used by `pytest` Windows matrix entries
- `integration-tests` venv-create step — used by the 3.13 bucket

Once the run is green, the changes in #16451 will be validated against real cache misses on every supported (OS, Python) combo. Then close this PR (or revert the salt).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Probe for #16451 (follow-up to #16449 / #16448).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI probe — exercised by the workflow itself on this PR.)

## Example entry for `config.yaml`:

```yaml
# N/A — workflow-only probe
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
