### PR TITLE
[esp32] Use new sdkconfig key names that replaced deprecated ones

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1962,7 +1962,7 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_HEAP_PLACE_FUNCTION_INTO_FLASH", True)
 
     # Setup watchdog
-    add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT", True)
+    add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT_INIT", True)
     add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT_PANIC", True)
     add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0", False)
     add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1", False)
@@ -2096,7 +2096,6 @@ async def to_code(config):
         for key, flag in ASSERTION_LEVELS.items():
             add_idf_sdkconfig_option(flag, assertion_level == key)
 
-    add_idf_sdkconfig_option("CONFIG_COMPILER_OPTIMIZATION_DEFAULT", False)
     compiler_optimization = advanced[CONF_COMPILER_OPTIMIZATION]
     for key, flag in COMPILER_OPTIMIZATIONS.items():
         add_idf_sdkconfig_option(flag, compiler_optimization == key)


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF renamed two sdkconfig symbols ESPHome was writing under the old names. IDF still accepts the old names via its `sdkconfig.rename` files but prints a deprecation line on every configure:

```
sdkconfig.test:5 CONFIG_COMPILER_OPTIMIZATION_DEFAULT was replaced with CONFIG_COMPILER_OPTIMIZATION_DEBUG
sdkconfig.test:16 CONFIG_ESP_TASK_WDT was replaced with CONFIG_ESP_TASK_WDT_INIT
```

Both renames are documented in IDF 5.5.4's `sdkconfig.rename` files (`components/esp_system/sdkconfig.rename:29` and `sdkconfig.rename:9` respectively).

Changes:

- **`CONFIG_ESP_TASK_WDT` → `CONFIG_ESP_TASK_WDT_INIT`**. Straight rename.
- **`CONFIG_COMPILER_OPTIMIZATION_DEFAULT`**: line removed entirely. The following loop already iterates `COMPILER_OPTIMIZATIONS` (which uses the new `CONFIG_COMPILER_OPTIMIZATION_<level>` names) and sets exactly one to True with the rest False, so the explicit `DEFAULT=False` was redundant. Worse, with IDF's rename folding `DEFAULT` into `DEBUG`, the orphan line was effectively writing `DEBUG=False` to sdkconfig in addition to the loop's `DEBUG=True` for users on the default `DEBUG` optimization — the final value depended on sdkconfig key ordering.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — sdkconfig-internal rename, no user-visible YAML surface.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No user-facing config change. Verified locally: pre-PR a standard ESP32-IDF compile prints both `was replaced with` lines; post-PR both are gone.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). — N/A; this is a sdkconfig key rename verified against IDF's own `sdkconfig.rename` table.