### PR TITLE
[esp32] Decouple esp-idf toolchain version check from PIO, honor framework source: override

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -797,8 +797,8 @@ def _resolve_framework_version(value):
 
     Normalises value[CONF_VERSION] to its string form and returns the parsed
     cv.Version. Shared between the PIO and esp-idf toolchain paths; toolchain-
-    specific concerns (source defaults, platform_version, recommended-version
-    warnings) live in the per-toolchain functions.
+    specific concerns (source defaults, platform_version) live in the per-
+    toolchain functions.
     """
     if value[CONF_VERSION] in PLATFORM_VERSION_LOOKUP:
         if value[CONF_TYPE] == FRAMEWORK_ARDUINO:
@@ -813,8 +813,17 @@ def _resolve_framework_version(value):
     if value[CONF_TYPE] == FRAMEWORK_ARDUINO:
         if version < cv.Version(3, 0, 0):
             raise cv.Invalid("Only Arduino 3.0+ is supported.")
-    elif version < cv.Version(5, 0, 0):
-        raise cv.Invalid("Only ESP-IDF 5.0+ is supported.")
+        recommended = ARDUINO_FRAMEWORK_VERSION_LOOKUP["recommended"]
+    else:
+        if version < cv.Version(5, 0, 0):
+            raise cv.Invalid("Only ESP-IDF 5.0+ is supported.")
+        recommended = ESP_IDF_FRAMEWORK_VERSION_LOOKUP["recommended"]
+
+    if version != recommended:
+        _LOGGER.warning(
+            "The selected framework version is not the recommended one. "
+            "If there are connectivity or build issues please remove the manual version."
+        )
 
     return version
 
@@ -836,7 +845,6 @@ def _check_pio_versions(config):
     version = _resolve_framework_version(value)
 
     if value[CONF_TYPE] == FRAMEWORK_ARDUINO:
-        recommended_version = ARDUINO_FRAMEWORK_VERSION_LOOKUP["recommended"]
         platform_lookup = ARDUINO_PLATFORM_VERSION_LOOKUP.get(version)
         value[CONF_SOURCE] = value.get(
             CONF_SOURCE, _format_framework_arduino_version(version)
@@ -844,7 +852,6 @@ def _check_pio_versions(config):
         if _is_framework_url(value[CONF_SOURCE]):
             value[CONF_SOURCE] = f"{ARDUINO_FRAMEWORK_PKG}@{value[CONF_SOURCE]}"
     else:
-        recommended_version = ESP_IDF_FRAMEWORK_VERSION_LOOKUP["recommended"]
         platform_lookup = ESP_IDF_PLATFORM_VERSION_LOOKUP.get(version)
         value[CONF_SOURCE] = value.get(
             CONF_SOURCE,
@@ -859,12 +866,6 @@ def _check_pio_versions(config):
                 "Framework version not recognized; please specify platform_version"
             )
         value[CONF_PLATFORM_VERSION] = _parse_pio_platform_version(str(platform_lookup))
-
-    if version != recommended_version:
-        _LOGGER.warning(
-            "The selected framework version is not the recommended one. "
-            "If there are connectivity or build issues please remove the manual version."
-        )
 
     if value[CONF_PLATFORM_VERSION] != _parse_pio_platform_version(
         str(PLATFORM_VERSION_LOOKUP["recommended"])
@@ -888,6 +889,12 @@ def _check_esp_idf_versions(config):
     value.pop(CONF_PLATFORM_VERSION, None)
 
     version = _resolve_framework_version(value)
+
+    if CONF_SOURCE in value:
+        _LOGGER.warning(
+            "A custom framework source is set. "
+            "If there are connectivity or build issues please remove the manual source."
+        )
 
     # Official ESP-IDF frameworks don't use the 'extra' semver component.
     value[CONF_VERSION] = str(cv.Version(version.major, version.minor, version.patch))

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -65,7 +65,6 @@ from .const import (  # noqa
     KEY_EXTRA_BUILD_FILES,
     KEY_FLASH_SIZE,
     KEY_FULL_CERT_BUNDLE,
-    KEY_IDF_FRAMEWORK_SOURCE,
     KEY_IDF_VERSION,
     KEY_PATH,
     KEY_REF,
@@ -478,14 +477,6 @@ def set_core_data(config):
             "Please update ARDUINO_IDF_VERSION_LOOKUP.",
             path=[CONF_FRAMEWORK, CONF_VERSION],
         )
-
-    # Under the esp-idf toolchain a user-supplied framework `source:` overrides
-    # the default download mirrors for the underlying ESP-IDF tarball. Applies
-    # regardless of framework type — in the arduino-on-IDF case arduino-esp32
-    # is pulled in as an IDF component on top of the same IDF framework
-    # download, so CONF_SOURCE governs the same artifact.
-    if CORE.using_toolchain_esp_idf:
-        CORE.data[KEY_ESP32][KEY_IDF_FRAMEWORK_SOURCE] = conf.get(CONF_SOURCE)
 
     CORE.data[KEY_ESP32][KEY_BOARD] = config[CONF_BOARD]
     CORE.data[KEY_ESP32][KEY_FLASH_SIZE] = config[CONF_FLASH_SIZE]

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -65,6 +65,7 @@ from .const import (  # noqa
     KEY_EXTRA_BUILD_FILES,
     KEY_FLASH_SIZE,
     KEY_FULL_CERT_BUNDLE,
+    KEY_IDF_FRAMEWORK_SOURCE,
     KEY_IDF_VERSION,
     KEY_PATH,
     KEY_REF,
@@ -478,6 +479,12 @@ def set_core_data(config):
             path=[CONF_FRAMEWORK, CONF_VERSION],
         )
 
+    # Under the esp-idf toolchain, a user-supplied framework `source:` overrides
+    # the default download mirrors. Stashed on CORE.data so toolchain.py can
+    # pick it up without re-parsing CONF_FRAMEWORK.
+    if CORE.using_toolchain_esp_idf and conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
+        CORE.data[KEY_ESP32][KEY_IDF_FRAMEWORK_SOURCE] = conf.get(CONF_SOURCE)
+
     CORE.data[KEY_ESP32][KEY_BOARD] = config[CONF_BOARD]
     CORE.data[KEY_ESP32][KEY_FLASH_SIZE] = config[CONF_FLASH_SIZE]
     CORE.data[KEY_ESP32][KEY_VARIANT] = variant
@@ -792,19 +799,15 @@ PLATFORM_VERSION_LOOKUP = {
 }
 
 
-def _check_pio_versions(config):
-    config = config.copy()
-    value = config[CONF_FRAMEWORK]
+def _resolve_framework_version(value):
+    """Resolve a named or raw framework version and validate the minimum.
 
