### PR TITLE
[espidf] Default to remote HEAD when cg.add_library URL has no #ref

### DIFF
--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -93,7 +93,7 @@ class URLSource(Source):
 
 
 class GitSource(Source):
-    def __init__(self, url: str, ref: str):
+    def __init__(self, url: str, ref: str | None):
         self.url = url
         self.ref = ref
 
@@ -109,7 +109,7 @@ class GitSource(Source):
         return path
 
     def __str__(self):
-        return f"{self.url}#{self.ref}"
+        return f"{self.url}#{self.ref}" if self.ref else self.url
 
 
 class InvalidIDFComponent(Exception):
@@ -362,10 +362,11 @@ def _convert_library_to_component(library: Library) -> IDFComponent:
     #  Repository is provided directly
     if library.repository:
         # Parse repository URL: path becomes the component name, fragment
-        # becomes the git ref stored on GitSource.
+        # (if any) becomes the git ref stored on GitSource. A missing
+        # fragment is fine -- clone_or_update leaves the depth-1 clone on
+        # the remote's default branch, matching PIO's lib_deps behavior
+        # and external_components handling.
         split_result = urlsplit(library.repository)
-        if not split_result.fragment.strip():
-            raise ValueError(f"Missing ref in URL {library.repository}")
 
         # Sanitize name
         name = str(split_result.path).strip("/")
@@ -377,7 +378,8 @@ def _convert_library_to_component(library: Library) -> IDFComponent:
         version = "*"
         repository = urlunsplit(split_result._replace(fragment=""))
 
-        source = GitSource(str(repository), split_result.fragment)
+        ref = split_result.fragment.strip() or None
+        source = GitSource(str(repository), ref)
 
     # Version is provided - resolve using PlatformIO registry
     elif library.version:

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -352,7 +352,6 @@ def _convert_library_to_component(library: Library) -> IDFComponent:
         IDFComponent: The resolved component with name, version, and URL
 
     Raises:
-        ValueError: If a repository URL is missing a reference (#)
         RuntimeError: If no artifact can be found for the library
     """
     name = None

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -436,11 +436,21 @@ def test_convert_library_with_branch_ref():
     assert result.source.ref == "some-branch"
 
 
-def test_convert_library_missing_ref():
+def test_convert_library_missing_ref_uses_default_branch():
+    """A bare URL with no #ref clones the remote's default branch.
+
+    Matches PIO's lib_deps behavior and external_components handling --
+    git.clone_or_update with ref=None leaves the depth-1 clone on
+    whatever branch the remote HEAD points at.
+    """
     lib = Library("name", None, "https://github.com/foo/bar.git")
 
-    with pytest.raises(ValueError):
-        _convert_library_to_component(lib)
+    result = _convert_library_to_component(lib)
+
+    assert result.name == "foo/bar"
+    assert result.version == "*"
+    assert isinstance(result.source, GitSource)
+    assert result.source.ref is None
 
 
 def test_convert_library_registry(monkeypatch):


### PR DESCRIPTION
## What does this implement/fix?

External components that call `cg.add_library("Name", None, "https://github.com/owner/repo.git")` (no `#ref` fragment) currently crash mid-codegen on the IDF toolchain with `ValueError: Missing ref in URL ...`, even though the same bare URL works fine on the PIO toolchain (PIO's LDF defaults to the remote's default branch).

For example, `PedroKTFC/esphome-tesla-ble` declares its C++ dependency this way:

```
Traceback (most recent call last):
  ...
  File "esphome/espidf/component.py", line 368, in _convert_library_to_component
    raise ValueError(f"Missing ref in URL {library.repository}")
ValueError: Missing ref in URL https://github.com/PedroKTFC/tesla-ble.git
```

The raise was a self-imposed ESPHome check, not an IDF Component Manager requirement. On the IDF path ESPHome clones the dependency itself via `git.clone_or_update` (`GitSource.download`) and hands IDF an `override_path`, which makes the `version`/`git` fields in `idf_component.yml` cosmetic. `clone_or_update(ref=None, ...)` already does the right thing — depth-1 clone of the remote default branch, same code path ESPHome's `external_components` uses for bare URLs.

This drops the raise and passes `ref=None` through to `GitSource` when the URL has no fragment, bringing IDF parity with both PIO `lib_deps` and `external_components`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Related issue or feature

External components with bare-URL `cg.add_library` calls failed on the native IDF toolchain.

## Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation

N/A — internal codegen behavior.

## Test Environment

- [x] ESP32 (idf, tested locally with `esphome-tesla-ble` external component)

## Example entry for `config.yaml`

N/A — external component change, no user-facing config.

## Checklist

- [x] Tests added
- [x] All tests pass (`pytest tests/unit_tests/test_espidf_component.py`)
- [x] The code change is tested and works locally.