### PR TITLE
[nrf52_pwm] Add PWM output platform

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -366,6 +366,7 @@ esphome/components/nfc/* @jesserockz @kbx81
 esphome/components/noblex/* @AGalfra
 esphome/components/npi19/* @bakerkj
 esphome/components/nrf52/* @tomaszduda23
+esphome/components/nrf52_pwm/* @spsancti
 esphome/components/number/* @esphome/core
 esphome/components/one_wire/* @ssieb
 esphome/components/online_image/* @clydebarrow @guillempages

--- a/esphome/components/nrf52_pwm/__init__.py
+++ b/esphome/components/nrf52_pwm/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@spsancti"]

--- a/esphome/components/nrf52_pwm/nrf52_pwm.cpp
+++ b/esphome/components/nrf52_pwm/nrf52_pwm.cpp
@@ -43,13 +43,15 @@ void Nrf52PWMOutput::dump_config() {
 
 uint32_t Nrf52PWMOutput::period_ns_() const { return static_cast<uint32_t>(roundf(1000000000.0f / this->frequency_)); }
 
-bool Nrf52PWMOutput::write_pwm_(float state) {
+bool Nrf52PWMOutput::write_pwm_() {
   const uint32_t period_ns = this->period_ns_();
-  const uint32_t pulse_ns = static_cast<uint32_t>(roundf(static_cast<float>(period_ns) * state));
+  const uint32_t pulse_ns = static_cast<uint32_t>(roundf(static_cast<float>(period_ns) * this->last_output_));
   pwm_flags_t flags = 0;
   if (this->pin_ != nullptr && this->pin_->is_inverted()) {
     flags |= PWM_POLARITY_INVERTED;
   }
+  // Zephyr pwm_nrfx drives pulse 0 and pulse >= period as constant pin states, and stops the PWM peripheral
+  // when every channel on it is constant. This matches LEDC-style stop behavior for 0% and 100% outputs.
   int ret = pwm_set(this->dev_, this->channel_, period_ns, pulse_ns, flags);
   if (ret != 0) {
     ESP_LOGE(TAG, "pwm_set() failed for channel %" PRIu32 ": %d", this->channel_, ret);
@@ -60,7 +62,7 @@ bool Nrf52PWMOutput::write_pwm_(float state) {
 
 void Nrf52PWMOutput::write_state(float state) {
   this->last_output_ = state;
-  this->write_pwm_(state);
+  this->write_pwm_();
 }
 
 void Nrf52PWMOutput::update_frequency(float frequency) {
@@ -69,7 +71,7 @@ void Nrf52PWMOutput::update_frequency(float frequency) {
     return;
   }
   this->frequency_ = frequency;
-  this->write_pwm_(this->last_output_);
+  this->write_pwm_();
 }
 
 }  // namespace esphome::nrf52_pwm

--- a/esphome/components/nrf52_pwm/nrf52_pwm.cpp
+++ b/esphome/components/nrf52_pwm/nrf52_pwm.cpp
@@ -1,0 +1,77 @@
+#ifdef USE_NRF52
+
+#include "nrf52_pwm.h"
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+#include <cinttypes>
+#include <cmath>
+
+namespace esphome::nrf52_pwm {
+
+// Zephyr PWM API: period and pulse widths are passed in nanoseconds to pwm_set().
+// https://docs.zephyrproject.org/latest/doxygen/html/group__pwm__interface.html
+static const char *const TAG = "nrf52_pwm";
+
+void Nrf52PWMOutput::setup() {
+  if (this->dev_ == nullptr) {
+    ESP_LOGE(TAG, "PWM device is not configured");
+    this->mark_failed();
+    return;
+  }
+  if (!device_is_ready(this->dev_)) {
+    ESP_LOGE(TAG, "PWM device is not ready");
+    this->mark_failed();
+    return;
+  }
+  this->turn_off();
+}
+
+void Nrf52PWMOutput::dump_config() {
+  ESP_LOGCONFIG(TAG,
+                "nRF52 PWM:\n"
+                "  Frequency: %.1f Hz\n"
+                "  Channel: %" PRIu32,
+                this->frequency_, this->channel_);
+  LOG_PIN("  Pin: ", this->pin_);
+  LOG_FLOAT_OUTPUT(this);
+  if (!this->runtime_frequency_mutable_) {
+    ESP_LOGCONFIG(TAG, "  Runtime frequency changes: disabled for shared PWM peripheral");
+  }
+}
+
+uint32_t Nrf52PWMOutput::period_ns_() const { return static_cast<uint32_t>(roundf(1000000000.0f / this->frequency_)); }
+
+bool Nrf52PWMOutput::write_pwm_(float state) {
+  const uint32_t period_ns = this->period_ns_();
+  const uint32_t pulse_ns = static_cast<uint32_t>(roundf(static_cast<float>(period_ns) * state));
+  pwm_flags_t flags = 0;
+  if (this->pin_ != nullptr && this->pin_->is_inverted()) {
+    flags |= PWM_POLARITY_INVERTED;
+  }
+  int ret = pwm_set(this->dev_, this->channel_, period_ns, pulse_ns, flags);
+  if (ret != 0) {
+    ESP_LOGE(TAG, "pwm_set() failed for channel %" PRIu32 ": %d", this->channel_, ret);
+    return false;
+  }
+  return true;
+}
+
+void Nrf52PWMOutput::write_state(float state) {
+  this->last_output_ = state;
+  this->write_pwm_(state);
+}
+
+void Nrf52PWMOutput::update_frequency(float frequency) {
+  if (!this->runtime_frequency_mutable_) {
+    ESP_LOGW(TAG, "Ignoring runtime frequency change on shared PWM peripheral");
+    return;
+  }
+  this->frequency_ = frequency;
+  this->write_pwm_(this->last_output_);
+}
+
+}  // namespace esphome::nrf52_pwm
+
+#endif  // USE_NRF52

--- a/esphome/components/nrf52_pwm/nrf52_pwm.h
+++ b/esphome/components/nrf52_pwm/nrf52_pwm.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#ifdef USE_NRF52
+
+#include "esphome/components/output/float_output.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/pwm.h>
+
+namespace esphome::nrf52_pwm {
+
+class Nrf52PWMOutput : public output::FloatOutput, public Component {
+ public:
+  void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
+  void set_device(const device *dev) { this->dev_ = dev; }
+  void set_channel(uint32_t channel) { this->channel_ = channel; }
+  void set_frequency(float frequency) { this->frequency_ = frequency; }
+  void set_runtime_frequency_mutable(bool mutable_frequency) { this->runtime_frequency_mutable_ = mutable_frequency; }
+
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  void update_frequency(float frequency) override;
+
+ protected:
+  void write_state(float state) override;
+  bool write_pwm_(float state);
+  uint32_t period_ns_() const;
+
+  InternalGPIOPin *pin_{nullptr};
+  const device *dev_{nullptr};
+  uint32_t channel_{0};
+  float frequency_{1000.0f};
+  float last_output_{0.0f};
+  bool runtime_frequency_mutable_{false};
+};
+
+template<typename... Ts> class SetFrequencyAction : public Action<Ts...> {
+ public:
+  explicit SetFrequencyAction(Nrf52PWMOutput *parent) : parent_(parent) {}
+  TEMPLATABLE_VALUE(float, frequency);
+
+  void play(const Ts &...x) override {
+    float freq = this->frequency_.value(x...);
+    this->parent_->update_frequency(freq);
+  }
+
+ protected:
+  Nrf52PWMOutput *parent_;
+};
+
+}  // namespace esphome::nrf52_pwm
+
+#endif  // USE_NRF52

--- a/esphome/components/nrf52_pwm/nrf52_pwm.h
+++ b/esphome/components/nrf52_pwm/nrf52_pwm.h
@@ -27,7 +27,7 @@ class Nrf52PWMOutput : public output::FloatOutput, public Component {
 
  protected:
   void write_state(float state) override;
-  bool write_pwm_(float state);
+  bool write_pwm_();
   uint32_t period_ns_() const;
 
   InternalGPIOPin *pin_{nullptr};

--- a/esphome/components/nrf52_pwm/output.py
+++ b/esphome/components/nrf52_pwm/output.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from esphome import automation, pins
+import esphome.codegen as cg
+from esphome.components import output
+from esphome.components.zephyr import zephyr_add_overlay, zephyr_add_prj_conf
+import esphome.config_validation as cv
+from esphome.const import CONF_FREQUENCY, CONF_ID, CONF_NUMBER, CONF_PIN
+from esphome.core import CORE, CoroPriority, coroutine_with_priority
+from esphome.cpp_generator import RawExpression
+import esphome.final_validate as fv
+
+DEPENDENCIES = ["nrf52"]
+
+_MAX_PWM_PERIPHERALS = 3
+_MAX_CHANNELS_PER_PWM = 4
+_DATA_KEY = "nrf52_pwm"
+
+# Zephyr's nordic,nrf-pwm binding requires pinctrl groups for enabled PWM devices.
+# https://docs.zephyrproject.org/latest/build/dts/api/bindings/pwm/nordic,nrf-pwm.html
+
+
+@dataclass
+class Nrf52PWMData:
+    configs: list[dict]
+    final_job_scheduled: bool = False
+
+
+def _get_data() -> Nrf52PWMData:
+    if _DATA_KEY not in CORE.data:
+        CORE.data[_DATA_KEY] = Nrf52PWMData(configs=[])
+    return CORE.data[_DATA_KEY]
+
+
+def _frequency_key(config: dict) -> int:
+    return int(round(config[CONF_FREQUENCY]))
+
+
+def _allocate_pwm(configs: list[dict]) -> list[tuple[dict, int, int, int]]:
+    frequency_groups: dict[int, list[dict]] = {}
+    for config in configs:
+        frequency_groups.setdefault(_frequency_key(config), []).append(config)
+
+    allocations: list[tuple[dict, int, int, int]] = []
+    pwm_num = 0
+    for group in frequency_groups.values():
+        for offset in range(0, len(group), _MAX_CHANNELS_PER_PWM):
+            if pwm_num >= _MAX_PWM_PERIPHERALS:
+                raise cv.Invalid(
+                    "nrf52_pwm supports up to 3 PWM peripherals with 4 channels each. "
+                    "Use fewer distinct frequencies or fewer outputs."
+                )
+            chunk = group[offset : offset + _MAX_CHANNELS_PER_PWM]
+            for channel, config in enumerate(chunk):
+                allocations.append((config, pwm_num, channel, len(chunk)))
+            pwm_num += 1
+    return allocations
+
+
+def _final_validate(config):
+    all_outputs = fv.full_config.get().get("output", [])
+    configs = [conf for conf in all_outputs if conf.get("platform") == "nrf52_pwm"]
+    _allocate_pwm(configs)
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
+
+
+nrf52_pwm_ns = cg.esphome_ns.namespace("nrf52_pwm")
+Nrf52PWMOutput = nrf52_pwm_ns.class_("Nrf52PWMOutput", output.FloatOutput, cg.Component)
+SetFrequencyAction = nrf52_pwm_ns.class_("SetFrequencyAction", automation.Action)
+validate_frequency = cv.All(cv.frequency, cv.float_range(min=1.0e-6))
+
+CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
+    {
+        cv.Required(CONF_ID): cv.declare_id(Nrf52PWMOutput),
+        cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
+        cv.Optional(CONF_FREQUENCY, default="1kHz"): validate_frequency,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+def _add_pwm_overlay(allocations: list[tuple[dict, int, int, int]]) -> None:
+    pwm_groups: dict[int, list[tuple[dict, int]]] = {}
+    for config, pwm_num, channel, _ in allocations:
+        pwm_groups.setdefault(pwm_num, []).append((config, channel))
+
+    pinctrl_entries = []
+    peripheral_entries = []
+    for pwm_num, items in sorted(pwm_groups.items()):
+        psel_entries = []
+        for config, channel in items:
+            pin_num = config[CONF_PIN][CONF_NUMBER]
+            psel_entries.append(
+                f"<NRF_PSEL(PWM_OUT{channel}, {pin_num // 32}, {pin_num % 32})>"
+            )
+        psels = ",\n                    ".join(psel_entries)
+        pinctrl_entries.append(
+            f"""
+            pwm{pwm_num}_default: pwm{pwm_num}_default {{
+                group1 {{
+                    psels = {psels};
+                }};
+            }};
+            pwm{pwm_num}_sleep: pwm{pwm_num}_sleep {{
+                group1 {{
+                    psels = {psels};
+                    low-power-enable;
+                }};
+            }};
+            """
+        )
+        peripheral_entries.append(
+            f"""
+            &pwm{pwm_num} {{
+                status = "okay";
+                pinctrl-0 = <&pwm{pwm_num}_default>;
+                pinctrl-1 = <&pwm{pwm_num}_sleep>;
+                pinctrl-names = "default", "sleep";
+            }};
+            """
+        )
+
+    zephyr_add_overlay(
+        f"""
+        &pinctrl {{
+            {"".join(pinctrl_entries)}
+        }};
+        {"".join(peripheral_entries)}
+        """
+    )
+
+
+@coroutine_with_priority(CoroPriority.FINAL)
+async def _finalize_pwm_outputs() -> None:
+    data = _get_data()
+    allocations = _allocate_pwm(data.configs)
+    _add_pwm_overlay(allocations)
+
+    for config, pwm_num, channel, group_size in allocations:
+        var = await cg.get_variable(config[CONF_ID])
+        device = RawExpression(f"DEVICE_DT_GET(DT_NODELABEL(pwm{pwm_num}))")
+        cg.add(var.set_device(device))
+        cg.add(var.set_channel(channel))
+        cg.add(var.set_runtime_frequency_mutable(group_size == 1))
+
+
+async def to_code(config) -> None:
+    zephyr_add_prj_conf("PWM", True)
+
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await output.register_output(var, config)
+
+    pin = await cg.gpio_pin_expression(config[CONF_PIN])
+    cg.add(var.set_pin(pin))
+    cg.add(var.set_frequency(config[CONF_FREQUENCY]))
+
+    data = _get_data()
+    if not data.final_job_scheduled:
+        CORE.add_job(_finalize_pwm_outputs)
+        data.final_job_scheduled = True
+    data.configs.append(config)
+
+
+@automation.register_action(
+    "output.nrf52_pwm.set_frequency",
+    SetFrequencyAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(Nrf52PWMOutput),
+            cv.Required(CONF_FREQUENCY): cv.templatable(validate_frequency),
+        }
+    ),
+    synchronous=True,
+)
+async def nrf52_pwm_set_frequency_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    template_ = await cg.templatable(config[CONF_FREQUENCY], args, cg.float_)
+    cg.add(var.set_frequency(template_))
+    return var

--- a/tests/components/nrf52_pwm/common.yaml
+++ b/tests/components/nrf52_pwm/common.yaml
@@ -1,0 +1,56 @@
+esphome:
+  on_boot:
+    then:
+      - output.set_level:
+          id: basic_pwm
+          level: 50%
+      - output.nrf52_pwm.set_frequency:
+          id: runtime_pwm
+          frequency: 2kHz
+      - light.turn_on:
+          id: pwm_light
+          brightness: 75%
+      - servo.write:
+          id: pwm_servo
+          level: 25%
+
+output:
+  - platform: nrf52_pwm
+    id: basic_pwm
+    pin: P0.13
+    frequency: 1kHz
+
+  - platform: nrf52_pwm
+    id: shared_pwm_1
+    pin: P0.14
+    frequency: 500Hz
+
+  - platform: nrf52_pwm
+    id: shared_pwm_2
+    pin:
+      number: P0.15
+      inverted: true
+    frequency: 500Hz
+
+  - platform: nrf52_pwm
+    id: runtime_pwm
+    pin: P0.16
+    frequency: 1.5kHz
+
+  - platform: nrf52_pwm
+    id: light_pwm
+    pin: P0.17
+    frequency: 1kHz
+
+light:
+  - platform: monochromatic
+    id: pwm_light
+    name: PWM Light
+    output: light_pwm
+
+servo:
+  id: pwm_servo
+  output: runtime_pwm
+  restore: true
+  min_level: 4%
+  max_level: 8%

--- a/tests/components/nrf52_pwm/common.yaml
+++ b/tests/components/nrf52_pwm/common.yaml
@@ -4,6 +4,18 @@ esphome:
       - output.set_level:
           id: basic_pwm
           level: 50%
+      - output.set_level:
+          id: basic_pwm
+          level: 100%
+      - output.set_level:
+          id: basic_pwm
+          level: 0%
+      - output.set_level:
+          id: shared_pwm_2
+          level: 50%
+      - output.set_level:
+          id: shared_pwm_1
+          level: 0%
       - output.nrf52_pwm.set_frequency:
           id: runtime_pwm
           frequency: 2kHz
@@ -13,6 +25,7 @@ esphome:
       - servo.write:
           id: pwm_servo
           level: 25%
+      - servo.detach: pwm_servo
 
 output:
   - platform: nrf52_pwm

--- a/tests/components/nrf52_pwm/test.nrf52-adafruit.yaml
+++ b/tests/components/nrf52_pwm/test.nrf52-adafruit.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/nrf52_pwm/test.nrf52-mcumgr.yaml
+++ b/tests/components/nrf52_pwm/test.nrf52-mcumgr.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

  Adds an `nrf52_pwm` output platform for ESPHome’s nRF52/Zephyr target.

  This implements hardware PWM output using Zephyr’s PWM driver and generated devicetree overlays. Outputs are grouped by configured frequency so up to four same-frequency channels can share one nRF PWM
  peripheral. Runtime frequency changes are supported for outputs that are alone on their PWM peripheral; shared outputs keep their configured frequency.

  ## Types of changes

  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
  - [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
  - [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
  - [ ] Code quality improvements to existing code or addition of tests
  - [ ] Other

  **Related issue or feature (if applicable):**

  - N/A

  **Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

  - TODO

  ## Test Environment

  - [ ] ESP32
  - [ ] ESP32 IDF
  - [ ] ESP8266
  - [ ] RP2040/RP2350
  - [ ] BK72xx
  - [ ] RTL87xx
  - [ ] LN882x
  - [x] nRF52840

  ## Example entry for `config.yaml`:

  ```yaml
  output:
    - platform: nrf52_pwm
      id: led_pwm
      pin: P0.13
      frequency: 1kHz
  ```

  ## Checklist:

  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under tests/ folder).

  If user exposed functionality or configuration variables are added/changed:

  - [ ] Documentation added/updated in esphome-docs (https://github.com/esphome/esphome-docs).