### PR TITLE
[lvgl] Memoize obj_schema by widget_type

### DIFF
--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -462,13 +462,23 @@ def base_update_schema(widget_type: WidgetType | LvType, parts):
     return schema
 
 
+# Widget types are module-level singletons populated at import time, so we
+# can cache compiled obj_schemas by widget_type identity for the lifetime of
+# the process. The strong reference in the value keeps the key (an id()
+# target) from being recycled.
+_OBJ_SCHEMA_CACHE: dict[int, tuple[WidgetType, cv.Schema]] = {}
+
+
 def obj_schema(widget_type: WidgetType):
     """
     Create a schema for a widget type itself i.e. no allowance for children
     :param widget_type:
     :return:
     """
-    return (
+    cached = _OBJ_SCHEMA_CACHE.get(id(widget_type))
+    if cached is not None and cached[0] is widget_type:
+        return cached[1]
+    schema = (
         part_schema(widget_type.parts)
         .extend(ALIGN_TO_SCHEMA)
         .extend(automation_schema(widget_type.w_type))
@@ -479,6 +489,8 @@ def obj_schema(widget_type: WidgetType):
             }
         )
     )
+    _OBJ_SCHEMA_CACHE[id(widget_type)] = (widget_type, schema)
+    return schema
 
 
 ALIGN_TO_SCHEMA = {

--- a/tests/component_tests/lvgl/test_obj_schema_cache.py
+++ b/tests/component_tests/lvgl/test_obj_schema_cache.py
@@ -1,0 +1,67 @@
+"""Tests for obj_schema() memoization."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+import esphome.components.lvgl  # noqa: F401
+from esphome.components.lvgl import schemas as lvgl_schemas
+from esphome.components.lvgl.schemas import WIDGET_TYPES, obj_schema
+
+
+@pytest.fixture(autouse=True)
+def _clear_obj_schema_cache() -> Generator[None]:
+    cache = getattr(lvgl_schemas, "_OBJ_SCHEMA_CACHE", None)
+    if cache is not None:
+        cache.clear()
+    yield
+    if cache is not None:
+        cache.clear()
+
+
+def _widget_type(name: str = "obj"):
+    wt = WIDGET_TYPES.get(name)
+    assert wt is not None, f"widget type {name!r} not registered"
+    return wt
+
+
+def test_same_widget_type_returns_same_schema() -> None:
+    wt = _widget_type("obj")
+    assert obj_schema(wt) is obj_schema(wt)
+
+
+def test_different_widget_types_return_different_schemas() -> None:
+    assert obj_schema(_widget_type("obj")) is not obj_schema(_widget_type("label"))
+
+
+def test_cache_is_populated_after_first_call() -> None:
+    wt = _widget_type("obj")
+    assert id(wt) not in lvgl_schemas._OBJ_SCHEMA_CACHE
+    obj_schema(wt)
+    assert id(wt) in lvgl_schemas._OBJ_SCHEMA_CACHE
+
+
+def test_cached_schema_produces_equivalent_output() -> None:
+    wt = _widget_type("obj")
+    cached_result = obj_schema(wt)({})
+    lvgl_schemas._OBJ_SCHEMA_CACHE.clear()
+    fresh_result = obj_schema(wt)({})
+    assert cached_result == fresh_result
+
+
+def test_id_recycling_is_caught_by_identity_guard() -> None:
+    wt = _widget_type("obj")
+    real_schema = obj_schema(wt)
+
+    cached_widget_type, _ = lvgl_schemas._OBJ_SCHEMA_CACHE[id(wt)]
+    sentinel_schema = object()
+    lvgl_schemas._OBJ_SCHEMA_CACHE[id(wt)] = (cached_widget_type, sentinel_schema)
+    assert obj_schema(wt) is sentinel_schema
+
+    other = _widget_type("label")
+    lvgl_schemas._OBJ_SCHEMA_CACHE[id(wt)] = (other, sentinel_schema)
+    rebuilt = obj_schema(wt)
+    assert rebuilt is not sentinel_schema
+    assert rebuilt is not real_schema


### PR DESCRIPTION
# What does this implement/fix?

The new device builder UI re-validates the configuration on every save, so `esphome config` latency is now a direct user-facing UX cost; LVGL configs have been one of the worst offenders. This PR targets the hottest path the profile shows.

`obj_schema(widget_type)` is called many times per `esphome config` run; on a typical LVGL config it fires ~100 times across roughly 25 widget types (once for the theme entry and again for every `container_schema` / `_theme_schema` lookup), and each call rebuilds the same chained-extend mapping.

Widget types are module-level singletons populated at import time, so the compiled `obj_schema` for a given type is stable for the lifetime of the process. This adds a small cache keyed by `id(widget_type)`; the strong reference in the value keeps the key from being recycled.

Measured on https://github.com/clydebarrow/lvtest `host.yaml`, in-process `read_config` (20 samples, 2 warmup runs, GC disabled):

```
baseline:  trimmed mean 0.2423s, stdev 0.0028
this PR:   trimmed mean 0.1132s, stdev 0.0020
```

About a 2.14x speed-up for `read_config` on this LVGL config; no behaviour change. With the device builder revalidating per save, that cost is paid on every edit.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
