### PR TITLE
[core] Persist & restore CORE.toolchain through StorageJSON

### DIFF
--- a/esphome/storage_json.py
+++ b/esphome/storage_json.py
@@ -136,8 +136,7 @@ class StorageJSON:
         self.framework = framework
         # The core platform of this firmware. Like "esp32", "rp2040", "host" etc.
         self.core_platform = core_platform
-        # The toolchain used for the build ("platformio" / "esp-idf"); only
-        # populated on the platforms that expose a toolchain choice in YAML.
+        # The toolchain used for the build ("platformio" / "esp-idf")
         self.toolchain = toolchain
 
     def as_dict(self):
@@ -282,10 +281,7 @@ class StorageJSON:
         """
         CORE.name = self.name
         CORE.build_path = self.build_path
-        # Restore the resolved toolchain (which validators set during a
-        # full compile). Without this the upload/logs fast path picks
-        # the PlatformIO fallback and CORE.firmware_bin points at a
-        # .pioenvs/<name>/firmware.bin the esp-idf toolchain never wrote.
+        # Restore toolchain so upload/logs picks the right firmware_bin path.
         if self.toolchain and CORE.toolchain is None:
             CORE.toolchain = Toolchain(self.toolchain)
         target_platform = self.core_platform or self.target_platform.lower()

--- a/esphome/storage_json.py
+++ b/esphome/storage_json.py
@@ -282,8 +282,17 @@ class StorageJSON:
         CORE.name = self.name
         CORE.build_path = self.build_path
         # Restore toolchain so upload/logs picks the right firmware_bin path.
+        # An unknown value (corrupt sidecar, or written by a newer ESPHome)
+        # just leaves CORE.toolchain None — the fallback then picks PlatformIO.
         if self.toolchain and CORE.toolchain is None:
-            CORE.toolchain = Toolchain(self.toolchain)
+            try:
+                CORE.toolchain = Toolchain(self.toolchain)
+            except ValueError:
+                _LOGGER.debug(
+                    "Ignoring unknown toolchain %r from %s",
+                    self.toolchain,
+                    storage_path(),
+                )
         target_platform = self.core_platform or self.target_platform.lower()
         CORE.data[KEY_CORE] = {
             KEY_TARGET_PLATFORM: target_platform,

--- a/esphome/storage_json.py
+++ b/esphome/storage_json.py
@@ -14,6 +14,7 @@ from esphome.const import (
     KEY_CORE,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
+    Toolchain,
 )
 from esphome.core import CORE
 from esphome.helpers import write_file_if_changed
@@ -98,6 +99,7 @@ class StorageJSON:
         no_mdns: bool,
         framework: str | None = None,
         core_platform: str | None = None,
+        toolchain: str | None = None,
     ) -> None:
         # Version of the storage JSON schema
         assert storage_version is None or isinstance(storage_version, int)
@@ -134,6 +136,9 @@ class StorageJSON:
         self.framework = framework
         # The core platform of this firmware. Like "esp32", "rp2040", "host" etc.
         self.core_platform = core_platform
+        # The toolchain used for the build ("platformio" / "esp-idf"); only
+        # populated on the platforms that expose a toolchain choice in YAML.
+        self.toolchain = toolchain
 
     def as_dict(self):
         return {
@@ -153,6 +158,7 @@ class StorageJSON:
             "no_mdns": self.no_mdns,
             "framework": self.framework,
             "core_platform": self.core_platform,
+            "toolchain": self.toolchain,
         }
 
     def to_json(self):
@@ -189,6 +195,7 @@ class StorageJSON:
             ),
             framework=esph.target_framework,
             core_platform=esph.target_platform,
+            toolchain=esph.toolchain.value if esph.toolchain is not None else None,
         )
 
     @staticmethod
@@ -236,6 +243,7 @@ class StorageJSON:
         no_mdns = storage.get("no_mdns", False)
         framework = storage.get("framework")
         core_platform = storage.get("core_platform")
+        toolchain = storage.get("toolchain")
         return StorageJSON(
             storage_version,
             name,
@@ -253,6 +261,7 @@ class StorageJSON:
             no_mdns,
             framework,
             core_platform,
+            toolchain,
         )
 
     @staticmethod
@@ -273,6 +282,12 @@ class StorageJSON:
         """
         CORE.name = self.name
         CORE.build_path = self.build_path
