### PR TITLE
[light] Add light.effect.next / light.effect.previous actions

### DIFF
--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -87,9 +87,21 @@ class EffectRef:
 
 
 @dataclass
+class EffectCycleRef:
+    """A pending light.effect.next/previous action to validate.
+
+    Records that the referenced light needs at least one effect configured.
+    """
+
+    light_id: ID
+    component_path: list[str | int]
+
+
+@dataclass
 class LightData:
     gamma_tables: dict = field(default_factory=dict)  # gamma_value -> fwd_arr
     effect_refs: list[EffectRef] = field(default_factory=list)
+    effect_cycle_refs: list[EffectCycleRef] = field(default_factory=list)
 
 
 def _get_data() -> LightData:
@@ -160,13 +172,15 @@ def _final_validate(config: ConfigType) -> ConfigType:
     this never runs — but the ID validator will catch the missing light ID separately.
     """
     data = _get_data()
-    if not data.effect_refs:
+    if not data.effect_refs and not data.effect_cycle_refs:
         return config
 
-    # Drain the list so we only validate once even though
+    # Drain the lists so we only validate once even though
     # FINAL_VALIDATE_SCHEMA runs for each light platform instance.
     refs = data.effect_refs
     data.effect_refs = []
+    cycle_refs = data.effect_cycle_refs
+    data.effect_cycle_refs = []
 
     fconf = fv.full_config.get()
 
@@ -185,6 +199,21 @@ def _final_validate(config: ConfigType) -> ConfigType:
                 f"Effect '{ref.effect_name}' not found for light "
                 f"'{ref.light_id}'. "
                 f"Available effects: {available_effects_str(effects)}",
+                path=[cv.ROOT_CONFIG_PATH] + ref.component_path,
+            )
+
+    for ref in cycle_refs:
+        try:
+            light_path = fconf.get_path_for_id(ref.light_id)[:-1]
+            light_config = fconf.get_config_for_path(light_path)
+        except KeyError:
+            continue
+
+        if not light_config.get(CONF_EFFECTS):
+            raise cv.FinalExternalInvalid(
+                f"Light '{ref.light_id}' has no effects configured, but a "
+                f"'light.effect.next' or 'light.effect.previous' action "
+                f"references it. Add at least one effect to the light.",
                 path=[cv.ROOT_CONFIG_PATH] + ref.component_path,
             )
 

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -104,6 +104,47 @@ template<bool HasTransitionLength, typename... Ts> class DimRelativeAction : pub
       transition_length_{};
 };
 
+// Cycle through the light's configured effects. `Forward` selects direction
+// at compile time so the chosen branch is the only one that gets instantiated
+// per action site. `include_none` is runtime so a single set of templates
+// covers both the "wrap through None" and "skip None" variants.
+template<bool Forward, typename... Ts> class LightEffectCycleAction : public Action<Ts...> {
+ public:
+  explicit LightEffectCycleAction(LightState *parent) : parent_(parent) {}
+
+  void set_include_none(bool include_none) { this->include_none_ = include_none; }
+
+  void play(const Ts &...) override {
+    size_t count = this->parent_->get_effect_count();
+    if (count == 0) {
+      return;
+    }
+    uint32_t current = this->parent_->get_current_effect_index();
+    uint32_t next;
+    if (this->include_none_) {
+      uint32_t total = static_cast<uint32_t>(count) + 1;
+      if constexpr (Forward) {
+        next = (current + 1) % total;
+      } else {
+        next = (current + total - 1) % total;
+      }
+    } else {
+      if constexpr (Forward) {
+        next = (current % static_cast<uint32_t>(count)) + 1;
+      } else {
+        next = (current <= 1) ? static_cast<uint32_t>(count) : current - 1;
+      }
+    }
+    auto call = this->parent_->turn_on();
+    call.set_effect(next);
+    call.perform();
+  }
+
+ protected:
+  LightState *parent_;
+  bool include_none_{false};
+};
+
 template<typename... Ts> class LightIsOnCondition : public Condition<Ts...> {
  public:
   explicit LightIsOnCondition(LightState *state) : state_(state) {}

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -306,7 +306,7 @@ async def _light_effect_cycle_to_code(config, action_id, template_arg, forward: 
     paren = await cg.get_variable(config[CONF_ID])
     cycle_template_arg = cg.TemplateArguments(forward, *template_arg)
     var = cg.new_Pvariable(action_id, cycle_template_arg, paren)
-    cg.add(var.set_include_off(config[CONF_INCLUDE_NONE]))
+    cg.add(var.set_include_none(config[CONF_INCLUDE_NONE]))
     return var
 
 

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -26,8 +26,8 @@ from esphome.const import (
     CONF_WARM_WHITE,
     CONF_WHITE,
 )
-from esphome.core import CORE, EsphomeError, Lambda
-from esphome.cpp_generator import LambdaExpression
+from esphome.core import CORE, ID, EsphomeError, Lambda
+from esphome.cpp_generator import LambdaExpression, MockObj, TemplateArgsType
 from esphome.types import ConfigType
 
 from .types import (
@@ -288,7 +288,12 @@ LIGHT_EFFECT_CYCLE_ACTION_SCHEMA = automation.maybe_simple_id(
     LIGHT_EFFECT_CYCLE_ACTION_SCHEMA,
     synchronous=True,
 )
-async def light_effect_next_to_code(config, action_id, template_arg, args):
+async def light_effect_next_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     return await _light_effect_cycle_to_code(config, action_id, template_arg, True)
 
 
@@ -298,11 +303,21 @@ async def light_effect_next_to_code(config, action_id, template_arg, args):
     LIGHT_EFFECT_CYCLE_ACTION_SCHEMA,
     synchronous=True,
 )
-async def light_effect_previous_to_code(config, action_id, template_arg, args):
+async def light_effect_previous_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     return await _light_effect_cycle_to_code(config, action_id, template_arg, False)
 
 
-async def _light_effect_cycle_to_code(config, action_id, template_arg, forward: bool):
+async def _light_effect_cycle_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    forward: bool,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     cycle_template_arg = cg.TemplateArguments(forward, *template_arg)
     var = cg.new_Pvariable(action_id, cycle_template_arg, paren)

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -39,11 +39,14 @@ from .types import (
     DimRelativeAction,
     LightCall,
     LightControlAction,
+    LightEffectCycleAction,
     LightIsOffCondition,
     LightIsOnCondition,
     LightState,
     ToggleAction,
 )
+
+CONF_INCLUDE_NONE = "include_none"
 
 
 @automation.register_action(
@@ -251,6 +254,60 @@ async def light_control_to_code(config, action_id, template_arg, args):
         return_type=cg.void,
     )
     return cg.new_Pvariable(action_id, template_arg, paren, apply_lambda)
+
+
+def _record_effect_cycle_ref(config: ConfigType) -> ConfigType:
+    """Record a cycle-action reference for later validation against the target light."""
+    from . import EffectCycleRef, _get_data
+
+    _get_data().effect_cycle_refs.append(
+        EffectCycleRef(
+            light_id=config[CONF_ID],
+            component_path=path_context.get(),
+        )
+    )
+    return config
+
+
+LIGHT_EFFECT_CYCLE_ACTION_BASE_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.use_id(LightState),
+        cv.Optional(CONF_INCLUDE_NONE, default=False): cv.boolean,
+    }
+)
+LIGHT_EFFECT_CYCLE_ACTION_BASE_SCHEMA.add_extra(_record_effect_cycle_ref)
+
+LIGHT_EFFECT_CYCLE_ACTION_SCHEMA = automation.maybe_simple_id(
+    LIGHT_EFFECT_CYCLE_ACTION_BASE_SCHEMA
+)
+
+
+@automation.register_action(
+    "light.effect.next",
+    LightEffectCycleAction,
+    LIGHT_EFFECT_CYCLE_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def light_effect_next_to_code(config, action_id, template_arg, args):
+    return await _light_effect_cycle_to_code(config, action_id, template_arg, True)
+
+
+@automation.register_action(
+    "light.effect.previous",
+    LightEffectCycleAction,
+    LIGHT_EFFECT_CYCLE_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def light_effect_previous_to_code(config, action_id, template_arg, args):
+    return await _light_effect_cycle_to_code(config, action_id, template_arg, False)
+
+
+async def _light_effect_cycle_to_code(config, action_id, template_arg, forward: bool):
+    paren = await cg.get_variable(config[CONF_ID])
+    cycle_template_arg = cg.TemplateArguments(forward, *template_arg)
+    var = cg.new_Pvariable(action_id, cycle_template_arg, paren)
+    cg.add(var.set_include_off(config[CONF_INCLUDE_NONE]))
+    return var
 
 
 CONF_RELATIVE_BRIGHTNESS = "relative_brightness"

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -39,6 +39,7 @@ LIMIT_MODES = {
 # Actions
 ToggleAction = light_ns.class_("ToggleAction", automation.Action)
 LightControlAction = light_ns.class_("LightControlAction", automation.Action)
+LightEffectCycleAction = light_ns.class_("LightEffectCycleAction", automation.Action)
 DimRelativeAction = light_ns.class_("DimRelativeAction", automation.Action)
 AddressableSet = light_ns.class_("AddressableSet", automation.Action)
 LightIsOnCondition = light_ns.class_("LightIsOnCondition", automation.Condition)

--- a/tests/component_tests/light/test_effect_validation.py
+++ b/tests/component_tests/light/test_effect_validation.py
@@ -9,13 +9,17 @@ import pytest
 
 from esphome import config_validation as cv
 from esphome.components.light import (
+    EffectCycleRef,
     EffectRef,
     _final_validate,
     _get_data,
     available_effects_str,
     find_effect_index,
 )
-from esphome.components.light.automation import _record_effect_ref
+from esphome.components.light.automation import (
+    _record_effect_cycle_ref,
+    _record_effect_ref,
+)
 from esphome.config import Config, path_context
 from esphome.const import CONF_EFFECT, CONF_EFFECTS, CONF_ID, CONF_NAME
 from esphome.core import ID, Lambda
@@ -215,6 +219,111 @@ def test_final_validate_drains_refs() -> None:
         fv.full_config.reset(token)
 
 
+# --- _final_validate: EffectCycleRef ---
+
+
+def _setup_cycle_final_validate(
+    cycle_refs: list[EffectCycleRef],
+    light_configs: list[ConfigType],
+    declare_ids: list[tuple[ID, list[str | int]]],
+) -> Token:
+    """Set up CORE.data and fv.full_config for EffectCycleRef final_validate tests."""
+    data = _get_data()
+    data.effect_cycle_refs = cycle_refs
+
+    full_conf = Config()
+    full_conf["light"] = light_configs
+    for id_, path in declare_ids:
+        full_conf.declare_ids.append((id_, path))
+
+    return fv.full_config.set(full_conf)
+
+
+def test_final_validate_cycle_accepts_light_with_effects() -> None:
+    """Cycle ref against a light with effects should not raise."""
+    light_id = ID("led1", is_declaration=True)
+    token = _setup_cycle_final_validate(
+        cycle_refs=[
+            EffectCycleRef(light_id=light_id, component_path=["esphome"]),
+        ],
+        light_configs=[{CONF_ID: light_id, CONF_EFFECTS: _make_effects("Fast Pulse")}],
+        declare_ids=[(light_id, ["light", 0, CONF_ID])],
+    )
+    try:
+        _final_validate({})
+    finally:
+        fv.full_config.reset(token)
+
+
+def test_final_validate_cycle_rejects_light_without_effects_key() -> None:
+    """Cycle ref against a light with no CONF_EFFECTS key should raise."""
+    light_id = ID("led1", is_declaration=True)
+    token = _setup_cycle_final_validate(
+        cycle_refs=[
+            EffectCycleRef(light_id=light_id, component_path=["esphome"]),
+        ],
+        light_configs=[{CONF_ID: light_id}],
+        declare_ids=[(light_id, ["light", 0, CONF_ID])],
+    )
+    try:
+        with pytest.raises(cv.FinalExternalInvalid, match="no effects configured"):
+            _final_validate({})
+    finally:
+        fv.full_config.reset(token)
+
+
+def test_final_validate_cycle_rejects_light_with_empty_effects() -> None:
+    """Cycle ref against a light with empty effects list should raise."""
+    light_id = ID("led1", is_declaration=True)
+    token = _setup_cycle_final_validate(
+        cycle_refs=[
+            EffectCycleRef(light_id=light_id, component_path=["esphome"]),
+        ],
+        light_configs=[{CONF_ID: light_id, CONF_EFFECTS: []}],
+        declare_ids=[(light_id, ["light", 0, CONF_ID])],
+    )
+    try:
+        with pytest.raises(cv.FinalExternalInvalid, match="no effects configured"):
+            _final_validate({})
+    finally:
+        fv.full_config.reset(token)
+
+
+def test_final_validate_cycle_unknown_light_id_skipped() -> None:
+    """Cycle refs to unknown light IDs should be silently skipped."""
+    data = _get_data()
+    data.effect_cycle_refs = [
+        EffectCycleRef(
+            light_id=ID("nonexistent", is_declaration=True),
+            component_path=["esphome"],
+        )
+    ]
+
+    full_conf = Config()
+    token = fv.full_config.set(full_conf)
+    try:
+        _final_validate({})
+    finally:
+        fv.full_config.reset(token)
+
+
+def test_final_validate_drains_cycle_refs() -> None:
+    """Cycle refs should be drained after validation to avoid redundant runs."""
+    light_id = ID("led1", is_declaration=True)
+    token = _setup_cycle_final_validate(
+        cycle_refs=[
+            EffectCycleRef(light_id=light_id, component_path=["esphome"]),
+        ],
+        light_configs=[{CONF_ID: light_id, CONF_EFFECTS: _make_effects("Fast Pulse")}],
+        declare_ids=[(light_id, ["light", 0, CONF_ID])],
+    )
+    try:
+        _final_validate({})
+        assert _get_data().effect_cycle_refs == []
+    finally:
+        fv.full_config.reset(token)
+
+
 # --- _record_effect_ref ---
 
 
@@ -278,3 +387,19 @@ def test_record_effect_ref_skips_no_effect_key() -> None:
     config: ConfigType = {CONF_ID: ID("led1", is_declaration=True)}
     _record_effect_ref(config)
     assert _get_data().effect_refs == []
+
+
+# --- _record_effect_cycle_ref ---
+
+
+@pytest.mark.usefixtures("_path_ctx")
+def test_record_effect_cycle_ref() -> None:
+    """Cycle-action config should be recorded with light_id and path."""
+    light_id = ID("led1", is_declaration=True)
+    config: ConfigType = {CONF_ID: light_id}
+    result = _record_effect_cycle_ref(config)
+    assert result is config
+    data = _get_data()
+    assert len(data.effect_cycle_refs) == 1
+    assert data.effect_cycle_refs[0].light_id is light_id
+    assert data.effect_cycle_refs[0].component_path == ["esphome"]

--- a/tests/components/light/common.yaml
+++ b/tests/components/light/common.yaml
@@ -103,6 +103,16 @@ esphome:
             - light.turn_on:
                 id: test_monochromatic_light
                 effect: !lambda 'return iteration > 1 ? "Strobe" : "none";'
+      # Cycle through configured effects (skip "None")
+      - light.effect.next: test_monochromatic_light
+      - light.effect.previous: test_monochromatic_light
+      # Cycle through effects including "None"
+      - light.effect.next:
+          id: test_monochromatic_light
+          include_none: true
+      - light.effect.previous:
+          id: test_monochromatic_light
+          include_none: true
       - light.dim_relative:
           id: test_monochromatic_light
           relative_brightness: 5%


### PR DESCRIPTION
# What does this implement/fix?

Adds two new automation actions for the \`light\` component: \`light.effect.next\` and \`light.effect.previous\`. They cycle through the effects configured on a light without requiring the user to hardcode effect names in lambdas or maintain a sidecar state variable.

A boolean \`include_none\` option (default \`false\`) controls whether the implicit "None" (no effect) slot participates in the cycle. With \`include_none: false\`, only the user-defined effects rotate; with \`include_none: true\`, the cycle passes through an un-effected state when wrapping around.

Cycle direction is selected at compile time via a template parameter on \`LightEffectCycleAction<bool Forward, Ts...>\`, so each call site only instantiates the branch it actually uses.

The referenced light must have at least one effect configured. This is checked at configuration validation time (in \`FINAL_VALIDATE_SCHEMA\`) by reusing the existing pending-ref + drain pattern that \`EffectRef\` already established for static effect-name validation. A new \`EffectCycleRef\` is recorded via \`add_extra\` on the action schema and validated against the target light's \`effects:\` list.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6649

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
light:
  - platform: monochromatic
    id: my_light
    output: my_output
    effects:
      - strobe:
      - flicker:
      - pulse:

binary_sensor:
  - platform: gpio
    pin: GPIO0
    on_press:
      - light.effect.next: my_light
    on_double_click:
      - light.effect.previous:
          id: my_light
          include_none: true
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