+    Normalises value[CONF_VERSION] to its string form and returns the parsed
+    cv.Version. Shared between the PIO and esp-idf toolchain paths; toolchain-
+    specific concerns (source defaults, platform_version, recommended-version
+    warnings) live in the per-toolchain functions.
+    """
     if value[CONF_VERSION] in PLATFORM_VERSION_LOOKUP:
-        if CONF_SOURCE in value or CONF_PLATFORM_VERSION in value:
-            raise cv.Invalid(
-                "Version needs to be explicitly set when a custom source or platform_version is used."
-            )
-
-        platform_lookup = PLATFORM_VERSION_LOOKUP[value[CONF_VERSION]]
-        value[CONF_PLATFORM_VERSION] = _parse_pio_platform_version(str(platform_lookup))
-
         if value[CONF_TYPE] == FRAMEWORK_ARDUINO:
             version = ARDUINO_FRAMEWORK_VERSION_LOOKUP[value[CONF_VERSION]]
         else:
@@ -817,6 +820,29 @@ def _check_pio_versions(config):
     if value[CONF_TYPE] == FRAMEWORK_ARDUINO:
         if version < cv.Version(3, 0, 0):
             raise cv.Invalid("Only Arduino 3.0+ is supported.")
+    elif version < cv.Version(5, 0, 0):
+        raise cv.Invalid("Only ESP-IDF 5.0+ is supported.")
+
+    return version
+
+
+def _check_pio_versions(config):
+    config = config.copy()
+    value = config[CONF_FRAMEWORK]
+
+    is_named_version = value[CONF_VERSION] in PLATFORM_VERSION_LOOKUP
+    if is_named_version and (CONF_SOURCE in value or CONF_PLATFORM_VERSION in value):
+        raise cv.Invalid(
+            "Version needs to be explicitly set when a custom source or platform_version is used."
+        )
+    if is_named_version:
+        value[CONF_PLATFORM_VERSION] = _parse_pio_platform_version(
+            str(PLATFORM_VERSION_LOOKUP[value[CONF_VERSION]])
+        )
+
+    version = _resolve_framework_version(value)
+
+    if value[CONF_TYPE] == FRAMEWORK_ARDUINO:
         recommended_version = ARDUINO_FRAMEWORK_VERSION_LOOKUP["recommended"]
         platform_lookup = ARDUINO_PLATFORM_VERSION_LOOKUP.get(version)
         value[CONF_SOURCE] = value.get(
@@ -825,8 +851,6 @@ def _check_pio_versions(config):
         if _is_framework_url(value[CONF_SOURCE]):
             value[CONF_SOURCE] = f"{ARDUINO_FRAMEWORK_PKG}@{value[CONF_SOURCE]}"
     else:
-        if version < cv.Version(5, 0, 0):
-            raise cv.Invalid("Only ESP-IDF 5.0+ is supported.")
         recommended_version = ESP_IDF_FRAMEWORK_VERSION_LOOKUP["recommended"]
         platform_lookup = ESP_IDF_PLATFORM_VERSION_LOOKUP.get(version)
         value[CONF_SOURCE] = value.get(
@@ -861,18 +885,19 @@ def _check_pio_versions(config):
 
 
 def _check_esp_idf_versions(config):
-    config = _check_pio_versions(config)
+    config = config.copy()
     value = config[CONF_FRAMEWORK]
 
-    # Remove unwanted keys if present
-    for key in (CONF_SOURCE, CONF_PLATFORM_VERSION):
-        value.pop(key, None)
+    # platform_version is a PlatformIO concept; drop it if a user carried it
+    # over from a PIO-style config. CONF_SOURCE, on the other hand, is kept:
+    # it lets a user override the framework tarball URL under the esp-idf
+    # toolchain (the espidf framework downloader consults it).
+    value.pop(CONF_PLATFORM_VERSION, None)
 
-    # Official ESP-IDF frameworks don't use extra
-    version = cv.Version.parse(value[CONF_VERSION])
-    version = cv.Version(version.major, version.minor, version.patch)
+    version = _resolve_framework_version(value)
 
-    value[CONF_VERSION] = str(version)
+    # Official ESP-IDF frameworks don't use the 'extra' semver component.
+    value[CONF_VERSION] = str(cv.Version(version.major, version.minor, version.patch))
 
     return config
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -479,10 +479,12 @@ def set_core_data(config):
             path=[CONF_FRAMEWORK, CONF_VERSION],
         )
 
-    # Under the esp-idf toolchain, a user-supplied framework `source:` overrides
-    # the default download mirrors. Stashed on CORE.data so toolchain.py can
-    # pick it up without re-parsing CONF_FRAMEWORK.
-    if CORE.using_toolchain_esp_idf and conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
+    # Under the esp-idf toolchain a user-supplied framework `source:` overrides
+    # the default download mirrors for the underlying ESP-IDF tarball. Applies
+    # regardless of framework type — in the arduino-on-IDF case arduino-esp32
+    # is pulled in as an IDF component on top of the same IDF framework
+    # download, so CONF_SOURCE governs the same artifact.
+    if CORE.using_toolchain_esp_idf:
         CORE.data[KEY_ESP32][KEY_IDF_FRAMEWORK_SOURCE] = conf.get(CONF_SOURCE)
 
     CORE.data[KEY_ESP32][KEY_BOARD] = config[CONF_BOARD]

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -792,7 +792,7 @@ PLATFORM_VERSION_LOOKUP = {
 }
 
 
-def _resolve_framework_version(value):
+def _resolve_framework_version(value: ConfigType) -> cv.Version:
     """Resolve a named or raw framework version and validate the minimum.
 
     Normalises value[CONF_VERSION] to its string form and returns the parsed
