### PR TITLE
[libretiny] Fix RTL8710B IRAM_ATTR section being dropped from flashed image

### DIFF
--- a/esphome/components/libretiny/hal.h
+++ b/esphome/components/libretiny/hal.h
@@ -11,12 +11,19 @@
 #include "esphome/core/time_64.h"
 
 // IRAM_ATTR places a function in executable RAM so it is callable from an
-// ISR even while flash is busy (XIP stall, OTA, logger flash write).
-// Each family uses a section its stock linker already routes to RAM:
-// RTL8710B → .data.iram_attr (lands in .ram_image2.data via *(.data*)),
-// RTL8720C → .sram.text. LN882H is the exception: its stock linker has no
-// matching glob, so patch_linker.py injects KEEP(*(.sram.text*)) into
-// .flash_copysection at pre-link.
+// ISR even while flash is busy (XIP stall, OTA, logger flash write). All
+// LibreTiny families that need it share the same .sram.text input section
+// name; how that section is routed into RAM differs per family:
+//   RTL8720C: stock linker consumes *(.sram.text*) into .ram.code_text.
+//   RTL8710B: patch_linker.py.script injects KEEP(*(.sram.text*)) at the
+//             top of .ram_image2.data (which IS in ltchiptool's
+//             sections_ram). The stock linker has KEEP(*(.image2.ram.text*))
+//             in .ram_image2.text but that output section is NOT in
+//             ltchiptool's AmebaZ elf2bin sections_ram list, so code routed
+//             there is dropped from the flashed binary.
+//   LN882H:   patch_linker.py.script injects KEEP(*(.sram.text*)) into
+//             .flash_copysection (> RAM0 AT> FLASH), after KEEP(*(.vectors))
+//             so the Cortex-M4 vector table stays 512-byte-aligned for VTOR.
 //
 // BK72xx (all variants) are left as a no-op: their SDK wraps flash
 // operations in GLOBAL_INT_DISABLE() which masks FIQ + IRQ at the CPU for
@@ -27,21 +34,7 @@
 // layer.
 #if defined(USE_BK72XX)
 #define IRAM_ATTR
-#elif defined(USE_LIBRETINY_VARIANT_RTL8710B)
-// The stock linker has KEEP(*(.image2.ram.text*)) in .ram_image2.text, but
-// ltchiptool's AmebaZ elf2bin (soc/ambz/binary.py) does NOT include
-// .ram_image2.text in its sections_ram list, so code routed there is silently
-// dropped from the flashed binary (zero-filled by objcopy gap-padding) and
-// the device faults on first IRAM_ATTR call. Use .data.iram_attr instead;
-// the stock linker's *(.data*) glob places it in .ram_image2.data, which IS
-// extracted. BD_RAM is rwx so execution is fine. The C startup does no
-// .data copy loop (the bootloader loads the whole image2 blob into BD_RAM
-// directly), so the inline code is not clobbered after boot.
-#define IRAM_ATTR __attribute__((noinline, section(".data.iram_attr")))
 #else
-// RTL8720C: stock linker consumes *(.sram.text*) into .ram.code_text.
-// LN882H: patch_linker.py.script injects *(.sram.text*) into
-// .flash_copysection (> RAM0 AT> FLASH).
 #define IRAM_ATTR __attribute__((noinline, section(".sram.text")))
 #endif
 #define PROGMEM

--- a/esphome/components/libretiny/hal.h
+++ b/esphome/components/libretiny/hal.h
@@ -13,9 +13,10 @@
 // IRAM_ATTR places a function in executable RAM so it is callable from an
 // ISR even while flash is busy (XIP stall, OTA, logger flash write).
 // Each family uses a section its stock linker already routes to RAM:
-// RTL8710B → .image2.ram.text, RTL8720C → .sram.text. LN882H is the
-// exception: its stock linker has no matching glob, so patch_linker.py
-// injects KEEP(*(.sram.text*)) into .flash_copysection at pre-link.
+// RTL8710B → .data.iram_attr (lands in .ram_image2.data via *(.data*)),
+// RTL8720C → .sram.text. LN882H is the exception: its stock linker has no
+// matching glob, so patch_linker.py injects KEEP(*(.sram.text*)) into
+// .flash_copysection at pre-link.
 //
 // BK72xx (all variants) are left as a no-op: their SDK wraps flash
 // operations in GLOBAL_INT_DISABLE() which masks FIQ + IRQ at the CPU for
@@ -27,8 +28,16 @@
 #if defined(USE_BK72XX)
 #define IRAM_ATTR
 #elif defined(USE_LIBRETINY_VARIANT_RTL8710B)
