### PR TITLE
[core] Refresh compiled config cache after upload/logs fallback

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2449,7 +2449,10 @@ def run_esphome(argv):
     # Skipped when -s overrides are passed, since the cache was written
     # against the previous substitution set.
     config: ConfigType | None = None
-    if args.command in ("upload", "logs") and not command_line_substitutions:
+    cache_eligible = (
+        args.command in ("upload", "logs") and not command_line_substitutions
+    )
+    if cache_eligible:
         from esphome.compiled_config import load_compiled_config
 
         config = load_compiled_config(conf_path)
@@ -2464,6 +2467,13 @@ def run_esphome(argv):
             command_line_substitutions,
             skip_external_update=skip_external,
         )
+        # Refresh the cache so the next upload/logs hits the fast path
+        # instead of re-running read_config. load_compiled_config still
+        # gates on the storage sidecar, so a save without one is inert.
+        if cache_eligible and config is not None:
+            from esphome.compiled_config import save_compiled_config
+
+            save_compiled_config(config)
     if config is None:
         return 2
     CORE.config = config

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2468,12 +2468,15 @@ def run_esphome(argv):
             skip_external_update=skip_external,
         )
         # Refresh the cache so the next upload/logs hits the fast path
-        # instead of re-running read_config. load_compiled_config still
-        # gates on the storage sidecar, so a save without one is inert.
+        # instead of re-running read_config. Skip when the storage
+        # sidecar is absent (no compile has run): the cache would
+        # never be loaded back, so writing secrets to disk is wasted.
         if cache_eligible and config is not None:
             from esphome.compiled_config import save_compiled_config
+            from esphome.storage_json import ext_storage_path
 
-            save_compiled_config(config)
+            if ext_storage_path(conf_path.name).exists():
+                save_compiled_config(config)
     if config is None:
         return 2
     CORE.config = config

--- a/tests/unit_tests/test_compiled_config.py
+++ b/tests/unit_tests/test_compiled_config.py
@@ -253,6 +253,79 @@ def test_run_esphome_upload_and_logs_fall_back_when_no_cache(
     mock_read.assert_called_once()
 
 
+@pytest.mark.parametrize("command", ["upload", "logs"])
+def test_run_esphome_upload_and_logs_refresh_cache_on_fallback(
+    tmp_path: Path, command: str
+) -> None:
+    """A stale-cache fallback rewrites the cache so the next call hits
+    the fast path. Without this, every upload/logs after a YAML edit
+    pays for read_config() until the next compile rewrites the cache."""
+    yaml_path = tmp_path / "lite_test.yaml"
+    yaml_path.write_text("esphome:\n  name: lite_test\n")
+    CORE.config_path = yaml_path
+
+    storage_dir = tmp_path / ".esphome" / "storage"
+    _write_storage(storage_dir / "lite_test.yaml.json")
+    cache = _write_cache(storage_dir / "lite_test.yaml.validated.yaml")
+    _set_cache_mtime(cache, yaml_path, offset=-60)  # stale
+
+    fresh_config = {"esphome": {"name": "lite_test"}, "logger": {}}
+
+    with (
+        patch("esphome.__main__.read_config", return_value=fresh_config),
+        patch(
+            "esphome.compiled_config.save_compiled_config", wraps=save_compiled_config
+        ) as mock_save,
+        patch.dict(
+            "esphome.__main__.POST_CONFIG_ACTIONS",
+            {command: lambda args, config: 0},
+        ),
+    ):
+        assert run_esphome(["esphome", command, str(yaml_path)]) == 0
+
+    mock_save.assert_called_once_with(fresh_config)
+    # mtime is now newer than the source YAML, so a follow-up call hits
+    # the fast path instead of repeating read_config.
+    assert cache.stat().st_mtime >= yaml_path.stat().st_mtime
+
+
+def test_run_esphome_upload_with_substitution_does_not_refresh_cache(
+    fresh_cache_files: Path,
+) -> None:
+    """`-s` substitutions skip the cache on both read and write -- saving
+    here would clobber the cache with a substitution-specific config."""
+    with (
+        patch("esphome.__main__.read_config", return_value={"esphome": {}}),
+        patch("esphome.compiled_config.save_compiled_config") as mock_save,
+        patch.dict(
+            "esphome.__main__.POST_CONFIG_ACTIONS",
+            {"upload": lambda args, config: 0},
+        ),
+    ):
+        run_esphome(["esphome", "-s", "var", "val", "upload", str(fresh_cache_files)])
+
+    mock_save.assert_not_called()
+
+
+def test_run_esphome_compile_does_not_refresh_cache_via_fallback(
+    fresh_cache_files: Path,
+) -> None:
+    """Compile writes the cache through update_storage_json, not via the
+    upload/logs fallback path -- the fallback save would skip the
+    storage_should_clean check."""
+    with (
+        patch("esphome.__main__.read_config", return_value={"esphome": {}}),
+        patch("esphome.compiled_config.save_compiled_config") as mock_save,
+        patch.dict(
+            "esphome.__main__.POST_CONFIG_ACTIONS",
+            {"compile": lambda args, config: 0},
+        ),
+    ):
+        run_esphome(["esphome", "compile", str(fresh_cache_files)])
+
+    mock_save.assert_not_called()
+
+
 def test_run_esphome_upload_with_substitution_skips_cache(
     fresh_cache_files: Path,
 ) -> None:

--- a/tests/unit_tests/test_compiled_config.py
+++ b/tests/unit_tests/test_compiled_config.py
@@ -253,6 +253,33 @@ def test_run_esphome_upload_and_logs_fall_back_when_no_cache(
     mock_read.assert_called_once()
 
 
+def test_run_esphome_upload_does_not_refresh_cache_without_sidecar(
+    tmp_path: Path,
+) -> None:
+    """Without a StorageJSON sidecar (no compile has run), the fallback
+    skips the cache write -- load_compiled_config requires the sidecar,
+    so writing the rendered (secret-resolved) YAML would be inert and
+    leak secrets to disk for nothing."""
+    yaml_path = tmp_path / "lite_test.yaml"
+    yaml_path.write_text("esphome:\n  name: lite_test\n")
+    CORE.config_path = yaml_path
+
+    with (
+        patch(
+            "esphome.__main__.read_config",
+            return_value={"esphome": {"name": "lite_test"}},
+        ),
+        patch("esphome.compiled_config.save_compiled_config") as mock_save,
+        patch.dict(
+            "esphome.__main__.POST_CONFIG_ACTIONS",
+            {"upload": lambda args, config: 0},
+        ),
+    ):
+        run_esphome(["esphome", "upload", str(yaml_path)])
+
+    mock_save.assert_not_called()
+
+
 @pytest.mark.parametrize("command", ["upload", "logs"])
 def test_run_esphome_upload_and_logs_refresh_cache_on_fallback(
     tmp_path: Path, command: str


### PR DESCRIPTION
# What does this implement/fix?

Closes a bug in #16381: when the validated-config cache is missing or stale, `upload` / `logs` correctly fall back to `read_config()`, but the result is never written back to the cache; every subsequent `upload` / `logs` call keeps paying for a full validation until the next `compile` rewrites the cache. Now we refresh the cache after the fallback so the next call hits the fast path.

The save is gated on the same conditions as the read (`upload`/`logs` only, no `-s` overrides); `load_compiled_config` still requires a storage sidecar, so a save written before any compile is inert.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes a regression in #16381

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No YAML or CLI change.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).