@@ -828,7 +828,7 @@ def _resolve_framework_version(value):
     return version
 
 
-def _check_pio_versions(config):
+def _check_pio_versions(config: ConfigType) -> ConfigType:
     config = config.copy()
     value = config[CONF_FRAMEWORK]
 
@@ -878,7 +878,7 @@ def _check_pio_versions(config):
     return config
 
 
-def _check_esp_idf_versions(config):
+def _check_esp_idf_versions(config: ConfigType) -> ConfigType:
     config = config.copy()
     value = config[CONF_FRAMEWORK]
 

--- a/esphome/components/esp32/const.py
+++ b/esphome/components/esp32/const.py
@@ -16,7 +16,6 @@ KEY_SUBMODULES = "submodules"
 KEY_EXTRA_BUILD_FILES = "extra_build_files"
 KEY_FULL_CERT_BUNDLE = "full_cert_bundle"
 KEY_IDF_VERSION = "idf_version"
-KEY_IDF_FRAMEWORK_SOURCE = "idf_framework_source"
 
 VARIANT_ESP32 = "ESP32"
 VARIANT_ESP32C2 = "ESP32C2"

--- a/esphome/components/esp32/const.py
+++ b/esphome/components/esp32/const.py
@@ -16,6 +16,7 @@ KEY_SUBMODULES = "submodules"
 KEY_EXTRA_BUILD_FILES = "extra_build_files"
 KEY_FULL_CERT_BUNDLE = "full_cert_bundle"
 KEY_IDF_VERSION = "idf_version"