-// Stock linker consumes *(.image2.ram.text*) into .ram_image2.text (> BD_RAM).
-#define IRAM_ATTR __attribute__((noinline, section(".image2.ram.text")))
+// The stock linker has KEEP(*(.image2.ram.text*)) in .ram_image2.text, but
+// ltchiptool's AmebaZ elf2bin (soc/ambz/binary.py) does NOT include
+// .ram_image2.text in its sections_ram list, so code routed there is silently
+// dropped from the flashed binary (zero-filled by objcopy gap-padding) and
+// the device faults on first IRAM_ATTR call. Use .data.iram_attr instead;
+// the stock linker's *(.data*) glob places it in .ram_image2.data, which IS
+// extracted. BD_RAM is rwx so execution is fine. The C startup does no
+// .data copy loop (the bootloader loads the whole image2 blob into BD_RAM
+// directly), so the inline code is not clobbered after boot.
+#define IRAM_ATTR __attribute__((noinline, section(".data.iram_attr")))
 #else
 // RTL8720C: stock linker consumes *(.sram.text*) into .ram.code_text.
 // LN882H: patch_linker.py.script injects *(.sram.text*) into

--- a/esphome/components/libretiny/patch_linker.py.script
+++ b/esphome/components/libretiny/patch_linker.py.script
@@ -45,6 +45,14 @@ _LN_COPY = re.compile(r"(KEEP\(\*\(\.vectors\)\)[^\n]*\n)")
 # sections ltchiptool's AmebaZ elf2bin extracts; BD_RAM is rwx so the code is
 # executable. AmbZ has no C runtime .data copy loop (the bootloader loads
 # image2 into BD_RAM whole) so the inline code is not clobbered after boot.
+#
+# The regex is intentionally strict (no attribute / ALIGN between the section
+# name and the opening brace, brace on its own line). If a future AmbZ SDK
+# linker template changes this format, _pre_link raises RuntimeError on the
+# unpatched .ld file(s), and the RTL8710B CI compile job in
+# tests/test_build_components fails on the PR, surfacing the mismatch loudly
+# rather than silently shipping a binary with IRAM_ATTR code dropped from
+# one or both OTA slots.
 _AMBZ_DATA = re.compile(r"(\.ram_image2\.data\s*:\s*\n?\s*\{\s*\n)")
 
 
@@ -98,13 +106,14 @@ def _patchers_for(variant):
 def _pre_link(target, source, env):
     build_dir = env.subst("$BUILD_DIR")
     ld_files = [f for f in os.listdir(build_dir) if f.endswith(".ld")]
-    patched = 0
+    patched = []
+    unpatched = []
     for name in ld_files:
         path = os.path.join(build_dir, name)
         with open(path, "r", encoding="utf-8") as fh:
             original = fh.read()
         if _MARKER in original:
-            patched += 1
+            patched.append(name)
             continue
         content = original
         for fn in _patchers:
@@ -113,12 +122,28 @@ def _pre_link(target, source, env):
             with open(path, "w", encoding="utf-8") as fh:
                 fh.write(content)
             print("ESPHome: patched {} for IRAM_ATTR placement".format(name))
-            patched += 1
+            patched.append(name)
+        else:
+            unpatched.append(name)
     if not patched:
         raise RuntimeError(
             "ESPHome: no .ld in {} was patched for IRAM_ATTR. Update the "
             "regex in patch_linker.py.script (_PATCHERS_BY_VARIANT).".format(
                 build_dir
+            )
+        )
+    # Every .ld in the build must be patched. RTL8710B generates one .ld per
+    # OTA slot (xip1, xip2); if only one matches, the unpatched slot would
+    # ship with IRAM_ATTR code dropped to zeros and brick the device on the
+    # boot after an OTA into that slot.
+    if unpatched:
+        raise RuntimeError(
+            "ESPHome: {} of {} .ld file(s) in {} were not patched for "
+            "IRAM_ATTR: {}. The regex in patch_linker.py.script "
+            "(_PATCHERS_BY_VARIANT[{!r}]) matched the others but not "
+            "these. Update the regex to cover all linker scripts.".format(
+                len(unpatched), len(ld_files), build_dir,
+                ", ".join(unpatched), _variant,
             )
         )
 

--- a/esphome/components/libretiny/patch_linker.py.script
+++ b/esphome/components/libretiny/patch_linker.py.script
@@ -6,12 +6,18 @@ import re
 import subprocess
 
 # ESPHome marks ISR code IRAM_ATTR, which on LibreTiny maps to a per-family
-# section routed into RAM-executable memory (see esphome/core/hal.h).
+# section routed into RAM-executable memory (see esphome/core/hal.h). The
+# input section name is always .sram.text; only the output section it lands
+# in differs per family.
 #
 # This script is NOT loaded on BK72xx (IRAM_ATTR is a no-op there; the SDK
 # masks FIQ+IRQ around flash writes). On the remaining families:
