### PR TITLE
[core] Add Codeberg as a supported git url

### DIFF
--- a/esphome/git.py
+++ b/esphome/git.py
@@ -253,6 +253,7 @@ def clone_or_update(
 
 
 GIT_DOMAINS = {
+    "codeberg": "codeberg.org",
     "github": "github.com",
     "gitlab": "gitlab.com",
 }
@@ -275,6 +276,8 @@ class GitFile:
     def raw_url(self) -> str:
         if self.ref is None:
             raise ValueError("URL has no ref")
+        if self.domain == "codeberg.org":
+            return f"https://codeberg.org/{self.owner}/{self.repo}/raw/branch/{self.ref}/{self.filename}"
         if self.domain == "github.com":
             return f"https://raw.githubusercontent.com/{self.owner}/{self.repo}/{self.ref}/{self.filename}"
         if self.domain == "gitlab.com":

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -277,7 +277,7 @@ class GitFile:
         if self.ref is None:
             raise ValueError("URL has no ref")
         if self.domain == "codeberg.org":
-            return f"https://codeberg.org/{self.owner}/{self.repo}/raw/branch/{self.ref}/{self.filename}"
+            return f"https://codeberg.org/{self.owner}/{self.repo}/raw/commit/{self.ref}/{self.filename}"
         if self.domain == "github.com":
             return f"https://raw.githubusercontent.com/{self.owner}/{self.repo}/{self.ref}/{self.filename}"
         if self.domain == "gitlab.com":


### PR DESCRIPTION
# What does this implement/fix?

Adds Codeberg as a supported Git URL for `dashboard_import` and short-form `packages`. 

> Codeberg is a democratic community-driven, non-profit software development platform operated by Codeberg e.V. and centered around Codeberg.org, a Forgejo-based software forge.\
Codeberg is not a for-profit corporation but an open community of free software enthusiasts providing a humane, non-commercial and privacy-friendly alternative to commercial services such as GitHub.

https://docs.codeberg.org/getting-started/what-is-codeberg/

I looked into adding tests but it would require hosting a file on Codeberg - I assume this is why the Gitlab URL does not have tests either.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #16497

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6653

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
dashboard_import:
  package_import_url: codeberg://elvinhome/ctrl-one/esphome/ctrl-one.yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
