### PR TITLE
[espidf] Drop version field from generated idf_component.yml

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2488,9 +2488,8 @@ def _write_sdkconfig():
 
 def _platformio_library_to_dependency(library: Library) -> tuple[str, dict[str, str]]:
     dependency: dict[str, str] = {}
-    name, version, path = generate_idf_component(library)
+    name, _version, path = generate_idf_component(library)
     dependency["override_path"] = str(path)
-    dependency["version"] = version
     return name, dependency
 
 

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -361,7 +361,8 @@ def _convert_library_to_component(library: Library) -> IDFComponent:
 
     #  Repository is provided directly
     if library.repository:
-        # Parse repository URL to extract name and version
+        # Parse repository URL: path becomes the component name, fragment
+        # becomes the git ref stored on GitSource.
         split_result = urlsplit(library.repository)
         if not split_result.fragment.strip():
             raise ValueError(f"Missing ref in URL {library.repository}")
@@ -595,21 +596,11 @@ def generate_idf_component_yml(component: IDFComponent) -> str:
         if "dependencies" not in data:
             data["dependencies"] = {}
 
-        # Add this dependency to dependencies
-        dep = {}
-
-        # Should use dependency.path as override path
-        try:
-            dep["override_path"] = str(dependency.path)
-        except RuntimeError as e:
-            # No local path: only a GitSource can substitute its URL.
-            if not isinstance(dependency.source, GitSource):
-                raise e
-            dep["git"] = dependency.source.url
-            if dependency.source.ref:
-                dep["version"] = dependency.source.ref
-
-        data["dependencies"][dependency.get_sanitized_name()] = dep
+        # Every dependency goes through _generate_idf_component →
+        # component.download() before this runs, so .path is always set.
+        data["dependencies"][dependency.get_sanitized_name()] = {
+            "override_path": str(dependency.path),
+        }
 
     return yaml_util.dump(data)
 

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -154,41 +154,6 @@ class IDFComponent:
         self.path = self.source.download(self.get_sanitized_name(), force=force)
 
 
-def _sanitize_version(version: str) -> str:
-    """
-    Sanitize a version string by removing common requirement prefixes or a leading v.
-
-    Args:
-        version: Version string to clean.
-
-    Returns:
-        Cleaned version string without common requirement symbols.
-    """
-    version = version.strip()
-
-    prefixes = (
-        "^",
-        "~=",
-        "~",
-        ">=",
-        "<=",
-        "==",
-        "!=",
-        ">",
-        "<",
-        "=",
-        "v",
-        "V",
-    )
-
-    for p in prefixes:
-        if version.startswith(p):
-            version = version[len(p) :]
-            break
-
-    return version.strip()
-
-
 def _get_package_from_pio_registry(
     username: str | None, pkgname: str, requirements: str
 ) -> tuple[str, str, str | None, str | None]:
@@ -405,8 +370,10 @@ def _convert_library_to_component(library: Library) -> IDFComponent:
         name = str(split_result.path).strip("/")
         name = name.removesuffix(".git")
 
-        # Sanitize version
-        version = _sanitize_version(split_result.fragment)
+        # IDF Component Manager only accepts "*", a 40-char commit hash, or
+        # semver here. The actual git ref is preserved in GitSource.ref;
+        # override_path makes this field cosmetic at build time.
+        version = "*"
         repository = urlunsplit(split_result._replace(fragment=""))
 
         source = GitSource(str(repository), split_result.fragment)
@@ -619,9 +586,6 @@ def generate_idf_component_yml(component: IDFComponent) -> str:
     if description:
         data["description"] = description
 
-    # Do not use the version from library.json/library.properties; it may be incorrect.
-    data["version"] = component.version
-
     repository = component.data.get("repository", {}).get("url", None)
     if repository:
         data["repository"] = repository
@@ -633,7 +597,6 @@ def generate_idf_component_yml(component: IDFComponent) -> str:
 
         # Add this dependency to dependencies
         dep = {}
-        dep["version"] = dependency.version
 
         # Should use dependency.path as override path
         try:
@@ -643,6 +606,8 @@ def generate_idf_component_yml(component: IDFComponent) -> str:
             if not isinstance(dependency.source, GitSource):
                 raise e
             dep["git"] = dependency.source.url
