### PR TITLE
[tests] Use larger app partition for esp32-c6-idf builds

### DIFF
--- a/tests/test_build_components/build_components_base.esp32-c6-idf.yaml
+++ b/tests/test_build_components/build_components_base.esp32-c6-idf.yaml
@@ -6,6 +6,9 @@ esp32:
   board: esp32-c6-devkitc-1
   framework:
     type: esp-idf
+  # Use custom partition table with larger app partition (3MB)
+  # Default IDF partitions only allow 1.75MB which is too small for grouped tests
+  partitions: ../partitions_testing.csv
 
 logger:
   level: VERY_VERBOSE


### PR DESCRIPTION
# What does this implement/fix?

The default IDF partition layout only leaves 1.75MB for the app, which is no longer enough for the grouped component tests on esp32-c6-idf; bluetooth_proxy currently overflows on dev. This switches the c6 test base config to the same `partitions_testing.csv` already used by `esp32-idf`, `esp32-c2-idf`, `esp32-c3-idf` and `esp32-s3-idf`, giving the tests a 3MB app partition.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).