### PR TITLE
[esp32] Fix sdkconfig int values silently clamped to default

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2004,7 +2004,8 @@ async def to_code(config):
     if not advanced[CONF_ENABLE_LWIP_MDNS_QUERIES]:
         add_idf_sdkconfig_option("CONFIG_LWIP_DNS_SUPPORT_MDNS_QUERIES", False)
     if not advanced[CONF_ENABLE_LWIP_BRIDGE_INTERFACE]:
-        add_idf_sdkconfig_option("CONFIG_LWIP_BRIDGEIF_MAX_PORTS", 0)
+        # Kconfig range is [1,63]; 0 gets clamped to the default.
+        add_idf_sdkconfig_option("CONFIG_LWIP_BRIDGEIF_MAX_PORTS", 1)
 
     _configure_lwip_max_sockets(conf)
 
@@ -2251,7 +2252,8 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_FATFS_VOLUME_COUNT", 2)
     elif advanced[CONF_DISABLE_FATFS]:
         add_idf_sdkconfig_option("CONFIG_FATFS_LFN_NONE", True)
-        add_idf_sdkconfig_option("CONFIG_FATFS_VOLUME_COUNT", 0)
+        # Kconfig range is [1,10]; 0 gets clamped to the default.
+        add_idf_sdkconfig_option("CONFIG_FATFS_VOLUME_COUNT", 1)
 
     for name, value in conf[CONF_SDKCONFIG_OPTIONS].items():
         add_idf_sdkconfig_option(name, RawSdkconfigValue(value))


### PR DESCRIPTION
# What does this implement/fix?

Two sdkconfig options were being written as `0` to disable a feature, but both had IDF Kconfig ranges starting at `1`. The values were rejected with a sdkconfig warning and silently clamped to the IDF default — defeating the "minimize footprint" intent the original PR (#13611) added them with.

- `CONFIG_FATFS_VOLUME_COUNT`: `0` → `1` (range `[1,10]`, default `2`)
- `CONFIG_LWIP_BRIDGEIF_MAX_PORTS`: `0` → `1` (range `[1,63]`, default `7`)

In both cases `MAX_PORTS` / `VOLUME_COUNT` only sizes static arrays — there's no Kconfig knob to compile out the underlying component itself, so the minimum (1) is the smallest legal value and matches the original intent.

These show up as `warning: user value 0 ... outside the active range ... falling back on defaults` in ESP-IDF builds.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  framework:
    type: esp-idf
    advanced:
      disable_fatfs: true
      enable_lwip_bridge_interface: false
```

Pre-PR: emits two `Invalid... falling back on defaults` warnings during sdkconfig generation. Post-PR: clean.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). — N/A; this only changes integer values written into the IDF sdkconfig, with no observable C++/Python surface to assert against in a unit test.