### PR TITLE
[lvgl] Build widget update action schemas lazily

### DIFF
--- a/esphome/components/lvgl/widgets/__init__.py
+++ b/esphome/components/lvgl/widgets/__init__.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 import sys
 from typing import Any
 
@@ -86,7 +87,9 @@ def _build_update_schema(widget_type: "WidgetType") -> Schema:
     )
 
 
-def _update_action_schema(widget_type: "WidgetType") -> Any:
+def _update_action_schema(
+    widget_type: "WidgetType",
+) -> Schema | Callable[[Any], Any]:
     """Return the registered schema for a widget's update action.
 
     When `EnableSchemaExtraction` is on (script/build_language_schema.py), the
@@ -102,12 +105,13 @@ def _update_action_schema(widget_type: "WidgetType") -> Any:
     if EnableSchemaExtraction:
         return _build_update_schema(widget_type)
 
-    built: list[Schema] = []
+    cached: Schema | None = None
 
     def get_schema() -> Schema:
-        if not built:
-            built.append(_build_update_schema(widget_type))
-        return built[0]
+        nonlocal cached
+        if cached is None:
+            cached = _build_update_schema(widget_type)
+        return cached
 
     def validator(value: Any) -> Any:
         return get_schema()(value)

--- a/esphome/components/lvgl/widgets/__init__.py
+++ b/esphome/components/lvgl/widgets/__init__.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Any
 
 from esphome import codegen as cg, config_validation as cv
 from esphome.automation import register_action
@@ -15,6 +16,7 @@ from esphome.const import (
 from esphome.core import ID, EsphomeError, TimePeriod
 from esphome.coroutine import FakeAwaitable
 from esphome.cpp_generator import MockObj
+from esphome.schema_extractors import EnableSchemaExtraction
 from esphome.types import Expression
 
 from ..defines import (
@@ -73,6 +75,46 @@ from ..types import (
 EVENT_LAMB = "event_lamb__"
 
 
+def _build_update_schema(widget_type: "WidgetType") -> Schema:
+    """Materialise the `lvgl.<widget>.update` action schema for a widget type."""
+    # Local import: `..schemas` imports `WidgetType` from this module, so a
+    # top-level import would loop.
+    from ..schemas import base_update_schema
+
+    return base_update_schema(widget_type, widget_type.parts).extend(
+        widget_type.modify_schema
+    )
+
+
+def _update_action_schema(widget_type: "WidgetType") -> Any:
+    """Return the registered schema for a widget's update action.
+
+    When `EnableSchemaExtraction` is on (script/build_language_schema.py), the
+    schema must be materialised eagerly so `schema_extractors` can introspect
+    the full mapping; the registry stores `raw_schema` directly and wrapping a
+    bare validator in `Schema()` would hide its structure from the dumper.
+
+    Otherwise the schema build is deferred until the first `lvgl.<widget>.update`
+    action is validated. That removes ~200 ms of cumulative voluptuous work
+    across ~25 widget types at lvgl module import time for any YAML that never
+    triggers an update action.
+    """
+    if EnableSchemaExtraction:
+        return _build_update_schema(widget_type)
+
+    built: list[Schema] = []
+
+    def get_schema() -> Schema:
+        if not built:
+            built.append(_build_update_schema(widget_type))
+        return built[0]
+
+    def validator(value: Any) -> Any:
+        return get_schema()(value)
+
+    return validator
+
+
 class WidgetType:
     """
     Describes a type of Widget, e.g. "bar" or "line"
@@ -113,18 +155,22 @@ class WidgetType:
 
         # Local import to avoid circular import
         from ..automation import update_to_code
-        from ..schemas import WIDGET_TYPES, base_update_schema
+        from ..schemas import WIDGET_TYPES
 
         if not is_mock:
             if self.name in WIDGET_TYPES:
                 raise EsphomeError(f"Duplicate definition of widget type '{self.name}'")
             WIDGET_TYPES[self.name] = self
 
