### PR TITLE
[growatt_solar] Replace hard coded register addresses with constexpr

### DIFF
--- a/esphome/components/growatt_solar/growatt_solar.cpp
+++ b/esphome/components/growatt_solar/growatt_solar.cpp
@@ -63,71 +63,88 @@ void GrowattSolar::on_modbus_data(const std::vector<uint8_t> &data) {
 
   switch (this->protocol_version_) {
     case RTU: {
-      publish_1_reg_sensor_state(this->inverter_status_, 0, 1);
+      publish_1_reg_sensor_state(this->inverter_status_, RTU_INVERTER_STATUS, 1);
 
-      publish_2_reg_sensor_state(this->pv_active_power_sensor_, 1, 2, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->pv_active_power_sensor_, RTU_PV_ACTIVE_POWER, RTU_PV_ACTIVE_POWER + 1,
+                                 ONE_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->pvs_[0].voltage_sensor_, 3, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->pvs_[0].current_sensor_, 4, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->pvs_[0].active_power_sensor_, 5, 6, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->pvs_[0].voltage_sensor_, RTU_PV1_VOLTAGE, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->pvs_[0].current_sensor_, RTU_PV1_CURRENT, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->pvs_[0].active_power_sensor_, RTU_PV1_ACTIVE_POWER, RTU_PV1_ACTIVE_POWER + 1,
+                                 ONE_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->pvs_[1].voltage_sensor_, 7, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->pvs_[1].current_sensor_, 8, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->pvs_[1].active_power_sensor_, 9, 10, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->pvs_[1].voltage_sensor_, RTU_PV2_VOLTAGE, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->pvs_[1].current_sensor_, RTU_PV2_CURRENT, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->pvs_[1].active_power_sensor_, RTU_PV2_ACTIVE_POWER, RTU_PV2_ACTIVE_POWER + 1,
+                                 ONE_DEC_UNIT);
 
-      publish_2_reg_sensor_state(this->grid_active_power_sensor_, 11, 12, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->grid_frequency_sensor_, 13, TWO_DEC_UNIT);
+      publish_2_reg_sensor_state(this->grid_active_power_sensor_, RTU_GRID_ACTIVE_POWER, RTU_GRID_ACTIVE_POWER + 1,
+                                 ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->grid_frequency_sensor_, RTU_GRID_FREQUENCY, TWO_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->phases_[0].voltage_sensor_, 14, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->phases_[0].current_sensor_, 15, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->phases_[0].active_power_sensor_, 16, 17, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[0].voltage_sensor_, RTU_PHASE1_VOLTAGE, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[0].current_sensor_, RTU_PHASE1_CURRENT, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->phases_[0].active_power_sensor_, RTU_PHASE1_ACTIVE_POWER,
+                                 RTU_PHASE1_ACTIVE_POWER + 1, ONE_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->phases_[1].voltage_sensor_, 18, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->phases_[1].current_sensor_, 19, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->phases_[1].active_power_sensor_, 20, 21, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[1].voltage_sensor_, RTU_PHASE2_VOLTAGE, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[1].current_sensor_, RTU_PHASE2_CURRENT, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->phases_[1].active_power_sensor_, RTU_PHASE2_ACTIVE_POWER,
+                                 RTU_PHASE2_ACTIVE_POWER + 1, ONE_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->phases_[2].voltage_sensor_, 22, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->phases_[2].current_sensor_, 23, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->phases_[2].active_power_sensor_, 24, 25, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[2].voltage_sensor_, RTU_PHASE3_VOLTAGE, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[2].current_sensor_, RTU_PHASE3_CURRENT, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->phases_[2].active_power_sensor_, RTU_PHASE3_ACTIVE_POWER,
+                                 RTU_PHASE3_ACTIVE_POWER + 1, ONE_DEC_UNIT);
 
-      publish_2_reg_sensor_state(this->today_production_, 26, 27, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->total_energy_production_, 28, 29, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->today_production_, RTU_TODAY_PRODUCTION, RTU_TODAY_PRODUCTION + 1, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->total_energy_production_, RTU_TOTAL_ENERGY_PRODUCTION,
+                                 RTU_TOTAL_ENERGY_PRODUCTION + 1, ONE_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->inverter_module_temp_, 32, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->inverter_module_temp_, RTU_INVERTER_MODULE_TEMP, ONE_DEC_UNIT);
       break;
     }
     case RTU2: {
-      publish_1_reg_sensor_state(this->inverter_status_, 0, 1);
+      publish_1_reg_sensor_state(this->inverter_status_, RTU2_INVERTER_STATUS, 1);
 
-      publish_2_reg_sensor_state(this->pv_active_power_sensor_, 1, 2, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->pv_active_power_sensor_, RTU2_PV_ACTIVE_POWER, RTU2_PV_ACTIVE_POWER + 1,
+                                 ONE_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->pvs_[0].voltage_sensor_, 3, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->pvs_[0].current_sensor_, 4, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->pvs_[0].active_power_sensor_, 5, 6, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->pvs_[0].voltage_sensor_, RTU2_PV1_VOLTAGE, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->pvs_[0].current_sensor_, RTU2_PV1_CURRENT, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->pvs_[0].active_power_sensor_, RTU2_PV1_ACTIVE_POWER, RTU2_PV1_ACTIVE_POWER + 1,
+                                 ONE_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->pvs_[1].voltage_sensor_, 7, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->pvs_[1].current_sensor_, 8, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->pvs_[1].active_power_sensor_, 9, 10, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->pvs_[1].voltage_sensor_, RTU2_PV2_VOLTAGE, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->pvs_[1].current_sensor_, RTU2_PV2_CURRENT, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->pvs_[1].active_power_sensor_, RTU2_PV2_ACTIVE_POWER, RTU2_PV2_ACTIVE_POWER + 1,
+                                 ONE_DEC_UNIT);
 
-      publish_2_reg_sensor_state(this->grid_active_power_sensor_, 35, 36, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->grid_frequency_sensor_, 37, TWO_DEC_UNIT);
+      publish_2_reg_sensor_state(this->grid_active_power_sensor_, RTU2_GRID_ACTIVE_POWER, RTU2_GRID_ACTIVE_POWER + 1,
+                                 ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->grid_frequency_sensor_, RTU2_GRID_FREQUENCY, TWO_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->phases_[0].voltage_sensor_, 38, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->phases_[0].current_sensor_, 39, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->phases_[0].active_power_sensor_, 40, 41, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[0].voltage_sensor_, RTU2_PHASE1_VOLTAGE, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[0].current_sensor_, RTU2_PHASE1_CURRENT, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->phases_[0].active_power_sensor_, RTU2_PHASE1_ACTIVE_POWER,
+                                 RTU2_PHASE1_ACTIVE_POWER + 1, ONE_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->phases_[1].voltage_sensor_, 42, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->phases_[1].current_sensor_, 43, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->phases_[1].active_power_sensor_, 44, 45, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[1].voltage_sensor_, RTU2_PHASE2_VOLTAGE, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[1].current_sensor_, RTU2_PHASE2_CURRENT, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->phases_[1].active_power_sensor_, RTU2_PHASE2_ACTIVE_POWER,
+                                 RTU2_PHASE2_ACTIVE_POWER + 1, ONE_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->phases_[2].voltage_sensor_, 46, ONE_DEC_UNIT);
-      publish_1_reg_sensor_state(this->phases_[2].current_sensor_, 47, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->phases_[2].active_power_sensor_, 48, 49, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[2].voltage_sensor_, RTU2_PHASE3_VOLTAGE, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->phases_[2].current_sensor_, RTU2_PHASE3_CURRENT, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->phases_[2].active_power_sensor_, RTU2_PHASE3_ACTIVE_POWER,
+                                 RTU2_PHASE3_ACTIVE_POWER + 1, ONE_DEC_UNIT);
 
-      publish_2_reg_sensor_state(this->today_production_, 53, 54, ONE_DEC_UNIT);
-      publish_2_reg_sensor_state(this->total_energy_production_, 55, 56, ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->today_production_, RTU2_TODAY_PRODUCTION, RTU2_TODAY_PRODUCTION + 1,
+                                 ONE_DEC_UNIT);
+      publish_2_reg_sensor_state(this->total_energy_production_, RTU2_TOTAL_ENERGY_PRODUCTION,
+                                 RTU2_TOTAL_ENERGY_PRODUCTION + 1, ONE_DEC_UNIT);
 
-      publish_1_reg_sensor_state(this->inverter_module_temp_, 93, ONE_DEC_UNIT);
+      publish_1_reg_sensor_state(this->inverter_module_temp_, RTU2_INVERTER_MODULE_TEMP, ONE_DEC_UNIT);
       break;
     }
   }

--- a/esphome/components/growatt_solar/growatt_solar.h
+++ b/esphome/components/growatt_solar/growatt_solar.h
@@ -16,6 +16,55 @@ enum GrowattProtocolVersion {
   RTU2,
 };
 
+// Register addresses for the RTU protocol.
+constexpr size_t RTU_INVERTER_STATUS = 0;           // length = 1
+constexpr size_t RTU_PV_ACTIVE_POWER = 1;           // length = 2
+constexpr size_t RTU_PV1_VOLTAGE = 3;               // length = 1
+constexpr size_t RTU_PV1_CURRENT = 4;               // length = 1
+constexpr size_t RTU_PV1_ACTIVE_POWER = 5;          // length = 2
+constexpr size_t RTU_PV2_VOLTAGE = 7;               // length = 1
+constexpr size_t RTU_PV2_CURRENT = 8;               // length = 1
+constexpr size_t RTU_PV2_ACTIVE_POWER = 9;          // length = 2
+constexpr size_t RTU_GRID_ACTIVE_POWER = 11;        // length = 2
+constexpr size_t RTU_GRID_FREQUENCY = 13;           // length = 1
+constexpr size_t RTU_PHASE1_VOLTAGE = 14;           // length = 1
+constexpr size_t RTU_PHASE1_CURRENT = 15;           // length = 1
+constexpr size_t RTU_PHASE1_ACTIVE_POWER = 16;      // length = 2
+constexpr size_t RTU_PHASE2_VOLTAGE = 18;           // length = 1
+constexpr size_t RTU_PHASE2_CURRENT = 19;           // length = 1
+constexpr size_t RTU_PHASE2_ACTIVE_POWER = 20;      // length = 2
+constexpr size_t RTU_PHASE3_VOLTAGE = 22;           // length = 1
+constexpr size_t RTU_PHASE3_CURRENT = 23;           // length = 1
+constexpr size_t RTU_PHASE3_ACTIVE_POWER = 24;      // length = 2
+constexpr size_t RTU_TODAY_PRODUCTION = 26;         // length = 2
+constexpr size_t RTU_TOTAL_ENERGY_PRODUCTION = 28;  // length = 2
+constexpr size_t RTU_INVERTER_MODULE_TEMP = 32;     // length = 1
+
+// Input register addresses for the RTU2 protocol as described
+// in the "GROWATT INVERTER MODBUS PROTOCOL_II V1.39" document.
+constexpr size_t RTU2_INVERTER_STATUS = 0;           // length = 1
+constexpr size_t RTU2_PV_ACTIVE_POWER = 1;           // length = 2
+constexpr size_t RTU2_PV1_VOLTAGE = 3;               // length = 1
+constexpr size_t RTU2_PV1_CURRENT = 4;               // length = 1
+constexpr size_t RTU2_PV1_ACTIVE_POWER = 5;          // length = 2
+constexpr size_t RTU2_PV2_VOLTAGE = 7;               // length = 1
+constexpr size_t RTU2_PV2_CURRENT = 8;               // length = 1
+constexpr size_t RTU2_PV2_ACTIVE_POWER = 9;          // length = 2
+constexpr size_t RTU2_GRID_ACTIVE_POWER = 35;        // length = 2
+constexpr size_t RTU2_GRID_FREQUENCY = 37;           // length = 1
+constexpr size_t RTU2_PHASE1_VOLTAGE = 38;           // length = 1
+constexpr size_t RTU2_PHASE1_CURRENT = 39;           // length = 1
+constexpr size_t RTU2_PHASE1_ACTIVE_POWER = 40;      // length = 2
+constexpr size_t RTU2_PHASE2_VOLTAGE = 42;           // length = 1
+constexpr size_t RTU2_PHASE2_CURRENT = 43;           // length = 1
+constexpr size_t RTU2_PHASE2_ACTIVE_POWER = 44;      // length = 2
+constexpr size_t RTU2_PHASE3_VOLTAGE = 46;           // length = 1
+constexpr size_t RTU2_PHASE3_CURRENT = 47;           // length = 1
+constexpr size_t RTU2_PHASE3_ACTIVE_POWER = 48;      // length = 2
+constexpr size_t RTU2_TODAY_PRODUCTION = 53;         // length = 2
+constexpr size_t RTU2_TOTAL_ENERGY_PRODUCTION = 55;  // length = 2
+constexpr size_t RTU2_INVERTER_MODULE_TEMP = 93;     // length = 1
+
 class GrowattSolar : public PollingComponent, public modbus::ModbusDevice {
  public:
   void loop() override;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This PR replaces hardcoded modbus register addresses with constants based on the Growatt modbus protocol documentation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
