### PR TITLE
[audio] Use RingBufferAudioSource for decoding

### DIFF
--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -190,7 +190,9 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
     // processed, so the source does not need to accumulate or stitch chunks across fill() calls.
     this->input_buffer_->fill(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS), false);
 
-    if (this->input_buffer_->available() == 0) {
+    const size_t available_before_decode = this->input_buffer_->available();
+
+    if (available_before_decode == 0) {
       // No data to decode, attempt to get more data next time
       state = FileDecoderState::IDLE;
     } else {
@@ -229,7 +231,16 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
     } else if (state == FileDecoderState::FAILED) {
       return AudioDecoderState::FAILED;
     } else if (state == FileDecoderState::MORE_TO_PROCESS) {
-      this->potentially_failed_count_ = 0;
+      // Reset the failsafe only when the iteration made forward progress: input was consumed or output was
+      // produced (output_transfer_buffer_ is drained empty above, so any available bytes are new). A
+      // MORE_TO_PROCESS that neither consumes input nor produces output means the decoder is stalled; count it
+      // toward the failsafe so a stuck stream eventually surfaces as FAILED instead of looping forever.
+      if ((this->input_buffer_->available() < available_before_decode) ||
+          (this->output_transfer_buffer_->available() > 0)) {
+        this->potentially_failed_count_ = 0;
+      } else {
+        ++this->potentially_failed_count_;
+      }
     }
   }
   return AudioDecoderState::DECODING;

--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -162,7 +162,8 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
       }
 
       if ((bytes_written > 0) && (this->output_transfer_buffer_->available() == 0)) {
-        // Wrote a full decoded chunk of audio
+        // All decoded audio has been flushed to the sink; return so the caller can react to stop/pause before
+        // decoding the next batch
         return AudioDecoderState::DECODING;
       }
     } else {

--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -9,7 +9,6 @@ namespace esphome::audio {
 
 static const char *const TAG = "audio.decoder";
 
-static const uint32_t DECODING_TIMEOUT_MS = 50;    // The decode function will yield after this duration
 static const uint32_t READ_WRITE_TIMEOUT_MS = 20;  // Timeout for transferring audio data
 
 static const uint32_t MAX_POTENTIALLY_FAILED_COUNT = 10;
@@ -20,11 +19,12 @@ AudioDecoder::AudioDecoder(size_t input_buffer_size, size_t output_buffer_size)
 }
 
 esp_err_t AudioDecoder::add_source(std::weak_ptr<ring_buffer::RingBuffer> &input_ring_buffer) {
-  auto source = AudioSourceTransferBuffer::create(this->input_buffer_size_);
+  // Zero-copy source reading directly from the ring buffer's internal storage. Raw file data is byte
+  // aligned, so no frame alignment is required.
+  auto source = RingBufferAudioSource::create(input_ring_buffer.lock(), this->input_buffer_size_);
   if (source == nullptr) {
     return ESP_ERR_NO_MEM;
   }
-  source->set_source(input_ring_buffer);
   this->input_buffer_ = std::move(source);
   return ESP_OK;
 }
@@ -142,13 +142,6 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
 
   FileDecoderState state = FileDecoderState::MORE_TO_PROCESS;
 
-  uint32_t decoding_start = millis();
-
-  bool first_loop_iteration = true;
-
-  size_t bytes_processed = 0;
-  size_t bytes_available_before_processing = 0;
-
   while (state == FileDecoderState::MORE_TO_PROCESS) {
     // Transfer decoded out
     if (!this->pause_output_) {
@@ -161,45 +154,27 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
         this->playback_ms_ +=
             this->audio_stream_info_.value().frames_to_milliseconds_with_remainder(&this->accumulated_frames_written_);
       }
+
+      if ((bytes_written > 0) && (this->output_transfer_buffer_->available() == 0)) {
+        // Wrote a full decoded chunk of audio
+        return AudioDecoderState::DECODING;
+      }
     } else {
       // If paused, block to avoid wasting CPU resources
       delay(READ_WRITE_TIMEOUT_MS);
     }
 
-    // Verify there is enough space to store more decoded audio and that the function hasn't been running too long
-    if ((this->output_transfer_buffer_->free() < this->free_buffer_required_) ||
-        (millis() - decoding_start > DECODING_TIMEOUT_MS)) {
+    if (this->output_transfer_buffer_->available() > 0) {
+      // Output transfer buffer indicates backpressure, return so caller can handle other events;
+      // e.g., stop/pause, before trying again
       return AudioDecoderState::DECODING;
     }
 
-    // Decode more audio
+    // Expose the next chunk of file data. Every decoder buffers internally and consumes only what it
+    // processed, so the source does not need to accumulate or stitch chunks across fill() calls.
+    this->input_buffer_->fill(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS), false);
 
-    // Never shift the input buffer; every decoder buffers internally and consumes only what it processed.
-    size_t bytes_read = this->input_buffer_->fill(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS), false);
-
-    if (!first_loop_iteration && (this->input_buffer_->available() < bytes_processed)) {
-      // Less data is available than what was processed in last iteration, so don't attempt to decode.
-      // This attempts to avoid the decoder from consistently trying to decode an incomplete frame. The transfer buffer
-      // will shift the remaining data to the start and copy more from the source the next time the decode function is
-      // called
-      break;
-    }
-
-    bytes_available_before_processing = this->input_buffer_->available();
-
-    if ((this->potentially_failed_count_ > 0) && (bytes_read == 0)) {
-      // Failed to decode in last attempt and there is no new data
-
-      if ((this->input_buffer_->free() == 0) && first_loop_iteration) {
-        // The input buffer is full (or read-only, e.g. const flash source). Since it previously failed on the exact
-        // same data, we can never recover. For const sources this is correct: the entire file is already available, so
-        // a decode failure is genuine, not a transient out-of-data condition.
-        state = FileDecoderState::FAILED;
-      } else {
-        // Attempt to get more data next time
-        state = FileDecoderState::IDLE;
-      }
-    } else if (this->input_buffer_->available() == 0) {
+    if (this->input_buffer_->available() == 0) {
       // No data to decode, attempt to get more data next time
       state = FileDecoderState::IDLE;
     } else {
@@ -230,9 +205,6 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
           break;
       }
     }
