### PR TITLE
[i2s_audio] Reset dout GPIO when stopping speaker driver

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -2,6 +2,7 @@
 
 #ifdef USE_ESP32
 
+#include <driver/gpio.h>
 #include <driver/i2s_std.h>
 
 #include "esphome/components/audio/audio.h"
@@ -299,6 +300,15 @@ void I2SAudioSpeakerBase::stop_i2s_driver_() {
     i2s_channel_disable(this->tx_handle_);
     i2s_del_channel(this->tx_handle_);
     this->tx_handle_ = nullptr;
+
+    // i2s_del_channel() leaves dout wired to this port's data-out signal in the GPIO matrix: it only
+    // clears an internal reservation mask, never the esp_rom_gpio_connect_out_signal() routing that
+    // setup installed. If another speaker reuses this port (shared bus), its audio still reaches our
+    // dout. Detach the pin and drive it low so a stale output stops driving downstream hardware: a
+    // SPDIF optical transmitter would otherwise stay lit, and an analog DAC would emit noise.
+    gpio_reset_pin(this->dout_pin_);
+    gpio_set_direction(this->dout_pin_, GPIO_MODE_OUTPUT);
+    gpio_set_level(this->dout_pin_, 0);
   }
   this->parent_->unlock();
 }


### PR DESCRIPTION
# What does this implement/fix?

When the I2S speaker driver stops, `i2s_del_channel()` only clears an internal
port reservation mask. It leaves the dout pin wired to the port's data-out
signal in the GPIO matrix, because nothing undoes the
`esp_rom_gpio_connect_out_signal()` routing that driver setup installed.

On a shared I2S bus, this means that after one speaker stops, a second speaker
reusing the same port still drives audio onto the first speaker's dout pin.
Downstream hardware sees a stale signal: a SPDIF optical transmitter stays lit,
and an analog DAC emits noise.

This detaches the dout pin from the GPIO matrix and drives it low when the
driver stops, so a stopped speaker no longer drives downstream hardware.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2s_audio:
  i2s_lrclk_pin: GPIO25
  i2s_bclk_pin: GPIO26

speaker:
  - platform: i2s_audio
    id: my_speaker
    dac_type: external
    i2s_dout_pin: GPIO22
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
