### PR TITLE
[homeassistant] Reduce log spam for sensors

### DIFF
--- a/esphome/components/homeassistant/sensor/homeassistant_sensor.cpp
+++ b/esphome/components/homeassistant/sensor/homeassistant_sensor.cpp
@@ -17,9 +17,9 @@ void HomeassistantSensor::setup() {
     }
 
     if (this->attribute_ != nullptr) {
-      ESP_LOGD(TAG, "'%s::%s': Got attribute state %.2f", this->entity_id_, this->attribute_, *val);
+      ESP_LOGV(TAG, "'%s::%s': Got attribute state %.2f", this->entity_id_, this->attribute_, *val);
     } else {
-      ESP_LOGD(TAG, "'%s': Got state %.2f", this->entity_id_, *val);
+      ESP_LOGV(TAG, "'%s': Got state %.2f", this->entity_id_, *val);
     }
     this->publish_state(*val);
   });


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Recent changes to logging moved sensor state logging from DEBUG to VERBOSE level with automatic reporting of all sensor changes unless the --no-states flag is used.

Home-assistant sensors though were still logging at DEBUG level, so change this to VERBOSE.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
