### PR TITLE
[esp32_ble_server] Honor client offset and MTU in long reads

### DIFF
--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -196,43 +196,35 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
         (*this->on_read_callback_)(param->read.conn_id);
       }
 
-      uint16_t max_offset = 22;
-
+      // Use the client-supplied offset for long reads; short reads always start at 0.
+      // The Bluedroid stack truncates ATT_READ_RSP / ATT_READ_BLOB_RSP to MTU-1, so we
+      // just provide as much data as we have from the requested offset and let the stack
+      // handle framing. The client issues subsequent blob reads with increasing offsets
+      // until it has received the whole value.
+      const uint16_t offset = param->read.is_long ? param->read.offset : 0;
+      esp_gatt_status_t status = ESP_GATT_OK;
       esp_gatt_rsp_t response;
-      if (param->read.is_long) {
-        if (this->value_read_offset_ >= this->value_.size()) {
-          response.attr_value.len = 0;
-          response.attr_value.offset = this->value_read_offset_;
-          this->value_read_offset_ = 0;
-        } else if (this->value_.size() - this->value_read_offset_ < max_offset) {
-          //  Last message in the chain
-          response.attr_value.len = this->value_.size() - this->value_read_offset_;
-          response.attr_value.offset = this->value_read_offset_;
-          memcpy(response.attr_value.value, this->value_.data() + response.attr_value.offset, response.attr_value.len);
-          this->value_read_offset_ = 0;
-        } else {
-          response.attr_value.len = max_offset;
-          response.attr_value.offset = this->value_read_offset_;
-          memcpy(response.attr_value.value, this->value_.data() + response.attr_value.offset, response.attr_value.len);
-          this->value_read_offset_ += max_offset;
-        }
+      response.attr_value.offset = offset;
+
+      if (offset > this->value_.size()) {
+        status = ESP_GATT_INVALID_OFFSET;
+        response.attr_value.len = 0;
       } else {
-        response.attr_value.offset = 0;
-        response.attr_value.len = this->value_.size();
-        if (response.attr_value.len > ESP_GATT_MAX_ATTR_LEN) {
-          ESP_LOGW(TAG, "Characteristic length %u exceeds buffer size of %u, truncating", response.attr_value.len,
-                   ESP_GATT_MAX_ATTR_LEN);
-          response.attr_value.len = ESP_GATT_MAX_ATTR_LEN;
+        size_t remaining = this->value_.size() - offset;
+        if (remaining > ESP_GATT_MAX_ATTR_LEN) {
+          ESP_LOGW(TAG, "Characteristic length %u exceeds buffer size of %u, truncating",
+                   static_cast<unsigned>(remaining), ESP_GATT_MAX_ATTR_LEN);
+          remaining = ESP_GATT_MAX_ATTR_LEN;
         }
-        memcpy(response.attr_value.value, this->value_.data(), response.attr_value.len);
-        this->value_read_offset_ = 0;
+        response.attr_value.len = remaining;
+        memcpy(response.attr_value.value, this->value_.data() + offset, remaining);
       }
 
       response.attr_value.handle = this->handle_;
       response.attr_value.auth_req = ESP_GATT_AUTH_REQ_NONE;
 
       esp_err_t err =
-          esp_ble_gatts_send_response(gatts_if, param->read.conn_id, param->read.trans_id, ESP_GATT_OK, &response);
+          esp_ble_gatts_send_response(gatts_if, param->read.conn_id, param->read.trans_id, status, &response);
       if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_ble_gatts_send_response failed: %d", err);
       }

--- a/esphome/components/esp32_ble_server/ble_characteristic.h
+++ b/esphome/components/esp32_ble_server/ble_characteristic.h
@@ -79,7 +79,6 @@ class BLECharacteristic {
   esp_gatt_char_prop_t properties_;
   uint16_t handle_{0xFFFF};
 
-  uint16_t value_read_offset_{0};
   std::vector<uint8_t> value_;
   std::vector<BLEDescriptor *> descriptors_;
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #16422. Fixes the GATT long-read (blob read) path in
`BLECharacteristic::gatts_event_handler`, which was tracking its own
internal cursor and replying in hard-coded 22-byte chunks regardless of
the negotiated MTU or the offset the client actually asked for.

With the old code, a client reading a value larger than the default MTU
only got correct data if it issued blob reads in strict 22-byte
increments starting from offset 0. Any other access pattern (resuming
at the offset returned by the previous truncated short read, retrying a
blob, etc.) returned wrong or duplicate bytes.

This PR:

- Uses `param->read.offset` directly for blob reads instead of the
  internal `value_read_offset_` counter.
- Returns all remaining bytes from that offset (capped to
  `ESP_GATT_MAX_ATTR_LEN` to guard the response buffer). The Bluedroid
  stack truncates the ATT response to MTU-1, so we don't need to chunk
  manually.
- Returns `ESP_GATT_INVALID_OFFSET` when the client requests an offset
  past the end of the value, per the ATT spec.
- Removes the now-unused `value_read_offset_` field.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- follow-up to #16422 / fixes https://github.com/esphome/esphome/issues/16420 for the long-read path

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — existing esp32_ble_server configs are unaffected.
esp32_ble_server:
  manufacturer: "ESPHome"
  model: "ESP32"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).