### PR TITLE
[espidf] Fix tarfile extract crashing on Python 3.11 with None mode

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -549,11 +549,11 @@ def _tar_extract_all(
                     if not (mode & stat.S_IXUSR):
                         mode &= ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
                     mode |= stat.S_IRUSR | stat.S_IWUSR
-                elif member.isdir() or member.issym():
-                    # Ignore mode for directories & symlinks
-                    mode = None
-                else:
-                    # Block special files
+                elif not (member.isdir() or member.issym()):
+                    # Block special files. Directories and symlinks keep
+                    # their masked-original mode — passing None here would
+                    # crash tarfile.extract on Python <3.12 (its chmod
+                    # path calls os.chmod unconditionally).
                     continue
 
                 member.mode = mode


### PR DESCRIPTION
# What does this implement/fix?

`_tar_extract_all` sanitises each member's permissions before letting Python's `tarfile` machinery do the extraction. For directories and symlinks the old code masked the original mode and then **overwrote it with `None`**, intending "don't chmod this." That works on Python 3.12+ — `tarfile.chmod` was updated to early-return when `tarinfo.mode is None` — but on Python **3.11** the same path calls `os.chmod(targetpath, tarinfo.mode)` unconditionally, and `os.chmod(path, None)` is a `TypeError`:

```
File ".../tarfile.py", line 2220, in _extract_member
  self.chmod(tarinfo, targetpath)
File ".../tarfile.py", line 2344, in chmod
  os.chmod(targetpath, tarinfo.mode)
TypeError: 'NoneType' object cannot be interpreted as an integer
```

Symptom: `esphome compile` on the IDF-native toolchain crashes mid-extract on any 3.11 host (e.g. Raspberry Pi OS Bookworm).

## The fix

Drop the `mode = None` overwrite for directories and symlinks. They fall through with the masked-original mode (the same value the file branch a few lines up already trusts), which is never `None` for real tar members, so Python 3.11's chmod path is happy.

```diff
-                elif member.isdir() or member.issym():
-                    # Ignore mode for directories & symlinks
-                    mode = None
-                else:
-                    # Block special files
+                elif not (member.isdir() or member.issym()):
+                    # Block special files. Directories and symlinks keep
+                    # their masked-original mode — passing None here would
+                    # crash tarfile.extract on Python <3.12 (its chmod
+                    # path calls os.chmod unconditionally).
                     continue
```

## Behaviour notes

- **Directories**: previously got the filesystem default via umask on 3.12 (typically `0o755`); now get the masked-original (typically `0o755` from the tar). Same outcome.
- **Symlinks**: `os.chmod` on a symlink follows the link on Linux, so the chmod we now make is going through to the *target*. Audited the IDF 5.5.4 tarball: 16 symlinks total. 15 point at `0o755` shell scripts (chmod is a no-op). 1 points at `syscfg.h` (`0o644`), which gets its mode bumped to `0o755` — cosmetic only; an executable bit on a `.h` source file is irrelevant to gcc/CMake/make.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal framework-install fix, no user-visible config surface.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No user-facing config change. Affects every IDF-native build on Python 3.11 hosts.

Pre-PR (Raspberry Pi OS Bookworm, Python 3.11):

```
INFO Extracting ESP-IDF 5.5.4 framework ...
Extracting: [                                                            ] 0% Traceback (most recent call last):
  ...
  File "/usr/lib/python3.11/tarfile.py", line 2344, in chmod
    os.chmod(targetpath, tarinfo.mode)
TypeError: 'NoneType' object cannot be interpreted as an integer
```

Post-PR: extraction completes normally and the build proceeds.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). — N/A; the change is a five-line condition swap in a path that would require mocking out the tarfile pipeline to exercise.