### PR TITLE
[api] Break api_connection/api_server include cycle to drop custom unique_ptr deleter

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1,6 +1,8 @@
 #include "api_connection.h"
 #ifdef USE_API
-#include "api_server.h"  // brings APIServer complete for encode_to_buffer/get_batch_delay_ms_
+// Pulls in api_server.h (APIServer complete) and the inline encode_to_buffer
+// and get_batch_delay_ms_ definitions that need it.
+#include "api_connection_buffer.h"
 #ifdef USE_API_NOISE
 #include "api_frame_helper_noise.h"
 #endif

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1,8 +1,6 @@
 #include "api_connection.h"
 #ifdef USE_API
-// Pulls in api_server.h (APIServer complete) and the inline encode_to_buffer
-// and get_batch_delay_ms_ definitions that need it.
-#include "api_connection_buffer.h"
+#include "api_connection_buffer.h"  // for encode_to_buffer / get_batch_delay_ms_ inlines
 #ifdef USE_API_NOISE
 #include "api_frame_helper_noise.h"
 #endif

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1,5 +1,6 @@
 #include "api_connection.h"
 #ifdef USE_API
+#include "api_server.h"  // brings APIServer complete for encode_to_buffer/get_batch_delay_ms_
 #ifdef USE_API_NOISE
 #include "api_frame_helper_noise.h"
 #endif

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -11,7 +11,8 @@
 #endif
 #include "api_pb2.h"
 #include "api_pb2_service.h"
-#include "api_server.h"
+#include "list_entities.h"
+#include "subscribe_state.h"
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
 #ifdef USE_ESP32_CRASH_HANDLER
