### PR TITLE
[tuya] Restore null guard on status_pin lost in #16353

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -203,16 +203,20 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       }
       if (this->init_state_ == TuyaInitState::INIT_CONF) {
         // If mcu returned status gpio, then we can omit sending wifi state
-        if (this->status_pin_reported_ != -1 && this->status_pin_ != nullptr) {
+        if (this->status_pin_reported_ != -1) {
           this->init_state_ = TuyaInitState::INIT_DATAPOINT;
           this->send_empty_command_(TuyaCommandType::DATAPOINT_QUERY);
-          // Configure status pin toggling (if reported and configured) or WIFI_STATE periodic send
-          if (this->status_pin_->get_pin() != this->status_pin_reported_) {
-            ESP_LOGW(TAG, "Supplied status_pin does not equal the reported pin %i. Using supplied pin anyway.",
+          if (this->status_pin_ != nullptr) {
+            if (this->status_pin_->get_pin() != this->status_pin_reported_) {
+              ESP_LOGW(TAG, "Supplied status_pin does not equal the reported pin %i. Using supplied pin anyway.",
+                       this->status_pin_reported_);
+            }
+            ESP_LOGV(TAG, "Configured status pin %i", this->status_pin_->get_pin());
+            this->set_interval("wifi", 1000, [this] { this->set_status_pin_(); });
+          } else {
+            ESP_LOGW(TAG, "MCU reported status_pin %i but no status_pin was configured; running in limited mode.",
                      this->status_pin_reported_);
           }
-          ESP_LOGV(TAG, "Configured status pin %i", this->status_pin_->get_pin());
-          this->set_interval("wifi", 1000, [this] { this->set_status_pin_(); });
         } else {
           this->init_state_ = TuyaInitState::INIT_WIFI;
           ESP_LOGV(TAG, "Configured WIFI_STATE periodic send");

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -203,14 +203,12 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       }
       if (this->init_state_ == TuyaInitState::INIT_CONF) {
         // If mcu returned status gpio, then we can omit sending wifi state
-        if (this->status_pin_reported_ != -1) {
+        if (this->status_pin_reported_ != -1 && this->status_pin_ != nullptr) {
           this->init_state_ = TuyaInitState::INIT_DATAPOINT;
           this->send_empty_command_(TuyaCommandType::DATAPOINT_QUERY);
-          bool is_pin_equals =
-              this->status_pin_ != nullptr && this->status_pin_->get_pin() == this->status_pin_reported_;
           // Configure status pin toggling (if reported and configured) or WIFI_STATE periodic send
-          if (!is_pin_equals) {
-            ESP_LOGW(TAG, "Supplied status_pin does not equals the reported pin %i. Using supplied pin anyway.",
+          if (this->status_pin_->get_pin() != this->status_pin_reported_) {
+            ESP_LOGW(TAG, "Supplied status_pin does not equal the reported pin %i. Using supplied pin anyway.",
                      this->status_pin_reported_);
           }
           ESP_LOGV(TAG, "Configured status pin %i", this->status_pin_->get_pin());


### PR DESCRIPTION
# What does this implement/fix?

Fixes #16536: BK72XX + TuyaMCU devices break on 2026.5.0. WiFi connects (device pingable) but TuyaMCU never initializes and the ESPHome API never comes up.

PR #16353 dropped the implicit null-pointer guard on `this->status_pin_` in `Tuya::handle_command_`. When the MCU reports a status pin (`status_pin_reported_ != -1`) but the user hasn't configured `tuya: status_pin:` (so `status_pin_ == nullptr`), the new code unconditionally calls `this->status_pin_->get_pin()` in `ESP_LOGV` and schedules `set_status_pin_()` to dereference the null pointer every second — crashing mid-handshake and stalling `App::setup()` before `api`/`ota` start.

This restores the null guard: the `INIT_DATAPOINT` transition + `DATAPOINT_QUERY` send stay at the top of the branch (unchanged from 2026.4.5), and only the pin-toggle log + interval are nested under `if (this->status_pin_ != nullptr)`. When the MCU reports a pin but the user didn't configure one, log the pre-#16353 "limited mode" warning and schedule no interval. The mismatched-pin warning #16353 introduced is preserved for users who *did* configure a pin. Also fixes "does not equals" → "does not equal".

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #16536 (regression introduced by #16353 in 2026.5.0)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (restores prior behavior)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Reporter's config -- see #16536. Key bit:
tuya:
  time_id: sntptime
# No status_pin: configured, MCU reports one -> crash on 2026.5.0.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).