### PR TITLE
[espidf] Filter noisy 'git rev-parse' errors when .git is stripped

### DIFF
--- a/esphome/espidf/runner.py
+++ b/esphome/espidf/runner.py
@@ -66,6 +66,12 @@ FILTER_IDF_LINES: list[str] = [
     # Drop the blank line rich emits after the note so the build log
     # doesn't end with an orphan gap before ESPHome's own status lines.
     r"\s*$",
+    # ESP-IDF shells out to ``git rev-parse`` to embed a commit hash;
+    # esphome-libs strips ``.git`` from the tarball so those probes fail
+    # noisily without affecting the build.
+    r"-- git rev-parse returned ",
+    r"fatal: not a git repository",
+    r"Stopping at filesystem boundary",
 ]
 
 


### PR DESCRIPTION
# What does this implement/fix?

The esphome-libs ESP-IDF release tarball ships with the `.git` directory stripped (smaller download, fewer files to copy). The downside: ESP-IDF itself, and several bundled components (`components/openthread/openthread`, `tools/cmake/third_party/GetGitRevisionDescription.cmake`), shell out to `git rev-parse` during the CMake configure to embed a commit hash. With no `.git`, each probe fails and prints to stderr, dumping lines like

```
-- git rev-parse returned 'fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).'
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
fatal: not a git repository: /data/idf/frameworks/5.5.4/components/openthread/openthread/.../.git/modules/components/openthread/openthread
```

on every configure. The hash is purely cosmetic (the build falls back to a sentinel) so the noise is pure clutter.

Add three regex patterns to the existing `FILTER_IDF_LINES` set in `espidf/runner.py` so they get dropped before reaching the parent process. The filter is automatically disabled when the user passes `-v` / `--verbose` to `esphome compile`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Any IDF-toolchain config will exhibit the issue today. Verified locally with a standard heatpumpir-on-ESP32-IDF compile: pre-PR, three flavours of `fatal:`/`Stopping at filesystem boundary` lines appear in every configure; post-PR they're filtered out.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). — N/A; this is log filtering, no observable C++ surface.