+            if dependency.source.ref:
+                dep["version"] = dependency.source.ref
 
         data["dependencies"][dependency.get_sanitized_name()] = dep
 

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -224,9 +224,9 @@ def test_generate_idf_component_yml_with_dependencies(tmp_component, tmp_path):
     )
 
 
-def test_generate_idf_component_yml_missing_path_reraises(tmp_component):
-    # A dep without a path and without a recognised source should re-raise
-    # the underlying RuntimeError instead of silently producing a bad manifest.
+def test_generate_idf_component_yml_missing_path_raises(tmp_component):
+    # A dep without a path is a contract violation — every dep is expected
+    # to have been downloaded before YAML generation. Raise loudly.
     dep = IDFComponent("foo/bar", "1.0", source=None)
 
     tmp_component.dependencies = [dep]

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -203,7 +203,7 @@ def test_generate_idf_component_yml_basic(tmp_component):
     tmp_component.data = {"description": "test", "repository": {"url": "http://aaa"}}
     result = generate_idf_component_yml(tmp_component)
 
-    assert result == "description: test\nversion: 1.0.0\nrepository: http://aaa\n"
+    assert result == "description: test\nrepository: http://aaa\n"
 
 
 def test_generate_idf_component_yml_with_dependencies(tmp_component, tmp_path):
@@ -217,10 +217,8 @@ def test_generate_idf_component_yml_with_dependencies(tmp_component, tmp_path):
 
     assert (
         result
-        == f"""version: 1.0.0
-dependencies:
+        == f"""dependencies:
   dep:
-    version: '1.0'
     override_path: {dep.path}
 """
     )
@@ -422,8 +420,20 @@ def test_convert_library_with_repository():
     result = _convert_library_to_component(lib)
 
     assert result.name == "foo/bar"
-    assert result.version == "1.2.3"
+    assert result.version == "*"
     assert isinstance(result.source, GitSource)
+    assert result.source.ref == "v1.2.3"
+
+
+def test_convert_library_with_branch_ref():
+    lib = Library("name", None, "https://github.com/foo/bar.git#some-branch")
+
+    result = _convert_library_to_component(lib)
+
+    assert result.name == "foo/bar"
+    assert result.version == "*"
+    assert isinstance(result.source, GitSource)
+    assert result.source.ref == "some-branch"
 
 
 def test_convert_library_missing_ref():


### PR DESCRIPTION
# What does this implement/fix?

`cg.add_library` with a `#fragment` URL (branch, commit SHA, or any value that isn't a semver or a 40-hex commit hash) gets rejected at IDF Component Manager manifest validation:

```
Invalid field "dependencies:owner/lib:version": Invalid version specification "<branch-name>"
```

The `version:` field was cosmetic in this code path — every dependency uses `override_path`, so IDF reads from the local disk regardless of what `version` says. `ComponentRequirement.validate_version_spec` accepts absent / `'*'` as "any", so omitting the field passes validation and lets arbitrary git refs (branch names, short SHAs) flow through.

Changes:

- `esphome/espidf/component.py` — drop `_sanitize_version`; git-source `version` becomes a placeholder `"*"` (actual ref still lives in `GitSource.ref`). Drop the project-level and library-level `version:` writes from `generate_idf_component_yml`. Drop the unreachable git-source fallback in the per-dep loop (every dep is downloaded via `_generate_idf_component` → `component.download()` before YAML generation, so `dependency.path` is always set; if it ever isn't, the `RuntimeError` from the `path` getter should surface, not be silently routed through `git:`).
- `esphome/components/esp32/__init__.py` — drop `dependency["version"] = version` in `_platformio_library_to_dependency`; not load-bearing once `override_path` is present.
- `tests/unit_tests/test_espidf_component.py` — update existing assertions, add regression test for branch-name URL fragments, rename `_reraises` test to `_raises` (no wrapper try/except to re-raise from anymore).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Reproduces with any `cg.add_library` that uses a non-semver `#fragment`. For instance, temporarily editing `esphome/components/heatpumpir/climate.py`:

```python
cg.add_library(
    "HeatpumpIR",
    None,
    "https://github.com/<owner>/arduino-heatpumpir.git#some-branch-name",
)
```

With a heatpumpir test config on ESP32 IDF, pre-PR fails at CMake configure with the validator error above; post-PR builds cleanly.

## Checklist:
  - [x] The code change is tested and works locally (verified end-to-end via heatpumpir ESP32 IDF build pulling from a branch-named git ref; previously failed manifest validation, now passes).
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).