### PR TITLE
[esp32_hosted] Bump esp_hosted to 2.12.8 and add use_psram option

### DIFF
--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from esphome import pins
 from esphome.components import esp32
+from esphome.components.const import CONF_USE_PSRAM
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CLK_PIN,
@@ -32,7 +33,6 @@ CONF_HANDSHAKE_PIN = "handshake_pin"
 CONF_SDIO_FREQUENCY = "sdio_frequency"
 CONF_SLOT = "slot"
 CONF_SPI_MODE = "spi_mode"
-CONF_USE_PSRAM = "use_psram"
 
 # Shared fields for both transport modes
 BASE_SCHEMA = cv.Schema(

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -32,6 +32,7 @@ CONF_HANDSHAKE_PIN = "handshake_pin"
 CONF_SDIO_FREQUENCY = "sdio_frequency"
 CONF_SLOT = "slot"
 CONF_SPI_MODE = "spi_mode"
+CONF_USE_PSRAM = "use_psram"
 
 # Shared fields for both transport modes
 BASE_SCHEMA = cv.Schema(
@@ -39,6 +40,7 @@ BASE_SCHEMA = cv.Schema(
         cv.Required(CONF_VARIANT): cv.one_of(*esp32.VARIANTS, upper=True),
         cv.Required(CONF_ACTIVE_HIGH): cv.boolean,
         cv.Required(CONF_RESET_PIN): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_USE_PSRAM, default=False): cv.boolean,
     }
 )
 
@@ -242,6 +244,12 @@ async def to_code(config):
     else:
         _configure_spi(config)
 
+    # Place the transport mempool in PSRAM. Required on memory-tight host
+    # configurations (e.g. P4 with a large LVGL UI) where the internal-RAM
+    # mempool allocation fails at boot with `sdio_mempool_create` assert.
+    if config[CONF_USE_PSRAM]:
+        esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_MEMPOOL_PREFER_SPIRAM", True)
+
     # Library versions
     idf_ver = esp32.idf_version()
     os.environ["ESP_IDF_VERSION"] = f"{idf_ver.major}.{idf_ver.minor}"
@@ -249,7 +257,7 @@ async def to_code(config):
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.5.1")
         esp32.add_idf_component(name="espressif/wifi_remote_over_eppp", ref="0.3.2")
         esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.5")
-        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.7")
+        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.8")
     else:
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="0.13.0")
         esp32.add_idf_component(name="espressif/eppp_link", ref="0.2.0")

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -36,7 +36,7 @@ dependencies:
     rules:
       - if: "target in [esp32h2, esp32p4]"
   espressif/esp_hosted:
-    version: 2.12.7
+    version: 2.12.8
     rules:
       - if: "target in [esp32h2, esp32p4]"
   zorxx/multipart-parser:

--- a/tests/components/esp32_hosted/common.yaml
+++ b/tests/components/esp32_hosted/common.yaml
@@ -3,6 +3,7 @@ esp32_hosted:
   slot: 1
   active_high: true
   reset_pin: GPIO15
+  use_psram: true
   cmd_pin: GPIO13
   clk_pin: GPIO12
   d0_pin: GPIO11


### PR DESCRIPTION
# What does this implement/fix?

Bumps the `esp_hosted` IDF component from 2.12.7 to 2.12.8 and exposes a new `use_psram` option in the `esp32_hosted` schema.

esp_hosted 2.12.8 adds `CONFIG_ESP_HOSTED_MEMPOOL_PREFER_SPIRAM`, which moves the transport buffer pool from internal DMA-capable RAM into PSRAM. On host chips where the GDMA can reach PSRAM through cache (ESP32-P4, ESP32-S3) this is sufficient; the relevant esp_hosted patch is upstream commit [da48eef](https://github.com/espressif/esp-hosted-mcu).

This is required on memory-tight host configs where the internal-RAM mempool allocation fails at boot with the `sdio_mempool_create` assert reported in #16574. The `esp_hosted_host_init` constructor (runs before `app_main`) calls `bus_init_internal()` → `sdio_mempool_create()`, which needs a large contiguous chunk of DMA-capable internal RAM. On a P4 with a large LVGL UI, ESP-IDF's own startup has already consumed enough internal RAM that the chunk is no longer available, and the assert fires. Moving the pool to PSRAM sidesteps the constraint entirely.

The new `use_psram` option defaults to `false` to preserve current behavior. Users on affected hardware enable it explicitly:

```yaml
esp32_hosted:
  variant: esp32c6
  active_high: true
  reset_pin: GPIO32
  cmd_pin: GPIO19
  clk_pin: GPIO18
  bus_width: 1
  d0_pin: GPIO14
  sdio_frequency: 40MHz
  use_psram: true
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16574

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6688

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
esp32_hosted:
  variant: esp32c6
  active_high: true
  reset_pin: GPIO32
  cmd_pin: GPIO19
  clk_pin: GPIO18
  bus_width: 1
  d0_pin: GPIO14
  sdio_frequency: 40MHz
  use_psram: true
\`\`\`

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).