### PR TITLE
[sen6x] Remove incorrect AQI device class from VOC and NOx Index sensors

### DIFF
--- a/esphome/components/sen6x/sensor.py
+++ b/esphome/components/sen6x/sensor.py
@@ -14,7 +14,6 @@ from esphome.const import (
     CONF_TEMPERATURE,
     CONF_TYPE,
     CONF_VOC,
-    DEVICE_CLASS_AQI,
     DEVICE_CLASS_CARBON_DIOXIDE,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_PM1,
@@ -93,13 +92,11 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_VOC): sensor.sensor_schema(
                 icon=ICON_RADIATOR,
                 accuracy_decimals=0,
-                device_class=DEVICE_CLASS_AQI,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_NOX): sensor.sensor_schema(
                 icon=ICON_RADIATOR,
                 accuracy_decimals=0,
-                device_class=DEVICE_CLASS_AQI,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_CO2): sensor.sensor_schema(


### PR DESCRIPTION
# What does this implement/fix?

The SEN6x VOC Index and NOx Index sensors are currently exposed to Home Assistant with `device_class: aqi`. The Sensirion VOC/NOx Index is a proprietary unitless number produced by their Gas Index Algorithm. A value of 100 represents the recent baseline, with lower values better and higher values worse. The Index is explicitly not a concentration measurement, nor an Air Quality Index in the conventional sense. See Sensirion's [VOC Index info note](https://sensirion.com/media/documents/02232963/6294E043/Info_Note_VOC_Index.pdf).

### Why `device_class: aqi` is wrong here

**Home Assistant treats `device_class: aqi` as an EPA-scale Air Quality Index.** HA's Google Assistant integration takes the numeric value from any sensor with `device_class: aqi` and buckets it into EPA AQI category labels using the literal EPA breakpoints, in [`homeassistant/components/google_assistant/trait.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/google_assistant/trait.py):

```
<= 50  -> "healthy"
<= 100 -> "moderate"
<= 150 -> "unhealthy for sensitive groups"
<= 200 -> "unhealthy"
<= 300 -> "very unhealthy"
else   -> "hazardous"
```

A Sensirion VOC Index value of 100, which per Sensirion means "the recent baseline, typical conditions", currently gets surfaced to Google Assistant as `"moderate air quality"`. A VOC Index of 250 ("deviated from baseline") gets reported as `"very unhealthy"`. Both reports are meaningless under Sensirion's actual definition.

Every other HA core integration using `SensorDeviceClass.AQI` ([`google_air_quality`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/google_air_quality/sensor.py), [`arve`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/arve/sensor.py), [`airobot`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/airobot/sensor.py)) uses it for a real composite multi-pollutant AQI, and ESPHome's own dedicated [`aqi`](https://github.com/esphome/esphome/blob/dev/esphome/components/aqi/__init__.py) component computes actual EPA or CAQI values from PM2.5 + PM10.

No other HA device class fits a vendor-proprietary relative index either: `volatile_organic_compounds` requires µg/m³, `volatile_organic_compounds_parts` requires ppb/ppm. The correct representation is a numeric sensor with `state_class: measurement` and no device class. Users who want a specific device class can still set one via the standard `device_class:` override in YAML.

This PR removes `device_class=DEVICE_CLASS_AQI` from the VOC and NOx schemas, and drops the now-unused import.

### Context

The AQI device class was originally added to the related `sgp4x` component in #4327 as a workaround for HA validation errors from the previous (also incorrect) `volatile_organic_compounds` / `nitrous_oxide` device classes, which require concentration units. The `sen6x` component later inherited the same pattern. AQI was chosen because it was the only air-quality-adjacent device class permitting a `None` UoM, not because the Sensirion Index is an AQI.

Parallel PRs fixing the same misclassification in the related Sensirion components:
- sen5x: https://github.com/esphome/esphome/pull/16463
- sgp4x: https://github.com/esphome/esphome/pull/16464

### Migration

Users whose Home Assistant dashboards, voice assistant exposure rules, or automations filter by `device_class: aqi` and want to preserve that behavior can opt in explicitly:

```yaml
sensor:
  - platform: sen6x
    voc:
      name: "VOC Index"
      device_class: aqi   # optional, restores previous behavior
    nox:
      name: "NOx Index"
      device_class: aqi   # optional, restores previous behavior
```

Long-term statistics are unaffected: `state_class: measurement` is preserved.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A (reported via the ESPHome Discord)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A. The SEN6x documentation does not currently mention the AQI device class.

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: sen6x
    type: SEN66
    voc:
      name: "VOC Index"
    nox:
      name: "NOx Index"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
