### PR TITLE
[api] Fix uint32_t/int32_t format strings for stricter GCC toolchain

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -1,6 +1,7 @@
 #include "api_server.h"
 #ifdef USE_API
 #include <cerrno>
+#include <cinttypes>
 #include "api_connection.h"
 #include "esphome/components/network/util.h"
 #include "esphome/core/application.h"
@@ -677,7 +678,7 @@ uint32_t APIServer::register_active_action_call(uint32_t client_call_id, APIConn
   // Schedule automatic cleanup after timeout (client will have given up by then)
   // Uses numeric ID overload to avoid heap allocation from str_sprintf
   this->set_timeout(action_call_id, USE_API_ACTION_CALL_TIMEOUT_MS, [this, action_call_id]() {
-    ESP_LOGD(TAG, "Action call %u timed out", action_call_id);
+    ESP_LOGD(TAG, "Action call %" PRIu32 " timed out", action_call_id);
     this->unregister_active_action_call(action_call_id);
   });
 
@@ -721,7 +722,7 @@ void APIServer::send_action_response(uint32_t action_call_id, bool success, Stri
       return;
     }
   }
-  ESP_LOGW(TAG, "Cannot send response: no active call found for action_call_id %u", action_call_id);
+  ESP_LOGW(TAG, "Cannot send response: no active call found for action_call_id %" PRIu32, action_call_id);
 }
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
 void APIServer::send_action_response(uint32_t action_call_id, bool success, StringRef error_message,
@@ -733,7 +734,7 @@ void APIServer::send_action_response(uint32_t action_call_id, bool success, Stri
       return;
     }
   }
-  ESP_LOGW(TAG, "Cannot send response: no active call found for action_call_id %u", action_call_id);
+  ESP_LOGW(TAG, "Cannot send response: no active call found for action_call_id %" PRIu32, action_call_id);
 }
 #endif  // USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
 #endif  // USE_API_USER_DEFINED_ACTION_RESPONSES

--- a/tests/components/api/common-base.yaml
+++ b/tests/components/api/common-base.yaml
@@ -120,12 +120,12 @@ api:
               lambda: 'return condition;'
             then:
               - logger.log:
-                  format: "Condition true, value: %d"
-                  args: ['value']
+                  format: "Condition true, value: %ld"
+                  args: ['(long) value']
             else:
               - logger.log:
-                  format: "Condition false, value: %d"
-                  args: ['value']
+                  format: "Condition false, value: %ld"
+                  args: ['(long) value']
         - logger.log: "After if/else"
     # Test nested IfAction (multiple ContinuationAction instances)
     - action: test_nested_if
@@ -171,8 +171,8 @@ api:
             count: !lambda 'return count;'
             then:
               - logger.log:
-                  format: "Repeat iteration: %d"
-                  args: ['iteration']
+                  format: "Repeat iteration: %lu"
+                  args: ['(unsigned long) iteration']
         - logger.log: "After repeat"
     # Test combined continuations (if + while + repeat)
     - action: test_combined_continuations
@@ -193,8 +193,8 @@ api:
                           lambda: 'return id(api_continuation_test_counter) > 0;'
                         then:
                           - logger.log:
-                              format: "Combined: repeat=%d, while=%d"
-                              args: ['iteration', 'id(api_continuation_test_counter)']
+                              format: "Combined: repeat=%lu, while=%d"
+                              args: ['(unsigned long) iteration', 'id(api_continuation_test_counter)']
                           - lambda: 'id(api_continuation_test_counter)--;'
             else:
               - logger.log: "Skipped loops"
@@ -208,8 +208,8 @@ api:
         - api.respond:
             success: true
         - logger.log:
-            format: "Status response sent (call_id=%d)"
-            args: [call_id]
+            format: "Status response sent (call_id=%lu)"
+            args: ['(unsigned long) call_id']
 
     - action: test_respond_status_error
       variables:
@@ -229,8 +229,8 @@ api:
         value: float
       then:
         - logger.log:
