### PR TITLE
[espidf] Print RAM summary on ESP32-S3 / unified-DIRAM variants

### DIFF
--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -94,11 +94,26 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         _LOGGER.debug("Skipping size summary: %s", e)
         return
 
-    dram = data.get("memory_types", {}).get("DRAM") or {}
+    memory_types = data.get("memory_types", {})
+    dram = memory_types.get("DRAM") or memory_types.get("DIRAM") or {}
     ram_used = dram.get("used")
     ram_total = dram.get("size")
     if ram_total and ram_used is not None:
-        print(f"RAM:   {_format_bar(ram_used, ram_total)}")
+        # On unified-DIRAM variants (S2, S3, C-series, H2, P4) ``.iram0.text``
+        # shares the DIRAM region but is flash-backed via the cache window,
+        # not actual SRAM consumption. Strip it from both used and total so
+        # the percentage reflects data RAM pressure rather than raw region
+        # utilization. No-op on the original ESP32, where ``.iram0.text``
+        # lives in a separate IRAM region.
+        text_size = sum(
+            sec.get("size", 0)
+            for sec in (dram.get("sections") or {}).values()
+            if sec.get("abbrev_name") == ".text"
+        )
+        ram_used -= text_size
+        ram_total -= text_size
+        if ram_total > 0:
+            print(f"RAM:   {_format_bar(ram_used, ram_total)}")
 
     image_size = data.get("image_size")
     if image_size is None or partitions_csv is None:

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -100,11 +100,14 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
     ram_total = ram_region.get("size")
     if ram_total and ram_used is not None:
         # On unified-DIRAM variants (S2, S3, C-series, H2, P4) any ``.text``
