### PR TITLE
[esp32] Demote IDF #warning deprecations from error under ESP-IDF toolchain

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1821,9 +1821,6 @@ async def to_code(config):
         cg.add_build_flag("-Wno-error=overloaded-virtual")
         cg.add_build_flag("-Wno-error=reorder")
         cg.add_build_flag("-Wno-error=volatile")
-        # IDF v6 headers (e.g. driver/twai.h) emit #warning deprecation
-        # notices that fire under -Werror. Demote to a warning so legacy
-        # components keep building until they migrate.
         cg.add_build_flag("-Wno-error=cpp")
         # -Wno- (not -Wno-error=): suppress entirely, too noisy on C++ aggregates
         cg.add_build_flag("-Wno-missing-field-initializers")

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1821,6 +1821,10 @@ async def to_code(config):
         cg.add_build_flag("-Wno-error=overloaded-virtual")
         cg.add_build_flag("-Wno-error=reorder")
         cg.add_build_flag("-Wno-error=volatile")
+        # IDF v6 headers (e.g. driver/twai.h) emit #warning deprecation
+        # notices that fire under -Werror. Demote to a warning so legacy
+        # components keep building until they migrate.
+        cg.add_build_flag("-Wno-error=cpp")
         # -Wno- (not -Wno-error=): suppress entirely, too noisy on C++ aggregates
         cg.add_build_flag("-Wno-missing-field-initializers")
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes #16571: ESP-IDF v6 builds fail on components that include legacy IDF headers — most visibly `esp32_can` pulling in `driver/twai.h`:

```
.esphome/idf/frameworks/6.0.1/components/driver/twai/include/driver/twai.h:17:2:
error: #warning "The legacy TWAI driver is deprecated, please use esp_twai.h" [-Werror=cpp]
```

IDF's `tools/cmake/build.cmake` sets a blanket `-Werror` and demotes only 5 classes (`unused-function`, `unused-variable`, `unused-but-set-variable`, `deprecated-declarations`, `extra`). ESPHome adds 5 more (`format`, `maybe-uninitialized`, `overloaded-virtual`, `reorder`, `volatile`). Every other warning class — including `-Wcpp` (preprocessor `#warning` directives) — is promoted to a hard build error.

IDF v6 newly carries 51 `#warning "...deprecated, please use X"` directives across its headers (`driver/twai.h`, `esp_event_loop.h`, `esp_rom_uart.h`, `xtensa/xtensa_context.h`, several `esp_pm/include/<variant>/pm.h` files, `apb_ctrl_reg.h`, etc.). All of them emit through the `-Wcpp` warning class, so a single `-Wno-error=cpp` covers every one — past and future — without touching any of the real bug-catching classes (`-Werror=return-type`, `-Werror=write-strings`, `-Werror=address`, `-Werror=uninitialized`, …).

The deprecation notices still **print** in the build log (good — keeps migration pressure visible). They just no longer fail compilation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #16571

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal build-flag change.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any esp_hosted / esp32_can / other component still on legacy IDF headers,
# built with framework.version >= 6.0.0:
esp32:
  framework:
    type: esp-idf
    version: 6.0.1

esp32_can:
  ...   # used to fail with -Werror=cpp on driver/twai.h; now compiles.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).