### PR TITLE
[espidf] Write version.txt after extract so bootloader shows the real version

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -783,6 +783,31 @@ def download_from_mirrors(
         return None
 
 
+def _write_idf_version_txt(framework_path: Path, version: str) -> None:
+    """Write <framework_path>/version.txt if missing.
+
+    IDF's build.cmake resolves the version it embeds in the firmware
+    (and stamps onto the bootloader) by first running ``git describe``
+    against IDF_PATH, then falling back to ``${IDF_PATH}/version.txt``.
+    The esphome-libs/esp-idf tarball strips ``.git``, so git_describe
+    returns junk (HEAD-HASH-NOTFOUND on a clean strip, ``<hash>-dirty``
+    on a partial strip) and the bootloader's version string ends up
+    matching. Drop a version.txt at the framework root so the fallback
+    reports the real release.
+    """
+    version_txt = framework_path / "version.txt"
+    if version_txt.is_file():
+        return
+    try:
+        version_txt.write_text(f"v{version}\n", encoding="utf-8")
+    except OSError as e:
+        _LOGGER.warning(
+            "Could not write %s (%s); bootloader version string may be incorrect.",
+            version_txt,
+            e,
+        )
+
+
 def _check_esphome_idf_framework_install(
     version: str,
     targets: list[str],
@@ -854,6 +879,11 @@ def _check_esphome_idf_framework_install(
             _LOGGER.info("Extracting ESP-IDF %s framework ...", version)
             archive_extract_all(tmp.file, framework_path, progress_header="Extracting")
             extracted_marker.touch()
+
+    # Idempotent post-extract patch: written every invocation so a build
+    # dir extracted before this fix gets the file too, without forcing a
+    # clean. Skips when version.txt already exists.
+    _write_idf_version_txt(framework_path, version)
 
     # 3. Check if the framework tools are the same and correctly installed
     if not install:

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -786,17 +786,20 @@ def download_from_mirrors(
 def _write_idf_version_txt(framework_path: Path, version: str) -> None:
     """Write <framework_path>/version.txt if missing.
 
-    IDF's build.cmake resolves the version it embeds in the firmware
-    (and stamps onto the bootloader) by first running ``git describe``
-    against IDF_PATH, then falling back to ``${IDF_PATH}/version.txt``.
-    The esphome-libs/esp-idf tarball strips ``.git``, so git_describe
-    returns junk (HEAD-HASH-NOTFOUND on a clean strip, ``<hash>-dirty``
-    on a partial strip) and the bootloader's version string ends up
-    matching. Drop a version.txt at the framework root so the fallback
-    reports the real release.
+    IDF's build.cmake picks the version it embeds in the firmware (and
+    stamps onto the bootloader) in this order: ``${IDF_PATH}/version.txt``
+    if present, else ``git describe`` against IDF_PATH, else the
+    ``IDF_VERSION_MAJOR/MINOR/PATCH`` triplet from ``tools/cmake/version.cmake``.
+    On a clean esphome-libs tarball ``.git`` is fully stripped, so
+    git_describe returns ``HEAD-HASH-NOTFOUND`` (falsy) and the triplet
+    wins -- correct by luck. But a *partial* ``.git`` (e.g. a custom
+    framework.source pointed at a real git URL where build artifacts
+    mark the tree dirty) makes git_describe return ``<hash>-dirty``,
+    which is what then gets baked into the bootloader. Dropping
+    version.txt forces the right answer regardless.
     """
     version_txt = framework_path / "version.txt"
-    if version_txt.is_file():
+    if version_txt.exists():
         return
     try:
         version_txt.write_text(f"v{version}\n", encoding="utf-8")


### PR DESCRIPTION
# What does this implement/fix?

The bootloader of a firmware built with the esp-idf toolchain reports the wrong version string, e.g.:

```
[C][esphome.ota:130]:   Bootloader: ESP-IDF 9e627e7-dirty
```

or, with a fully-stripped tarball:

```
[C][esphome.ota:130]:   Bootloader: ESP-IDF HEAD-HASH-NOTFOUND
```

instead of the expected `ESP-IDF v5.5.4` (or whatever IDF release is configured).

## Root cause

IDF's `tools/cmake/build.cmake:97-111` (`__build_get_idf_git_revision`) resolves the `IDF_VER` it embeds in the firmware and stamps onto the bootloader banner by first running `git describe` against `IDF_PATH`, then preferring `${IDF_PATH}/version.txt` when present:

```cmake
git_describe(idf_ver_git "${idf_path}" "--match=v*.*")
if(EXISTS "${idf_path}/version.txt")
    file(STRINGS "${idf_path}/version.txt" idf_ver_t)
    ...
else()
    set(idf_ver_t ${idf_ver_git})
endif()
```

The esphome-libs/esp-idf tarball strips `.git`, so `git describe` either returns nothing (→ IDF falls back to its internal `HEAD-HASH-NOTFOUND` placeholder) or, on a partial strip that leaves git metadata referencing modified files, returns something like `<hash>-dirty`. Either way it ends up in the bootloader.

## Fix

Drop a `version.txt` with the real IDF release string into the framework root after extraction. Since `version.txt` takes precedence over `git describe` (per the cmake snippet above), the bootloader picks it up.

- Helper `_write_idf_version_txt(framework_path, version)` writes `v{version}\n` to `<framework_path>/version.txt`.
- Skipped when the file already exists, so a future IDF release that ships its own `version.txt` isn't stomped.
- Called from `_check_esphome_idf_framework_install` on every install check — idempotent, so a build dir extracted before this fix gets the file too without a clean.
- Same shape as the existing `_patch_tools_json_for_linux_arm64` helper one PR over.

## Verified

Against an existing IDF 5.5.4 extraction:

```
$ ls /home/jon/.../idf/frameworks/5.5.4/version.txt
ls: cannot access ...: No such file or directory

$ python3 -c "from esphome.espidf import framework; framework._write_idf_version_txt(Path('.../5.5.4'), '5.5.4')"
$ cat /home/jon/.../idf/frameworks/5.5.4/version.txt
v5.5.4
```

Second invocation is a no-op (file exists). Re-built ESPHome firmware then reports:

```
[C][esphome.ota:130]:   Bootloader: ESP-IDF v5.5.4
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes #16529

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal framework-install fix, no user-visible YAML surface.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No user-facing config change. Affects every IDF-native build.

Pre-PR: bootloader banner shows the git-describe fallback string.
Post-PR: bootloader banner shows the configured IDF release.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). — N/A; the helper writes a small file to disk in the IDF framework dir and is platform-gated by the absence of an existing file. A meaningful test would need to mock out the extraction pipeline.