### PR TITLE
[esp32] Decode crash PCs via IDF toolchain on IDF builds

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2658,13 +2658,21 @@ def copy_files():
 
 
 def _decode_pc(config, addr):
-    from esphome.platformio import toolchain
+    if CORE.using_toolchain_esp_idf:
+        from esphome.espidf import toolchain as idf_toolchain
 
-    idedata = toolchain.get_idedata(config)
-    if not idedata.addr2line_path or not idedata.firmware_elf_path:
+        addr2line_path = idf_toolchain.get_addr2line_path()
+        firmware_elf_path = idf_toolchain.get_elf_path()
+    else:
+        from esphome.platformio import toolchain
+
+        idedata = toolchain.get_idedata(config)
+        addr2line_path = idedata.addr2line_path
+        firmware_elf_path = idedata.firmware_elf_path
+    if not addr2line_path or not firmware_elf_path:
         _LOGGER.debug("decode_pc no addr2line")
         return
-    command = [idedata.addr2line_path, "-pfiaC", "-e", idedata.firmware_elf_path, addr]
+    command = [str(addr2line_path), "-pfiaC", "-e", str(firmware_elf_path), addr]
     try:
         translation = subprocess.check_output(command, close_fds=False).decode().strip()
     except Exception:  # pylint: disable=broad-except

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -46,7 +46,7 @@ from esphome.const import (
     Toolchain,
     __version__,
 )
-from esphome.core import CORE, HexInt, Library
+from esphome.core import CORE, EsphomeError, HexInt, Library
 from esphome.core.config import BOARD_MAX_LENGTH
 from esphome.coroutine import CoroPriority, coroutine_with_priority
 from esphome.espidf.component import generate_idf_component
@@ -2658,11 +2658,19 @@ def copy_files():
 
 
 def _decode_pc(config, addr):
+    # _decode_pc runs from the api log processor's asyncio callback, which
+    # only catches EsphomeError. Any other exception escaping here tears down
+    # the protocol and triggers an infinite reconnect/replay loop. Convert
+    # toolchain-resolution errors (e.g. missing build dir / cmake cache) into
+    # EsphomeError so the caller can disable decoding cleanly.
     if CORE.using_toolchain_esp_idf:
         from esphome.espidf import toolchain as idf_toolchain
 
-        addr2line_path = idf_toolchain.get_addr2line_path()
-        firmware_elf_path = idf_toolchain.get_elf_path()
+        try:
+            addr2line_path = idf_toolchain.get_addr2line_path()
+            firmware_elf_path = idf_toolchain.get_elf_path()
+        except RuntimeError as err:
+            raise EsphomeError(f"ESP-IDF toolchain not available: {err}") from err
     else:
         from esphome.platformio import toolchain
 


### PR DESCRIPTION
# What does this implement/fix?

`_decode_pc` in `esphome/components/esp32/__init__.py` previously always pulled `addr2line` + ELF paths from the PlatformIO toolchain's `get_idedata()`. On ESP-IDF builds there is no `platformio.ini` in the build dir, so every crash-dump line in `esphome logs` failed with `NotPlatformIOProjectError` / "Could not match idedata" instead of decoding the frame.

This branches on `CORE.using_toolchain_esp_idf` and uses the existing `espidf.toolchain.get_addr2line_path()` / `get_elf_path()` helpers (which read `CMAKE_ADDR2LINE` from the cmake cache and point at `<build>/build/firmware.elf`) on IDF builds.

Before:
```
NotPlatformIOProjectError: Not a PlatformIO project. `platformio.ini` file has not been found in current working directory (/path/.esphome/build/<name>)
ERROR Could not match idedata, please report this error
```

After: crash PCs decode through IDF's `riscv32-esp-elf-addr2line` (or xtensa equivalent) and the firmware ELF, surfacing the symbol/file/line in the logs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any ESP32 IDF config; observable when the device prints a crash dump
# during `esphome logs` (PC/RA/EXCVADDR/MEPC/backtrace lines).
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).