+        # Restore the resolved toolchain (which validators set during a
+        # full compile). Without this the upload/logs fast path picks
+        # the PlatformIO fallback and CORE.firmware_bin points at a
+        # .pioenvs/<name>/firmware.bin the esp-idf toolchain never wrote.
+        if self.toolchain and CORE.toolchain is None:
+            CORE.toolchain = Toolchain(self.toolchain)
         target_platform = self.core_platform or self.target_platform.lower()
         CORE.data[KEY_CORE] = {
             KEY_TARGET_PLATFORM: target_platform,

--- a/tests/unit_tests/test_storage_json.py
+++ b/tests/unit_tests/test_storage_json.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from esphome import storage_json
-from esphome.const import CONF_DISABLED, CONF_MDNS
+from esphome.const import CONF_DISABLED, CONF_MDNS, Toolchain
 from esphome.core import CORE
 
 
@@ -308,6 +308,7 @@ def test_storage_json_from_esphome_core(setup_core: Path) -> None:
     mock_core.loaded_platforms = {"sensor"}
     mock_core.config = {CONF_MDNS: {CONF_DISABLED: True}}
     mock_core.target_framework = "esp-idf"
+    mock_core.toolchain = Toolchain.ESP_IDF
 
     with patch("esphome.components.esp32.get_esp32_variant") as mock_variant:
         mock_variant.return_value = "ESP32-C3"
@@ -327,6 +328,7 @@ def test_storage_json_from_esphome_core(setup_core: Path) -> None:
     assert result.no_mdns is True
     assert result.framework == "esp-idf"
     assert result.core_platform == "esp32"
+    assert result.toolchain == "esp-idf"
 
 
 def test_storage_json_from_esphome_core_mdns_enabled(setup_core: Path) -> None:
@@ -345,10 +347,12 @@ def test_storage_json_from_esphome_core_mdns_enabled(setup_core: Path) -> None:
     mock_core.loaded_platforms = set()
     mock_core.config = {}  # No MDNS config means enabled
     mock_core.target_framework = "arduino"
+    mock_core.toolchain = None
 
     result = storage_json.StorageJSON.from_esphome_core(mock_core, old=None)
 
     assert result.no_mdns is False
+    assert result.toolchain is None
 
 
 def test_storage_json_load_valid_file(tmp_path: Path) -> None:
@@ -468,6 +472,73 @@ def test_storage_json_equality() -> None:
     assert storage1 == storage2
     assert storage1 != storage3
     assert storage1 != "not a storage object"
+
+
+def _make_storage_with_toolchain(
+    toolchain: str | None,
+) -> storage_json.StorageJSON:
+    return storage_json.StorageJSON(
+        storage_version=1,
+        name="dev",
+        friendly_name=None,
+        comment=None,
+        esphome_version="2024.1.0",
+        src_version=1,
+        address="dev.local",
+        web_port=None,
+        target_platform="ESP32",
+        build_path=Path("/build"),
+        firmware_bin_path=Path("/build/firmware.bin"),
+        loaded_integrations=set(),
+        loaded_platforms=set(),
+        no_mdns=False,
+        framework="esp-idf",
+        core_platform="esp32",
+        toolchain=toolchain,
+    )
+
+
+def test_storage_json_toolchain_round_trip(setup_core: Path) -> None:
+    """Sidecar toolchain survives save -> load -> apply_to_core."""
+    storage = _make_storage_with_toolchain("esp-idf")
+    path = setup_core / "storage.json"
+    path.write_text(storage.to_json())
+
+    # Serialization key is stable -- device-builder relies on it.
+    assert json.loads(path.read_text())["toolchain"] == "esp-idf"
+
+    loaded = storage_json.StorageJSON.load(path)
+    assert loaded is not None
+    assert loaded.toolchain == "esp-idf"
+
+    CORE.toolchain = None
+    with patch("esphome.components.esp32.get_esp32_variant"):
+        loaded.apply_to_core()
+    assert CORE.toolchain == Toolchain.ESP_IDF
+
+
+def test_storage_json_apply_to_core_preserves_cli_toolchain(
+    setup_core: Path,
+) -> None:
+    """A CLI-set CORE.toolchain wins over the sidecar value."""
+    loaded = _make_storage_with_toolchain("esp-idf")
+
+    CORE.toolchain = Toolchain.PLATFORMIO
+    with patch("esphome.components.esp32.get_esp32_variant"):
+        loaded.apply_to_core()
+    assert CORE.toolchain == Toolchain.PLATFORMIO
+
+
+def test_storage_json_apply_to_core_ignores_unknown_toolchain(
+    setup_core: Path,
+) -> None:
+    """Unknown enum values (corrupt sidecar / newer ESPHome) fall through to None."""
+    loaded = _make_storage_with_toolchain("gcc")
+
+    CORE.toolchain = None
+    with patch("esphome.components.esp32.get_esp32_variant"):
+        loaded.apply_to_core()
+    assert CORE.toolchain is None
 
 
 def test_esphome_storage_json_as_dict() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`esphome upload` (and `esphome logs`) on a config that selects `toolchain: esp-idf` in YAML can fall over with:

```
ERROR Cannot read bootloader file '/config/esphome/.esphome/build/<name>/.pioenvs/<name>/bootloader.bin': [Errno 2] No such file or directory
```

or, for plain uploads:

```
FileNotFoundError: '/config/esphome/.esphome/build/<name>/.pioenvs/<name>/firmware.bin'
```

Passing `--toolchain esp-idf` on the CLI works around it. Reported in #16526.

## Root cause

The upload / logs fast path reuses the validated-config cache (`<file>.validated.yaml` + the `StorageJSON` sidecar) and **skips `read_config`** to save time. But `CORE.toolchain` is only set inside the per-platform validators (`esp32._check_versions`, `nrf52._check_versions`) — those run as part of `read_config`. On the cache-hit path they don't run, so `CORE.toolchain` stays `None`, the `__main__.py` fallback sets it to `Toolchain.PLATFORMIO`, and `CORE.firmware_bin` then resolves to the PlatformIO `.pioenvs/<name>/firmware.bin` path — which the esp-idf toolchain never wrote.

## Fix

Capture the resolved toolchain into `StorageJSON` at compile time and restore it from there on the cache-hit path. This is the same pattern the sidecar already uses for `core_platform`, `target_platform`, `framework`, etc. — all fields that validators populate during a full compile and that the fast path needs to recover.

- `StorageJSON.__init__` gains a `toolchain: str | None = None` field.
- `from_esphome_core` captures `esph.toolchain.value` (or `None` if unset — covers the never-resolved case from outside-test contexts).
- `_load_impl` reads the new top-level `"toolchain"` key (`storage.get(...)` returns `None` for older sidecars without the field, so this is backwards-compatible).
- `apply_to_core` restores `CORE.toolchain = Toolchain(self.toolchain)` when present, **only if** `CORE.toolchain` is still `None` — so a `--toolchain` CLI flag still wins.
- 15-line change in a single file. The existing `__main__.py:2474` `Toolchain.PLATFORMIO` fallback still covers stale sidecars written by older esphome (until a recompile rewrites the JSON).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes #16526

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Any ESP32 config that selects the esp-idf toolchain:

```yaml
esp32:
  variant: esp32
  toolchain: esp-idf
  framework:
    type: esp-idf
```

Pre-PR, after `esphome compile <file>` succeeds:

```
$ esphome upload <file>
INFO Loaded validated config cache for <file>, skipping validation.
INFO Connecting to ...
...
FileNotFoundError: '/config/esphome/.esphome/build/<name>/.pioenvs/<name>/firmware.bin'
```

Post-PR: upload picks the correct `build/<name>/build/<name>.bin` and completes normally.

Verified locally on a Raspberry Pi 5 / Python 3.11 / ESP32 IDF 5.5.4 build.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). — N/A; this mirrors the existing untested round-trip of `framework` / `core_platform` through `StorageJSON`. Worth a future refactor that adds a single round-trip test covering all the validator-set fields, but out of scope for the fix.