@@ -35,6 +36,11 @@ class ComponentIterator;
 }  // namespace esphome
 
 namespace esphome::api {
+
+// Forward declaration to break the api_connection.h <-> api_server.h include cycle.
+// APIServer is only used through pointers/references in this header; methods that
+// need the complete type are defined inline at the bottom of api_server.h.
+class APIServer;
 
 // Keepalive timeout in milliseconds
 static constexpr uint32_t KEEPALIVE_TIMEOUT_MS = 60000;
@@ -413,42 +419,10 @@ class APIConnection final : public APIServerConnectionBase {
 
   // Core batch encoding logic. Computes header size, checks fit, resizes buffer, encodes.
   // ALWAYS_INLINE so the compiler can devirtualize encode_fn at hot call sites.
-  static inline uint16_t ESPHOME_ALWAYS_INLINE encode_to_buffer(uint32_t calculated_size, MessageEncodeFn encode_fn,
-                                                                const void *msg, APIConnection *conn,
-                                                                uint32_t remaining_size) {
-#ifdef HAS_PROTO_MESSAGE_DUMP
-    if (conn->flags_.log_only_mode) {
-      auto *proto_msg = static_cast<const ProtoMessage *>(msg);
-      DumpBuffer dump_buf;
-      conn->log_send_message_(proto_msg->message_name(), proto_msg->dump_to(dump_buf));
-      return 1;
-    }
-#endif
-    const uint8_t footer_size = conn->helper_->frame_footer_size();
-
-    // First message uses max padding (already in buffer), subsequent use exact header size
-    size_t to_add;
-    if (conn->flags_.batch_first_message) {
-      conn->flags_.batch_first_message = false;
-      conn->batch_header_size_ = conn->helper_->frame_header_padding();
-      to_add = calculated_size;
-    } else {
-      conn->batch_header_size_ = conn->helper_->frame_header_size(calculated_size, conn->batch_message_type_);
-      to_add = calculated_size + conn->batch_header_size_ + footer_size;
-    }
-
-    // Check if it fits (using actual header size, not max padding)
-    uint16_t total_calculated_size = calculated_size + conn->batch_header_size_ + footer_size;
-    if (total_calculated_size > remaining_size)
-      return 0;
-
-    auto &shared_buf = conn->parent_->get_shared_buffer_ref();
-    shared_buf.resize(shared_buf.size() + to_add);
-    ProtoWriteBuffer buffer{&shared_buf, shared_buf.size() - calculated_size};
-    encode_fn(msg, buffer PROTO_ENCODE_DEBUG_INIT(&shared_buf));
-
-    return total_calculated_size;
-  }
+  // Definition is at the bottom of api_server.h, where APIServer is a complete type
+  // (needed for conn->parent_->get_shared_buffer_ref()). Callers must include api_server.h.
+  static uint16_t ESPHOME_ALWAYS_INLINE encode_to_buffer(uint32_t calculated_size, MessageEncodeFn encode_fn,
+                                                         const void *msg, APIConnection *conn, uint32_t remaining_size);
 
   // Noinline version of encode_to_buffer for cold paths (entity info, zero-payload messages).
   // All cold callers share this single copy instead of each getting an ALWAYS_INLINE expansion.
@@ -792,7 +766,8 @@ class APIConnection final : public APIServerConnectionBase {
   // Read by process_batch_multi_ to pass into MessageInfo.
   uint8_t batch_header_size_{0};
 
-  uint32_t get_batch_delay_ms_() const { return this->parent_->get_batch_delay(); }
+  // Definition at the bottom of api_server.h (needs APIServer complete).
+  uint32_t get_batch_delay_ms_() const;
   // Message will use 8 more bytes than the minimum size, and typical
   // MTU is 1500. Sometimes users will see as low as 1460 MTU.
   // If its IPv6 the header is 40 bytes, and if its IPv4

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -37,9 +37,7 @@ class ComponentIterator;
 
 namespace esphome::api {
 
-// Forward declaration to break the api_connection.h <-> api_server.h include cycle.
-// APIServer is only used through pointers/references in this header; the few
-// inline methods that need the complete type are defined in api_connection_buffer.h.
+// Forward-declared to break the api_server.h cycle; full-type inlines are in api_connection_buffer.h.
 class APIServer;
 
 // Keepalive timeout in milliseconds
@@ -417,11 +415,8 @@ class APIConnection final : public APIServerConnectionBase {
   // Non-template buffer management for send_message
   bool send_message_(uint32_t payload_size, uint8_t message_type, MessageEncodeFn encode_fn, const void *msg);
 
-  // Core batch encoding logic. Computes header size, checks fit, resizes buffer, encodes.
-  // ALWAYS_INLINE so the compiler can devirtualize encode_fn at hot call sites.
-  // Definition lives in api_connection_buffer.h, where APIServer is a complete type
-  // (needed for conn->parent_->get_shared_buffer_ref()). Callers must include
-  // api_connection_buffer.h.
+  // Core batch encoding logic. ALWAYS_INLINE so encode_fn devirtualizes at hot call sites.
+  // Defined in api_connection_buffer.h (needs APIServer complete).
   static uint16_t ESPHOME_ALWAYS_INLINE encode_to_buffer(uint32_t calculated_size, MessageEncodeFn encode_fn,
                                                          const void *msg, APIConnection *conn, uint32_t remaining_size);
 
@@ -767,7 +762,7 @@ class APIConnection final : public APIServerConnectionBase {
   // Read by process_batch_multi_ to pass into MessageInfo.
   uint8_t batch_header_size_{0};
 
-  // Definition in api_connection_buffer.h (needs APIServer complete).
+  // Defined in api_connection_buffer.h (needs APIServer complete).
   uint32_t get_batch_delay_ms_() const;
   // Message will use 8 more bytes than the minimum size, and typical
   // MTU is 1500. Sometimes users will see as low as 1460 MTU.

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -38,8 +38,8 @@ class ComponentIterator;
 namespace esphome::api {
 
 // Forward declaration to break the api_connection.h <-> api_server.h include cycle.
-// APIServer is only used through pointers/references in this header; methods that
-// need the complete type are defined inline at the bottom of api_server.h.
+// APIServer is only used through pointers/references in this header; the few
+// inline methods that need the complete type are defined in api_connection_buffer.h.
 class APIServer;
 
 // Keepalive timeout in milliseconds
@@ -419,8 +419,9 @@ class APIConnection final : public APIServerConnectionBase {
 
   // Core batch encoding logic. Computes header size, checks fit, resizes buffer, encodes.
   // ALWAYS_INLINE so the compiler can devirtualize encode_fn at hot call sites.
-  // Definition is at the bottom of api_server.h, where APIServer is a complete type
-  // (needed for conn->parent_->get_shared_buffer_ref()). Callers must include api_server.h.
+  // Definition lives in api_connection_buffer.h, where APIServer is a complete type
+  // (needed for conn->parent_->get_shared_buffer_ref()). Callers must include
+  // api_connection_buffer.h.
   static uint16_t ESPHOME_ALWAYS_INLINE encode_to_buffer(uint32_t calculated_size, MessageEncodeFn encode_fn,
                                                          const void *msg, APIConnection *conn, uint32_t remaining_size);
 
@@ -766,7 +767,7 @@ class APIConnection final : public APIServerConnectionBase {
   // Read by process_batch_multi_ to pass into MessageInfo.
   uint8_t batch_header_size_{0};
 
-  // Definition at the bottom of api_server.h (needs APIServer complete).
+  // Definition in api_connection_buffer.h (needs APIServer complete).
   uint32_t get_batch_delay_ms_() const;
   // Message will use 8 more bytes than the minimum size, and typical
   // MTU is 1500. Sometimes users will see as low as 1460 MTU.

--- a/esphome/components/api/api_connection_buffer.h
+++ b/esphome/components/api/api_connection_buffer.h
@@ -3,15 +3,8 @@
 #include "esphome/core/defines.h"
 #ifdef USE_API
 
-// Inline definitions for APIConnection members that need the complete
-// APIServer type (currently encode_to_buffer for the hot batch-send path and
-// get_batch_delay_ms_). Pulled into a dedicated header so api_server.h does
-// not have to carry APIConnection method bodies and api_connection.h can
-// keep just a forward declaration of APIServer, breaking the include cycle
-// that previously forced a custom std::unique_ptr deleter on libc++.
-//
-// Include this header from translation units that call encode_to_buffer or
-// any other APIConnection inline that touches APIServer.
+// Inline APIConnection methods that need APIServer complete. Include this
+// instead of api_connection.h when calling encode_to_buffer or get_batch_delay_ms_.
 
 #include "api_connection.h"
 #include "api_server.h"

--- a/esphome/components/api/api_connection_buffer.h
+++ b/esphome/components/api/api_connection_buffer.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+#ifdef USE_API
+
+// Inline definitions for APIConnection members that need the complete
+// APIServer type (currently encode_to_buffer for the hot batch-send path and
+// get_batch_delay_ms_). Pulled into a dedicated header so api_server.h does
+// not have to carry APIConnection method bodies and api_connection.h can
+// keep just a forward declaration of APIServer, breaking the include cycle
+// that previously forced a custom std::unique_ptr deleter on libc++.
+//
+// Include this header from translation units that call encode_to_buffer or
+// any other APIConnection inline that touches APIServer.
+
+#include "api_connection.h"
+#include "api_server.h"
+
+namespace esphome::api {
+
+inline uint16_t ESPHOME_ALWAYS_INLINE APIConnection::encode_to_buffer(uint32_t calculated_size,
+                                                                      MessageEncodeFn encode_fn, const void *msg,
+                                                                      APIConnection *conn, uint32_t remaining_size) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  if (conn->flags_.log_only_mode) {
+    auto *proto_msg = static_cast<const ProtoMessage *>(msg);
+    DumpBuffer dump_buf;
+    conn->log_send_message_(proto_msg->message_name(), proto_msg->dump_to(dump_buf));
+    return 1;
+  }
+#endif
+  const uint8_t footer_size = conn->helper_->frame_footer_size();
+
+  // First message uses max padding (already in buffer), subsequent use exact header size
+  size_t to_add;
+  if (conn->flags_.batch_first_message) {
+    conn->flags_.batch_first_message = false;
+    conn->batch_header_size_ = conn->helper_->frame_header_padding();
+    to_add = calculated_size;
+  } else {
+    conn->batch_header_size_ = conn->helper_->frame_header_size(calculated_size, conn->batch_message_type_);
+    to_add = calculated_size + conn->batch_header_size_ + footer_size;
+  }
+
+  // Check if it fits (using actual header size, not max padding)
+  uint16_t total_calculated_size = calculated_size + conn->batch_header_size_ + footer_size;
+  if (total_calculated_size > remaining_size)
+    return 0;
+
+  auto &shared_buf = conn->parent_->get_shared_buffer_ref();
+  shared_buf.resize(shared_buf.size() + to_add);
+  ProtoWriteBuffer buffer{&shared_buf, shared_buf.size() - calculated_size};
+  encode_fn(msg, buffer PROTO_ENCODE_DEBUG_INIT(&shared_buf));
+
+  return total_calculated_size;
+}
+
+inline uint32_t APIConnection::get_batch_delay_ms_() const { return this->parent_->get_batch_delay(); }
+
+}  // namespace esphome::api
+#endif

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -30,11 +30,6 @@ APIServer *global_api_server = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-c
 
 APIServer::APIServer() { global_api_server = this; }
 
-// Custom deleter defined here so `delete` sees the complete APIConnection type.
-// This prevents libc++ from emitting an "incomplete type" error when other
-// translation units only have the forward declaration of APIConnection.
-void APIServer::APIConnectionDeleter::operator()(APIConnection *p) const { delete p; }
-
 void APIServer::socket_failed_(const LogString *msg) {
   ESP_LOGW(TAG, "Socket %s: errno %d", LOG_STR_ARG(msg), errno);
   this->destroy_socket_();

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -357,49 +357,5 @@ template<typename... Ts> class APIConnectedCondition : public Condition<Ts...> {
   }
 };
 
-// Inline definitions for APIConnection members declared in api_connection.h
-// that need the complete APIServer type. Defined here, after APIServer is
-// complete, so api_connection.h can break the include cycle by only
-// forward-declaring APIServer.
-
-inline uint16_t ESPHOME_ALWAYS_INLINE APIConnection::encode_to_buffer(uint32_t calculated_size,
-                                                                      MessageEncodeFn encode_fn, const void *msg,
-                                                                      APIConnection *conn, uint32_t remaining_size) {
-#ifdef HAS_PROTO_MESSAGE_DUMP
-  if (conn->flags_.log_only_mode) {
-    auto *proto_msg = static_cast<const ProtoMessage *>(msg);
-    DumpBuffer dump_buf;
-    conn->log_send_message_(proto_msg->message_name(), proto_msg->dump_to(dump_buf));
-    return 1;
-  }
-#endif
-  const uint8_t footer_size = conn->helper_->frame_footer_size();
-
-  // First message uses max padding (already in buffer), subsequent use exact header size
-  size_t to_add;
-  if (conn->flags_.batch_first_message) {
-    conn->flags_.batch_first_message = false;
-    conn->batch_header_size_ = conn->helper_->frame_header_padding();
-    to_add = calculated_size;
-  } else {
-    conn->batch_header_size_ = conn->helper_->frame_header_size(calculated_size, conn->batch_message_type_);
-    to_add = calculated_size + conn->batch_header_size_ + footer_size;
-  }
-
-  // Check if it fits (using actual header size, not max padding)
-  uint16_t total_calculated_size = calculated_size + conn->batch_header_size_ + footer_size;
-  if (total_calculated_size > remaining_size)
-    return 0;
-
-  auto &shared_buf = conn->parent_->get_shared_buffer_ref();
-  shared_buf.resize(shared_buf.size() + to_add);
-  ProtoWriteBuffer buffer{&shared_buf, shared_buf.size() - calculated_size};
-  encode_fn(msg, buffer PROTO_ENCODE_DEBUG_INIT(&shared_buf));
-
-  return total_calculated_size;
-}
-
-inline uint32_t APIConnection::get_batch_delay_ms_() const { return this->parent_->get_batch_delay(); }
-
 }  // namespace esphome::api
 #endif

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -3,11 +3,7 @@
 #include "esphome/core/defines.h"
 #ifdef USE_API
 #include "api_buffer.h"
-// api_connection.h must be included before clients_ is declared so APIConnection
-// is a complete type when std::unique_ptr<APIConnection> is instantiated. libc++
-// otherwise trips static_assert(sizeof(_Tp) >= 0, "cannot delete an incomplete
-// type") while parsing the array member. api_connection.h transitively brings in
-// list_entities.h and subscribe_state.h.
+// Must precede clients_ so APIConnection is complete for default_delete (libc++).
 #include "api_connection.h"
 #include "api_noise_context.h"
 #include "api_pb2.h"

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -3,6 +3,12 @@
 #include "esphome/core/defines.h"
 #ifdef USE_API
 #include "api_buffer.h"
+// api_connection.h must be included before clients_ is declared so APIConnection
+// is a complete type when std::unique_ptr<APIConnection> is instantiated. libc++
+// otherwise trips static_assert(sizeof(_Tp) >= 0, "cannot delete an incomplete
+// type") while parsing the array member. api_connection.h transitively brings in
+// list_entities.h and subscribe_state.h.
+#include "api_connection.h"
 #include "api_noise_context.h"
 #include "api_pb2.h"
 #include "api_pb2_service.h"
@@ -12,8 +18,6 @@
 #include "esphome/core/controller.h"
 #include "esphome/core/log.h"
 #include "esphome/core/string_ref.h"
-#include "list_entities.h"
-#include "subscribe_state.h"
 #ifdef USE_LOGGER
 #include "esphome/components/logger/logger.h"
 #endif
@@ -191,15 +195,9 @@ class APIServer final : public Component,
   bool is_connected_with_state_subscription() const;
 
   // Range-for view over the populated slice [0, api_connection_count_). Read-only with respect
-  // to ownership — callers get `const unique_ptr&` so they can invoke non-const methods on the
+  // to ownership; callers get `const unique_ptr&` so they can invoke non-const methods on the
   // APIConnection but cannot reset/move the slot and break the count invariant.
-  // Custom deleter is defined out-of-line in api_server.cpp so libc++ does not
-  // eagerly instantiate `delete static_cast<APIConnection *>(p)` here, where
-  // only the forward declaration of APIConnection is visible (incomplete type).
-  struct APIConnectionDeleter {
-    void operator()(APIConnection *p) const;
-  };
-  using APIConnectionPtr = std::unique_ptr<APIConnection, APIConnectionDeleter>;
+  using APIConnectionPtr = std::unique_ptr<APIConnection>;
   class ActiveClientsView {
     const APIConnectionPtr *begin_;
     const APIConnectionPtr *end_;
@@ -358,6 +356,50 @@ template<typename... Ts> class APIConnectedCondition : public Condition<Ts...> {
     return global_api_server->is_connected();
   }
 };
+
+// Inline definitions for APIConnection members declared in api_connection.h
+// that need the complete APIServer type. Defined here, after APIServer is
+// complete, so api_connection.h can break the include cycle by only
+// forward-declaring APIServer.
+
+inline uint16_t ESPHOME_ALWAYS_INLINE APIConnection::encode_to_buffer(uint32_t calculated_size,
+                                                                      MessageEncodeFn encode_fn, const void *msg,
+                                                                      APIConnection *conn, uint32_t remaining_size) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  if (conn->flags_.log_only_mode) {
+    auto *proto_msg = static_cast<const ProtoMessage *>(msg);
+    DumpBuffer dump_buf;
+    conn->log_send_message_(proto_msg->message_name(), proto_msg->dump_to(dump_buf));
+    return 1;
+  }
+#endif
+  const uint8_t footer_size = conn->helper_->frame_footer_size();
+
+  // First message uses max padding (already in buffer), subsequent use exact header size
+  size_t to_add;
+  if (conn->flags_.batch_first_message) {
+    conn->flags_.batch_first_message = false;
+    conn->batch_header_size_ = conn->helper_->frame_header_padding();
+    to_add = calculated_size;
+  } else {
+    conn->batch_header_size_ = conn->helper_->frame_header_size(calculated_size, conn->batch_message_type_);
+    to_add = calculated_size + conn->batch_header_size_ + footer_size;
+  }
+
+  // Check if it fits (using actual header size, not max padding)
+  uint16_t total_calculated_size = calculated_size + conn->batch_header_size_ + footer_size;
+  if (total_calculated_size > remaining_size)
+    return 0;
+
+  auto &shared_buf = conn->parent_->get_shared_buffer_ref();
+  shared_buf.resize(shared_buf.size() + to_add);
+  ProtoWriteBuffer buffer{&shared_buf, shared_buf.size() - calculated_size};
+  encode_fn(msg, buffer PROTO_ENCODE_DEBUG_INIT(&shared_buf));
+
+  return total_calculated_size;
+}
+
+inline uint32_t APIConnection::get_batch_delay_ms_() const { return this->parent_->get_batch_delay(); }
 
 }  // namespace esphome::api
 #endif

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -1,5 +1,6 @@
 #include "bluetooth_proxy.h"
 
+#include "esphome/components/api/api_server.h"
 #include "esphome/core/log.h"
 #include "esphome/core/macros.h"
 #include "esphome/core/application.h"


### PR DESCRIPTION
# What does this implement/fix?

Speculative attempt to address the LN882H boot crash reported in #16540. Reorganises the api_connection.h / api_server.h include cycle so APIConnection is a complete type at the point std::unique_ptr<APIConnection> is instantiated; that lets clients_ drop the custom APIConnectionDeleter added in #16050. The deleter was the only substantive change between 2026.4.5 and 2026.5.0 the reporter could identify, so removing it as a suspect is the goal here.

Changes:
- api_connection.h now forward-declares APIServer instead of including api_server.h, and pulls list_entities.h / subscribe_state.h directly.
- api_server.h includes api_connection.h before the clients_ array, so APIConnection is complete when std::unique_ptr<APIConnection> is instantiated; the APIConnectionDeleter struct and its out-of-line operator() are gone.
- The two APIConnection inlines that touch APIServer (encode_to_buffer in the hot batch-send path, plus get_batch_delay_ms_) move into a new api_connection_buffer.h. ESPHOME_ALWAYS_INLINE semantics are preserved.
- api_connection.cpp includes api_connection_buffer.h (which transitively brings in api_server.h, used in 18 places there).

No behavior change, no public-API change, no Python side touched.

Verified locally on macOS:
- python3.14 -m esphome compile on the host-mode climate fixture builds clean; that is the exact reproducer for the original libc++ incomplete-type error PR #16050 was working around.
- Host-mode integration tests pass: noise encryption (2 cases), climate, homeassistant, action responses, custom services.

Leaving as draft until we get the serial log from the reporter; we still do not have an LN882H here, so this is a candidate fix rather than a confirmed one.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16540

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change; internal include refactor only.
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
