### PR TITLE
[esp32] Defer esp_panic_handler wrap so arduino-esp32 IDF component skips it

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1743,6 +1743,29 @@ async def _add_yaml_idf_components(components: list[ConfigType]):
         )
 
 
+@coroutine_with_priority(CoroPriority.FINAL - 1)
+async def _finalize_arduino_aware_flags():
+    """Build flags that depend on whether arduino-esp32 is linked in.
+
+    Runs after FINAL so KEY_COMPONENTS is fully populated.
+
+    - Skip our esp_panic_handler wrap when Arduino is linked; Arduino
+      wraps the same symbol and the linker errors on the duplicate.
+    - Define USE_ARDUINO in the hybrid esp-idf+arduino-esp32-component
+      case so ESPHome's ``#ifdef USE_ARDUINO`` paths light up. The
+      framework=arduino branch already adds it inline in to_code.
+    """
+    arduino_linked = (
+        CORE.using_arduino
+        or "espressif/arduino-esp32" in CORE.data[KEY_ESP32][KEY_COMPONENTS]
+    )
+    if not arduino_linked:
+        cg.add_build_flag("-Wl,--wrap=esp_panic_handler")
+        cg.add_define("USE_ESP32_CRASH_HANDLER")
+    elif not CORE.using_arduino:
+        cg.add_build_flag("-DUSE_ARDUINO")
+
+
 async def to_code(config):
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
     conf = config[CONF_FRAMEWORK]
@@ -1802,11 +1825,8 @@ async def to_code(config):
     cg.add_build_flag("-DUSE_ESP32")
     cg.add_define("USE_NATIVE_64BIT_TIME")
     cg.add_build_flag("-Wl,-z,noexecstack")
-    # Arduino already wraps esp_panic_handler for its own backtrace handler,
-    # so only add our wrap when using ESP-IDF framework to avoid linker conflicts.
-    if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
-        cg.add_build_flag("-Wl,--wrap=esp_panic_handler")
-        cg.add_define("USE_ESP32_CRASH_HANDLER")
+    # Deferred so KEY_COMPONENTS is fully populated -- see the coroutine.
+    CORE.add_job(_finalize_arduino_aware_flags)
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     variant = config[CONF_VARIANT]
     cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{variant}")

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -113,6 +113,7 @@ ARDUINO_FRAMEWORK_NAME = "framework-arduinoespressif32"
 ARDUINO_FRAMEWORK_PKG = f"pioarduino/{ARDUINO_FRAMEWORK_NAME}"
 ARDUINO_LIBS_NAME = f"{ARDUINO_FRAMEWORK_NAME}-libs"
 ARDUINO_LIBS_PKG = f"pioarduino/{ARDUINO_LIBS_NAME}"
+ARDUINO_ESP32_COMPONENT_NAME = "espressif/arduino-esp32"
 
 LOG_LEVELS_IDF = [
     "NONE",
@@ -1747,7 +1748,9 @@ async def _add_yaml_idf_components(components: list[ConfigType]):
 async def _finalize_arduino_aware_flags():
     """Build flags that depend on whether arduino-esp32 is linked in.
 
-    Runs after FINAL so KEY_COMPONENTS is fully populated.
+    Scheduler runs lower priority values later, so ``FINAL - 1`` fires
+    after every ``FINAL`` job (incl. ``_add_yaml_idf_components``) --
+    by then ``KEY_COMPONENTS`` is fully populated.
 
     - Skip our esp_panic_handler wrap when Arduino is linked; Arduino
       wraps the same symbol and the linker errors on the duplicate.
@@ -1757,7 +1760,7 @@ async def _finalize_arduino_aware_flags():
     """
     arduino_linked = (
         CORE.using_arduino
-        or "espressif/arduino-esp32" in CORE.data[KEY_ESP32][KEY_COMPONENTS]
+        or ARDUINO_ESP32_COMPONENT_NAME in CORE.data[KEY_ESP32][KEY_COMPONENTS]
     )
     if not arduino_linked:
         cg.add_build_flag("-Wl,--wrap=esp_panic_handler")
@@ -2587,7 +2590,7 @@ def _write_idf_component_yml():
 
         if CORE.using_toolchain_esp_idf:
             add_idf_component(
-                name="espressif/arduino-esp32",
+                name=ARDUINO_ESP32_COMPONENT_NAME,
                 ref=str(CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]),
             )
 


### PR DESCRIPTION
## What does this implement/fix?

The `-Wl,--wrap=esp_panic_handler` build flag (plus the matching `USE_ESP32_CRASH_HANDLER` define that turns on ESPHome's crash handler) was guarded inline in `esp32.to_code` by `framework: type: esp-idf`. That guard misses the hybrid case where a user stays on the esp-idf framework but pulls `espressif/arduino-esp32` in via `esp32.add_idf_component(...)` (e.g. from an external component or YAML `idf_components:`): Arduino also wraps `esp_panic_handler` for its own backtrace handler, and the linker hard-errors on the duplicate wrap.

Move the decision out of `to_code` and into a `CoroPriority.FINAL - 1` coroutine, so by the time we check, every `add_idf_component()` call (including YAML-registered components at `FINAL`) has populated `CORE.data[KEY_ESP32][KEY_COMPONENTS]`. Skip the wrap when Arduino is linked by either mechanism (`CORE.using_arduino` or `"espressif/arduino-esp32"` present in the component registry).

While the wrap was being deferred anyway, I also auto-`-DUSE_ARDUINO` in the hybrid case so ESPHome's `#ifdef USE_ARDUINO` C++ paths light up the same way they do on `framework: type: arduino`. The framework=arduino branch already sets it inline at `to_code`, so the new code only patches the hybrid path.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Related issue or feature

Surfaced when bringing up an external component that calls `esp32.add_idf_component(name="espressif/arduino-esp32", ...)` while leaving the user's framework on `esp-idf`.

## Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation

N/A — internal code-gen behavior.

## Test Environment

- [x] ESP32 (idf)
- [x] ESP32 (arduino) — unchanged, regression-free via `CORE.using_arduino` short-circuit

## Example entry for `config.yaml`

N/A — no user-facing config change.

## Checklist

- [x] The code change is tested and works locally.
- [x] Existing tests still pass (`pytest tests/unit_tests/test_espidf_toolchain.py tests/unit_tests/test_storage_json.py`).