### PR TITLE
[tests] Mock determine_cpp_unit_tests in clang_tidy_mode tests

### DIFF
--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -2659,6 +2659,15 @@ def test_main_force_all_overrides_detection(
             return_value={"should_run": "false"},
         ),
         patch.object(determine_jobs, "should_run_benchmarks", return_value=False),
+        # create_intelligent_batches scans every tests/components/<name>/*.yaml
+        # under --force-all (~2500 YAML loads, ~10s in CI). This test only
+        # asserts that main() routes to it and returns non-empty -- the
+        # batching logic itself has its own dedicated tests.
+        patch.object(
+            determine_jobs,
+            "create_intelligent_batches",
+            return_value=([["fake_batch"]], None),
+        ),
     ):
         determine_jobs.main()
 

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -1518,6 +1518,7 @@ def test_clang_tidy_mode_full_scan(
     mock_should_run_clang_tidy: Mock,
     mock_should_run_clang_format: Mock,
     mock_should_run_python_linters: Mock,
+    mock_determine_cpp_unit_tests: Mock,
     mock_changed_files: Mock,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
@@ -1529,6 +1530,9 @@ def test_clang_tidy_mode_full_scan(
     mock_should_run_clang_tidy.return_value = True
     mock_should_run_clang_format.return_value = False
     mock_should_run_python_linters.return_value = False
+    # Without this mock, main() runs the real determine_cpp_unit_tests
+    # which loads the full component graph (~5s import of every component).
+    mock_determine_cpp_unit_tests.return_value = (False, [])
 
     # Mock changed_files to return no component files
     mock_changed_files.return_value = []
@@ -1584,6 +1588,7 @@ def test_clang_tidy_mode_targeted_scan(
     mock_should_run_clang_tidy: Mock,
     mock_should_run_clang_format: Mock,
     mock_should_run_python_linters: Mock,
+    mock_determine_cpp_unit_tests: Mock,
     mock_changed_files: Mock,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
@@ -1595,6 +1600,9 @@ def test_clang_tidy_mode_targeted_scan(
     mock_should_run_clang_tidy.return_value = True
     mock_should_run_clang_format.return_value = False
     mock_should_run_python_linters.return_value = False
+    # Without this mock, main() runs the real determine_cpp_unit_tests
+    # which loads the full component graph (~5s import of every component).
+    mock_determine_cpp_unit_tests.return_value = (False, [])
 
     # Create component names
     components = [f"comp{i}" for i in range(component_count)]


### PR DESCRIPTION
# What does this implement/fix?

The pytest duration logging from #16455 surfaced these as the top offenders by a wide margin:

```
============================= slowest 30 durations =============================
7.92s call     tests/script/test_determine_jobs.py::test_clang_tidy_mode_full_scan
3.17s call     tests/script/test_determine_jobs.py::test_main_force_all_overrides_detection
...
```

Two unrelated heavy paths were being executed unnecessarily by tests in `tests/script/test_determine_jobs.py`. Both are now mocked.

## Fix 1 — `test_clang_tidy_mode_full_scan` + `test_clang_tidy_mode_targeted_scan` (5 params)

These tests called `determine_jobs.main()` without mocking `determine_cpp_unit_tests`. `main()` then ran the real function, which called `create_components_graph()` and imported every ESPHome component module just to walk `DEPENDENCIES` / `AUTO_LOAD` metadata — ~5s on a cold component-graph cache. (Per the docstring on `create_components_graph`: *"This function is expensive (5-6 seconds)"*.)

Neither test exercises C++ unit-test detection — they only assert which clang-tidy mode `main()` selects. Adding `mock_determine_cpp_unit_tests` follows the same pattern every other `main()` test in this file already uses.

## Fix 2 — `test_main_force_all_overrides_detection`

Under `--force-all`, `main()` walks every component in `tests/components/` and runs `create_intelligent_batches` over them — which calls `analyze_all_components` and parses roughly 2500 `test.*.yaml` / `validate.*.yaml` files to group components with compatible buses. In CI this showed up as a 12.12s test on its own (3.17s locally with the components-graph cache already warm).

The test isn't validating the batching logic itself (`create_intelligent_batches` has its own dedicated tests in this file). It only asserts that `main()` routes to the matrix-population path under `--force-all` and returns non-empty results. Mocking `create_intelligent_batches` to return a canned `([["fake_batch"]], None)` preserves the routing check without paying the YAML I/O.

## Local timings

Before (this file in CI's durations log): `test_clang_tidy_mode_full_scan` at 7.92s, `test_main_force_all_overrides_detection` at 12.12s, dominating the top-30.

After (local):

```
============================= slowest 10 durations =============================
0.11s call  tests/script/test_determine_jobs.py::test_main_force_all_overrides_detection
0.02s call  tests/script/test_determine_jobs.py::test_component_batching_beta_branch_40_per_batch
0.02s call  tests/script/test_determine_jobs.py::test_main_all_tests_should_run
...
209 passed in 0.38s
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #16455 (CI duration logging).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Test-only change — `pytest tests/script/test_determine_jobs.py` passes locally; 209 tests in 0.38s.)

## Example entry for `config.yaml`:

```yaml
# N/A — test-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
