### PR TITLE
[mipi_spi] Cache code generation across display tests

### DIFF
--- a/tests/component_tests/mipi_spi/conftest.py
+++ b/tests/component_tests/mipi_spi/conftest.py
@@ -1,11 +1,13 @@
 """Tests for mpip_spi configuration validation."""
 
 from collections.abc import Callable, Generator
+from pathlib import Path
 from unittest import mock
 
 import pytest
 
 from esphome import config_validation as cv
+from esphome.components.display import DisplayMetaData, get_all_display_metadata
 from esphome.components.esp32 import KEY_ESP32, KEY_VARIANT, VARIANTS
 from esphome.components.esp32.gpio import validate_gpio_pin
 from esphome.const import CONF_INPUT, CONF_OUTPUT
@@ -21,6 +23,40 @@ def mock_spi_final_validate():
         return_value=lambda config: None,
     ):
         yield
+
+
+@pytest.fixture(scope="session")
+def _generation_cache() -> dict[Path, tuple[str, dict[str, DisplayMetaData]]]:
+    """Session-wide cache of generation output keyed by fixture yaml path.
+
+    Stores ``(main_cpp_text, display_metadata_snapshot)`` so multiple tests
+    that exercise the same fixture only pay for code generation once.
+    """
+    return {}
+
+
+@pytest.fixture
+def cached_generate_main(
+    generate_main: Callable[[str | Path], str],
+    _generation_cache: dict[Path, tuple[str, dict[str, DisplayMetaData]]],
+) -> Callable[[Path], tuple[str, dict[str, DisplayMetaData]]]:
+    """Like ``generate_main`` but caches results across the test session.
+
+    Returns ``(main_cpp_text, display_metadata_snapshot)``; the snapshot is
+    captured at generation time so callers see the same data after CORE has
+    been reset for the next test.
+    """
+
+    def _get(path: Path) -> tuple[str, dict[str, DisplayMetaData]]:
+        path = Path(path)
+        cached = _generation_cache.get(path)
+        if cached is None:
+            main_cpp = generate_main(path)
+            cached = (main_cpp, dict(get_all_display_metadata()))
+            _generation_cache[path] = cached
+        return cached
+
+    return _get
 
 
 @pytest.fixture

--- a/tests/component_tests/mipi_spi/test_display_metadata.py
+++ b/tests/component_tests/mipi_spi/test_display_metadata.py
@@ -173,12 +173,11 @@ def test_metadata_multiple_displays_independent(
 
 
 def test_metadata_via_code_generation_native(
-    generate_main: Callable[[str | Path], str],
+    cached_generate_main: Callable[[Path], tuple[str, dict[str, DisplayMetaData]]],
     component_fixture_path: Callable[[str], Path],
 ) -> None:
     """Full code generation for native.yaml should produce correct metadata."""
-    generate_main(component_fixture_path("native.yaml"))
-    all_meta = get_all_display_metadata()
+    _, all_meta = cached_generate_main(component_fixture_path("native.yaml"))
     # native.yaml: model JC3636W518 -> 360x360, no writer, full hardware rotation
     assert len(all_meta) == 1
     meta = next(iter(all_meta.values()))
@@ -188,12 +187,11 @@ def test_metadata_via_code_generation_native(
 
 
 def test_metadata_via_code_generation_lvgl(
-    generate_main: Callable[[str | Path], str],
+    cached_generate_main: Callable[[Path], tuple[str, dict[str, DisplayMetaData]]],
     component_fixture_path: Callable[[str], Path],
 ) -> None:
     """Full code generation for lvgl.yaml should produce correct metadata."""
-    generate_main(component_fixture_path("lvgl.yaml"))
-    all_meta = get_all_display_metadata()
+    _, all_meta = cached_generate_main(component_fixture_path("lvgl.yaml"))
     # lvgl.yaml: model ST7735 -> 128x160, no writer (lvgl draws directly), full hw rotation
     assert len(all_meta) == 1
     meta = next(iter(all_meta.values()))

--- a/tests/component_tests/mipi_spi/test_init.py
+++ b/tests/component_tests/mipi_spi/test_init.py
@@ -307,12 +307,12 @@ def test_all_predefined_models(
 
 
 def test_native_generation(
-    generate_main: Callable[[str | Path], str],
+    cached_generate_main: Callable[[Path], tuple[str, dict[str, Any]]],
     component_fixture_path: Callable[[str], Path],
 ) -> None:
     """Test code generation for display."""
 
-    main_cpp = generate_main(component_fixture_path("native.yaml"))
+    main_cpp, _ = cached_generate_main(component_fixture_path("native.yaml"))
     assert (
         "mipi_spi::MipiSpiBuffer<uint16_t, mipi_spi::PIXEL_MODE_16, true, mipi_spi::PIXEL_MODE_16, mipi_spi::BUS_TYPE_QUAD, 360, 360, 0, 1, 0, true, 1, 1>()"
         in main_cpp
@@ -323,12 +323,12 @@ def test_native_generation(
 
 
 def test_lvgl_generation(
-    generate_main: Callable[[str | Path], str],
+    cached_generate_main: Callable[[Path], tuple[str, dict[str, Any]]],
     component_fixture_path: Callable[[str], Path],
 ) -> None:
     """Test LVGL generation configuration."""
 
-    main_cpp = generate_main(component_fixture_path("lvgl.yaml"))
+    main_cpp, _ = cached_generate_main(component_fixture_path("lvgl.yaml"))
     assert (
         "mipi_spi::MipiSpi<uint16_t, mipi_spi::PIXEL_MODE_16, true, mipi_spi::PIXEL_MODE_16, mipi_spi::BUS_TYPE_SINGLE, 128, 160, 0, 0, 0, true>();"
         in main_cpp


### PR DESCRIPTION
# What does this implement/fix?

The native.yaml and lvgl.yaml fixtures under tests/component_tests/mipi_spi are each compiled twice today; once by the codegen assertions in test_init.py and once by the metadata assertions in test_display_metadata.py. The two duplicated tests show up as some of the slowest in CI. This adds a session scoped cache that captures the generated main.cpp text and a snapshot of the display metadata, so the second test for each fixture is a cache hit instead of re-running full code generation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