-# - RTL8710B: hal.h uses section(".image2.ram.text"); stock linker consumes it.
-# - RTL8720C: hal.h uses section(".sram.text"); stock linker consumes it.
+# - RTL8720C: stock linker consumes *(.sram.text*) into .ram.code_text.
+# - RTL8710B: stock linker has KEEP(*(.image2.ram.text*)) in .ram_image2.text,
+#   but ltchiptool's AmebaZ elf2bin (soc/ambz/binary.py) does NOT list
+#   .ram_image2.text in sections_ram, so code there is silently dropped from
+#   the flashed image. Inject KEEP(*(.sram.text*)) at the top of
+#   .ram_image2.data (which IS extracted) instead.
 # - LN882H: stock linker has no glob for ".sram.text", so we inject
 #   KEEP(*(.sram.text*)) into ".flash_copysection" (> RAM0 AT> FLASH)
 #   immediately after KEEP(*(.vectors)), so the vector table stays at
@@ -34,6 +40,12 @@ _KEEP_LINE = (
 # aligned address; injecting before the vectors would push them to an
 # unaligned offset and mis-route every IRQ handler.
 _LN_COPY = re.compile(r"(KEEP\(\*\(\.vectors\)\)[^\n]*\n)")
+# Inject at the top of .ram_image2.data, before __data_start__ so our code
+# does not fall inside the data range markers. .ram_image2.data is one of the
+# sections ltchiptool's AmebaZ elf2bin extracts; BD_RAM is rwx so the code is
+# executable. AmbZ has no C runtime .data copy loop (the bootloader loads
+# image2 into BD_RAM whole) so the inline code is not clobbered after boot.
+_AMBZ_DATA = re.compile(r"(\.ram_image2\.data\s*:\s*\n?\s*\{\s*\n)")
 
 
 def _detect(env):
@@ -71,12 +83,11 @@ def _inject_keep(host_section):
 
 
 # Variants not listed here intentionally have no .ld patcher:
-# - RTL8710B: hal.h uses section(".image2.ram.text") which the stock linker
-#   already routes into .ram_image2.text (> BD_RAM).
-# - RTL8720C: stock linker already consumes *(.sram.text*).
+# - RTL8720C: stock linker already consumes *(.sram.text*) into .ram.code_text.
 # - BK72xx (all): SDK masks FIQ+IRQ around flash writes, IRAM_ATTR is no-op.
 _PATCHERS_BY_VARIANT = {
     "LN882H": (_inject_keep(_LN_COPY),),
+    "RTL8710B": (_inject_keep(_AMBZ_DATA),),
 }
 
 


### PR DESCRIPTION
# What does this implement/fix?

#15766 made `IRAM_ATTR` functional on RTL8710B by routing into `.image2.ram.text`; the stock AmbZ linker has `KEEP(*(.image2.ram.text*))` in `.ram_image2.text`, so it looked correct. However ltchiptool's `AmebaZBinary.elf2bin` (`soc/ambz/binary.py`) does not include `.ram_image2.text` in its `sections_ram` list, so `objcopy -j ... -O binary` zero-fills the LMA gap where that section sits. The IRAM_ATTR code is silently dropped from the flashed image; the device faults on the first IRAM_ATTR call (no LED, app never starts, WiFi MAC keeps DHCP alive). RTL8720C and LN882H pipelines already include the sections their IRAM_ATTR targets, so only RTL8710B is affected.

Switch RTL8710B to the same shape as the LN882H fix: hal.h uses `.sram.text` for all non-BK72xx variants, and `patch_linker.py.script` injects `KEEP(*(.sram.text*))` at the top of `.ram_image2.data` (which IS extracted). BD_RAM is rwx so execution is fine, and the AmbZ startup does no `.data` copy loop (the bootloader loads the image2 blob directly into BD_RAM), so the inline code is not clobbered after boot.

Also tightens the `_pre_link` guard so it now raises if ANY .ld in the build directory went un-patched, not just when zero did. RTL8710B's `env.GenerateLinkerScript` emits one .ld per OTA slot (xip1, xip2); if the regex ever matched one but missed the other, the unpatched slot would ship with IRAM_ATTR code dropped and brick the device on the boot after an OTA into that slot. Per-file tracking makes that failure mode loud on the PR via the RTL8710B CI compile job.

## Hardware validation

Both Realtek families covered:

- **RTL8710B (BW12, RTL8710BX)** with `bw12.yaml` (logger + wifi + captive_portal + ota + safe_mode + mdns + gpio output/binary_sensor + sensor/text_sensor + 1s interval + 30s preferences flush):
  - `dev` tip: hangs at `Setup gpio.output`, the first call site that touches inlined `millis()` / `wake_loop_any_context`; matches the WR3E reporter's brick.
  - This branch: full boot, WiFi scan, ISR-driven binary_sensor, periodic preferences writes; indefinitely stable. Post-link summary prints `.sram.text: 456 bytes at 0x10005b70 - 0x10005d38` (within BD_RAM). UART flash, ESPHome OTA, and reboot path all confirmed.
- **RTL8720C (BW15)**: this branch boots cleanly with WiFi + web_server + api + ota + mdns + debug; confirms the rework did not regress the RTL8720C path, which still routes through the stock linker's `.ram.code_text` consumption of `*(.sram.text*)` unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16612

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config change; IRAM_ATTR is internal.
rtl87xx:
  board: bw12
  framework:
    version: recommended
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).