### PR TITLE
[ethernet] Offload W5500 bulk SPI transfers from the busy-wait path

### DIFF
--- a/esphome/components/ethernet/ethernet_component_esp32.cpp
+++ b/esphome/components/ethernet/ethernet_component_esp32.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "w5500_custom_spi.h"
 
 #include <lwip/dns.h>
 #include <cinttypes>
@@ -207,6 +208,10 @@ void EthernetComponent::setup() {
 #ifdef USE_ETHERNET_SPI_POLLING_SUPPORT
   w5500_config.poll_period_ms = this->polling_interval_;
 #endif
+  // Install the custom SPI driver that offloads the bulk RX/TX frame transfers off the busy-wait
+  // path. w5500_config (and the devcfg it references) outlives esp_eth_mac_new_w5500() below, which
+  // runs the driver's init().
+  install_w5500_async_spi(w5500_config);
 #elif defined(USE_ETHERNET_DM9051)
   dm9051_config.int_gpio_num = this->interrupt_pin_;
 #ifdef USE_ETHERNET_SPI_POLLING_SUPPORT

--- a/esphome/components/ethernet/w5500_custom_spi.cpp
+++ b/esphome/components/ethernet/w5500_custom_spi.cpp
@@ -69,7 +69,7 @@ esp_err_t w5500_custom_spi_transfer(W5500CustomSpiContext *ctx, spi_transaction_
     ret = spi_device_polling_transmit(ctx->handle, trans);
   }
   xSemaphoreGive(ctx->lock);
-  return ret == ESP_OK ? ESP_OK : ESP_FAIL;
+  return ret;
 }
 
 esp_err_t w5500_custom_spi_write(void *spi_ctx, uint32_t cmd, uint32_t addr, const void *data, uint32_t len) {

--- a/esphome/components/ethernet/w5500_custom_spi.cpp
+++ b/esphome/components/ethernet/w5500_custom_spi.cpp
@@ -94,7 +94,7 @@ esp_err_t w5500_custom_spi_read(void *spi_ctx, uint32_t cmd, uint32_t addr, void
   trans.length = 8 * len;
   trans.rx_buffer = data;
   esp_err_t ret = w5500_custom_spi_transfer(ctx, &trans, len);
-  if (use_rxdata) {
+  if (use_rxdata && (ret == ESP_OK)) {
     memcpy(data, trans.rx_data, len);
   }
   return ret;

--- a/esphome/components/ethernet/w5500_custom_spi.cpp
+++ b/esphome/components/ethernet/w5500_custom_spi.cpp
@@ -1,0 +1,118 @@
+#include "w5500_custom_spi.h"
+
+#if defined(USE_ESP32) && defined(USE_ETHERNET_W5500)
+
+#include <driver/spi_master.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <cstring>
+#include <new>
+
+namespace esphome::ethernet {
+
+namespace {
+
+// Per-device context returned by init() and handed back to read/write/deinit.
+struct W5500CustomSpiContext {
+  spi_device_handle_t handle;
+  SemaphoreHandle_t lock;
+};
+
+// Transfers up to the ESP32 SPI hardware FIFO size (64 bytes) stay on the polling path; larger
+// transfers (the frame payloads) use the blocking, DMA-backed transmit.
+constexpr uint32_t W5500_SPI_BULK_THRESHOLD = 64;
+constexpr uint32_t W5500_SPI_LOCK_TIMEOUT_MS = 50;
+
+void *w5500_custom_spi_init(const void *spi_config) {
+  const auto *config = static_cast<const eth_w5500_config_t *>(spi_config);
+  auto *ctx = new (std::nothrow) W5500CustomSpiContext{};
+  if (ctx == nullptr) {
+    return nullptr;
+  }
+  // The W5500 SPI frame carries the 16-bit address in the command phase and the 8-bit control
+  // byte in the address phase; mirror what the stock driver configures.
+  spi_device_interface_config_t devcfg = *config->spi_devcfg;
+  devcfg.command_bits = 16;
+  devcfg.address_bits = 8;
+  if (spi_bus_add_device(config->spi_host_id, &devcfg, &ctx->handle) != ESP_OK) {
+    delete ctx;
+    return nullptr;
+  }
+  ctx->lock = xSemaphoreCreateMutex();
+  if (ctx->lock == nullptr) {
+    spi_bus_remove_device(ctx->handle);
+    delete ctx;
+    return nullptr;
+  }
+  return ctx;
+}
+
+esp_err_t w5500_custom_spi_deinit(void *spi_ctx) {
+  auto *ctx = static_cast<W5500CustomSpiContext *>(spi_ctx);
+  spi_bus_remove_device(ctx->handle);
+  vSemaphoreDelete(ctx->lock);
+  delete ctx;
+  return ESP_OK;
+}
+
+// Runs one transaction under the device lock, choosing the polling vs blocking transmit by size.
+// Bulk payloads (> FIFO size) block so the calling task sleeps while DMA runs; small register
+// accesses stay on the cheaper polling path. Used by both read and write.
+esp_err_t w5500_custom_spi_transfer(W5500CustomSpiContext *ctx, spi_transaction_t *trans, uint32_t len) {
+  if (xSemaphoreTake(ctx->lock, pdMS_TO_TICKS(W5500_SPI_LOCK_TIMEOUT_MS)) != pdTRUE) {
+    return ESP_ERR_TIMEOUT;
+  }
+  esp_err_t ret;
+  if (len > W5500_SPI_BULK_THRESHOLD) {
+    ret = spi_device_transmit(ctx->handle, trans);
+  } else {
+    ret = spi_device_polling_transmit(ctx->handle, trans);
+  }
+  xSemaphoreGive(ctx->lock);
+  return ret == ESP_OK ? ESP_OK : ESP_FAIL;
+}
+
+esp_err_t w5500_custom_spi_write(void *spi_ctx, uint32_t cmd, uint32_t addr, const void *data, uint32_t len) {
+  auto *ctx = static_cast<W5500CustomSpiContext *>(spi_ctx);
+  spi_transaction_t trans = {};
+  trans.cmd = static_cast<uint16_t>(cmd);
+  trans.addr = addr;
+  trans.length = 8 * len;
+  trans.tx_buffer = data;
+  return w5500_custom_spi_transfer(ctx, &trans, len);
+}
+
+esp_err_t w5500_custom_spi_read(void *spi_ctx, uint32_t cmd, uint32_t addr, void *data, uint32_t len) {
+  auto *ctx = static_cast<W5500CustomSpiContext *>(spi_ctx);
+  spi_transaction_t trans = {};
+  // Reads of <= 4 bytes use the transaction's inline RX buffer to avoid 4-byte boundary
+  // overwrites of adjacent registers (same guard the stock driver uses).
+  const bool use_rxdata = len <= 4;
+  trans.flags = use_rxdata ? SPI_TRANS_USE_RXDATA : 0;
+  trans.cmd = static_cast<uint16_t>(cmd);
+  trans.addr = addr;
+  trans.length = 8 * len;
+  trans.rx_buffer = data;
+  esp_err_t ret = w5500_custom_spi_transfer(ctx, &trans, len);
+  if (use_rxdata) {
+    memcpy(data, trans.rx_data, len);
+  }
+  return ret;
+}
+
+}  // namespace
+
+void install_w5500_async_spi(eth_w5500_config_t &config) {
+  // Point the custom driver's config at the W5500 config itself; init() reads spi_host_id and
+  // spi_devcfg back out of it. The self-reference is valid because both the config and the
+  // spi_devcfg it points at outlive the esp_eth_mac_new_w5500() call that runs init().
+  config.custom_spi_driver.config = &config;
+  config.custom_spi_driver.init = w5500_custom_spi_init;
+  config.custom_spi_driver.deinit = w5500_custom_spi_deinit;
+  config.custom_spi_driver.read = w5500_custom_spi_read;
+  config.custom_spi_driver.write = w5500_custom_spi_write;
+}
+
+}  // namespace esphome::ethernet
+
+#endif  // USE_ESP32 && USE_ETHERNET_W5500

--- a/esphome/components/ethernet/w5500_custom_spi.h
+++ b/esphome/components/ethernet/w5500_custom_spi.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#if defined(USE_ESP32) && defined(USE_ETHERNET_W5500)
+
+#include <esp_idf_version.h>
+// IDF 6.0 moved the per-chip SPI MAC drivers to the Espressif Component Registry; eth_w5500_config_t
+// is no longer reachable through esp_eth.h and needs the explicit header.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include <esp_eth_mac_w5500.h>
+#else
+#include <esp_eth.h>
+#endif
+
+namespace esphome::ethernet {
+
+// Installs a custom W5500 SPI driver that offloads the bulk frame transfers off the busy-wait path.
+//
+// The stock W5500 driver runs every SPI transfer through spi_device_polling_transmit(), which
+// busy-waits the CPU for the whole transfer. The frame payload (one large read per received frame,
+// one large write per transmitted frame) is by far the biggest transfer, so the RX task and the TX
+// caller each spin for hundreds of microseconds per frame. This driver sends payload transfers
+// through the blocking, interrupt-driven spi_device_transmit() instead, so the calling task sleeps
+// while DMA moves the bytes. Small register accesses stay on the polling path, where the busy-wait
+// is cheaper than an interrupt round-trip.
+//
+// Must be called before esp_eth_mac_new_w5500(). The driver reads spi_host_id and spi_devcfg back
+// out of `config` in its init() callback, so `config` (and the spi_devcfg it points at) must stay
+// alive until esp_eth_mac_new_w5500() returns.
+void install_w5500_async_spi(eth_w5500_config_t &config);
+
+}  // namespace esphome::ethernet
+
+#endif  // USE_ESP32 && USE_ETHERNET_W5500


### PR DESCRIPTION
# What does this implement/fix?

The ESP-IDF W5500 driver runs every SPI transfer through
`spi_device_polling_transmit()`, which busy-waits the CPU until the transfer
finishes. The largest transfers are the frame payloads (one read per received
frame, one write per transmitted frame), so the receive task and the transmit
caller each spin for hundreds of microseconds per frame.

This installs a custom SPI driver through the
`eth_w5500_config_t.custom_spi_driver` hook (available since IDF 5.0).
Transfers larger than the 64-byte SPI FIFO go through the blocking,
interrupt-driven `spi_device_transmit()`, so the calling task sleeps while DMA
moves the bytes. Register-sized transfers (64 bytes or fewer) stay on the
polling path, where the busy-wait is cheaper than an interrupt round trip.
Everything else matches the stock driver: framing bits, the small-read register
guard, the bus mutex and its 50 ms timeout, and the error codes.

Large transfers use DMA the same way the stock polling path already does on the
DMA-enabled bus, and IDF transparently bounces any buffer that is not
DMA-capable, so this does not add a new buffer requirement.

The driver lives in its own translation unit (`w5500_custom_spi.{h,cpp}`) and is
wired in from `EthernetComponent::setup()` with a single
`install_w5500_async_spi()` call. It is always on for the W5500; there is no new
configuration option.

Measured on hardware streaming 48 kHz 24-bit stereo FLAC, the ethernet task CPU
usage dropped from about 5% (range 4.1 to 6.1%) to about 3.8% (range 3.0 to
4.4%), roughly a quarter lower, with peaks falling from about 6% to about 5%.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

CPU usage optimization for the W5500 SPI driver. No user-facing or API change.

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable (no configuration change)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No new options. Existing W5500 configs get the lower CPU usage automatically.
ethernet:
  type: W5500
  clk_pin: 19
  mosi_pin: 21
  miso_pin: 23
  cs_pin: 18
  interrupt_pin: 36
  reset_pin: 22
  clock_speed: 10Mhz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

The existing `tests/components/ethernet/test-w5500.esp32-idf.yaml` already compiles this path, since the driver is always on, so no new test file was added.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

Not applicable; no exposed configuration changed.