-            format: "Optional response (call_id=%d, return_response=%d)"
-            args: [call_id, return_response]
+            format: "Optional response (call_id=%lu, return_response=%lu)"
+            args: ['(unsigned long) call_id', '(unsigned long) return_response']
         - api.respond:
             data: !lambda |-
               root["sensor"] = sensor_name;
@@ -264,8 +264,8 @@ api:
         input: string
       then:
         - logger.log:
-            format: "Only response (call_id=%d)"
-            args: [call_id]
+            format: "Only response (call_id=%lu)"
+            args: ['(unsigned long) call_id']
         - api.respond:
             data: !lambda |-
               root["input"] = input;


### PR DESCRIPTION
# What does this implement/fix?

The xtensa-esp-elf GCC 14.2 toolchain (`esp-14.2.0_20260121`) enforces `-Werror=format=` strictly. On this toolchain, `int32_t` and `uint32_t` are typedef'd to `long int` / `long unsigned int` (not the plain `int` / `unsigned int` they aliased to under older toolchains). Existing `%d` / `%u` format specifiers used against these types now produce a fatal type mismatch:

```
api_server.cpp:680: error: format '%u' expects argument of type 'unsigned int',
  but argument 5 has type 'long unsigned int' [-Werror=format=]
```

This is currently breaking the **"Test components with native ESP-IDF"** job on every PR that runs against the updated toolchain (including #14012). PR #16599's blanket `-Wno-error` change to `esp32/__init__.py` doesn't reach this code path under the `test_build_components` framework, so the fix has to come from the format strings themselves.

This PR contains two commits, both addressing the same root cause:

## 1. C++ source: `esphome/components/api/api_server.cpp`

Three `ESP_LOGD` / `ESP_LOGW` call sites print `action_call_id` (`uint32_t`) via `%u`. Switched to the portable C99 `PRIu32` macro from `<cinttypes>`.

```diff
-    ESP_LOGD(TAG, \"Action call %u timed out\", action_call_id);
+    ESP_LOGD(TAG, \"Action call %\" PRIu32 \" timed out\", action_call_id);
```

`PRIu32` is the portable choice for C++ source — it expands to whichever specifier is correct for `uint32_t` on the target platform via preprocessor string-literal concatenation.

## 2. Test fixtures: `tests/components/api/common-base.yaml`

Seven `logger.log` format strings in test YAML lambdas used `%d` for automation variables whose underlying C++ types are `int32_t` (from `int` declared via action `variables:`) or `uint32_t` (auto-injected `call_id`, `return_response`, repeat `iteration`).

`PRIu32` can't be embedded directly in a YAML format string (the format field is `cv.string`, no preprocessor expansion at codegen time). The portable pattern is to **cast the arg to `long` / `unsigned long`** and use `%ld` / `%lu` in the format — `long` is guaranteed ≥ 32 bits on every platform, regardless of whether `int32_t`'s underlying type is `int` or `long int` on a given target.

This pattern was already established at [`common-base.yaml:83-93`](https://github.com/esphome/esphome/blob/dev/tests/components/api/common-base.yaml#L83-L93) (`(long) int_arr[0]` with `%ld`); the new fixes follow it consistently.

```diff
   - logger.log:
-      format: \"Condition true, value: %d\"
-      args: ['value']
+      format: \"Condition true, value: %ld\"
+      args: ['(long) value']
```

Line 161 (`While loop iteration: %d` with `id(api_continuation_test_counter)`) is correctly left alone — its arg is a global declared `type: int` which maps to plain C++ `int`, so `%d` already matches.

## No behavior change

Rendered log output is identical across all platforms in both commits.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A — toolchain-driven build failure surfaced post-merge of #16599 + GCC 14.2 bump. Currently blocks #14012 and any other PR that touches the \`api\` test path.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal log format string fix with no user-visible impact.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

The C++ fix (\`PRIu32\`) and the YAML fix (\`(long)\` cast + \`%ld\`) are both portable across every ESPHome target. The CI failure is currently observed under ESP32-IDF, but the YAML test fixtures compile under all targets that include \`tests/components/api/common.yaml\` (esp32-idf, esp8266-ard, rp2040-ard, ln882x-ard, host).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder). — N/A: existing tests exercise the code path; the YAML fixtures themselves are the tests.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). — N/A