+KEY_IDF_FRAMEWORK_SOURCE = "idf_framework_source"
 
 VARIANT_ESP32 = "ESP32"
 VARIANT_ESP32C2 = "ESP32C2"

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -826,6 +826,12 @@ def _check_esphome_idf_framework_install(
     env_stamp_file = framework_path / ESPHOME_STAMP_FILE
     idf_tools_path = framework_path / "tools" / "idf_tools.py"
     _LOGGER.info("Checking ESP-IDF %s framework ...", version)
+    # Log the override every invocation, including the cached-framework case,
+    # so the user can verify what's in effect even when no download runs.
+    # (Note: a *changed* override won't trigger re-extraction on its own —
+    # use ``esphome clean`` to force a re-download against the new URL.)
+    if source_url:
+        _LOGGER.info("Using framework source override: %s", source_url)
 
     # 2. Download and extract the framework if not already extracted.
     # The marker is written last after extraction succeeds, so its presence
@@ -853,11 +859,7 @@ def _check_esphome_idf_framework_install(
             except ValueError:
                 pass
 
-            if source_url:
-                _LOGGER.info("Using framework source override: %s", source_url)
-                mirrors = [source_url]
-            else:
-                mirrors = ESPHOME_IDF_FRAMEWORK_MIRRORS
+            mirrors = [source_url] if source_url else ESPHOME_IDF_FRAMEWORK_MIRRORS
             download_from_mirrors(mirrors, substitutions, tmp.file)
 
             _LOGGER.info("Extracting ESP-IDF %s framework ...", version)

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -826,10 +826,8 @@ def _check_esphome_idf_framework_install(
     env_stamp_file = framework_path / ESPHOME_STAMP_FILE
     idf_tools_path = framework_path / "tools" / "idf_tools.py"
     _LOGGER.info("Checking ESP-IDF %s framework ...", version)
-    # Log the override every invocation, including the cached-framework case,
-    # so the user can verify what's in effect even when no download runs.
-    # (Note: a *changed* override won't trigger re-extraction on its own —
-    # use ``esphome clean`` to force a re-download against the new URL.)
+    # Logged every invocation (not just on install) so the user can verify the
+    # override. A changed URL needs ``esphome clean`` to force a re-download.
     if source_url:
         _LOGGER.info("Using framework source override: %s", source_url)
 

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -803,7 +803,8 @@ def _check_esphome_idf_framework_install(
         source_url: Optional override URL for the framework tarball. Supports
             the same ``{VERSION}`` / ``{MAJOR}`` / ``{MINOR}`` / ``{PATCH}`` /
             ``{EXTRA}`` substitutions as ESPHOME_IDF_FRAMEWORK_MIRRORS. When
-            set, it's tried before the default mirror list.
+            set, it replaces the default mirror list — no implicit fallback,
+            so a misspelled URL fails loudly.
 
     Returns:
         tuple of (framework_path, install_flag)
@@ -852,9 +853,11 @@ def _check_esphome_idf_framework_install(
             except ValueError:
                 pass
 
-            mirrors = ESPHOME_IDF_FRAMEWORK_MIRRORS
             if source_url:
-                mirrors = [source_url, *mirrors]
+                _LOGGER.info("Using framework source override: %s", source_url)
+                mirrors = [source_url]
+            else:
+                mirrors = ESPHOME_IDF_FRAMEWORK_MIRRORS
             download_from_mirrors(mirrors, substitutions, tmp.file)
 
             _LOGGER.info("Extracting ESP-IDF %s framework ...", version)
@@ -1028,9 +1031,10 @@ def check_esp_idf_install(
         tools: list of tools to install
         features: Features to install
         force: If True, force reinstallation
-        source_url: Optional override URL for the framework tarball. Forwarded
+        source_url: Optional override URL for the framework tarball. When
+            set, it replaces the default mirror list (no fallback). Forwarded
             to ``_check_esphome_idf_framework_install``; supports the same URL
-            substitutions as the default mirror list.
+            substitutions.
 
     Returns:
         tuple of (framework_path, python_env_path)

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -789,6 +789,7 @@ def _check_esphome_idf_framework_install(
     tools: list[str],
     force: bool = False,
     env: dict[str, str] | None = None,
+    source_url: str | None = None,
 ) -> tuple[Path, bool]:
     """
     Check and install ESP-IDF framework.
@@ -799,6 +800,10 @@ def _check_esphome_idf_framework_install(
         tools: list of tools to install
         force: If True, force reinstallation
         env: Optional dictionary of environment variables to set
+        source_url: Optional override URL for the framework tarball. Supports
+            the same ``{VERSION}`` / ``{MAJOR}`` / ``{MINOR}`` / ``{PATCH}`` /
+            ``{EXTRA}`` substitutions as ESPHOME_IDF_FRAMEWORK_MIRRORS. When
+            set, it's tried before the default mirror list.
 
     Returns:
         tuple of (framework_path, install_flag)
@@ -847,9 +852,10 @@ def _check_esphome_idf_framework_install(
             except ValueError:
                 pass
 
-            download_from_mirrors(
-                ESPHOME_IDF_FRAMEWORK_MIRRORS, substitutions, tmp.file
-            )
+            mirrors = ESPHOME_IDF_FRAMEWORK_MIRRORS
+            if source_url:
+                mirrors = [source_url, *mirrors]
+            download_from_mirrors(mirrors, substitutions, tmp.file)
 
             _LOGGER.info("Extracting ESP-IDF %s framework ...", version)
             archive_extract_all(tmp.file, framework_path, progress_header="Extracting")
@@ -1011,6 +1017,7 @@ def check_esp_idf_install(
     tools: list[str] | None = None,
     features: list[str] | None = None,
     force: bool = False,
+    source_url: str | None = None,
 ) -> tuple[Path, Path]:
     """
     Check and install ESP-IDF framework and Python environment.
@@ -1021,6 +1028,9 @@ def check_esp_idf_install(
         tools: list of tools to install
         features: Features to install
         force: If True, force reinstallation
+        source_url: Optional override URL for the framework tarball. Forwarded
+            to ``_check_esphome_idf_framework_install``; supports the same URL
+            substitutions as the default mirror list.
 
     Returns:
         tuple of (framework_path, python_env_path)
@@ -1043,7 +1053,7 @@ def check_esp_idf_install(
 
     # 1) Framework
     framework_path, installed = _check_esphome_idf_framework_install(
-        version, targets, tools, force=force, env=env
+        version, targets, tools, force=force, env=env, source_url=source_url
     )
 
     features = features or ESPHOME_IDF_DEFAULT_FEATURES

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -9,7 +9,12 @@ import re
 import shutil
 import subprocess
 
-from esphome.components.esp32.const import KEY_ESP32, KEY_FLASH_SIZE, KEY_IDF_VERSION
+from esphome.components.esp32.const import (
+    KEY_ESP32,
+    KEY_FLASH_SIZE,
+    KEY_IDF_FRAMEWORK_SOURCE,
+    KEY_IDF_VERSION,
+)
 from esphome.core import CORE, EsphomeError
 from esphome.espidf.framework import check_esp_idf_install, get_framework_env
 from esphome.espidf.size_summary import print_summary
@@ -43,7 +48,8 @@ def _get_esphome_esp_idf_paths(
     version = version or _get_core_framework_version()
     paths = _cache().paths
     if version not in paths:
-        paths[version] = check_esp_idf_install(version)
+        source_url = CORE.data.get(KEY_ESP32, {}).get(KEY_IDF_FRAMEWORK_SOURCE)
+        paths[version] = check_esp_idf_install(version, source_url=source_url)
     return paths[version]
 
 

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -47,7 +47,7 @@ def _get_framework_source_override() -> str | None:
     """
     if CORE.config is None:
         return None
-    return CORE.config.get("esp32", {}).get(CONF_FRAMEWORK, {}).get(CONF_SOURCE)
+    return CORE.config.get(KEY_ESP32, {}).get(CONF_FRAMEWORK, {}).get(CONF_SOURCE)
 
 
 def _get_esphome_esp_idf_paths(

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -9,12 +9,8 @@ import re
 import shutil
 import subprocess
 
-from esphome.components.esp32.const import (
-    KEY_ESP32,
-    KEY_FLASH_SIZE,
-    KEY_IDF_FRAMEWORK_SOURCE,
-    KEY_IDF_VERSION,
-)
+from esphome.components.esp32.const import KEY_ESP32, KEY_FLASH_SIZE, KEY_IDF_VERSION
+from esphome.const import CONF_FRAMEWORK, CONF_SOURCE
 from esphome.core import CORE, EsphomeError
 from esphome.espidf.framework import check_esp_idf_install, get_framework_env
 from esphome.espidf.size_summary import print_summary
@@ -42,14 +38,27 @@ def _get_core_framework_version():
     return str(CORE.data[KEY_ESP32][KEY_IDF_VERSION])
 
 
+def _get_framework_source_override() -> str | None:
+    """Return the user-supplied esp32.framework.source override, if any.
+
+    The override lets a user point the IDF tarball download at a custom URL
+    (mirror, fork, local server). Substitutions like ``{VERSION}`` /
+    ``{MAJOR}`` etc. work the same as in the default mirror list.
+    """
+    if CORE.config is None:
+        return None
+    return CORE.config.get("esp32", {}).get(CONF_FRAMEWORK, {}).get(CONF_SOURCE)
+
+
 def _get_esphome_esp_idf_paths(
     version: str | None = None,
 ) -> tuple[os.PathLike, os.PathLike]:
     version = version or _get_core_framework_version()
     paths = _cache().paths
     if version not in paths:
-        source_url = CORE.data.get(KEY_ESP32, {}).get(KEY_IDF_FRAMEWORK_SOURCE)
-        paths[version] = check_esp_idf_install(version, source_url=source_url)
+        paths[version] = check_esp_idf_install(
+            version, source_url=_get_framework_source_override()
+        )
     return paths[version]
 
 

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -1,0 +1,58 @@
+"""Tests for esphome.espidf.toolchain helpers."""
+
+# pylint: disable=protected-access
+
+from unittest.mock import patch
+
+from esphome.const import CONF_FRAMEWORK, CONF_SOURCE
+from esphome.core import CORE
+from esphome.espidf import toolchain
+
+
+def test_get_framework_source_override_no_config():
+    """When CORE.config hasn't been set, no override is returned."""
+    CORE.config = None
+    assert toolchain._get_framework_source_override() is None
+
+
+def test_get_framework_source_override_no_esp32_section():
+    """A config without an esp32 section yields no override."""
+    CORE.config = {}
+    assert toolchain._get_framework_source_override() is None
+
+
+def test_get_framework_source_override_no_framework_source():
+    """An esp32 section without framework.source yields no override."""
+    CORE.config = {"esp32": {CONF_FRAMEWORK: {}}}
+    assert toolchain._get_framework_source_override() is None
+
+
+def test_get_framework_source_override_returns_value():
+    """A user-supplied framework source is returned verbatim."""
+    url = "https://example.com/esp-idf-v{VERSION}.tar.xz"
+    CORE.config = {"esp32": {CONF_FRAMEWORK: {CONF_SOURCE: url}}}
+    assert toolchain._get_framework_source_override() == url
+
+
+def test_get_esphome_esp_idf_paths_forwards_source_override():
+    """_get_esphome_esp_idf_paths threads the override into check_esp_idf_install."""
+    url = "https://my-mirror/esp-idf-v{VERSION}.tar.xz"
+    CORE.config = {"esp32": {CONF_FRAMEWORK: {CONF_SOURCE: url}}}
+    # Hit a fresh cache key so check_esp_idf_install is actually called.
+    toolchain._cache().paths.clear()
+    with patch.object(
+        toolchain, "check_esp_idf_install", return_value=("/fw", "/penv")
+    ) as mock_install:
+        toolchain._get_esphome_esp_idf_paths("5.5.4")
+    mock_install.assert_called_once_with("5.5.4", source_url=url)
+
+
+def test_get_esphome_esp_idf_paths_no_override():
+    """When no source override is configured, source_url=None is passed."""
+    CORE.config = {}
+    toolchain._cache().paths.clear()
+    with patch.object(
+        toolchain, "check_esp_idf_install", return_value=("/fw", "/penv")
+    ) as mock_install:
+        toolchain._get_esphome_esp_idf_paths("5.5.4")
+    mock_install.assert_called_once_with("5.5.4", source_url=None)


### PR DESCRIPTION
# What does this implement/fix?

Two related changes to the ESP32 framework version handling under the **esp-idf toolchain**.

## 1. Decouple esp-idf version check from the PIO checker

`_check_esp_idf_versions` used to call `_check_pio_versions` and then pop the bits it didn't want. That pulled in PIO-only logic that doesn't apply to native ESP-IDF builds:

- `Framework version not recognized; please specify platform_version` raised when the version wasn't in `ARDUINO_PLATFORM_VERSION_LOOKUP` / `ESP_IDF_PLATFORM_VERSION_LOOKUP`. Under the esp-idf toolchain there's no PlatformIO at all, so `platform_version` is meaningless.
- The `WARNING The selected platform version is not the recommended one` fired even though the `platform_version` concept is PIO-specific.

Extracted a `_resolve_framework_version` helper for the bits both toolchains need: named-version lookup (`"recommended"` / `"latest"` / `"dev"`), version normalisation, minimum-version range check, and the **framework-version** "not recommended" warning. The framework-version warning is intentionally kept for both toolchains — pinning to a non-recommended ESP-IDF version (e.g. `6.0.1` vs the recommended `5.5.4`) is just as likely to surface compat issues as pinning to a non-recommended arduino version. Only the **platform-version** warning is PIO-only and stays in `_check_pio_versions`.

Warning matrix after the refactor:

| toolchain | framework-version not recommended | platform-version not recommended | custom `source:` |
|---|---|---|---|
| platformio | warn (shared helper) | warn (PIO-only) | — |
| esp-idf | warn (shared helper) | n/a, suppressed | warn (new) |

## 2. Honor `framework.source:` under the esp-idf toolchain

The schema already accepts `source:` on the framework block, but `_check_esp_idf_versions` was popping it. Under the esp-idf toolchain, the underlying ESP-IDF tarball is downloaded by `espidf/framework.py:_check_esphome_idf_framework_install`, which only consulted `ESPHOME_IDF_FRAMEWORK_MIRRORS` (env-var or built-in default). There was no per-config way to override the source.

Now:

- `_check_esp_idf_versions` keeps `source:` (only `platform_version` gets popped; `platform_version` is genuinely PIO-only).
- `espidf/toolchain.py:_get_framework_source_override()` reads `CORE.config[KEY_ESP32]["framework"]["source"]` and passes it to `check_esp_idf_install` as `source_url=`.
- `espidf/framework.py:check_esp_idf_install` / `_check_esphome_idf_framework_install` accept `source_url`. When set, it **replaces** the default mirror list — no implicit fallback. A misspelled URL fails loudly instead of silently dropping back to esphome-libs. The override URL supports the same `{VERSION}` / `{MAJOR}` / `{MINOR}` / `{PATCH}` / `{EXTRA}` substitutions as the default mirror list.
- The override is logged at INFO **every invocation**, including when the framework is already extracted (cached run), so a build run always confirms which source is in effect.
- A `source:` warning is emitted from `_check_esp_idf_versions` so the user is reminded that a non-default source is in effect.
- **Known limitation:** a *changed* override on a cached extraction doesn't automatically re-download — use `esphome clean` to force a re-extract. This is called out in a comment in `framework.py`.
- The override applies to both `framework.type: esp-idf` and `framework.type: arduino` under `toolchain: esp-idf`, since arduino-on-IDF pulls arduino-esp32 in as an IDF component on top of the same IDF framework download.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — `framework.source:` was already a documented option for the PIO toolchain; this change extends the same field to the esp-idf toolchain semantically.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Pull the IDF framework from a custom mirror under the esp-idf toolchain:

```yaml
esp32:
  variant: esp32
  toolchain: esp-idf
  framework:
    type: esp-idf
    version: 6.0.1
    source: https://my.internal-mirror/esp-idf-v{VERSION}.tar.xz
```

**Pre-PR:**
- `framework.source:` was silently dropped before the framework download ran, so the override had no effect — the build downloaded from the esphome-libs default mirrors regardless.
- A framework version not in `ESP_IDF_PLATFORM_VERSION_LOOKUP` aborted validation with `Framework version not recognized; please specify platform_version`, even though `platform_version` doesn't apply under the esp-idf toolchain.

**Post-PR:**
- The example above downloads from the configured URL.
- Build output logs `INFO Using framework source override: https://...` even on cached re-runs.
- The irrelevant `platform_version`-not-recommended warning is gone; the framework-version-not-recommended warning is kept since it's meaningful under both toolchains.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). — N/A; this is config validation refactoring + new pass-through to an existing download path. No new C++ surface.