### PR TITLE
[esp32] Replace per-class -Wno-error=X demotes with blanket -Wno-error for ESP-IDF toolchain

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1816,9 +1816,8 @@ async def to_code(config):
                 Path(__file__).parent / "iram_fix.py.script",
             )
     else:
-        # Undo IDF's blanket -Werror. Warnings still print; they just don't
-        # fail the build. Avoids needing a new -Wno-error=<class> entry every
-        # time a GCC/IDF bump newly errors on third-party (PIO-converted) code.
+        # Undo IDF's blanket -Werror so third-party libraries and user
+        # lambdas don't need a -Wno-error=<class> entry per warning class.
         cg.add_build_flag("-Wno-error")
         # -Wno- (not -Wno-error=): suppress entirely, too noisy on C++ aggregates
         cg.add_build_flag("-Wno-missing-field-initializers")

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1816,12 +1816,10 @@ async def to_code(config):
                 Path(__file__).parent / "iram_fix.py.script",
             )
     else:
-        cg.add_build_flag("-Wno-error=format")
-        cg.add_build_flag("-Wno-error=maybe-uninitialized")
-        cg.add_build_flag("-Wno-error=overloaded-virtual")
-        cg.add_build_flag("-Wno-error=reorder")
-        cg.add_build_flag("-Wno-error=volatile")
-        cg.add_build_flag("-Wno-error=cpp")
+        # Undo IDF's blanket -Werror. Warnings still print; they just don't
+        # fail the build. Avoids needing a new -Wno-error=<class> entry every
+        # time a GCC/IDF bump newly errors on third-party (PIO-converted) code.
+        cg.add_build_flag("-Wno-error")
         # -Wno- (not -Wno-error=): suppress entirely, too noisy on C++ aggregates
         cg.add_build_flag("-Wno-missing-field-initializers")
 


### PR DESCRIPTION
# What does this implement/fix?

The ESP-IDF toolchain block in `esp32/__init__.py` had been growing a list of `-Wno-error=<class>` demotes (`format`, `maybe-uninitialized`, `overloaded-virtual`, `reorder`, `volatile`, `cpp`). Each entry was added in response to a specific user-reported build break. Replace the list with a single blanket `-Wno-error` so new third-party libraries and user lambdas don't keep needing a new entry per warning class. Warnings still **print** in the build log; only the build-failure escalation is removed.

This matches the PIO/arduino-esp32 behavior: `platform.txt` sets `compiler.warning_flags=-w` plus only `-Werror=return-type` as a specific error, so PIO builds already don't fail on warnings either.

## Verification

End-to-end tested on IDF 6.0.1 + GCC 15.2.0 + the `gps` component (which pulls in `TinyGPSPlus`):

**Before:** `error: this statement may fall through [-Werror=implicit-fallthrough=]` → ninja stops.

**After:** `warning: this statement may fall through [-Wimplicit-fallthrough=]` → `INFO Successfully compiled program.`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Supersedes #16571 / #16584 per-class demote pattern.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal build-flag change.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  framework:
    type: esp-idf
    version: 6.0.1
gps:
  ...   # used to fail on TinyGPSPlus's implicit-fallthrough; now compiles.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).