### PR TITLE
[espidf] Honor the dict shorthand for library.json dependencies

### DIFF
--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -655,6 +655,23 @@ def _process_dependencies(component: IDFComponent):
     if not dependencies:
         return
 
+    # PIO's library.json accepts both the list-of-dicts form and the
+    # shorthand dict form ``{"owner/Name": "version_spec"}``. Normalize
+    # the dict form so the loop below sees a uniform list. Iterating a
+    # dict gives string keys, which would silently fail the
+    # ``"name" in dependency`` substring check and skip every entry.
+    if isinstance(dependencies, dict):
+        normalized = []
+        for raw_name, spec in dependencies.items():
+            owner, _, pkgname = raw_name.rpartition("/")
+            entry = {"name": pkgname, "owner": owner or None}
+            if isinstance(spec, dict):
+                entry.update(spec)
+            else:
+                entry["version"] = spec
+            normalized.append(entry)
+        dependencies = normalized
+
     _LOGGER.info("Processing %s@%s component dependencies...", name, version)
     for dependency in dependencies:
         # Validate dependency structure

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -663,8 +663,11 @@ def _process_dependencies(component: IDFComponent):
     if isinstance(dependencies, dict):
         normalized = []
         for raw_name, spec in dependencies.items():
-            owner, _, pkgname = raw_name.rpartition("/")
-            entry = {"name": pkgname, "owner": owner or None}
+            if "/" in raw_name:
+                owner, pkgname = raw_name.split("/", 1)
+            else:
+                owner, pkgname = None, raw_name
+            entry = {"name": pkgname, "owner": owner}
             if isinstance(spec, dict):
                 entry.update(spec)
             else:

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -495,3 +495,65 @@ def test_process_dependencies_skips_invalid(tmp_component):
     _process_dependencies(tmp_component)
 
     assert tmp_component.dependencies == []
