### PR TITLE
[sx126x] Assert NSS before wait_busy so commands wake the chip from sleep

### DIFF
--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -29,9 +29,14 @@ static constexpr uint8_t OCP_140MA = 0x38;  // 140 mA max current
 // LoRa low data rate optimization threshold
 static constexpr float LOW_DATA_RATE_OPTIMIZE_THRESHOLD = 16.38f;  // 16.38 ms
 
+// Datasheet §8.3: every SPI transaction is "NSS low, then wait BUSY low,
+// then send opcode". The NSS falling edge is also what wakes the chip from
+// sleep, so the order must be CS-low first and wait_busy_() second --
+// otherwise any command issued while the chip is in sleep deadlocks waiting
+// for a BUSY edge that only the NSS-low can trigger.
 uint8_t SX126x::read_fifo_(uint8_t offset, std::vector<uint8_t> &packet) {
-  this->wait_busy_();
   this->enable();
+  this->wait_busy_();
   this->transfer_byte(RADIO_READ_BUFFER);
   this->transfer_byte(offset);
   uint8_t status = this->transfer_byte(0x00);
@@ -43,8 +48,8 @@ uint8_t SX126x::read_fifo_(uint8_t offset, std::vector<uint8_t> &packet) {
 }
 
 void SX126x::write_fifo_(uint8_t offset, const std::vector<uint8_t> &packet) {
-  this->wait_busy_();
   this->enable();
+  this->wait_busy_();
   this->transfer_byte(RADIO_WRITE_BUFFER);
   this->transfer_byte(offset);
   for (const uint8_t &byte : packet) {
@@ -55,8 +60,8 @@ void SX126x::write_fifo_(uint8_t offset, const std::vector<uint8_t> &packet) {
 }
 
 uint8_t SX126x::read_opcode_(uint8_t opcode, uint8_t *data, uint8_t size) {
-  this->wait_busy_();
   this->enable();
+  this->wait_busy_();
   this->transfer_byte(opcode);
   uint8_t status = this->transfer_byte(0x00);
   for (int32_t i = 0; i < size; i++) {
@@ -67,8 +72,8 @@ uint8_t SX126x::read_opcode_(uint8_t opcode, uint8_t *data, uint8_t size) {
 }
 
 void SX126x::write_opcode_(uint8_t opcode, uint8_t *data, uint8_t size) {
-  this->wait_busy_();
   this->enable();
+  this->wait_busy_();
   this->transfer_byte(opcode);
   for (int32_t i = 0; i < size; i++) {
     this->transfer_byte(data[i]);
@@ -78,8 +83,8 @@ void SX126x::write_opcode_(uint8_t opcode, uint8_t *data, uint8_t size) {
 }
 
 void SX126x::read_register_(uint16_t reg, uint8_t *data, uint8_t size) {
-  this->wait_busy_();
   this->enable();
+  this->wait_busy_();
   this->write_byte(RADIO_READ_REGISTER);
   this->write_byte((reg >> 8) & 0xFF);
   this->write_byte((reg >> 0) & 0xFF);
@@ -91,8 +96,8 @@ void SX126x::read_register_(uint16_t reg, uint8_t *data, uint8_t size) {
 }
 
 void SX126x::write_register_(uint16_t reg, uint8_t *data, uint8_t size) {
-  this->wait_busy_();
   this->enable();
+  this->wait_busy_();
   this->write_byte(RADIO_WRITE_REGISTER);
   this->write_byte((reg >> 8) & 0xFF);
   this->write_byte((reg >> 0) & 0xFF);

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -29,11 +29,6 @@ static constexpr uint8_t OCP_140MA = 0x38;  // 140 mA max current
 // LoRa low data rate optimization threshold
 static constexpr float LOW_DATA_RATE_OPTIMIZE_THRESHOLD = 16.38f;  // 16.38 ms
 
-// Datasheet §8.3: every SPI transaction is "NSS low, then wait BUSY low,
-// then send opcode". The NSS falling edge is also what wakes the chip from
-// sleep, so the order must be CS-low first and wait_busy_() second --
-// otherwise any command issued while the chip is in sleep deadlocks waiting
-// for a BUSY edge that only the NSS-low can trigger.
 uint8_t SX126x::read_fifo_(uint8_t offset, std::vector<uint8_t> &packet) {
   this->enable();
   this->wait_busy_();


### PR DESCRIPTION
# What does this implement/fix?

The six SPI entry points in the SX126x driver (`read_fifo_`, `write_fifo_`, `read_opcode_`, `write_opcode_`, `read_register_`, `write_register_`) all started with `wait_busy_()` and then asserted NSS via `enable()`. Per the SX126x datasheet §8.3 and Semtech's reference driver, the order must be inverted: the NSS falling edge is what triggers the chip's wake-from-sleep, and BUSY only drops *after* that edge. Waiting for BUSY-low before pulling NSS-low means any command issued while the chip is sleeping deadlocks until the `BUSY_TIMEOUT_MS = 20` timeout fires and the component is marked failed.

This breaks every action that follows `transmit_packet` (which puts the radio into warm sleep before returning) — most visibly the new cold-sleep action added in #16144. Pattern reported in https://github.com/orgs/esphome/discussions/3638:

```yaml
- sx126x.send_packet:
    data: !lambda |- ...
- sx126x.set_mode_sleep:
    cold: true
```

…fails with:

```
[E][sx126x:480]: Wait busy timeout
[E][component:284]: sx126x was marked as failed
```

because `send_packet` internally calls `set_mode_sleep()` at the end of `transmit_packet`, and the subsequent `set_mode_sleep(cold)` opcode call deadlocks in `wait_busy_()`. Same trap applies to any post-sleep action (e.g. the "Heltec Sleep" pattern that does `set_mode_sleep` then `set_mode_rx`).

## Fix

Invert the order: `enable()` first (asserts NSS), then `wait_busy_()`. For the awake path this is a no-op — BUSY is already low between commands so `wait_busy_()` returns immediately. For the wake-from-sleep path the NSS falling edge starts the ~3.5 ms wake handshake and `wait_busy_()` then completes well inside the 20 ms budget.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- discussion https://github.com/orgs/esphome/discussions/3638

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any sx126x config -- the fix is internal to the driver. The pattern below
# was reported as broken pre-fix and works after:
sx126x:
  # ...
button:
  - platform: template
    name: "TX then deep sleep"
    on_press:
      then:
        - sx126x.send_packet:
            data: [0x01, 0x02, 0x03]
        - sx126x.set_mode_sleep:
            cold: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).