### PR TITLE
[lvgl] Build container_schema and widget update schemas lazily

### DIFF
--- a/esphome/components/lvgl/helpers.py
+++ b/esphome/components/lvgl/helpers.py
@@ -16,6 +16,11 @@ def lazy_once(build: Callable[[], T]) -> Callable[[], T]:
     Used to defer voluptuous schema construction until first validation. Many
     of the lvgl schemas would otherwise be built at module-import time even for
     YAMLs that never reach them.
+
+    Not thread-safe — concurrent first-callers would each run ``build``. esphome
+    config validation is single-threaded so this is fine in practice. If
+    ``build`` raises, the cache stays empty and the next call retries; there is
+    no negative-cache.
     """
     cached: list[T] = []
 

--- a/esphome/components/lvgl/helpers.py
+++ b/esphome/components/lvgl/helpers.py
@@ -1,9 +1,30 @@
+from collections.abc import Callable
 import re
+from typing import TypeVar
 
 from esphome import config_validation as cv
 from esphome.const import CONF_ARGS, CONF_FORMAT
 
 CONF_IF_NAN = "if_nan"
+
+T = TypeVar("T")
+
+
+def lazy_once(build: Callable[[], T]) -> Callable[[], T]:
+    """Return a no-arg callable that runs ``build`` at most once and caches it.
+
+    Used to defer voluptuous schema construction until first validation. Many
+    of the lvgl schemas would otherwise be built at module-import time even for
+    YAMLs that never reach them.
+    """
+    cached: list[T] = []
+
+    def get() -> T:
+        if not cached:
+            cached.append(build())
+        return cached[0]
+
+    return get
 
 
 # noqa

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import Any
 
 from esphome import config_validation as cv
 from esphome.automation import Trigger, validate_automation
@@ -534,7 +535,7 @@ def strip_defaults(schema: cv.Schema):
     return cv.Schema({cv.Optional(k): v for k, v in schema.schema.items()})
 
 
-def container_schema(widget_type: WidgetType, extras=None):
+def container_schema(widget_type: WidgetType, extras=None) -> Callable[[Any], Any]:
     """
     Create a schema for a container widget of a given type. All obj properties are available, plus
     the extras passed in, plus any defined for the specific widget being specified.
@@ -558,7 +559,7 @@ def container_schema(widget_type: WidgetType, extras=None):
 
     get_schema = lazy_once(build)
 
-    def validator(value):
+    def validator(value: Any) -> Any:
         value = value or {}
         return append_layout_schema(get_schema(), value)(value)
 

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -40,7 +40,7 @@ from .defines import (
     get_remapped_uses,
     is_press_event,
 )