-
-    first_loop_iteration = false;
-    bytes_processed = bytes_available_before_processing - this->input_buffer_->available();
 
     if (state == FileDecoderState::POTENTIALLY_FAILED) {
       ++this->potentially_failed_count_;

--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -27,7 +27,8 @@ esp_err_t AudioDecoder::add_source(std::weak_ptr<ring_buffer::RingBuffer> &input
   // aligned, so no frame alignment is required.
   auto source = RingBufferAudioSource::create(input_ring_buffer.lock(), this->input_buffer_size_);
   if (source == nullptr) {
-    return ESP_ERR_NO_MEM;
+    // create() only returns nullptr for invalid arguments (expired ring buffer or zero buffer size)
+    return ESP_ERR_INVALID_ARG;
   }
   this->input_buffer_ = std::move(source);
   return ESP_OK;

--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -11,6 +11,10 @@ static const char *const TAG = "audio.decoder";
 
 static const uint32_t READ_WRITE_TIMEOUT_MS = 20;  // Timeout for transferring audio data
 
+// Max consecutive decode iterations that consume input but produce no output; e.g., skipping a large metadata block,
+// before yielding and returning.
+static const uint8_t MAX_NO_OUTPUT_ITERATIONS = 32;
+
 static const uint32_t MAX_POTENTIALLY_FAILED_COUNT = 10;
 
 AudioDecoder::AudioDecoder(size_t input_buffer_size, size_t output_buffer_size)
@@ -141,6 +145,7 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
   }
 
   FileDecoderState state = FileDecoderState::MORE_TO_PROCESS;
+  uint8_t no_output_iterations = 0;
 
   while (state == FileDecoderState::MORE_TO_PROCESS) {
     // Transfer decoded out
@@ -167,6 +172,15 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
     if (this->output_transfer_buffer_->available() > 0) {
       // Output transfer buffer indicates backpressure, return so caller can handle other events;
       // e.g., stop/pause, before trying again
+      return AudioDecoderState::DECODING;
+    }
+
+    // Reaching here means no decoded output is pending (any would have returned above). Bounds long no-output
+    // stretches; e.g., skipping a large metadata block, so a source that keeps the ring buffer full can't spin this
+    // loop without yielding and trip the watchdog. The delay yields allowing other tasks to feed the watchdog and
+    // the return keeps stop/pause responsive.
+    if (++no_output_iterations >= MAX_NO_OUTPUT_ITERATIONS) {
+      delay(1);
       return AudioDecoderState::DECODING;
     }
 

--- a/esphome/components/audio/audio_decoder.h
+++ b/esphome/components/audio/audio_decoder.h
@@ -70,7 +70,7 @@ class AudioDecoder {
   /// @brief Adds a source ring buffer for raw file data. Shares ownership of the ring buffer via a shared_ptr.
   /// The decoder reads directly from the ring buffer's internal storage with a zero-copy RingBufferAudioSource.
   /// @param input_ring_buffer weak_ptr of the source ring buffer to read from
-  /// @return ESP_OK if successful, ESP_ERR_NO_MEM if the source couldn't be created
+  /// @return ESP_OK if successful, ESP_ERR_INVALID_ARG if the ring buffer is expired or the buffer size is zero
   esp_err_t add_source(std::weak_ptr<ring_buffer::RingBuffer> &input_ring_buffer);
 
   /// @brief Adds a sink ring buffer for decoded audio. Takes ownership of the ring buffer in a shared_ptr.

--- a/esphome/components/audio/audio_decoder.h
+++ b/esphome/components/audio/audio_decoder.h
@@ -61,15 +61,16 @@ class AudioDecoder {
    */
  public:
   /// @brief Allocates the output transfer buffer and stores the input buffer size for later use by add_source()
-  /// @param input_buffer_size Size of the input transfer buffer in bytes.
+  /// @param input_buffer_size Soft cap on the bytes a ring buffer source exposes per fill, in bytes.
   /// @param output_buffer_size Size of the output transfer buffer in bytes.
   AudioDecoder(size_t input_buffer_size, size_t output_buffer_size);
 
   ~AudioDecoder() = default;
 
-  /// @brief Adds a source ring buffer for raw file data. Takes ownership of the ring buffer in a shared_ptr.
-  /// @param input_ring_buffer weak_ptr of a shared_ptr of the sink ring buffer to transfer ownership
-  /// @return ESP_OK if successsful, ESP_ERR_NO_MEM if the transfer buffer wasn't allocated
+  /// @brief Adds a source ring buffer for raw file data. Shares ownership of the ring buffer via a shared_ptr.
+  /// The decoder reads directly from the ring buffer's internal storage with a zero-copy RingBufferAudioSource.
+  /// @param input_ring_buffer weak_ptr of the source ring buffer to read from
+  /// @return ESP_OK if successful, ESP_ERR_NO_MEM if the source couldn't be created
   esp_err_t add_source(std::weak_ptr<ring_buffer::RingBuffer> &input_ring_buffer);
 
   /// @brief Adds a sink ring buffer for decoded audio. Takes ownership of the ring buffer in a shared_ptr.


### PR DESCRIPTION
# What does this implement/fix?

Replaces the AudioSourceTransferBuffer with a RingBufferAudioSource in the AudioDecoder class and refactors early returns.

- Eliminates one buffer allocation and eliminates an extra copy every iteration
- `decode` returns early whenever a full encoded audio chunk is processed or if there is back pressure on the output or no output has been produced for several iterations
  - Allows the caller to handle stop or pause events more quickly (the next call will continue to push audio)
  - Eliminates the `millis()` check as it now returns earlier without hitting the timeout
  - Allows task to yield when processing large metadata chunks without continuously spinning the CPU

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

The `AudioDecoder` class is only used by the speaker media player.

```yaml
# Example config.yaml

media_player:
  - platform: speaker
    name: None
    id: speaker_media_player
    announcement_pipeline:
      speaker: box_speaker
      format: MP3
      sample_rate: 48000
      num_channels: 2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
