### PR TITLE
[core] Preserve shared caches during project clean rebuilds

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -488,6 +488,12 @@ def clean_cmake_cache():
 
 
 def clean_build(clear_pio_cache: bool = True):
+    """Clean per-project build artifacts.
+
+    ``clear_pio_cache=False`` still allows a project rebuild while preserving
+    shared caches such as ``<data_dir>/pio_components`` and PlatformIO's global
+    package cache.
+    """
     # Allow skipping cache cleaning for integration tests
     if os.environ.get("ESPHOME_SKIP_CLEAN_BUILD"):
         _LOGGER.warning("Skipping build cleaning (ESPHOME_SKIP_CLEAN_BUILD set)")

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -276,31 +276,17 @@ def test_native_idf_enables_reproducible_build(
     assert sdkconfig.get("CONFIG_APP_REPRODUCIBLE_BUILD") is True
 
 
-def test_platformio_sdkconfig_change_cleans_build(tmp_path: Path) -> None:
-    """The PlatformIO path still cleans build artifacts on sdkconfig changes."""
+@pytest.mark.parametrize("toolchain", [Toolchain.PLATFORMIO, Toolchain.ESP_IDF])
+def test_sdkconfig_change_cleans_project_build(
+    tmp_path: Path, toolchain: Toolchain
+) -> None:
+    """Sdkconfig changes clean project artifacts regardless of the toolchain."""
     from esphome.components import esp32
 
     CORE.config_path = tmp_path / "test.yaml"
     CORE.build_path = tmp_path / "build" / "test"
     CORE.name = "test"
-    CORE.toolchain = Toolchain.PLATFORMIO
-    CORE.data[KEY_CORE] = {KEY_FRAMEWORK_VERSION: cv.Version(5, 5, 4)}
-    CORE.data[KEY_ESP32] = {KEY_SDKCONFIG_OPTIONS: {"CONFIG_FREERTOS_HZ": 1000}}
-
-    with patch("esphome.components.esp32.clean_build") as mock_clean:
-        esp32._write_sdkconfig()
-
-    mock_clean.assert_called_once_with(clear_pio_cache=False)
-
-
-def test_native_idf_sdkconfig_change_cleans_project_build(tmp_path: Path) -> None:
-    """Native ESP-IDF keeps the same project-clean behavior as PlatformIO."""
-    from esphome.components import esp32
-
-    CORE.config_path = tmp_path / "test.yaml"
-    CORE.build_path = tmp_path / "build" / "test"
-    CORE.name = "test"
-    CORE.toolchain = Toolchain.ESP_IDF
+    CORE.toolchain = toolchain
     CORE.data[KEY_CORE] = {KEY_FRAMEWORK_VERSION: cv.Version(5, 5, 4)}
     CORE.data[KEY_ESP32] = {KEY_SDKCONFIG_OPTIONS: {"CONFIG_FREERTOS_HZ": 1000}}
 

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -5,6 +5,7 @@ Test ESP32 configuration
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -16,6 +17,8 @@ from esphome.const import (
     CONF_ESPHOME,
     CONF_IGNORE_PIN_VALIDATION_ERROR,
     CONF_NUMBER,
+    KEY_CORE,
+    KEY_FRAMEWORK_VERSION,
     PlatformFramework,
     Toolchain,
 )
@@ -271,3 +274,40 @@ def test_native_idf_enables_reproducible_build(
 
     sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
     assert sdkconfig.get("CONFIG_APP_REPRODUCIBLE_BUILD") is True
+
+
+def test_platformio_sdkconfig_change_cleans_build(tmp_path: Path) -> None:
+    """The PlatformIO path still cleans build artifacts on sdkconfig changes."""
+    from esphome.components import esp32
+
+    CORE.config_path = tmp_path / "test.yaml"
+    CORE.build_path = tmp_path / "build" / "test"
+    CORE.name = "test"
+    CORE.toolchain = Toolchain.PLATFORMIO
+    CORE.data[KEY_CORE] = {KEY_FRAMEWORK_VERSION: cv.Version(5, 5, 4)}
+    CORE.data[KEY_ESP32] = {KEY_SDKCONFIG_OPTIONS: {"CONFIG_FREERTOS_HZ": 1000}}
+
+    with patch("esphome.components.esp32.clean_build") as mock_clean:
+        esp32._write_sdkconfig()
+
+    mock_clean.assert_called_once_with(clear_pio_cache=False)
+
+
+def test_native_idf_sdkconfig_change_cleans_project_build(tmp_path: Path) -> None:
+    """Native ESP-IDF keeps the same project-clean behavior as PlatformIO."""
+    from esphome.components import esp32
+
+    CORE.config_path = tmp_path / "test.yaml"
+    CORE.build_path = tmp_path / "build" / "test"
+    CORE.name = "test"
+    CORE.toolchain = Toolchain.ESP_IDF
+    CORE.data[KEY_CORE] = {KEY_FRAMEWORK_VERSION: cv.Version(5, 5, 4)}
+    CORE.data[KEY_ESP32] = {KEY_SDKCONFIG_OPTIONS: {"CONFIG_FREERTOS_HZ": 1000}}
+
+    with patch("esphome.components.esp32.clean_build") as mock_clean:
+        esp32._write_sdkconfig()
+
+    mock_clean.assert_called_once_with(clear_pio_cache=False)
+    assert CORE.relative_build_path("sdkconfig.test").read_text() == (
+        "# ESPHOME_IDF_VERSION=5.5.4\nCONFIG_FREERTOS_HZ=1000\n"
+    )

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -542,8 +542,12 @@ def test_clean_build_preserves_shared_caches_when_pio_cache_disabled(
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / "project" / name
+    mock_core.data_dir = tmp_path / ".esphome"
 
-    clean_build(clear_pio_cache=False)
+    with patch(
+        "platformio.project.config.ProjectConfig.get_instance"
+    ) as mock_get_instance:
+        clean_build(clear_pio_cache=False)
 
     assert not pioenvs_dir.exists()
     assert not piolibdeps_dir.exists()
@@ -552,6 +556,7 @@ def test_clean_build_preserves_shared_caches_when_pio_cache_disabled(
     assert not managed_components_dir.exists()
     assert shared_pio_components.exists()
     assert platformio_cache_dir.exists()
+    mock_get_instance.assert_not_called()
 
 
 @patch("esphome.writer.CORE")

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -507,6 +507,54 @@ def test_clean_build(
 
 
 @patch("esphome.writer.CORE")
+def test_clean_build_preserves_shared_caches_when_pio_cache_disabled(
+    mock_core: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """clear_pio_cache=False cleans the project but keeps shared caches."""
+    pioenvs_dir = tmp_path / "project" / ".pioenvs"
+    pioenvs_dir.mkdir(parents=True)
+    (pioenvs_dir / "firmware.o").write_text("object")
+
+    piolibdeps_dir = tmp_path / "project" / ".piolibdeps"
+    piolibdeps_dir.mkdir(parents=True)
+    (piolibdeps_dir / "library").mkdir()
+
+    dependencies_lock = tmp_path / "project" / "dependencies.lock"
+    dependencies_lock.write_text("lock")
+
+    idf_build_dir = tmp_path / "project" / "build"
+    idf_build_dir.mkdir(parents=True)
+    (idf_build_dir / "CMakeCache.txt").write_text("cache")
+
+    managed_components_dir = tmp_path / "project" / "managed_components"
+    managed_components_dir.mkdir(parents=True)
+    (managed_components_dir / "espressif__mdns").mkdir()
+
+    shared_pio_components = tmp_path / ".esphome" / "pio_components"
+    shared_pio_components.mkdir(parents=True)
+    (shared_pio_components / "converted-lib").mkdir()
+
+    platformio_cache_dir = tmp_path / ".platformio" / ".cache"
+    platformio_cache_dir.mkdir(parents=True)
+    (platformio_cache_dir / "package.tar.gz").write_text("package")
+
+    mock_core.relative_pioenvs_path.return_value = pioenvs_dir
+    mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
+    mock_core.relative_build_path.side_effect = lambda name: tmp_path / "project" / name
+
+    clean_build(clear_pio_cache=False)
+
+    assert not pioenvs_dir.exists()
+    assert not piolibdeps_dir.exists()
+    assert not dependencies_lock.exists()
+    assert not idf_build_dir.exists()
+    assert not managed_components_dir.exists()
+    assert shared_pio_components.exists()
+    assert platformio_cache_dir.exists()
+
+
+@patch("esphome.writer.CORE")
 def test_clean_build_partial_exists(
     mock_core: MagicMock,
     tmp_path: Path,


### PR DESCRIPTION
## What does this implement/fix?

Documents and tests the cache boundary used by project clean rebuilds.

`clean_build(clear_pio_cache=False)` still removes per-project build artifacts such as `<build_path>/build`, `<build_path>/managed_components`, `.pioenvs`, `.piolibdeps`, and `dependencies.lock`. It preserves shared caches such as `<data_dir>/pio_components` and PlatformIO's global package cache.

ESP32 `sdkconfig` changes keep using the safer project-clean path while preserving those shared caches.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`

```yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf
```

## Checklist

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the fix works.
