### PR TITLE
[ci] Fix flash memory overflow on tests

### DIFF
--- a/tests/components/bluetooth_proxy/test.esp32-c6-idf.yaml
+++ b/tests/components/bluetooth_proxy/test.esp32-c6-idf.yaml
@@ -1,6 +1,8 @@
 <<: !include common.yaml
 
 esp32_ble_tracker:
+
+esp32_ble:
   max_connections: 9
 
 bluetooth_proxy:

--- a/tests/test_build_components/build_components_base.esp32-c6-idf.yaml
+++ b/tests/test_build_components/build_components_base.esp32-c6-idf.yaml
@@ -4,6 +4,7 @@ esphome:
 
 esp32:
   board: esp32-c6-devkitc-1
+  flash_size: 8MB
   framework:
     type: esp-idf
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fixes testing error when using:

```
script/test_build_components.py -c bluetooth_proxy,zigbee -t esp32-c6-idf -e compile
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
