### PR TITLE
[esp32] Disable IDF's COMPILER_DISABLE_DEFAULT_ERRORS so -Wno-error actually undoes -Werror

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1816,6 +1816,12 @@ async def to_code(config):
                 Path(__file__).parent / "iram_fix.py.script",
             )
     else:
+        # IDF's top-level CMakeLists rewrites the blanket -Werror to
+        # -Werror=all when CONFIG_COMPILER_DISABLE_DEFAULT_ERRORS=y (its
+        # Kconfig default). -Werror=all can only be undone per-warning-class,
+        # not globally, so our -Wno-error below would be a no-op. Disable
+        # the rewrite so -Werror stays as the blanket form -Wno-error can undo.
+        add_idf_sdkconfig_option("CONFIG_COMPILER_DISABLE_DEFAULT_ERRORS", False)
         # Undo IDF's blanket -Werror so third-party libraries and user
         # lambdas don't need a -Wno-error=<class> entry per warning class.
         cg.add_build_flag("-Wno-error")

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1816,14 +1816,11 @@ async def to_code(config):
                 Path(__file__).parent / "iram_fix.py.script",
             )
     else:
-        # IDF's top-level CMakeLists rewrites the blanket -Werror to
-        # -Werror=all when CONFIG_COMPILER_DISABLE_DEFAULT_ERRORS=y (its
-        # Kconfig default). -Werror=all can only be undone per-warning-class,
-        # not globally, so our -Wno-error below would be a no-op. Disable
-        # the rewrite so -Werror stays as the blanket form -Wno-error can undo.
+        # Demote IDF's blanket -Werror to warnings so third-party libs
+        # and user lambdas don't need a -Wno-error=<class> per warning.
+        # The sdkconfig knob disables IDF's rewrite to -Werror=all (which
+        # can't be globally undone); -Wno-error then handles the demotion.
         add_idf_sdkconfig_option("CONFIG_COMPILER_DISABLE_DEFAULT_ERRORS", False)
-        # Undo IDF's blanket -Werror so third-party libraries and user
-        # lambdas don't need a -Wno-error=<class> entry per warning class.
         cg.add_build_flag("-Wno-error")
         # -Wno- (not -Wno-error=): suppress entirely, too noisy on C++ aggregates
         cg.add_build_flag("-Wno-missing-field-initializers")


### PR DESCRIPTION
# What does this implement/fix?

PR #16599 (\`-Wno-error\` for the ESP-IDF toolchain) was silently a no-op. IDF's top-level \`CMakeLists.txt:202-206\` rewrites the blanket \`-Werror\` to \`-Werror=all\` when \`CONFIG_COMPILER_DISABLE_DEFAULT_ERRORS=y\` — which is the Kconfig default. \`-Werror=all\` is the umbrella form that can only be undone per-warning-class; bare \`-Wno-error\` doesn't touch it. Verified by inspecting the actual gcc rsp file and reproducing locally:

```
flags=[-Wall -Werror     -Wno-error]      exit=0   ← what we expected
flags=[-Wall -Werror=all -Wno-error]      exit=1   ← what actually runs
flags=[-Wall -Werror=all -Wno-error=all]  exit=1   ← also no-op
flags=[-Wall -Werror=all -Wno-error=format] exit=0   ← per-class works
```

Disable the rewrite via \`sdkconfig\` so \`-Werror\` stays in its blanket form that \`-Wno-error\` can actually undo.

Surfaced by PR #16603's CI: \`api_server.cpp\` \`%u\` for \`uint32_t\` errored under \`-Werror=format=\` despite dev having the \`-Wno-error\` flag.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes the no-op landed in #16599. Unblocks #16603-style CI failures that hit \`-Werror=format=\` despite the project-level demote.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal build-flag change.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

```yaml
# No user-facing change. The failing test_build_components.py invocation
# now compiles cleanly with -Werror=format= demoted to a warning:
#
#   script/test_build_components.py -c api -t esp32-idf -e compile --toolchain esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).