### PR TITLE
[libretiny] Fix LN882H IRAM_ATTR injection point in patch_linker.py

### DIFF
--- a/esphome/components/libretiny/patch_linker.py.script
+++ b/esphome/components/libretiny/patch_linker.py.script
@@ -13,7 +13,9 @@ import subprocess
 # - RTL8710B: hal.h uses section(".image2.ram.text"); stock linker consumes it.
 # - RTL8720C: hal.h uses section(".sram.text"); stock linker consumes it.
 # - LN882H: stock linker has no glob for ".sram.text", so we inject
-#   KEEP(*(.sram.text*)) into ".flash_copysection" (> RAM0 AT> FLASH).
+#   KEEP(*(.sram.text*)) into ".flash_copysection" (> RAM0 AT> FLASH)
+#   immediately after KEEP(*(.vectors)), so the vector table stays at
+#   __copysection_ram0_start (0x20000000) for correct Cortex-M4 VTOR alignment.
 #
 # All families also get a post-link summary showing where IRAM_ATTR landed.
 
@@ -27,7 +29,11 @@ _KEEP_LINE = (
     "__esphome_sram_text_end = .; "
     + _MARKER + "\n"
 )
-_LN_COPY = re.compile(r"(\.flash_copysection\s*:\s*\{\s*\n)")
+# Inject after KEEP(*(.vectors)) so the vector table stays at
+# __copysection_ram0_start (0x20000000). Cortex-M4 VTOR requires a 512-byte-
+# aligned address; injecting before the vectors would push them to an
+# unaligned offset and mis-route every IRQ handler.
+_LN_COPY = re.compile(r"(KEEP\(\*\(\.vectors\)\)[^\n]*\n)")
 
 
 def _detect(env):
@@ -56,7 +62,7 @@ KNOWN_VARIANTS = frozenset({
 
 
 def _inject_keep(host_section):
-    """Return a patcher that injects _KEEP_LINE at the top of `host_section`."""
+    """Return a patcher that injects _KEEP_LINE after `host_section` match."""
     def patch(content):
         if _MARKER in content:
             return content


### PR DESCRIPTION
## Description

Fixes the LN882H-specific regex in `patch_linker.py.script` that routes `IRAM_ATTR` functions into RAM via `.flash_copysection`.

### Root cause

The original regex:
```python
_LN_COPY = re.compile(r"(\.flash_copysection\s*:\s*\{\s*
)")
```
has two problems on LN882H:

1. **Never matches** — the LN882H linker script (`ln882hki_bsp.template.ld`) has `{` on its own line after `:`, so the regex silently does nothing and `.sram.text` sections are left unplaced.

2. **Wrong injection point even if it did match** — injecting at the opening brace places `.sram.text` before `__copysection_ram0_start = .;`. The LN882H startup code copies only `[__copysection_ram0_start, __copysection_ram0_end]`, so any code placed before that symbol never gets written to RAM. Calling an `IRAM_ATTR` function jumps to uninitialized RAM → hard fault → silent hang on boot.

An intermediate fix (inject after `__copysection_ram0_start`) also fails: it displaces the interrupt vector table from `0x20000000` to an unaligned address. Cortex-M4 VTOR requires 512-byte alignment, so all IRQ handlers mis-route → same hang symptom.

### Fix

Inject after `KEEP(*(.vectors))` so:
- Vector table stays at `0x20000000` (correct VTOR alignment)
- `.sram.text` follows at the next address, inside `[__copysection_ram0_start, __copysection_ram0_end]`
- Startup copy covers both

```python
_LN_COPY = re.compile(r"(KEEP\(\*\(\.vectors\)\)[^
]*
)")
```

Confirmed placement after fix:
```
ESPHome: patched ln882hki_bsp.ld for IRAM_ATTR placement
ESPHome: IRAM_ATTR placement summary (LN882H):
  .sram.text:  384 bytes at 0x200003c0 - 0x20000540
```

## Testing

Tested on DS-101JL dual light switch (LN882H / generic-ln882hki, LibreTiny v1.12.1):
- 2026.5.0 without fix: silent hang on boot, no UART output
- 2026.5.0 with this fix: boots normally, WiFi connects, HA API connects, all functions working

## Related

Fixes #16540

Note: libretiny-eu/libretiny#375 (static IP fix for LN882H, used in production for several months) is also pending review — it is independent of this issue but affects the same hardware.