+
+
+def test_process_dependencies_dict_form(tmp_component, monkeypatch):
+    """PIO library.json shorthand ``{"owner/Name": "version"}`` is honored.
+
+    Iterating a dict gives string keys, which would silently fail the
+    ``"name" in dependency`` substring check. Normalize to list-of-dicts
+    first so the dict form (used by e.g. tesla-ble for its nanopb dep)
+    is treated the same as the verbose list form.
+    """
+    captured: list[Library] = []
+
+    def fake_generate(library):
+        captured.append(library)
+        return IDFComponent(
+            library.name, library.version, source=URLSource("http://dummy.com")
+        )
+
+    tmp_component.data = {
+        "dependencies": {
+            "nanopb/Nanopb": "^0.4.91",
+            "BareName": "1.2.3",
+        }
+    }
+    monkeypatch.setattr(
+        esphome.espidf.component, "_generate_idf_component", fake_generate
+    )
+    monkeypatch.setattr(esphome.espidf.component, "_check_library_data", lambda x: None)
+
+    _process_dependencies(tmp_component)
+
+    assert len(tmp_component.dependencies) == 2
+    names = sorted(lib.name for lib in captured)
+    versions = sorted(lib.version for lib in captured)
+    assert names == ["BareName", "nanopb/Nanopb"]
+    assert versions == ["1.2.3", "^0.4.91"]
+
+
+def test_process_dependencies_dict_form_with_url_value(tmp_component, monkeypatch):
+    """A dict-value that's a URL gets routed to ``repository`` like the list form."""
+    captured: list[Library] = []
+
+    def fake_generate(library):
+        captured.append(library)
+        return IDFComponent(library.name, "*", source=URLSource("http://dummy.com"))
+
+    tmp_component.data = {
+        "dependencies": {
+            "foo/Bar": "https://github.com/foo/bar.git#main",
+        }
+    }
+    monkeypatch.setattr(
+        esphome.espidf.component, "_generate_idf_component", fake_generate
+    )
+    monkeypatch.setattr(esphome.espidf.component, "_check_library_data", lambda x: None)
+
+    _process_dependencies(tmp_component)
+
+    assert len(captured) == 1
+    assert captured[0].name == "foo/Bar"
+    assert captured[0].version is None
+    assert captured[0].repository == "https://github.com/foo/bar.git#main"

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -557,3 +557,51 @@ def test_process_dependencies_dict_form_with_url_value(tmp_component, monkeypatc
     assert captured[0].name == "foo/Bar"
     assert captured[0].version is None
     assert captured[0].repository == "https://github.com/foo/bar.git#main"
+
+
+def test_process_dependencies_dict_form_with_nested_spec(tmp_component, monkeypatch):
+    """A dict-value that's itself a dict is merged into the entry.
+
+    PIO's library.json allows ``{"owner/Name": {"version": "...", ...}}``
+    for entries that need fields beyond just a version (platforms,
+    frameworks, etc.). The extra fields flow into _check_library_data
+    via the entry merge.
+    """
+    captured: list[Library] = []
+    checked: list[dict] = []
+
+    def fake_generate(library):
+        captured.append(library)
+        return IDFComponent(
+            library.name, library.version, source=URLSource("http://dummy.com")
+        )
+
+    tmp_component.data = {
+        "dependencies": {
+            "nanopb/Nanopb": {"version": "^0.4.91", "platforms": "espidf"},
+        }
+    }
+    monkeypatch.setattr(
+        esphome.espidf.component, "_generate_idf_component", fake_generate
+    )
+    monkeypatch.setattr(
+        esphome.espidf.component,
+        "_check_library_data",
+        checked.append,
+    )
+
+    _process_dependencies(tmp_component)
+
+    assert len(captured) == 1
+    assert captured[0].name == "nanopb/Nanopb"
+    assert captured[0].version == "^0.4.91"
+    # Extra spec fields reach _check_library_data so platform/framework
+    # gating still applies.
+    assert checked == [
+        {
+            "name": "Nanopb",
+            "owner": "nanopb",
+            "version": "^0.4.91",
+            "platforms": "espidf",
+        }
+    ]


### PR DESCRIPTION
## What does this implement/fix?

PIO's `library.json` spec accepts two shapes for the `dependencies` key:

```json
"dependencies": [
  {"owner": "nanopb", "name": "Nanopb", "version": "^0.4.91"}
]
```

```json
"dependencies": {
  "nanopb/Nanopb": "^0.4.91"
}
```

The IDF dependency processor only handled the list form. Iterating the dict form gives string keys (e.g. `"nanopb/Nanopb"`), which silently fail the `all(k in dependency for k in ("name", "version"))` substring check at `_process_dependencies` and skip every entry. The user-visible symptom is that transitive C++ deps declared in dict form aren't cloned into IDF components — e.g. external components like `PedroKTFC/esphome-tesla-ble` (whose `tesla-ble` library declares `"nanopb/Nanopb": "^0.4.91"` in dict form) fail to build with `fatal error: pb.h: No such file or directory` on the IDF toolchain.

Normalize the dict form to list-of-dicts at the top of `_process_dependencies` so the existing loop is unchanged. Both string values (`{"name": "version"}`) and nested-dict values (`{"name": {"version": "...", "platforms": "..."}}`) are supported.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Related issue or feature

Surfaced while bringing `PedroKTFC/esphome-tesla-ble` up on the native IDF toolchain.

## Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation

N/A — internal codegen behavior.

## Test Environment

- [x] ESP32 (idf, tested locally with `PedroKTFC/esphome-tesla-ble`)

## Example entry for `config.yaml`

N/A — external component change, no user-facing config.

## Checklist

- [x] Tests added (`test_process_dependencies_dict_form`, `test_process_dependencies_dict_form_with_url_value`)
- [x] All tests pass (`pytest tests/unit_tests/test_espidf_component.py`)
- [x] The code change is tested and works locally.