-from .helpers import CONF_IF_NAN, validate_printf
+from .helpers import CONF_IF_NAN, lazy_once, validate_printf
 from .layout import (
     FLEX_OBJ_SCHEMA,
     GRID_CELL_SCHEMA,
@@ -542,27 +542,25 @@ def container_schema(widget_type: WidgetType, extras=None):
     :param extras:  Additional options to be made available, e.g. layout properties for children
     :return: The schema for this type of widget.
     """
+
     # Schema construction is deferred until first validation. obj_schema and the
     # part_schema -> base_update_schema chain account for ~225ms of cumulative
     # work at lvgl module import time across ~9 callers; building lazily keeps
     # `esphome config` fast for YAMLs that never reach this widget type.
-    schema_holder: list = []
-
     def build() -> cv.Schema:
-        if not schema_holder:
-            built = obj_schema(widget_type).extend(
-                {cv.GenerateID(): cv.declare_id(widget_type.w_type)}
-            )
-            if extras:
-                built = built.extend(extras)
-            # Delayed evaluation for recursion
-            built = built.extend(widget_type.schema)
-            schema_holder.append(built)
-        return schema_holder[0]
+        built = obj_schema(widget_type).extend(
+            {cv.GenerateID(): cv.declare_id(widget_type.w_type)}
+        )
+        if extras:
+            built = built.extend(extras)
+        # Delayed evaluation for recursion
+        return built.extend(widget_type.schema)
+
+    get_schema = lazy_once(build)
 
     def validator(value):
         value = value or {}
-        return append_layout_schema(build(), value)(value)
+        return append_layout_schema(get_schema(), value)(value)
 
     return validator
 

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -542,18 +542,27 @@ def container_schema(widget_type: WidgetType, extras=None):
     :param extras:  Additional options to be made available, e.g. layout properties for children
     :return: The schema for this type of widget.
     """
-    schema = obj_schema(widget_type).extend(
-        {cv.GenerateID(): cv.declare_id(widget_type.w_type)}
-    )
-    if extras:
-        schema = schema.extend(extras)
-    # Delayed evaluation for recursion
+    # Schema construction is deferred until first validation. obj_schema and the
+    # part_schema -> base_update_schema chain account for ~225ms of cumulative
+    # work at lvgl module import time across ~9 callers; building lazily keeps
+    # `esphome config` fast for YAMLs that never reach this widget type.
+    schema_holder: list = []
 
-    schema = schema.extend(widget_type.schema)
+    def build() -> cv.Schema:
+        if not schema_holder:
+            built = obj_schema(widget_type).extend(
+                {cv.GenerateID(): cv.declare_id(widget_type.w_type)}
+            )
+            if extras:
+                built = built.extend(extras)
+            # Delayed evaluation for recursion
+            built = built.extend(widget_type.schema)
+            schema_holder.append(built)
+        return schema_holder[0]
 
     def validator(value):
         value = value or {}
-        return append_layout_schema(schema, value)(value)
+        return append_layout_schema(build(), value)(value)
 
     return validator
 

--- a/esphome/components/lvgl/widgets/__init__.py
+++ b/esphome/components/lvgl/widgets/__init__.py
@@ -48,6 +48,7 @@ from ..defines import (
     join_enums,
     literal,
 )
+from ..helpers import lazy_once
 from ..lv_validation import lv_int
 from ..lvcode import (
     LvConditional,
@@ -80,8 +81,11 @@ def _lazy_update_schema(widget_type: "WidgetType"):
     voluptuous schemas and is invoked once per WidgetType at import time. The
     caller (register_action) only needs a validator, so wrap the build in a
     closure that materialises on the first validation and caches the result.
+
+    The ``from ..schemas import base_update_schema`` import stays inside the
+    closure because ``schemas`` imports ``WidgetType`` from this module — top-
+    level would deadlock the import.
     """
-    from ..helpers import lazy_once
 
     def build():
         from ..schemas import base_update_schema

--- a/esphome/components/lvgl/widgets/__init__.py
+++ b/esphome/components/lvgl/widgets/__init__.py
@@ -81,18 +81,19 @@ def _lazy_update_schema(widget_type: "WidgetType"):
     caller (register_action) only needs a validator, so wrap the build in a
     closure that materialises on the first validation and caches the result.
     """
-    compiled: list = []
+    from ..helpers import lazy_once
+
+    def build():
+        from ..schemas import base_update_schema
+
+        return base_update_schema(widget_type, widget_type.parts).extend(
+            widget_type.modify_schema
+        )
+
+    get_schema = lazy_once(build)
 
     def validator(value):
-        if not compiled:
-            from ..schemas import base_update_schema
-
-            compiled.append(
-                base_update_schema(widget_type, widget_type.parts).extend(
-                    widget_type.modify_schema
-                )
-            )
-        return compiled[0](value)
+        return get_schema()(value)
 
     return validator
 

--- a/esphome/components/lvgl/widgets/__init__.py
+++ b/esphome/components/lvgl/widgets/__init__.py
@@ -73,6 +73,30 @@ from ..types import (
 EVENT_LAMB = "event_lamb__"
 
 
+def _lazy_update_schema(widget_type: "WidgetType"):
+    """Defer construction of a widget's update-action schema until first use.
+
+    base_update_schema(...).extend(widget_type.modify_schema) compiles several
+    voluptuous schemas and is invoked once per WidgetType at import time. The
+    caller (register_action) only needs a validator, so wrap the build in a
+    closure that materialises on the first validation and caches the result.
+    """
+    compiled: list = []
+
+    def validator(value):
+        if not compiled:
+            from ..schemas import base_update_schema
+
+            compiled.append(
+                base_update_schema(widget_type, widget_type.parts).extend(
+                    widget_type.modify_schema
+                )
+            )
+        return compiled[0](value)
+
+    return validator
+
+
 class WidgetType:
     """
     Describes a type of Widget, e.g. "bar" or "line"
@@ -113,18 +137,23 @@ class WidgetType:
 
         # Local import to avoid circular import
         from ..automation import update_to_code
-        from ..schemas import WIDGET_TYPES, base_update_schema
+        from ..schemas import WIDGET_TYPES
 
         if not is_mock:
             if self.name in WIDGET_TYPES:
                 raise EsphomeError(f"Duplicate definition of widget type '{self.name}'")
             WIDGET_TYPES[self.name] = self
 
-            # Register the update action automatically, adding widget-specific properties
+            # Register the update action automatically, adding widget-specific
+            # properties. The update schema is built lazily on first validation:
+            # base_update_schema involves part_schema / Schema.extend chains that
+            # cost ~7ms per widget at import time (~200ms total across ~25
+            # widgets) and is unused for any YAML that never triggers a
+            # `lvgl.<widget>.update` action.
             register_action(
                 f"lvgl.{self.name}.update",
                 ObjUpdateAction,
-                base_update_schema(self, self.parts).extend(self.modify_schema),
+                _lazy_update_schema(self),
                 synchronous=True,
             )(update_to_code)
 

--- a/esphome/components/lvgl/widgets/__init__.py
+++ b/esphome/components/lvgl/widgets/__init__.py
@@ -1,4 +1,6 @@
+from collections.abc import Callable
 import sys
+from typing import Any
 
 from esphome import codegen as cg, config_validation as cv
 from esphome.automation import register_action
@@ -74,7 +76,7 @@ from ..types import (
 EVENT_LAMB = "event_lamb__"
 
 
-def _lazy_update_schema(widget_type: "WidgetType"):
+def _lazy_update_schema(widget_type: "WidgetType") -> Callable[[Any], Any]:
     """Defer construction of a widget's update-action schema until first use.
 
     base_update_schema(...).extend(widget_type.modify_schema) compiles several
@@ -87,7 +89,7 @@ def _lazy_update_schema(widget_type: "WidgetType"):
     level would deadlock the import.
     """
 
-    def build():
+    def build() -> Schema:
         from ..schemas import base_update_schema
 
         return base_update_schema(widget_type, widget_type.parts).extend(
@@ -96,7 +98,7 @@ def _lazy_update_schema(widget_type: "WidgetType"):
 
     get_schema = lazy_once(build)
 
-    def validator(value):
+    def validator(value: Any) -> Any:
         return get_schema()(value)
 
     return validator


### PR DESCRIPTION
# What does this implement/fix?

Speeds up cold validation of any YAML that pulls in the `lvgl` component. The dominant cost in `import esphome.components.lvgl` is voluptuous schema construction inside `container_schema()` and the `register_action()` chain in `WidgetType.__init__`; both run eagerly at import time even when the YAML never reaches the lvgl block.

**This is the smallest minimal change.** Two surgical sites, no widget-by-widget rewrites, no API changes — just defer the build to first use. There is more headroom available (see "Further work" below) but this lands the largest-bang-for-buck slice first and lets it bake before pulling on the next thread.

### The change

- `container_schema()` now returns a validator that builds its underlying schema on first call (lazy). The eager build was responsible for ~225ms cumulative across 9 callers (`msgbox`/`tabview`/`tileview` widget files plus 4 sites inside top-level `LVGL_SCHEMA`).
- `WidgetType.__init__` now registers a lazy validator with `register_action()`, so `base_update_schema(self, self.parts).extend(self.modify_schema)` is only evaluated when an `lvgl.<widget>.update` action is actually validated. That was ~196ms cumulative across the ~25 widget types.
- Both call sites share a small `lazy_once(build)` helper in `helpers.py` so the build-once-cache pattern lives in one place.

### Measured impact

**`import esphome.components.lvgl`** — cold subprocess, M-series Mac, 5 runs:

| Before (ms) | After (ms) |
|-------------|------------|
| 389 | 229 |
| 385 | 217 |
| 389 | 218 |
| 384 | 215 |
| 380 | 215 |
| **avg 385** | **avg 219** |

**43% reduction.** The widgets that previously dominated the trace (msgbox at 33ms, tileview at 12ms, tabview at 11ms, keyboard at 10ms) all drop below 2ms in `python -X importtime` after the change.

**Real `esphome -q config` on a representative LVGL YAML** (MasterOfNone's m5-cores3.yaml from the Slack repro, 558 lines, ~120-line lvgl block, fonts, sensors, touchscreen, etc.), same machine, 5 cold subprocess runs each:

| | avg |
|--|--|
| Before (upstream/dev) | 980 ms |
| After (this PR)       | 855 ms |

~125 ms / ~13% off total wall time. The 13% is smaller than the 43% on pure lvgl-import because `esphome config` also pays for YAML loading, `esp32` platform import, external_components hashing, etc., which are unchanged. On the Celeron N5105 dashboard hosts in the original bug repro (Python ~5× slower), this translates to roughly **~600 ms shaved off cold dashboard saves** for any LVGL YAML.

`tests/components/lvgl/test.host.yaml` similarly drops from ~770ms → ~550ms cold.

### Functional equivalence

- `script/test_build_components -c lvgl -e config` passes on host, esp32-idf, and esp32-p4-idf (all three lvgl test configs upstream ships).
- `script/build_language_schema.py` produces a byte-identical lvgl sub-tree before vs after — only an unrelated ordering change in the esp32 CPU-frequency enum appeared in the diff.

### Further work (out of scope for this PR)

The remaining ~219 ms of `import esphome.components.lvgl` is dominated by `automation.py` (~149 ms, eager `@register_action` decorators) and `schemas.py` (~124 ms, top-level `STYLE_SCHEMA`/`FULL_STYLE_SCHEMA`/`STATE_SCHEMA` plus the `time`/`RealTimeClock` transitive imports). Those are addressable with the same lazy pattern but each requires touching more files, so saving for a follow-up once this lands.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a (performance-only change, no behavior change)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a — no user-facing config changes.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Tested via `script/test_build_components -c lvgl -e config` on the three lvgl test configs: host, esp32-idf, esp32-p4-idf. No platform-specific code touched.)

## Example entry for `config.yaml`:

```yaml
# No user-facing change. Any existing lvgl YAML continues to validate
# and code-gen identically. Example unchanged:
lvgl:
  pages:
    - id: main_page
      widgets:
        - label:
            text: "Hello"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

(Relies on the existing `tests/components/lvgl/test.*.yaml` suite — all three pass via `script/test_build_components -c lvgl -e config`.)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).