### PR TITLE
[espidf] Backport ninja linux-arm64 entry into tools.json on aarch64 hosts

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import platform
 import shutil
 import subprocess
 import sys
@@ -811,6 +812,63 @@ def _write_idf_version_txt(framework_path: Path, version: str) -> None:
         )
 
 
+# Backport of espressif/esp-idf#18272: every ESPHome-supported IDF release
+# through v6.0 ships a tools.json whose ninja 1.12.1 entry has no
+# ``linux-arm64`` source. ``idf_tools.py`` then either fails to find a
+# matching binary or grabs the x86_64 one, which can't execute on
+# aarch64. cmake is already populated across the same release range; we
+# only need to inject ninja. Values lifted verbatim from the IDF v6.0.1
+# tools.json where the fix landed natively.
+_NINJA_ARM64_BACKPORT: dict[str, dict[str, str | int]] = {
+    "1.12.1": {
+        "rename_dist": "ninja-linux-arm64-v1.12.1.zip",
+        "sha256": "5c25c6570b0155e95fce5918cb95f1ad9870df5768653afe128db822301a05a1",
+        "size": 121787,
+        "url": "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux-aarch64.zip",
+    },
+}
+
+
+def _patch_tools_json_for_linux_arm64(framework_path: Path) -> None:
+    """Inject ninja linux-arm64 entries into the framework's tools.json on aarch64.
+
+    Idempotent: a tools.json that already has the entry, or a host that
+    isn't aarch64, is a no-op. Applied unconditionally on every install
+    check so a build dir extracted before the backport got fixed up
+    without forcing a clean.
+    """
+    if platform.machine() != "aarch64":
+        return
+
+    tools_json = framework_path / "tools" / "tools.json"
+    if not tools_json.is_file():
+        return
+
+    with open(tools_json, encoding="utf-8") as f:
+        data = json.load(f)
+
+    changed = False
+    for tool in data.get("tools", []):
+        if tool.get("name") != "ninja":
+            continue
+        for ver in tool.get("versions", []):
+            entry = _NINJA_ARM64_BACKPORT.get(ver.get("name"))
+            if entry is None or ver.get("linux-arm64"):
+                continue
+            ver["linux-arm64"] = entry
+            changed = True
+
+    if changed:
+        with open(tools_json, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        _LOGGER.info(
+            "Patched %s to add ninja linux-arm64 download "
+            "(espressif/esp-idf#18272 backport).",
+            tools_json,
+        )
+
+
 def _check_esphome_idf_framework_install(
     version: str,
     targets: list[str],
@@ -896,6 +954,11 @@ def _check_esphome_idf_framework_install(
     # dir extracted before this fix gets the file too, without forcing a
     # clean. Skips when version.txt already exists.
     _write_idf_version_txt(framework_path, version)
+
+    # Apply the ninja linux-arm64 backport on every invocation, not just on
+    # fresh extracts — idempotent and cheap, and lets a build dir carrying
+    # a pre-patch tools.json get fixed up without forcing a clean.
+    _patch_tools_json_for_linux_arm64(framework_path)
 
     # 3. Check if the framework tools are the same and correctly installed
     if not install:

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -18,7 +18,7 @@ import requests
 
 from esphome.config_validation import Version
 from esphome.core import CORE
-from esphome.helpers import ProgressBar, get_str_env, rmtree
+from esphome.helpers import ProgressBar, get_str_env, rmtree, write_file_if_changed
 
 PathType = str | os.PathLike
 
@@ -844,8 +844,18 @@ def _patch_tools_json_for_linux_arm64(framework_path: Path) -> None:
     if not tools_json.is_file():
         return
 
-    with open(tools_json, encoding="utf-8") as f:
-        data = json.load(f)
+    try:
+        with open(tools_json, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        _LOGGER.warning(
+            "Could not parse %s for linux-arm64 backport (%s); "
+            "skipping. A clean reinstall of the framework directory "
+            "may be needed.",
+            tools_json,
+            e,
+        )
+        return
 
     changed = False
     for tool in data.get("tools", []):
@@ -859,9 +869,10 @@ def _patch_tools_json_for_linux_arm64(framework_path: Path) -> None:
             changed = True
 
     if changed:
-        with open(tools_json, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2)
-            f.write("\n")
+        # write_file_if_changed stages a tempfile in the destination dir
+        # and atomically replaces — safe against mid-write interruption
+        # and concurrent invocations.
+        write_file_if_changed(tools_json, json.dumps(data, indent=2) + "\n")
         _LOGGER.info(
             "Patched %s to add ninja linux-arm64 download "
             "(espressif/esp-idf#18272 backport).",


### PR DESCRIPTION
# What does this implement/fix?

Every ESP-IDF release through v6.0 ships a `tools.json` whose ninja 1.12.1 entry has no `linux-arm64` source. `idf_tools.py` then either fails to find a matching binary or grabs the x86_64 one, which dies at first invocation on aarch64 with:


```
ninja: 1: Syntax error: "(" unexpected
```

— a glibc error from trying to execute a Linux x86_64 ELF on aarch64. The upstream fix is in espressif/esp-idf#18272 (closed/done) and landed natively in **v6.0.1**, but isn't in any other released branch. Every other IDF release ESPHome ships from esphome-libs/esp-idf (v5.1.7, v5.2.7, v5.3.5, v5.4.4, v5.5.3, v5.5.4, v6.0) is affected on Raspberry-Pi-class HA installs.

Ninja is the only missing piece: cmake's `linux-arm64` source is already populated across the same release range, and the binary version is the same `1.12.1` across all eight supported IDF releases.

## What changed

Add a small helper, `_patch_tools_json_for_linux_arm64`, that injects the `linux-arm64` block under `ninja → 1.12.1` if missing. Called from `_check_esphome_idf_framework_install` right after extraction. The patch is:

- **Idempotent** — re-running on an already-patched file is a no-op (the helper short-circuits when the entry is present).
- **Aarch64-gated** — `platform.machine() == "aarch64"` check first; non-aarch64 hosts pay zero cost.
- **Applied every invocation** — not just on fresh extracts, so a build dir carrying a pre-patch tools.json gets fixed up without forcing a `clean`.

Values lifted verbatim from IDF v6.0.1's own tools.json (where the fix landed natively).

### Diff against a real IDF 5.5.4 tools.json

```diff
@@ -772,6 +772,12 @@
             "sha256": "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a",
             "size": 275425,
             "url": "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip"
+          },
+          "linux-arm64": {
+            "rename_dist": "ninja-linux-arm64-v1.12.1.zip",
+            "sha256": "5c25c6570b0155e95fce5918cb95f1ad9870df5768653afe128db822301a05a1",
+            "size": 121787,
+            "url": "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux-aarch64.zip"
           }
         }
       ]
```

cmake and every other tool are untouched.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes: https://github.com/esphome/esphome/issues/16525

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal toolchain-install fix, no user-visible config surface.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No user-facing config change. Affects every IDF-native build on aarch64 hosts (e.g. HA add-on on Raspberry Pi 4/5).

Pre-PR: `idf.py` falls over with `ninja: 1: Syntax error` after framework install.
Post-PR: install pulls the correct `ninja-linux-aarch64.zip`; build proceeds normally.

## Checklist:
  - [x] The code change is tested and works locally — verified against the real IDF 5.5.4 tools.json; diff is the expected six-line addition under the ninja 1.12.1 block; second invocation is a no-op.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). — None added; the helper is platform-gated and reads/writes a vendored IDF file, neither of which a unit test can usefully exercise without mocking out half the framework install path.