### PR TITLE
[lvgl] Memoize and lazily build container_schema

### DIFF
--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -545,6 +545,13 @@ _CONTAINER_SCHEMA_CACHE: dict[
 def container_schema(
     widget_type: WidgetType, extras: Any = None
 ) -> Callable[[Any], Any]:
+    """
+    Create a schema for a container widget of a given type. All obj properties are available, plus
+    the extras passed in, plus any defined for the specific widget being specified.
+    :param widget_type:     The widget type, e.g. "image"
+    :param extras:  Additional options to be made available, e.g. layout properties for children
+    :return: The schema for this type of widget.
+    """
     cache_key = (id(widget_type), id(extras))
     cached = _CONTAINER_SCHEMA_CACHE.get(cache_key)
     if cached is not None:

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import Any
 
 from esphome import config_validation as cv
 from esphome.automation import Trigger, validate_automation
@@ -534,7 +535,23 @@ def strip_defaults(schema: cv.Schema):
     return cv.Schema({cv.Optional(k): v for k, v in schema.schema.items()})
 
 
-def container_schema(widget_type: WidgetType, extras=None):
+# Memoize the validators produced by `container_schema()` so that repeat calls
+# with the same (widget_type, extras) return the same validator. The dominant
+# cost of a widget validation today is voluptuous schema construction inside
+# this function; without caching, `any_widget_schema()`'s per-entry loop and
+# the various top-level callers (LVGL_SCHEMA, msgbox, tabview, tileview) each
+# rebuild the same nested schema tree from scratch. The key is `id()` based
+# because `extras` may be a non-hashable dict, and the stored tuple keeps the
+# originals alive so id-recycling after GC does not return a stale validator
+# (verified by the `is` guard below).
+_CONTAINER_SCHEMA_CACHE: dict[
+    tuple[int, int], tuple[Any, Any, Callable[[Any], Any]]
+] = {}
+
+
+def container_schema(
+    widget_type: WidgetType, extras: Any = None
+) -> Callable[[Any], Any]:
     """
     Create a schema for a container widget of a given type. All obj properties are available, plus
     the extras passed in, plus any defined for the specific widget being specified.
@@ -542,19 +559,37 @@ def container_schema(widget_type: WidgetType, extras=None):
     :param extras:  Additional options to be made available, e.g. layout properties for children
     :return: The schema for this type of widget.
     """
-    schema = obj_schema(widget_type).extend(
-        {cv.GenerateID(): cv.declare_id(widget_type.w_type)}
-    )
-    if extras:
-        schema = schema.extend(extras)
-    # Delayed evaluation for recursion
+    cache_key = (id(widget_type), id(extras))
+    cached = _CONTAINER_SCHEMA_CACHE.get(cache_key)
+    if cached is not None:
+        cached_widget_type, cached_extras, cached_validator = cached
+        if cached_widget_type is widget_type and cached_extras is extras:
+            return cached_validator
 
-    schema = schema.extend(widget_type.schema)
+    # The schema is built on first validation rather than at construction
+    # time. This keeps `container_schema()` calls cheap at module import; the
+    # ~225ms of cumulative voluptuous work previously done eagerly by
+    # LVGL_SCHEMA / msgbox / tabview / tileview only happens when validation
+    # actually reaches one of these widgets.
+    built: list[cv.Schema] = []
 
-    def validator(value):
+    def get_schema() -> cv.Schema:
+        if not built:
+            schema = obj_schema(widget_type).extend(
+                {cv.GenerateID(): cv.declare_id(widget_type.w_type)}
+            )
+            if extras:
+                schema = schema.extend(extras)
+            # Delayed evaluation for recursion
+            schema = schema.extend(widget_type.schema)
+            built.append(schema)
+        return built[0]
+
+    def validator(value: Any) -> Any:
         value = value or {}
-        return append_layout_schema(schema, value)(value)
+        return append_layout_schema(get_schema(), value)(value)
 
+    _CONTAINER_SCHEMA_CACHE[cache_key] = (widget_type, extras, validator)
     return validator
 
 

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -536,9 +536,7 @@ def strip_defaults(schema: cv.Schema):
 
 
 # Keyed by (id(widget_type), id(extras)); strong refs in the value keep both
-# alive so id() can't be recycled. Bounded in practice by the caller set
-# (top-level LVGL_SCHEMA / msgbox / tabview / tileview plus any_widget_schema's
-# per-widget loop, all of which reuse module-level extras).
+# alive so id() can't be recycled.
 _CONTAINER_SCHEMA_CACHE: dict[
     tuple[int, int], tuple[Any, Any, Callable[[Any], Any]]
 ] = {}

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -535,15 +535,10 @@ def strip_defaults(schema: cv.Schema):
     return cv.Schema({cv.Optional(k): v for k, v in schema.schema.items()})
 
 
-# Memoize the validators produced by `container_schema()` so that repeat calls
-# with the same (widget_type, extras) return the same validator. The dominant
-# cost of a widget validation today is voluptuous schema construction inside
-# this function; without caching, `any_widget_schema()`'s per-entry loop and
-# the various top-level callers (LVGL_SCHEMA, msgbox, tabview, tileview) each
-# rebuild the same nested schema tree from scratch. The key is `id()` based
-# because `extras` may be a non-hashable dict, and the stored tuple keeps the
-# originals alive so id-recycling after GC does not return a stale validator
-# (verified by the `is` guard below).
+# Keyed by (id(widget_type), id(extras)); strong refs in the value keep both
+# alive so id() can't be recycled. Bounded in practice by the caller set
+# (top-level LVGL_SCHEMA / msgbox / tabview / tileview plus any_widget_schema's
+# per-widget loop, all of which reuse module-level extras).
 _CONTAINER_SCHEMA_CACHE: dict[
     tuple[int, int], tuple[Any, Any, Callable[[Any], Any]]
 ] = {}
@@ -552,13 +547,6 @@ _CONTAINER_SCHEMA_CACHE: dict[
 def container_schema(
     widget_type: WidgetType, extras: Any = None
 ) -> Callable[[Any], Any]:
-    """
-    Create a schema for a container widget of a given type. All obj properties are available, plus
-    the extras passed in, plus any defined for the specific widget being specified.
-    :param widget_type:     The widget type, e.g. "image"
-    :param extras:  Additional options to be made available, e.g. layout properties for children
-    :return: The schema for this type of widget.
-    """
     cache_key = (id(widget_type), id(extras))
     cached = _CONTAINER_SCHEMA_CACHE.get(cache_key)
     if cached is not None:
@@ -566,24 +554,18 @@ def container_schema(
         if cached_widget_type is widget_type and cached_extras is extras:
             return cached_validator
 
-    # The schema is built on first validation rather than at construction
-    # time. This keeps `container_schema()` calls cheap at module import; the
-    # ~225ms of cumulative voluptuous work previously done eagerly by
-    # LVGL_SCHEMA / msgbox / tabview / tileview only happens when validation
-    # actually reaches one of these widgets.
-    built: list[cv.Schema] = []
+    cached_schema: cv.Schema | None = None
 
     def get_schema() -> cv.Schema:
-        if not built:
+        nonlocal cached_schema
+        if cached_schema is None:
             schema = obj_schema(widget_type).extend(
                 {cv.GenerateID(): cv.declare_id(widget_type.w_type)}
             )
             if extras:
                 schema = schema.extend(extras)
-            # Delayed evaluation for recursion
-            schema = schema.extend(widget_type.schema)
-            built.append(schema)
-        return built[0]
+            cached_schema = schema.extend(widget_type.schema)
+        return cached_schema
 
     def validator(value: Any) -> Any:
         value = value or {}

--- a/tests/component_tests/lvgl/test_container_schema_cache.py
+++ b/tests/component_tests/lvgl/test_container_schema_cache.py
@@ -1,11 +1,4 @@
-"""Tests for the memoization / lazy build behaviour of `container_schema()`.
-
-The validator returned by ``container_schema()`` is cached keyed by
-``(id(widget_type), id(extras))`` and the underlying voluptuous schema is
-materialised only on first validation. These tests pin those invariants;
-without them a refactor could silently revert the per-validation speedup
-without breaking the existing functional lvgl test configs.
-"""
+"""Tests for container_schema() memoization and lazy build."""
 
 from __future__ import annotations
 
@@ -15,9 +8,6 @@ from unittest.mock import patch
 import pytest
 
 from esphome import config_validation as cv
-
-# Importing the lvgl package populates the WIDGET_TYPES registry as a side
-# effect; we read widget types from it for cache-key differentiation tests.
 import esphome.components.lvgl  # noqa: F401
 from esphome.components.lvgl import schemas as lvgl_schemas
 from esphome.components.lvgl.schemas import WIDGET_TYPES, container_schema
@@ -25,13 +15,6 @@ from esphome.components.lvgl.schemas import WIDGET_TYPES, container_schema
 
 @pytest.fixture(autouse=True)
 def _clear_container_schema_cache() -> Generator[None]:
-    """The cache is module global; clear it around each test to keep the
-    assertions about cache hits / misses independent of import order.
-
-    Tolerant of the cache attribute being absent so the behavioural tests
-    still produce meaningful failures (rather than setup errors) if the
-    cache layer is ever removed.
-    """
     cache = getattr(lvgl_schemas, "_CONTAINER_SCHEMA_CACHE", None)
     if cache is not None:
         cache.clear()
@@ -41,96 +24,59 @@ def _clear_container_schema_cache() -> Generator[None]:
 
 
 def _widget_type(name: str = "obj"):
-    """Return a widget type registered by the lvgl package."""
     wt = WIDGET_TYPES.get(name)
     assert wt is not None, f"widget type {name!r} not registered"
     return wt
 
 
 def test_same_args_return_same_validator() -> None:
-    """Repeat calls with identical arguments must return the cached validator
-    instance (the property `any_widget_schema()`'s per-entry loop relies on)."""
     wt = _widget_type("obj")
-    first = container_schema(wt)
-    second = container_schema(wt)
-    assert first is second
+    assert container_schema(wt) is container_schema(wt)
 
 
 def test_extras_none_vs_truthy_get_different_validators() -> None:
-    """``extras=None`` and ``extras={...}`` must not collide in the cache;
-    the schemas they materialise have different shapes."""
     wt = _widget_type("obj")
     no_extras = container_schema(wt)
-    # Use a voluptuous-compatible extras dict so the schema also validates on
-    # the dev (pre-memoization) code path; the test is about cache key
-    # differentiation, not extras validity.
     extras = {cv.Optional("custom_extra"): cv.string}
-    with_extras = container_schema(wt, extras)
-    assert no_extras is not with_extras
+    assert no_extras is not container_schema(wt, extras)
 
 
 def test_different_widget_types_get_different_validators() -> None:
-    """Different widget types must have distinct cached validators even when
-    extras is identical (``None``)."""
-    obj = container_schema(_widget_type("obj"))
-    label = container_schema(_widget_type("label"))
-    assert obj is not label
+    assert container_schema(_widget_type("obj")) is not container_schema(
+        _widget_type("label")
+    )
 
 
 def test_schema_build_is_deferred_until_first_validation() -> None:
-    """``container_schema()`` must not materialise the underlying voluptuous
-    schema at construction time; only the first call to the returned
-    validator should trigger the build."""
     wt = _widget_type("obj")
     with patch.object(
         lvgl_schemas, "obj_schema", wraps=lvgl_schemas.obj_schema
     ) as obj_schema_mock:
         validator = container_schema(wt)
-        assert obj_schema_mock.call_count == 0, (
-            "obj_schema() must not be invoked at container_schema() time"
-        )
+        assert obj_schema_mock.call_count == 0
         validator({})
-        assert obj_schema_mock.call_count == 1, (
-            "obj_schema() must be invoked exactly once on first validation"
-        )
+        assert obj_schema_mock.call_count == 1
         validator({})
-        assert obj_schema_mock.call_count == 1, (
-            "obj_schema() must not be invoked again on subsequent validations"
-        )
+        assert obj_schema_mock.call_count == 1
 
 
 def test_cached_validator_produces_equivalent_output() -> None:
-    """A validator pulled from the cache must yield the same validated output
-    as one produced without the cache for the same input. This protects
-    against bugs where the cache returns a stale or wrong validator."""
     wt = _widget_type("obj")
     cached = container_schema(wt)
-    # Bypass the cache by clearing it before building a reference.
     cached_result = cached({})
     lvgl_schemas._CONTAINER_SCHEMA_CACHE.clear()
     reference = container_schema(wt)
-    assert cached is not reference, "cache should have been cleared"
+    assert cached is not reference
     assert cached_result == reference({})
 
 
 def test_id_recycling_is_caught_by_identity_guard() -> None:
-    """If a previously cached ``extras`` object is garbage collected and a new
-    object reuses its ``id()``, the cache must not return the stale validator.
-    Simulated here by mutating the cache to look as if collision happened."""
     wt = _widget_type("obj")
     real_extras = {cv.Optional("a"): cv.int_}
     validator_a = container_schema(wt, real_extras)
 
-    # Find the cache key that was used so we can substitute a fake "old"
-    # object that will fail the `is` identity guard when looked up with new
-    # extras at the same id().
     cache_key = (id(wt), id(real_extras))
     cached_entry = lvgl_schemas._CONTAINER_SCHEMA_CACHE[cache_key]
-    assert cached_entry[1] is real_extras
-
-    # Replace the stored extras with an unrelated object that has the same
-    # type but is not identical. Looking up with the original real_extras
-    # should now fail the `is` guard and force a rebuild.
     sentinel = {cv.Optional("a"): cv.int_}
     lvgl_schemas._CONTAINER_SCHEMA_CACHE[cache_key] = (
         cached_entry[0],
@@ -138,7 +84,4 @@ def test_id_recycling_is_caught_by_identity_guard() -> None:
         cached_entry[2],
     )
 
-    rebuilt = container_schema(wt, real_extras)
-    assert rebuilt is not validator_a, (
-        "identity guard must reject the stale entry and rebuild"
-    )
+    assert container_schema(wt, real_extras) is not validator_a

--- a/tests/component_tests/lvgl/test_container_schema_cache.py
+++ b/tests/component_tests/lvgl/test_container_schema_cache.py
@@ -1,0 +1,144 @@
+"""Tests for the memoization / lazy build behaviour of `container_schema()`.
+
+The validator returned by ``container_schema()`` is cached keyed by
+``(id(widget_type), id(extras))`` and the underlying voluptuous schema is
+materialised only on first validation. These tests pin those invariants;
+without them a refactor could silently revert the per-validation speedup
+without breaking the existing functional lvgl test configs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from esphome import config_validation as cv
+
+# Importing the lvgl package populates the WIDGET_TYPES registry as a side
+# effect; we read widget types from it for cache-key differentiation tests.
+import esphome.components.lvgl  # noqa: F401
+from esphome.components.lvgl import schemas as lvgl_schemas
+from esphome.components.lvgl.schemas import WIDGET_TYPES, container_schema
+
+
+@pytest.fixture(autouse=True)
+def _clear_container_schema_cache() -> Generator[None]:
+    """The cache is module global; clear it around each test to keep the
+    assertions about cache hits / misses independent of import order.
+
+    Tolerant of the cache attribute being absent so the behavioural tests
+    still produce meaningful failures (rather than setup errors) if the
+    cache layer is ever removed.
+    """
+    cache = getattr(lvgl_schemas, "_CONTAINER_SCHEMA_CACHE", None)
+    if cache is not None:
+        cache.clear()
+    yield
+    if cache is not None:
+        cache.clear()
+
+
+def _widget_type(name: str = "obj"):
+    """Return a widget type registered by the lvgl package."""
+    wt = WIDGET_TYPES.get(name)
+    assert wt is not None, f"widget type {name!r} not registered"
+    return wt
+
+
+def test_same_args_return_same_validator() -> None:
+    """Repeat calls with identical arguments must return the cached validator
+    instance (the property `any_widget_schema()`'s per-entry loop relies on)."""
+    wt = _widget_type("obj")
+    first = container_schema(wt)
+    second = container_schema(wt)
+    assert first is second
+
+
+def test_extras_none_vs_truthy_get_different_validators() -> None:
+    """``extras=None`` and ``extras={...}`` must not collide in the cache;
+    the schemas they materialise have different shapes."""
+    wt = _widget_type("obj")
+    no_extras = container_schema(wt)
+    # Use a voluptuous-compatible extras dict so the schema also validates on
+    # the dev (pre-memoization) code path; the test is about cache key
+    # differentiation, not extras validity.
+    extras = {cv.Optional("custom_extra"): cv.string}
+    with_extras = container_schema(wt, extras)
+    assert no_extras is not with_extras
+
+
+def test_different_widget_types_get_different_validators() -> None:
+    """Different widget types must have distinct cached validators even when
+    extras is identical (``None``)."""
+    obj = container_schema(_widget_type("obj"))
+    label = container_schema(_widget_type("label"))
+    assert obj is not label
+
+
+def test_schema_build_is_deferred_until_first_validation() -> None:
+    """``container_schema()`` must not materialise the underlying voluptuous
+    schema at construction time; only the first call to the returned
+    validator should trigger the build."""
+    wt = _widget_type("obj")
+    with patch.object(
+        lvgl_schemas, "obj_schema", wraps=lvgl_schemas.obj_schema
+    ) as obj_schema_mock:
+        validator = container_schema(wt)
+        assert obj_schema_mock.call_count == 0, (
+            "obj_schema() must not be invoked at container_schema() time"
+        )
+        validator({})
+        assert obj_schema_mock.call_count == 1, (
+            "obj_schema() must be invoked exactly once on first validation"
+        )
+        validator({})
+        assert obj_schema_mock.call_count == 1, (
+            "obj_schema() must not be invoked again on subsequent validations"
+        )
+
+
+def test_cached_validator_produces_equivalent_output() -> None:
+    """A validator pulled from the cache must yield the same validated output
+    as one produced without the cache for the same input. This protects
+    against bugs where the cache returns a stale or wrong validator."""
+    wt = _widget_type("obj")
+    cached = container_schema(wt)
+    # Bypass the cache by clearing it before building a reference.
+    cached_result = cached({})
+    lvgl_schemas._CONTAINER_SCHEMA_CACHE.clear()
+    reference = container_schema(wt)
+    assert cached is not reference, "cache should have been cleared"
+    assert cached_result == reference({})
+
+
+def test_id_recycling_is_caught_by_identity_guard() -> None:
+    """If a previously cached ``extras`` object is garbage collected and a new
+    object reuses its ``id()``, the cache must not return the stale validator.
+    Simulated here by mutating the cache to look as if collision happened."""
+    wt = _widget_type("obj")
+    real_extras = {cv.Optional("a"): cv.int_}
+    validator_a = container_schema(wt, real_extras)
+
+    # Find the cache key that was used so we can substitute a fake "old"
+    # object that will fail the `is` identity guard when looked up with new
+    # extras at the same id().
+    cache_key = (id(wt), id(real_extras))
+    cached_entry = lvgl_schemas._CONTAINER_SCHEMA_CACHE[cache_key]
+    assert cached_entry[1] is real_extras
+
+    # Replace the stored extras with an unrelated object that has the same
+    # type but is not identical. Looking up with the original real_extras
+    # should now fail the `is` guard and force a rebuild.
+    sentinel = {cv.Optional("a"): cv.int_}
+    lvgl_schemas._CONTAINER_SCHEMA_CACHE[cache_key] = (
+        cached_entry[0],
+        sentinel,
+        cached_entry[2],
+    )
+
+    rebuilt = container_schema(wt, real_extras)
+    assert rebuilt is not validator_a, (
+        "identity guard must reject the stale entry and rebuild"
+    )


### PR DESCRIPTION
# What does this implement/fix?

`container_schema()` was rebuilding the same voluptuous schema for every caller and on every validation; LVGL_SCHEMA / msgbox / tabview / tileview at import, plus `any_widget_schema()`'s per-entry loop. Most of lvgl validation time was spent here.

Cache the validator by `(id(widget_type), id(extras))` with strong refs in the value, and defer the schema build to first validation. Same validator returned to repeat callers; same schema used by every call.

`tests/component_tests/mipi_spi/fixtures/lvgl.yaml` on M-series Mac:
- repeated validation median: 210 ms → 17 ms
- cold subprocess + 1 validation median: 688 ms → 489 ms

`script/build_language_schema.py` output is byte identical to dev; `script/test_build_components -c lvgl -e config` passes for host, esp32-idf, esp32-p4-idf.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
