### PR TITLE
[audio] Add `clear_buffered_data` method to RingBufferAudioSource

### DIFF
--- a/esphome/components/audio/audio_transfer_buffer.cpp
+++ b/esphome/components/audio/audio_transfer_buffer.cpp
@@ -252,6 +252,22 @@ void RingBufferAudioSource::consume(size_t bytes) {
   }
 }
 
+void RingBufferAudioSource::clear_buffered_data() {
+  // Release the held item before reset() so the source no longer references memory the reset will reclaim.
+  if (this->acquired_item_ != nullptr) {
+    this->ring_buffer_->receive_release(this->acquired_item_);
+    this->acquired_item_ = nullptr;
+  }
+  this->current_data_ = nullptr;
+  this->current_available_ = 0;
+  this->queued_data_ = nullptr;
+  this->queued_length_ = 0;
+  this->item_trailing_ptr_ = nullptr;
+  this->item_trailing_length_ = 0;
+  this->splice_length_ = 0;
+  this->ring_buffer_->reset();
+}
+
 bool RingBufferAudioSource::has_buffered_data() const {
   // splice_length_ is deliberately not considered here. It holds an incomplete frame whose completion
   // bytes must still arrive through the ring buffer, which ring_buffer_->available() already reports.

--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -250,6 +250,10 @@ class RingBufferAudioSource : public AudioReadableBuffer {
   /// exposure stays in place and fill() returns 0 until it is fully consumed.
   size_t fill(TickType_t ticks_to_wait, bool pre_shift) override;
 
+  /// @brief Discards all buffered audio: releases any held ring buffer item, clears the source's in-flight
+  /// state, and resets the underlying ring buffer. Must be invoked from the ring buffer's consumer thread.
+  void clear_buffered_data();
+
   /// @brief Returns a mutable pointer to the currently exposed audio data.
   /// The pointer may reference the ring buffer's internal storage or, when exposing a stitched frame
   /// across a wrap boundary, an internal splice buffer. In either case mutations are safe but data


### PR DESCRIPTION
# What does this implement/fix?

Adds a `clear_buffered_data` method to reset internally held data and the ring buffer. 

Both `micro_wake_word` and `voice_assistant` components are good candidates for using the `RingBufferAudioSource` class, but they also both require being able to clear the ring buffer/data. It is really only safe to reset the ring buffer on the consumer thread, but that's exactly the `RingBufferAudioSource`'s role, so there are no safety issues with calling this function on the consumer side.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
