### PR TITLE
[uart] clock_source option

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -176,6 +176,19 @@ UART_PARITY_OPTIONS = {
 CONF_FLUSH_TIMEOUT = "flush_timeout"
 CONF_RX_FULL_THRESHOLD = "rx_full_threshold"
 CONF_RX_TIMEOUT = "rx_timeout"
+CONF_CLOCK_SOURCE = "clock_source"
+
+UARTClockSource = uart_ns.enum("UARTClockSource")
+# Maps to ESP-IDF uart_config_t::source_clk. XTAL/REF_TICK are independent of
+# the APB clock and keep the baud rate stable when Dynamic Frequency Scaling
+# (CONFIG_PM_ENABLE) is active. Availability differs per ESP32 variant.
+UART_CLOCK_SOURCES = {
+    "DEFAULT": UARTClockSource.UART_CLOCK_SOURCE_DEFAULT,
+    "APB": UARTClockSource.UART_CLOCK_SOURCE_APB,
+    "XTAL": UARTClockSource.UART_CLOCK_SOURCE_XTAL,
+    "RTC": UARTClockSource.UART_CLOCK_SOURCE_RTC,
+    "REF_TICK": UARTClockSource.UART_CLOCK_SOURCE_REF_TICK,
+}
 
 UARTDirection = uart_ns.enum("UARTDirection")
 UART_DIRECTIONS = {
@@ -260,6 +273,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_FLUSH_TIMEOUT): cv.All(
                 cv.only_on_esp32, cv.positive_time_period_milliseconds
             ),
+            cv.Optional(CONF_CLOCK_SOURCE): cv.All(
+                cv.only_on_esp32, cv.enum(UART_CLOCK_SOURCES, upper=True)
+            ),
             cv.Optional(CONF_STOP_BITS, default=1): cv.one_of(1, 2, int=True),
             cv.Optional(CONF_DATA_BITS, default=8): cv.int_range(min=5, max=8),
             cv.Optional(CONF_PARITY, default="NONE"): cv.enum(
@@ -341,6 +357,8 @@ async def to_code(config):
         cg.add(var.set_rx_timeout(config[CONF_RX_TIMEOUT]))
         if CONF_FLUSH_TIMEOUT in config:
             cg.add(var.set_flush_timeout(config[CONF_FLUSH_TIMEOUT]))
+        if CONF_CLOCK_SOURCE in config:
+            cg.add(var.set_clock_source(config[CONF_CLOCK_SOURCE]))
     cg.add(var.set_stop_bits(config[CONF_STOP_BITS]))
     cg.add(var.set_data_bits(config[CONF_DATA_BITS]))
     cg.add(var.set_parity(config[CONF_PARITY]))

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -9,6 +9,7 @@
 #include "driver/gpio.h"
 #include "esp_private/gpio.h"
 #include "soc/gpio_num.h"
+#include "soc/soc_caps.h"
 #include "soc/uart_pins.h"
 
 #ifdef USE_UART_WAKE_LOOP_ON_RX
@@ -35,6 +36,64 @@ static const char *const TAG = "uart.idf";
 /// causing TX data to loop back into RX on the same pin.
 static constexpr bool is_default_uart0_pin(int8_t pin_num) {
   return pin_num == U0TXD_GPIO_NUM || pin_num == U0RXD_GPIO_NUM;
+}
+
+/// Resolve the ESPHome clock source selection to the ESP-IDF uart_sclk_t value.
+/// Returns whether the selection is available on the target chip; an unsupported
+/// source resolves to UART_SCLK_DEFAULT and returns false. When out_clk is
+/// non-null it receives the resolved value (pass nullptr to only query support).
+/// Each case is guarded by the same SOC_UART_SUPPORT_* macro that gates the
+/// corresponding uart_sclk_t enumerator, so an unsupported source is compiled out
+/// and falls through to the default branch.
+static bool resolve_clock_source(UARTClockSource clock_source, uart_sclk_t *out_clk = nullptr) {
+  uart_sclk_t clk = UART_SCLK_DEFAULT;
+  bool supported = true;
+  switch (clock_source) {
+    case UART_CLOCK_SOURCE_DEFAULT:
+      break;
+#if SOC_UART_SUPPORT_APB_CLK
+    case UART_CLOCK_SOURCE_APB:
+      clk = UART_SCLK_APB;
+      break;
+#endif
+#if SOC_UART_SUPPORT_XTAL_CLK
+    case UART_CLOCK_SOURCE_XTAL:
+      clk = UART_SCLK_XTAL;
+      break;
+#endif
+#if SOC_UART_SUPPORT_RTC_CLK
+    case UART_CLOCK_SOURCE_RTC:
+      clk = UART_SCLK_RTC;
+      break;
+#endif
+#if SOC_UART_SUPPORT_REF_TICK
+    case UART_CLOCK_SOURCE_REF_TICK:
+      clk = UART_SCLK_REF_TICK;
+      break;
+#endif
+    default:
+      supported = false;
+      break;
+  }
+  if (out_clk != nullptr)
+    *out_clk = clk;
+  return supported;
+}
+
+static const char *clock_source_to_str(UARTClockSource clock_source) {
+  switch (clock_source) {
+    case UART_CLOCK_SOURCE_APB:
+      return "APB";
+    case UART_CLOCK_SOURCE_XTAL:
+      return "XTAL";
+    case UART_CLOCK_SOURCE_RTC:
+      return "RTC";
+    case UART_CLOCK_SOURCE_REF_TICK:
+      return "REF_TICK";
+    case UART_CLOCK_SOURCE_DEFAULT:
+    default:
+      return "DEFAULT";
+  }
 }
 
 uart_config_t IDFUARTComponent::get_config_() {
@@ -70,7 +129,7 @@ uart_config_t IDFUARTComponent::get_config_() {
   uart_config.parity = parity;
   uart_config.stop_bits = this->stop_bits_ == 1 ? UART_STOP_BITS_1 : UART_STOP_BITS_2;
   uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
-  uart_config.source_clk = UART_SCLK_DEFAULT;
+  resolve_clock_source(this->clock_source_, &uart_config.source_clk);
   uart_config.rx_flow_ctrl_thresh = 122;
 
   return uart_config;
@@ -153,6 +212,10 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   // rate or framing settings. Calling uart_param_config here ensures the requested
   // settings are applied after the reset and before pin routing, inversion, and
   // threshold configuration.
+  if (!resolve_clock_source(this->clock_source_)) {
+    ESP_LOGW(TAG, "Clock source %s is not available on this chip, using default",
+             clock_source_to_str(this->clock_source_));
+  }
   uart_config_t uart_config = this->get_config_();
   err = uart_param_config(this->uart_num_, &uart_config);
   if (err != ESP_OK) {
@@ -265,16 +328,22 @@ void IDFUARTComponent::dump_config() {
   if (this->flush_timeout_ms_ > 0) {
     ESP_LOGCONFIG(TAG, "  Flush Timeout: %" PRIu32 " ms", this->flush_timeout_ms_);
   }
+  const char *clock_source = clock_source_to_str(this->clock_source_);
+  if (!resolve_clock_source(this->clock_source_)) {
+    clock_source = "DEFAULT (requested source unavailable)";
+  }
   ESP_LOGCONFIG(TAG,
                 "  Baud Rate: %" PRIu32 " baud\n"
                 "  Data Bits: %u\n"
                 "  Parity: %s\n"
-                "  Stop bits: %u"
+                "  Stop bits: %u\n"
+                "  Clock Source: %s"
 #ifdef USE_UART_WAKE_LOOP_ON_RX
                 "\n  Wake on data RX: ENABLED"
 #endif
                 ,
-                this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
+                this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_,
+                clock_source);
   this->check_logger_conflict();
 }
 

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -11,6 +11,22 @@
 
 namespace esphome::uart {
 
+/// UART peripheral clock source.
+///
+/// Selects the clock that drives the UART baud-rate generator. The default
+/// tracks the APB clock, whose frequency changes when ESP-IDF Dynamic
+/// Frequency Scaling (CONFIG_PM_ENABLE) is active, causing baud-rate drift.
+/// Selecting XTAL or REF_TICK keeps the baud rate stable because those clocks
+/// are independent of APB. Available sources differ per ESP32 variant; an
+/// unsupported selection falls back to the default with a logged warning.
+enum UARTClockSource : uint8_t {
+  UART_CLOCK_SOURCE_DEFAULT = 0,
+  UART_CLOCK_SOURCE_APB,
+  UART_CLOCK_SOURCE_XTAL,
+  UART_CLOCK_SOURCE_RTC,
+  UART_CLOCK_SOURCE_REF_TICK,
+};
+
 /// ESP-IDF UART driver wrapper.
 ///
 /// Thread safety: All public methods must only be called from the main loop.
@@ -34,6 +50,8 @@ class IDFUARTComponent : public UARTComponent, public Component {
   UARTFlushResult flush() override;
 
   void set_flush_timeout(uint32_t flush_timeout_ms) override { this->flush_timeout_ms_ = flush_timeout_ms; }
+
+  void set_clock_source(UARTClockSource clock_source) { this->clock_source_ = clock_source; }
 
   uint8_t get_hw_serial_number() { return this->uart_num_; }
 
@@ -60,6 +78,7 @@ class IDFUARTComponent : public UARTComponent, public Component {
   bool has_peek_{false};
   uint8_t peek_byte_;
   uint32_t flush_timeout_ms_{0};  ///< 0 means wait indefinitely (portMAX_DELAY).
+  UARTClockSource clock_source_{UART_CLOCK_SOURCE_DEFAULT};
 
 #ifdef USE_UART_WAKE_LOOP_ON_RX
   // ISR callback for UART RX data notification — wakes the main loop directly.

--- a/tests/components/uart/test.esp32-c3-idf.yaml
+++ b/tests/components/uart/test.esp32-c3-idf.yaml
@@ -24,5 +24,6 @@ uart:
     tx_pin: 18
     rx_pin: 19
     baud_rate: 115200
+    clock_source: XTAL
     debug:
       debug_prefix: "[UART1] "

--- a/tests/components/uart/test.esp32-idf.yaml
+++ b/tests/components/uart/test.esp32-idf.yaml
@@ -28,6 +28,7 @@ uart:
     tx_pin: 21
     rx_pin: 22
     baud_rate: 115200
+    clock_source: REF_TICK
     debug:
       debug_prefix: "[UART1] "
   - id: uart_debug_custom


### PR DESCRIPTION
# What does this implement/fix?                                                                                                                                                               

Adds a `clock_source` option to the ESP32 UART bus, exposing the ESP-IDF `uart_config_t::source_clk` field. It accepts `DEFAULT`, `APB`, `XTAL`, `RTC`, and `REF_TICK`.

By default the ESP-IDF UART component hardcodes the clock source to `UART_SCLK_DEFAULT`, which on most ESP32 variants tracks the APB clock. When ESP-IDF Dynamic Frequency Scaling is enabled (`CONFIG_PM_ENABLE` + `CONFIG_PM_DFS_INIT_AUTO`), the APB clock changes frequency at runtime, which drifts the UART baud rate and corrupts communication. Selecting `XTAL` or `REF_TICK` sources the UART from a clock that is independent of APB, keeping the baud rate stable while DFS is active.

This is the ESP-IDF-component equivalent of the Arduino-only change in the closed PR #10238; that component no longer exists, as ESP32 (both Arduino and ESP-IDF frameworks) now uses `uart_component_esp_idf.cpp`.

Implementation notes:
- The selection maps to `uart_sclk_t` in `get_config_()`. Each case is guarded by the same `SOC_UART_SUPPORT_*` macro that gates the corresponding `uart_sclk_t` enumerator in ESP-IDF, so a source not available on the target variant is compiled out and falls back to `UART_SCLK_DEFAULT` with a logged warning — never a compile error.
- `dump_config()` reports the effective source; if the requested source is unavailable on the variant, it is shown as `DEFAULT (requested source unavailable)`.
- Default behavior is unchanged: omitting the option keeps `UART_SCLK_DEFAULT`.

Verified on real hardware: an ESP32-S3 running a Modbus RTU device at 9600 baud. With DFS enabled and the default clock source, the bus was flooded with `modbus: Stop waiting for response` timeouts. With `clock_source: XTAL`, all Modbus reads succeed and idle power dropped noticeably as DFS is now usable. Also, ensured that dynamic scaling actualy does it job (adhoc profiling via esp_pm_impl_dump_stats()`):

```
  [22:30:26.171]Mode stats:
  [22:30:26.171]Mode      CPU_freq    Time(us)    Time(%)
  [22:30:26.171]APB_MIN   40 M        44871981    72%
  [22:30:26.171]APB_MAX   80 M        0           0 %
  [22:30:26.171]CPU_MAX   240M        17244080    27%
```

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
- fixes N/A — related prior art: #10238 (closed, Arduino-only)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
- esphome/esphome-docs#6641

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
  # Example config.yaml
  uart:
    - id: uart_bus
      tx_pin: GPIO17
      rx_pin: GPIO18
      baud_rate: 9600
      clock_source: XTAL
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