-        # section in this region (e.g. ``.iram0.text``) is flash-backed via
-        # the cache window, not actual SRAM consumption. Strip it from both
-        # used and total so the percentage reflects data RAM pressure rather
-        # than raw region utilization. No-op on the original ESP32, where
-        # ``.text`` sections live in a separate IRAM region instead.
+        # section in this region (e.g. ``.iram0.text``) is code, not data --
+        # it still consumes SRAM, but it's reported on its own row in the
+        # per-region table and isn't what the RAM line is meant to track.
+        # Strip it from both used and total so the percentage matches the
+        # original ESP32's ``DRAM`` accounting (which excludes code by
+        # virtue of code living in a separate ``IRAM`` region there) and
+        # reflects data RAM pressure (.bss/.data/.noinit). No-op on the
+        # original ESP32, where ``.text`` sections never land in DRAM.
         text_size = sum(
             sec.get("size", 0)
             for sec in (ram_region.get("sections") or {}).values()

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -99,19 +99,7 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
     ram_used = ram_region.get("used")
     ram_total = ram_region.get("size")
     if ram_total and ram_used is not None:
-        # Strip code from the RAM line so unified-DIRAM variants (S2, S3,
-        # C/H/P) report data-side pressure only, matching the original
-        # ESP32 where code lives in a separate IRAM region. No-op on the
-        # original ESP32: .text never lands in DRAM there.
-        text_size = sum(
-            sec.get("size", 0)
-            for sec in (ram_region.get("sections") or {}).values()
-            if sec.get("abbrev_name") == ".text"
-        )
-        ram_used -= text_size
-        ram_total -= text_size
-        if ram_total > 0:
-            print(f"RAM:   {_format_bar(ram_used, ram_total)}")
+        print(f"RAM:   {_format_bar(ram_used, ram_total)}")
 
     image_size = data.get("image_size")
     if image_size is None or partitions_csv is None:

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -99,15 +99,10 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
     ram_used = ram_region.get("used")
     ram_total = ram_region.get("size")
     if ram_total and ram_used is not None:
-        # On unified-DIRAM variants (S2, S3, C-series, H2, P4) any ``.text``
-        # section in this region (e.g. ``.iram0.text``) is code, not data --
-        # it still consumes SRAM, but it's reported on its own row in the
-        # per-region table and isn't what the RAM line is meant to track.
-        # Strip it from both used and total so the percentage matches the
-        # original ESP32's ``DRAM`` accounting (which excludes code by
-        # virtue of code living in a separate ``IRAM`` region there) and
-        # reflects data RAM pressure (.bss/.data/.noinit). No-op on the
-        # original ESP32, where ``.text`` sections never land in DRAM.
+        # Strip code from the RAM line so unified-DIRAM variants (S2, S3,
+        # C/H/P) report data-side pressure only, matching the original
+        # ESP32 where code lives in a separate IRAM region. No-op on the
+        # original ESP32: .text never lands in DRAM there.
         text_size = sum(
             sec.get("size", 0)
             for sec in (ram_region.get("sections") or {}).values()

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -95,19 +95,19 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         return
 
     memory_types = data.get("memory_types", {})
-    dram = memory_types.get("DRAM") or memory_types.get("DIRAM") or {}
-    ram_used = dram.get("used")
-    ram_total = dram.get("size")
+    ram_region = memory_types.get("DRAM") or memory_types.get("DIRAM") or {}
+    ram_used = ram_region.get("used")
+    ram_total = ram_region.get("size")
     if ram_total and ram_used is not None:
-        # On unified-DIRAM variants (S2, S3, C-series, H2, P4) ``.iram0.text``
-        # shares the DIRAM region but is flash-backed via the cache window,
-        # not actual SRAM consumption. Strip it from both used and total so
-        # the percentage reflects data RAM pressure rather than raw region
-        # utilization. No-op on the original ESP32, where ``.iram0.text``
-        # lives in a separate IRAM region.
+        # On unified-DIRAM variants (S2, S3, C-series, H2, P4) any ``.text``
+        # section in this region (e.g. ``.iram0.text``) is flash-backed via
+        # the cache window, not actual SRAM consumption. Strip it from both
+        # used and total so the percentage reflects data RAM pressure rather
+        # than raw region utilization. No-op on the original ESP32, where
+        # ``.text`` sections live in a separate IRAM region instead.
         text_size = sum(
             sec.get("size", 0)
-            for sec in (dram.get("sections") or {}).values()
+            for sec in (ram_region.get("sections") or {}).values()
             if sec.get("abbrev_name") == ".text"
         )
         ram_used -= text_size

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -83,28 +83,25 @@ def test_print_summary_esp32_uses_dram(
 def test_print_summary_s3_falls_back_to_diram(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """ESP32-S3 with no DRAM key falls back to DIRAM and strips ``.iram0.text``."""
+    """ESP32-S3 with no DRAM key falls back to DIRAM and reports raw region usage."""
     size_json = _write_size_json(tmp_path, _s3_size_data())
     print_summary(size_json, partitions_csv=None)
     out = capsys.readouterr().out
-    # used = 104999 - 58051 = 46948; total = 341760 - 58051 = 283709
-    assert "used 46948 bytes from 283709 bytes" in out
+    assert "used 104999 bytes from 341760 bytes" in out
 
 
 def test_print_summary_skips_when_diram_total_collapses(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """If subtracting ``.text`` would zero out the total, drop the RAM line rather than divide by zero."""
+    """A zero-size region drops the RAM line rather than divide by zero."""
     size_json = _write_size_json(
         tmp_path,
         {
             "memory_types": {
                 "DIRAM": {
-                    "size": 1000,
-                    "used": 1000,
-                    "sections": {
-                        ".iram0.text": {"abbrev_name": ".text", "size": 1000},
-                    },
+                    "size": 0,
+                    "used": 0,
+                    "sections": {},
                 },
             },
         },

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -1,0 +1,131 @@
+"""Tests for esphome.espidf.size_summary.print_summary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from esphome.espidf.size_summary import print_summary
+
+
+def _write_size_json(tmp_path: Path, data: dict) -> Path:
+    """Drop a fake esp_idf_size.json under ``tmp_path`` and return the path."""
+    out = tmp_path / "esp_idf_size.json"
+    out.write_text(json.dumps(data))
+    return out
+
+
+def _esp32_size_data() -> dict:
+    """Synthetic esp_idf_size.json for the original ESP32 (split IRAM/DRAM)."""
+    return {
+        "image_size": 827455,
+        "memory_types": {
+            "DRAM": {
+                "size": 180736,
+                "used": 47332,
+                "sections": {
+                    ".dram0.bss": {"abbrev_name": ".bss", "size": 30616},
+                    ".dram0.data": {"abbrev_name": ".data", "size": 16716},
+                },
+            },
+            "IRAM": {
+                "size": 131072,
+                "used": 80351,
+                "sections": {
+                    ".iram0.text": {"abbrev_name": ".text", "size": 79323},
+                    ".iram0.vectors": {"abbrev_name": ".vectors", "size": 1028},
+                },
+            },
+        },
+    }
+
+
+def _s3_size_data() -> dict:
+    """Synthetic esp_idf_size.json for ESP32-S3 (unified DIRAM)."""
+    return {
+        "image_size": 724215,
+        "memory_types": {
+            "DIRAM": {
+                "size": 341760,
+                "used": 104999,
+                "sections": {
+                    ".iram0.text": {"abbrev_name": ".text", "size": 58051},
+                    ".dram0.bss": {"abbrev_name": ".bss", "size": 27088},
+                    ".dram0.data": {"abbrev_name": ".data", "size": 19708},
+                    ".noinit": {"abbrev_name": ".noinit", "size": 152},
+                },
+            },
+            "IRAM": {
+                "size": 16384,
+                "used": 16384,
+                "sections": {
+                    ".iram0.text": {"abbrev_name": ".text", "size": 15356},
+                    ".iram0.vectors": {"abbrev_name": ".vectors", "size": 1028},
+                },
+            },
+        },
+    }
+
+
+def test_print_summary_esp32_uses_dram(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Original ESP32: DRAM has no ``.text``, so RAM = DRAM.used / DRAM.size unchanged."""
+    size_json = _write_size_json(tmp_path, _esp32_size_data())
+    print_summary(size_json, partitions_csv=None)
+    out = capsys.readouterr().out
+    assert "RAM:" in out
+    assert "used 47332 bytes from 180736 bytes" in out
+
+
+def test_print_summary_s3_falls_back_to_diram(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """ESP32-S3 with no DRAM key falls back to DIRAM and strips ``.iram0.text``."""
+    size_json = _write_size_json(tmp_path, _s3_size_data())
+    print_summary(size_json, partitions_csv=None)
+    out = capsys.readouterr().out
+    # used = 104999 - 58051 = 46948; total = 341760 - 58051 = 283709
+    assert "used 46948 bytes from 283709 bytes" in out
+
+
+def test_print_summary_skips_when_diram_total_collapses(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """If subtracting ``.text`` would zero out the total, drop the RAM line rather than divide by zero."""
+    size_json = _write_size_json(
+        tmp_path,
+        {
+            "memory_types": {
+                "DIRAM": {
+                    "size": 1000,
+                    "used": 1000,
+                    "sections": {
+                        ".iram0.text": {"abbrev_name": ".text", "size": 1000},
+                    },
+                },
+            },
+        },
+    )
+    print_summary(size_json, partitions_csv=None)
+    out = capsys.readouterr().out
+    assert "RAM:" not in out
+
+
+def test_print_summary_handles_missing_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Missing size json is non-fatal and prints nothing."""
+    print_summary(tmp_path / "does_not_exist.json", partitions_csv=None)
+    assert capsys.readouterr().out == ""
+
+
+def test_print_summary_handles_no_memory_types(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A size json without ``memory_types`` still doesn't crash."""
+    size_json = _write_size_json(tmp_path, {"image_size": 0})
+    print_summary(size_json, partitions_csv=None)
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## What does this implement/fix?

Fixes a regression visible since #16394: the `RAM:` summary one-liner is silently dropped on every ESP32 variant with a unified-DIRAM memory layout (S2, S3, C2, C3, C5, C6, H2, P4 — basically every modern chip except the original ESP32).

The summary code at `esphome/espidf/size_summary.py:97` hard-coded a lookup for `memory_types["DRAM"]`. On unified-DIRAM chips, `esp_idf_size` reports the combined region under `"DIRAM"` instead, the lookup misses, and the line is skipped.

### Example: ESP32-S3 build (before this PR)

```
┃ Memory Type/Section ┃ Used [bytes] ┃ Used [%] ┃ Remain [bytes] ┃ Total [bytes] ┃
│ Flash Code          │       524420 │          │                │               │
│    .text            │       524420 │          │                │               │
│ DIRAM               │       104539 │    30.59 │         237221 │        341760 │
│    .text            │        57711 │    16.89 │                │               │
│    .bss             │        26864 │     7.86 │                │               │
│    .data            │        19812 │      5.8 │                │               │
│ IRAM                │        16384 │    100.0 │              0 │         16384 │
└─────────────────────┴──────────────┴──────────┴────────────────┴───────────────┘
Total image size: 724215 bytes (.bin may be padded larger)
Flash: [====      ]  39.5% (used 724215 bytes from 1835008 bytes)
                                    ^^^ no RAM line ^^^
```

### Example: ESP32 build (before this PR — works fine)

```
│ DRAM                  │        47332 │    26.19 │         133404 │        180736 │
...
RAM:   [===       ]  26.2% (used 47332 bytes from 180736 bytes)
Flash: [=====     ]  45.1% (used 827455 bytes from 1835008 bytes)
```

### Fix

Fall back to `DIRAM` when `DRAM` is absent in `memory_types`. The raw `used` / `size` from the linker map are reported as-is — same shape the original ESP32's DRAM row produces, just from the unified region on the chips that have one. Numbers match what users see in the per-region table immediately above.

For the S3 build shown above this PR prints:

```
RAM:   [===       ]  30.6% (used 104539 bytes from 341760 bytes)
```

### Backwards compatibility

No-op on the original ESP32: that chip's `memory_types` still has `DRAM`, the existing lookup wins, and the output is unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regressed in #16394 (the original RAM/Flash summary feature was tested only on the original ESP32).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — no user-visible API change, only fixes a missing log line.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No YAML schema changes. Verified manually by compiling for both
# esp32 and esp32-s3 variants with esp-idf framework and confirming
# the RAM: line is now printed for both.
```

## Checklist:

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
