### PR TITLE
[dashboard] Disable caching for dashboard edit responses

### DIFF
--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -1282,6 +1282,7 @@ class EditRequestHandler(BaseHandler):
         )
         if content is not None:
             self.set_header("Content-Type", "application/yaml")
+            self.set_header("Cache-Control", "no-store")
             self.write(content)
 
     def _read_file(self, filename: str, configuration: str) -> bytes | None:
@@ -1312,6 +1313,7 @@ class EditRequestHandler(BaseHandler):
         await loop.run_in_executor(None, write_file, filename, self.request.body)
         # Ensure the StorageJSON is updated as well
         DASHBOARD.entries.async_schedule_storage_json_update(filename)
+        self.set_header("Cache-Control", "no-store")
         self.set_status(200)
 
 


### PR DESCRIPTION
# What does this implement/fix?

Avoids that the browser does cache the yaml files and does not recognize that storing wasn't successful, as it's read back is from the browser cache.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