-            # Register the update action automatically, adding widget-specific properties
+            # Register the update action automatically, adding widget-specific
+            # properties. The schema is materialised lazily on first validation
+            # (see `_update_action_schema`); the schema dumper still sees the
+            # full mapping because that helper picks the eager build when
+            # schema extraction is enabled.
             register_action(
                 f"lvgl.{self.name}.update",
                 ObjUpdateAction,
-                base_update_schema(self, self.parts).extend(self.modify_schema),
+                _update_action_schema(self),
                 synchronous=True,
             )(update_to_code)
 

--- a/esphome/components/lvgl/widgets/__init__.py
+++ b/esphome/components/lvgl/widgets/__init__.py
@@ -77,9 +77,7 @@ EVENT_LAMB = "event_lamb__"
 
 
 def _build_update_schema(widget_type: "WidgetType") -> Schema:
-    """Materialise the `lvgl.<widget>.update` action schema for a widget type."""
-    # Local import: `..schemas` imports `WidgetType` from this module, so a
-    # top-level import would loop.
+    # Local import: ..schemas imports WidgetType from this module.
     from ..schemas import base_update_schema
 
     return base_update_schema(widget_type, widget_type.parts).extend(
@@ -90,18 +88,8 @@ def _build_update_schema(widget_type: "WidgetType") -> Schema:
 def _update_action_schema(
     widget_type: "WidgetType",
 ) -> Schema | Callable[[Any], Any]:
-    """Return the registered schema for a widget's update action.
-
-    When `EnableSchemaExtraction` is on (script/build_language_schema.py), the
-    schema must be materialised eagerly so `schema_extractors` can introspect
-    the full mapping; the registry stores `raw_schema` directly and wrapping a
-    bare validator in `Schema()` would hide its structure from the dumper.
-
-    Otherwise the schema build is deferred until the first `lvgl.<widget>.update`
-    action is validated. That removes ~200 ms of cumulative voluptuous work
-    across ~25 widget types at lvgl module import time for any YAML that never
-    triggers an update action.
-    """
+    # Eager when extracting so build_language_schema.py sees the mapping;
+    # lazy otherwise to skip ~200 ms of import-time voluptuous work.
     if EnableSchemaExtraction:
         return _build_update_schema(widget_type)
 
@@ -166,11 +154,6 @@ class WidgetType:
                 raise EsphomeError(f"Duplicate definition of widget type '{self.name}'")
             WIDGET_TYPES[self.name] = self
 
-            # Register the update action automatically, adding widget-specific
-            # properties. The schema is materialised lazily on first validation
-            # (see `_update_action_schema`); the schema dumper still sees the
-            # full mapping because that helper picks the eager build when
-            # schema extraction is enabled.
             register_action(
                 f"lvgl.{self.name}.update",
                 ObjUpdateAction,

--- a/esphome/components/lvgl/widgets/__init__.py
+++ b/esphome/components/lvgl/widgets/__init__.py
@@ -95,14 +95,11 @@ def _update_action_schema(
 
     cached: Schema | None = None
 
-    def get_schema() -> Schema:
+    def validator(value: Any) -> Any:
         nonlocal cached
         if cached is None:
             cached = _build_update_schema(widget_type)
-        return cached
-
-    def validator(value: Any) -> Any:
-        return get_schema()(value)
+        return cached(value)
 
     return validator
 

--- a/tests/component_tests/lvgl/test_update_action_lazy.py
+++ b/tests/component_tests/lvgl/test_update_action_lazy.py
@@ -1,20 +1,10 @@
-"""Tests for the lazy build behaviour of `lvgl.<widget>.update` action schemas.
-
-`WidgetType.__init__` registers each widget's update-action schema lazily so
-that ~200 ms of cumulative voluptuous work is skipped at lvgl import time
-for YAMLs that never invoke an update action. The registry stores
-`raw_schema` directly, so the build must be eager when the language-schema
-dumper is collecting structure; these tests pin both halves.
-"""
+"""Tests for lvgl.<widget>.update lazy schema build."""
 
 from __future__ import annotations
 
 from unittest.mock import patch
 
 from esphome.automation import ACTION_REGISTRY
-
-# Importing the lvgl package populates the WIDGET_TYPES and ACTION_REGISTRY
-# entries used by these tests as a side effect.
 import esphome.components.lvgl  # noqa: F401
 from esphome.components.lvgl.schemas import WIDGET_TYPES
 from esphome.components.lvgl.widgets import _update_action_schema
@@ -28,62 +18,36 @@ def _widget_type(name: str = "obj"):
 
 
 def test_registry_entry_uses_lazy_validator() -> None:
-    """The default import path (EnableSchemaExtraction off) must store a
-    bare callable in `raw_schema`, not a fully materialised `Schema`. A
-    `Schema` instance here means the schema was built eagerly at import."""
     entry = ACTION_REGISTRY["lvgl.label.update"]
-    assert callable(entry.raw_schema), "raw_schema must be callable"
-    assert not isinstance(entry.raw_schema, Schema), (
-        "raw_schema should be the lazy validator, not a materialised Schema; "
-        "an eagerly built Schema means the import-time deferral was reverted"
-    )
+    assert callable(entry.raw_schema)
+    assert not isinstance(entry.raw_schema, Schema)
 
 
 def test_lazy_validator_defers_build_until_first_call() -> None:
-    """`_update_action_schema()` must not invoke `_build_update_schema` at
-    construction time; only the first call to the returned validator should
-    trigger the build."""
     wt = _widget_type("label")
     with patch(
         "esphome.components.lvgl.widgets._build_update_schema",
         wraps=lambda w: Schema({}),
     ) as build_mock:
         validator = _update_action_schema(wt)
-        assert build_mock.call_count == 0, (
-            "_build_update_schema must not be invoked at construction time"
-        )
+        assert build_mock.call_count == 0
         validator({})
-        assert build_mock.call_count == 1, (
-            "_build_update_schema must be invoked exactly once on first call"
-        )
+        assert build_mock.call_count == 1
         validator({})
-        assert build_mock.call_count == 1, (
-            "_build_update_schema must not be invoked again on subsequent calls"
-        )
+        assert build_mock.call_count == 1
 
 
 def test_eager_build_when_schema_extraction_enabled() -> None:
-    """When `EnableSchemaExtraction` is on (set by build_language_schema.py
-    before importing esphome modules), `_update_action_schema()` must
-    materialise the schema eagerly so the dumper can introspect the mapping;
-    a bare validator would render as opaque in the language schema output."""
     wt = _widget_type("label")
     with patch("esphome.components.lvgl.widgets.EnableSchemaExtraction", True):
         result = _update_action_schema(wt)
-    assert isinstance(result, Schema), (
-        "with EnableSchemaExtraction=True, _update_action_schema must return "
-        "a Schema instance so schema_extractors can walk its mapping"
-    )
+    assert isinstance(result, Schema)
 
 
 def test_lazy_and_eager_produce_equivalent_validation() -> None:
-    """The lazy validator and an eagerly built schema must accept the same
-    inputs; a bug in the deferral or the cached materialisation could yield
-    a divergent validator while still being structurally callable."""
     wt = _widget_type("label")
     with patch("esphome.components.lvgl.widgets.EnableSchemaExtraction", True):
         eager = _update_action_schema(wt)
     lazy = _update_action_schema(wt)
-
     sample = {"id": "label_id"}
     assert lazy(sample) == eager(sample)

--- a/tests/component_tests/lvgl/test_update_action_lazy.py
+++ b/tests/component_tests/lvgl/test_update_action_lazy.py
@@ -1,0 +1,89 @@
+"""Tests for the lazy build behaviour of `lvgl.<widget>.update` action schemas.
+
+`WidgetType.__init__` registers each widget's update-action schema lazily so
+that ~200 ms of cumulative voluptuous work is skipped at lvgl import time
+for YAMLs that never invoke an update action. The registry stores
+`raw_schema` directly, so the build must be eager when the language-schema
+dumper is collecting structure; these tests pin both halves.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from esphome.automation import ACTION_REGISTRY
+
+# Importing the lvgl package populates the WIDGET_TYPES and ACTION_REGISTRY
+# entries used by these tests as a side effect.
+import esphome.components.lvgl  # noqa: F401
+from esphome.components.lvgl.schemas import WIDGET_TYPES
+from esphome.components.lvgl.widgets import _update_action_schema
+from esphome.config_validation import Schema
+
+
+def _widget_type(name: str = "obj"):
+    wt = WIDGET_TYPES.get(name)
+    assert wt is not None, f"widget type {name!r} not registered"
+    return wt
+
+
+def test_registry_entry_uses_lazy_validator() -> None:
+    """The default import path (EnableSchemaExtraction off) must store a
+    bare callable in `raw_schema`, not a fully materialised `Schema`. A
+    `Schema` instance here means the schema was built eagerly at import."""
+    entry = ACTION_REGISTRY["lvgl.label.update"]
+    assert callable(entry.raw_schema), "raw_schema must be callable"
+    assert not isinstance(entry.raw_schema, Schema), (
+        "raw_schema should be the lazy validator, not a materialised Schema; "
+        "an eagerly built Schema means the import-time deferral was reverted"
+    )
+
+
+def test_lazy_validator_defers_build_until_first_call() -> None:
+    """`_update_action_schema()` must not invoke `_build_update_schema` at
+    construction time; only the first call to the returned validator should
+    trigger the build."""
+    wt = _widget_type("label")
+    with patch(
+        "esphome.components.lvgl.widgets._build_update_schema",
+        wraps=lambda w: Schema({}),
+    ) as build_mock:
+        validator = _update_action_schema(wt)
+        assert build_mock.call_count == 0, (
+            "_build_update_schema must not be invoked at construction time"
+        )
+        validator({})
+        assert build_mock.call_count == 1, (
+            "_build_update_schema must be invoked exactly once on first call"
+        )
+        validator({})
+        assert build_mock.call_count == 1, (
+            "_build_update_schema must not be invoked again on subsequent calls"
+        )
+
+
+def test_eager_build_when_schema_extraction_enabled() -> None:
+    """When `EnableSchemaExtraction` is on (set by build_language_schema.py
+    before importing esphome modules), `_update_action_schema()` must
+    materialise the schema eagerly so the dumper can introspect the mapping;
+    a bare validator would render as opaque in the language schema output."""
+    wt = _widget_type("label")
+    with patch("esphome.components.lvgl.widgets.EnableSchemaExtraction", True):
+        result = _update_action_schema(wt)
+    assert isinstance(result, Schema), (
+        "with EnableSchemaExtraction=True, _update_action_schema must return "
+        "a Schema instance so schema_extractors can walk its mapping"
+    )
+
+
+def test_lazy_and_eager_produce_equivalent_validation() -> None:
+    """The lazy validator and an eagerly built schema must accept the same
+    inputs; a bug in the deferral or the cached materialisation could yield
+    a divergent validator while still being structurally callable."""
+    wt = _widget_type("label")
+    with patch("esphome.components.lvgl.widgets.EnableSchemaExtraction", True):
+        eager = _update_action_schema(wt)
+    lazy = _update_action_schema(wt)
+
+    sample = {"id": "label_id"}
+    assert lazy(sample) == eager(sample)


### PR DESCRIPTION
# What does this implement/fix?

Each `WidgetType.__init__` runs `base_update_schema(...).extend(self.modify_schema)` eagerly to register `lvgl.<widget>.update`, ~7 ms per widget × ~25 widgets = ~200 ms of voluptuous work at every lvgl import.

Defer the build to first validation. The registry stores `raw_schema` directly, so the helper picks the eager build when `schema_extractors.EnableSchemaExtraction` is on, which is exactly when `script/build_language_schema.py` needs the full mapping.

Cold `import esphome.components.lvgl` on M series Mac (5 runs each): median 614 ms → 419 ms.

`script/build_language_schema.py` output is byte identical to dev; `script/test_build_components -c lvgl -e config` passes (hello_world exercises lvgl.label.update / lvgl.spinner.update / lvgl.widget.refresh).

Independent from #16567.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
