### PR TITLE
[bluetooth_proxy] Recover slot stuck in DISCONNECTING when CLOSE_EVT is dropped

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -144,7 +144,7 @@ void BluetoothConnection::loop() {
   }
 }
 
-void BluetoothConnection::on_disconnect_complete_(esp_err_t reason) {
+void BluetoothConnection::on_disconnect_complete(esp_err_t reason) {
   // Called from both the CLOSE_EVT handler and the DISCONNECTING safety timeout in the
   // base class. Free the proxy slot, notify the API client, and reset send_service_.
   // address_ may already be 0 if reset_connection_ ran earlier on this teardown.

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -135,8 +135,11 @@ void BluetoothConnection::loop() {
   // - For V3_WITH_CACHE: Services are never sent, disable after INIT state
   // - For V3_WITHOUT_CACHE: Disable only after service discovery is complete
   //   (send_service_ == DONE_SENDING_SERVICES, which is only set after services are sent)
-  if (this->state() != espbt::ClientState::INIT && (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
-                                                    this->send_service_ == DONE_SENDING_SERVICES)) {
+  // Never disable while DISCONNECTING — BLEClientBase::loop() needs to keep running so the
+  // 10s safety timeout can force IDLE if CLOSE_EVT is never delivered.
+  if (this->state() != espbt::ClientState::INIT && this->state() != espbt::ClientState::DISCONNECTING &&
+      (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
+       this->send_service_ == DONE_SENDING_SERVICES)) {
     this->disable_loop();
   }
 }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -144,14 +144,15 @@ void BluetoothConnection::loop() {
   }
 }
 
-void BluetoothConnection::on_disconnect_timeout_() {
-  // The base class forced IDLE because CLOSE_EVT never arrived. Run the same slot
-  // cleanup the CLOSE_EVT path would have done so the proxy slot is freed, the API
-  // client is notified, and send_service_ is reset for the next connection.
+void BluetoothConnection::on_disconnect_complete_(esp_err_t reason) {
+  // Called from both the CLOSE_EVT handler and the DISCONNECTING safety timeout in the
+  // base class. Free the proxy slot, notify the API client, and reset send_service_.
+  // address_ may already be 0 if reset_connection_ ran earlier on this teardown.
   if (this->address_ == 0) {
     return;
   }
-  this->reset_connection_(ESP_GATT_CONN_TIMEOUT);
+  ESP_LOGD(TAG, "[%d] [%s] Close, reason=0x%02x, freeing slot", this->connection_index_, this->address_str_, reason);
+  this->reset_connection_(reason);
 }
 
 void BluetoothConnection::reset_connection_(esp_err_t reason) {
@@ -383,14 +384,6 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
                param->disconnect.reason);
       // Send disconnection notification but don't free the slot yet
       this->proxy_->send_device_connection(this->address_, false, 0, param->disconnect.reason);
-      break;
-    }
-    case ESP_GATTC_CLOSE_EVT: {
-      ESP_LOGD(TAG, "[%d] [%s] Close, reason=0x%02x, freeing slot", this->connection_index_, this->address_str_,
-               param->close.reason);
-      // Now the GATT connection is fully closed and controller resources are freed
-      // Safe to mark the connection slot as available
-      this->reset_connection_(param->close.reason);
       break;
     }
     case ESP_GATTC_OPEN_EVT: {

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -144,6 +144,16 @@ void BluetoothConnection::loop() {
   }
 }
 
+void BluetoothConnection::on_disconnect_timeout_() {
+  // The base class forced IDLE because CLOSE_EVT never arrived. Run the same slot
+  // cleanup the CLOSE_EVT path would have done so the proxy slot is freed, the API
+  // client is notified, and send_service_ is reset for the next connection.
+  if (this->address_ == 0) {
+    return;
+  }
+  this->reset_connection_(ESP_GATT_CONN_TIMEOUT);
+}
+
 void BluetoothConnection::reset_connection_(esp_err_t reason) {
   // Send disconnection notification
   this->proxy_->send_device_connection(this->address_, false, 0, reason);

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -33,6 +33,8 @@ class BluetoothConnection final : public esp32_ble_client::BLEClientBase {
  protected:
   friend class BluetoothProxy;
 
+  void on_disconnect_timeout_() override;
+
   bool supports_efficient_uuids_() const;
   void send_service_for_discovery_();
   void reset_connection_(esp_err_t reason);

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -33,7 +33,7 @@ class BluetoothConnection final : public esp32_ble_client::BLEClientBase {
  protected:
   friend class BluetoothProxy;
 
-  void on_disconnect_complete_(esp_err_t reason) override;
+  void on_disconnect_complete(esp_err_t reason) override;
 
   bool supports_efficient_uuids_() const;
   void send_service_for_discovery_();

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -33,7 +33,7 @@ class BluetoothConnection final : public esp32_ble_client::BLEClientBase {
  protected:
   friend class BluetoothProxy;
 
-  void on_disconnect_timeout_() override;
+  void on_disconnect_complete_(esp_err_t reason) override;
 
   bool supports_efficient_uuids_() const;
   void send_service_for_discovery_();

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -72,7 +72,7 @@ void BLEClientBase::loop() {
     // never delivered CLOSE_EVT/DISCONNECT_EVT, services would leak without this call.
     this->release_services();
     this->set_idle_();
-    this->on_disconnect_complete_(ESP_GATT_CONN_TIMEOUT);
+    this->on_disconnect_complete(ESP_GATT_CONN_TIMEOUT);
   }
 }
 
@@ -419,7 +419,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       this->log_gattc_lifecycle_event_("CLOSE");
       this->release_services();
       this->set_idle_();
-      this->on_disconnect_complete_(param->close.reason);
+      this->on_disconnect_complete(param->close.reason);
       break;
     }
     case ESP_GATTC_SEARCH_RES_EVT: {

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -72,6 +72,9 @@ void BLEClientBase::loop() {
     // never delivered CLOSE_EVT/DISCONNECT_EVT, services would leak without this call.
     this->release_services();
     this->set_idle_();
+    // Notify subclasses so they can release any extra per-connection state (e.g. bluetooth_proxy
+    // slot accounting) that would normally be cleared by the CLOSE_EVT handler.
+    this->on_disconnect_timeout_();
   }
 }
 

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -72,9 +72,7 @@ void BLEClientBase::loop() {
     // never delivered CLOSE_EVT/DISCONNECT_EVT, services would leak without this call.
     this->release_services();
     this->set_idle_();
-    // Notify subclasses so they can release any extra per-connection state (e.g. bluetooth_proxy
-    // slot accounting) that would normally be cleared by the CLOSE_EVT handler.
-    this->on_disconnect_timeout_();
+    this->on_disconnect_complete_(ESP_GATT_CONN_TIMEOUT);
   }
 }
 
@@ -421,6 +419,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       this->log_gattc_lifecycle_event_("CLOSE");
       this->release_services();
       this->set_idle_();
+      this->on_disconnect_complete_(param->close.reason);
       break;
     }
     case ESP_GATTC_SEARCH_RES_EVT: {

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -145,7 +145,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   /// Subclasses with extra per-connection accounting (e.g. bluetooth_proxy slot state)
   /// override this to release that state. `reason` is the controller reason code, or
   /// ESP_GATT_CONN_TIMEOUT for the safety-timeout path.
-  virtual void on_disconnect_complete_(esp_err_t reason) {}
+  virtual void on_disconnect_complete(esp_err_t reason) {}
   /// Transition to IDLE and reset conn_id — call when the connection is fully dead.
   void set_idle_() {
     this->set_state(espbt::ClientState::IDLE);

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -140,10 +140,12 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void log_gattc_warning_(const char *operation, esp_err_t err);
   void log_connection_params_(const char *param_type);
   void handle_connection_result_(esp_err_t ret);
-  /// Hook called from the DISCONNECTING safety timeout after the base class forces IDLE.
+  /// Hook called once a connection has been fully torn down (after release_services() and
+  /// set_idle_()), from both the CLOSE_EVT handler and the DISCONNECTING safety timeout.
   /// Subclasses with extra per-connection accounting (e.g. bluetooth_proxy slot state)
-  /// override this to perform the same cleanup the normal CLOSE_EVT path would do.
-  virtual void on_disconnect_timeout_() {}
+  /// override this to release that state. `reason` is the controller reason code, or
+  /// ESP_GATT_CONN_TIMEOUT for the safety-timeout path.
+  virtual void on_disconnect_complete_(esp_err_t reason) {}
   /// Transition to IDLE and reset conn_id — call when the connection is fully dead.
   void set_idle_() {
     this->set_state(espbt::ClientState::IDLE);

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -149,6 +149,10 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void set_disconnecting_() {
     this->disconnecting_started_ = millis();
     this->set_state(espbt::ClientState::DISCONNECTING);
+    // BluetoothConnection::loop() disables the component loop after service discovery
+    // completes, so the DISCONNECTING timeout check in loop() would never run if CLOSE_EVT
+    // gets lost. Re-enable the loop so the 10s safety timeout can force IDLE.
+    this->enable_loop();
   }
   // Compact error logging helpers to reduce flash usage
   void log_error_(const char *message);

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -140,6 +140,10 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void log_gattc_warning_(const char *operation, esp_err_t err);
   void log_connection_params_(const char *param_type);
   void handle_connection_result_(esp_err_t ret);
+  /// Hook called from the DISCONNECTING safety timeout after the base class forces IDLE.
+  /// Subclasses with extra per-connection accounting (e.g. bluetooth_proxy slot state)
+  /// override this to perform the same cleanup the normal CLOSE_EVT path would do.
+  virtual void on_disconnect_timeout_() {}
   /// Transition to IDLE and reset conn_id — call when the connection is fully dead.
   void set_idle_() {
     this->set_state(espbt::ClientState::IDLE);


### PR DESCRIPTION
# What does this implement/fix?

A BLE proxy connection can get stuck in DISCONNECTING forever when ESP-IDF drops `CLOSE_EVT`; the slot is then permanently blocked. The existing 10s safety timeout in `BLEClientBase::loop()` was meant to recover from this, but it never ran because the component loop was disabled, and even if it did fire, the proxy slot accounting was not released. This PR makes the recovery actually work.

Changes:

1. `set_disconnecting_()` calls `enable_loop()`, so the loop wakes up after a previous tick had disabled it.
2. `BluetoothConnection::loop()` no longer re-disables the loop while DISCONNECTING; otherwise it would turn the loop back off on the very next tick and the timeout would still never fire.
3. New `on_disconnect_complete_(reason)` virtual hook on `BLEClientBase`, called from both the CLOSE_EVT handler and the DISCONNECTING safety timeout after `set_idle_()`. `BluetoothConnection` overrides it once to free the slot, notify the API client, and reset `send_service_`. The duplicate CLOSE_EVT case in `BluetoothConnection::gattc_event_handler` is removed so both teardown paths now funnel through the same hook.

When the timeout fires, `ESP_LOGE` logs `Timeout waiting for CLOSE_EVT after disconnect, forcing IDLE` so the recovery is visible in device logs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/Bluetooth-Devices/habluetooth/issues/340

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
