### PR TITLE
[ci] Move ha-addon and schema release triggers to version-notifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,74 +212,6 @@ jobs:
           docker buildx imagetools create $(jq -Rcnr 'inputs | . / "," | map("-t " + .) | join(" ")' <<< "${{ steps.tags.outputs.tags}}") \
             $(printf '${{ steps.tags.outputs.image }}@sha256:%s ' *)
 
-  deploy-ha-addon-repo:
-    if: github.repository == 'esphome/esphome' && needs.init.outputs.branch_build == 'false'
-    runs-on: ubuntu-latest
-    needs:
-      - init
-      - deploy-manifest
-    steps:
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
-          owner: esphome
-          repositories: home-assistant-addon
-          permission-actions: write  # actions.createWorkflowDispatch on the target repo (only API call made with this token)
-
-      - name: Trigger Workflow
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            let description = "ESPHome";
-            if (context.eventName == "release") {
-              description = ${{ toJSON(github.event.release.body) }};
-            }
-            github.rest.actions.createWorkflowDispatch({
-              owner: "esphome",
-              repo: "home-assistant-addon",
-              workflow_id: "bump-version.yml",
-              ref: "main",
-              inputs: {
-                version: "${{ needs.init.outputs.tag }}",
-                content: description
-              }
-            })
-
-  deploy-esphome-schema:
-    if: github.repository == 'esphome/esphome' && needs.init.outputs.branch_build == 'false'
-    runs-on: ubuntu-latest
-    needs: [init]
-    environment: ${{ needs.init.outputs.deploy_env }}
-    steps:
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
-          owner: esphome
-          repositories: esphome-schema
-          permission-actions: write  # actions.createWorkflowDispatch on the target repo (only API call made with this token)
-
-      - name: Trigger Workflow
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: "esphome",
-              repo: "esphome-schema",
-              workflow_id: "generate-schemas.yml",
-              ref: "main",
-              inputs: {
-                version: "${{ needs.init.outputs.tag }}",
-              }
-            })
-
   version-notifier:
     if: github.repository == 'esphome/esphome' && needs.init.outputs.branch_build == 'false'
     runs-on: ubuntu-latest
@@ -302,7 +234,7 @@ jobs:
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
-            github.rest.actions.createWorkflowDispatch({
+            await github.rest.actions.createWorkflowDispatch({
               owner: "esphome",
               repo: "version-notifier",
               workflow_id: "notify.yml",


### PR DESCRIPTION
# What does this implement/fix?

Move the `ha-addon` and `schema` downstream-trigger jobs out of `release.yml` into the `esphome/version-notifier` repo. The remaining `version-notifier` job in this workflow is now the single fan-out point: it dispatches `notify.yml`, and subscriber workflows in `version-notifier` (`trigger-ha-addon.yml`, `trigger-schema.yml`, and the existing `update-firmware-repos.yml`) handle the actual dispatch to `home-assistant-addon` and `esphome-schema`. This keeps `release.yml` focused on producing the release artefacts and centralises all "react to a new release" logic in `version-notifier`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — workflow-only change

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome/esphome-docs](https://github.com/esphome/esphome-docs).

---

One of three coupled PRs:

- esphome/home-assistant-addon#237 — drops the `content` input from `bump-version.yml` and fetches the release body via `gh`.
- esphome/version-notifier#12 — adds the `trigger-ha-addon.yml` and `trigger-schema.yml` subscriber workflows.
- This PR — removes `deploy-ha-addon-repo` and `deploy-esphome-schema` from `release.yml`.

Land esphome/home-assistant-addon#237 before this one to avoid a window where `release.yml` is passing a `content` input that no longer exists on the addon workflow.