### PR TITLE
[esp32_hosted] Bring up coprocessor in arch_init

### DIFF
--- a/esphome/components/esp32/hal.cpp
+++ b/esphome/components/esp32/hal.cpp
@@ -14,6 +14,10 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
+#ifdef USE_ESP32_HOSTED
+#include <esp_hosted.h>
+#endif
+
 // Empty esp32 namespace block to satisfy ci-custom's lint_namespace check.
 // HAL functions live in namespace esphome (root) — they are not part of the
 // esp32 component's API.
@@ -57,6 +61,14 @@ void arch_init() {
   // in which case safe_mode will mark it valid after confirming successful boot.
 #ifndef USE_OTA_ROLLBACK
   esp_ota_mark_app_valid_cancel_rollback();
+#endif
+
+#ifdef USE_ESP32_HOSTED
+  // Bring up the esp_hosted coprocessor transport before any component setup runs.
+  // The SDIO mempool allocation needs a large contiguous chunk of DMA-capable internal RAM;
+  // doing it here (rather than lazily from wifi/ble/update setup) avoids fragmentation
+  // from later component allocations on memory-tight builds (e.g. P4 + C6 + large LVGL UI).
+  esp_hosted_connect_to_slave();  // NOLINT
 #endif
 }
 

--- a/esphome/components/esp32/hal.cpp
+++ b/esphome/components/esp32/hal.cpp
@@ -14,12 +14,8 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
-// USE_ESP32_HOSTED is set unconditionally in defines.h for static analysis, so
-// the header may not actually be on the include path under Arduino builds
-// where the esp_hosted IDF component is not linked. Guard with __has_include.
-#if defined(USE_ESP32_HOSTED) && __has_include(<esp_hosted.h>)
+#ifdef CONFIG_ESP_HOSTED_ENABLED
 #include <esp_hosted.h>
-#define ESPHOME_HAVE_ESP_HOSTED
 #endif
 
 // Empty esp32 namespace block to satisfy ci-custom's lint_namespace check.
@@ -67,7 +63,7 @@ void arch_init() {
   esp_ota_mark_app_valid_cancel_rollback();
 #endif
 
-#ifdef ESPHOME_HAVE_ESP_HOSTED
+#ifdef CONFIG_ESP_HOSTED_ENABLED
   // Bring up the esp_hosted coprocessor transport before any component setup runs.
   // The SDIO mempool allocation needs a large contiguous chunk of DMA-capable internal RAM;
   // doing it here (rather than lazily from wifi/ble/update setup) avoids fragmentation

--- a/esphome/components/esp32/hal.cpp
+++ b/esphome/components/esp32/hal.cpp
@@ -14,8 +14,12 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
-#ifdef USE_ESP32_HOSTED
+// USE_ESP32_HOSTED is set unconditionally in defines.h for static analysis, so
+// the header may not actually be on the include path under Arduino builds
+// where the esp_hosted IDF component is not linked. Guard with __has_include.
+#if defined(USE_ESP32_HOSTED) && __has_include(<esp_hosted.h>)
 #include <esp_hosted.h>
+#define ESPHOME_HAVE_ESP_HOSTED
 #endif
 
 // Empty esp32 namespace block to satisfy ci-custom's lint_namespace check.
@@ -63,7 +67,7 @@ void arch_init() {
   esp_ota_mark_app_valid_cancel_rollback();
 #endif
 
-#ifdef USE_ESP32_HOSTED
+#ifdef ESPHOME_HAVE_ESP_HOSTED
   // Bring up the esp_hosted coprocessor transport before any component setup runs.
   // The SDIO mempool allocation needs a large contiguous chunk of DMA-capable internal RAM;
   // doing it here (rather than lazily from wifi/ble/update setup) avoids fragmentation

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -192,8 +192,6 @@ bool ESP32BLE::ble_setup_() {
 
   esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
 #else
-  esp_hosted_connect_to_slave();  // NOLINT
-
   if (esp_hosted_bt_controller_init() != ESP_OK) {
     ESP_LOGW(TAG, "esp_hosted_bt_controller_init failed");
     return false;

--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -82,11 +82,6 @@ static int compare_versions(int major1, int minor1, int patch1, int major2, int 
 void Esp32HostedUpdate::setup() {
   this->update_info_.title = "ESP32 Hosted Coprocessor";
 
-#ifndef USE_WIFI
-  // If WiFi is not present, connect to the coprocessor
-  esp_hosted_connect_to_slave();  // NOLINT
-#endif
-
   // Get coprocessor version
   esp_hosted_coprocessor_fwver_t ver_info;
   if (esp_hosted_get_coprocessor_fwversion(&ver_info) == ESP_OK) {


### PR DESCRIPTION
# What does this implement/fix?

Moves `esp_hosted_connect_to_slave()` out of component `setup()` paths and into `arch_init()` in the esp32 HAL. The SDIO/SPI transport mempool now gets allocated before any other component setup runs.

## Why

The esp_hosted SDIO mempool needs a large contiguous chunk of DMA-capable internal RAM. On memory-tight builds (e.g. ESP32-P4 + C6 with a large LVGL UI), allocating it later — during wifi/ble/update component setup — can fail because intervening component allocations have already fragmented internal RAM. The failure surfaces as:

```
E (2140) HS_MP: mempool create failed: no mem
assert failed: sdio_mempool_create sdio_drv.c:255 (buf_mp_g)
```

Before: connect-to-slave was called as a fallback in `esp32_hosted_update::setup()` (`#ifndef USE_WIFI`) and in `esp32_ble::ble.cpp` (bluedroid path). When WiFi is compiled in, the bring-up was triggered implicitly via `esp_wifi_init` → `esp_wifi_remote` → eppp → esp_hosted, which runs well into component setup.

After: a single `esp_hosted_connect_to_slave()` call in `arch_init()` (gated `#ifdef USE_ESP32_HOSTED`), placed after WDT add and OTA-rollback handling so the long slave-bringup runs with WDT armed. The function is idempotent — WiFi's implicit bring-up path becomes a no-op.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16574

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32_hosted:
  variant: esp32c6
  active_high: true
  reset_pin: GPIO32
  cmd_pin: GPIO19
  clk_pin: GPIO18
  bus_width: 1
  d0_pin: GPIO14
  sdio_frequency: 40MHz
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).