### PR TITLE
[espidf] Switch direct framework downloader to esphome-libs/esp-idf tarballs

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -69,7 +69,7 @@ ESPHOME_IDF_DEFAULT_FEATURES = _str_to_lst_of_str(
 ESPHOME_IDF_FRAMEWORK_MIRRORS = _str_to_lst_of_str(
     os.environ.get(
         "ESPHOME_IDF_FRAMEWORK_MIRRORS",
-        "https://github.com/espressif/esp-idf/releases/download/v{VERSION}/esp-idf-v{VERSION}.zip;https://github.com/espressif/esp-idf/releases/download/v{MAJOR}.{MINOR}/esp-idf-v{MAJOR}.{MINOR}.zip",
+        "https://github.com/esphome-libs/esp-idf/releases/download/v{VERSION}/esp-idf-v{VERSION}.tar.xz;https://github.com/esphome-libs/esp-idf/releases/download/v{MAJOR}.{MINOR}/esp-idf-v{MAJOR}.{MINOR}.tar.xz",
     )
 )
 


### PR DESCRIPTION
## What does this implement/fix?

Points the direct ESP-IDF framework downloader at `esphome-libs/esp-idf` and switches the default extension from `.zip` to `.tar.xz`.

`esphome-libs/esp-idf` ships slim release archives — the source tree only, with no bundled `.git/` directory or submodule packfiles. For v6.0.1 that's about **65 MiB** vs **1741 MiB** for the upstream Espressif release zip (~26× smaller). The installer extracts the source tree and never needs the git history, so the slim variant is a drop-in replacement.

The `tar.xz` extension is preferred over `tar.gz` because LZMA2 produces noticeably smaller archives on source trees with negligible runtime cost on download/extract.

Only the direct downloader in `esphome/espidf/framework.py` is touched. The PlatformIO/pioarduino framework spec in `esphome/components/esp32/__init__.py` is **unchanged** — PlatformIO-managed builds continue to pull from `pioarduino/esp-idf` exactly as before.

Mirrors are still overridable via `ESPHOME_IDF_FRAMEWORK_MIRRORS` for users who want to pin to a different source.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal mirror change, no user-visible API)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No YAML schema changes — this PR only swaps the default mirror URL
# used by the direct ESP-IDF downloader.
```

## Checklist:

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
