### PR TITLE
[espidf] Warn instead of skipping libraries with framework mismatch

### DIFF
--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -610,11 +610,17 @@ def _check_library_data(data: dict):
     """
     Check if a library data is compatible with the ESP-IDF framework.
 
+    A platform mismatch (e.g. an AVR-only library on ESP32) raises
+    ``InvalidIDFComponent`` so the caller skips the library. A framework
+    mismatch only logs a warning — PIO manifests often understate the
+    frameworks they actually compile under, and IDF (unlike PIO's
+    ``lib_compat_mode``) has no opt-out, so we include the library anyway.
+
     Args:
-        component: IDFComponent object being processed
+        data: PIO library manifest dict being processed.
 
     Raises:
-        ValueError: If library has unsupported platforms or frameworks
+        InvalidIDFComponent: If the library does not support the ESP32 platform.
     """
     platforms = data.get("platforms", "*")
     if isinstance(platforms, str):
@@ -642,7 +648,8 @@ def _check_library_data(data: dict):
 
     if not valid_framework:
         _LOGGER.warning(
-            "Library declares frameworks %s which does not include '%s'; including anyway",
+            "Library %s declares frameworks %s that do not include '%s'; including anyway",
+            data.get("name", "<unknown>"),
             frameworks,
             framework,
         )

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -632,12 +632,20 @@ def _check_library_data(data: dict):
         frameworks = [a.strip() for a in frameworks.split(",")]
     frameworks = _ensure_list(frameworks)
 
-    # Check if library supports ESP-IDF framework
+    # Check if library declares the active framework. PIO library manifests
+    # often list only "arduino" even when the library actually compiles fine
+    # under ESP-IDF, and IDF (unlike PIO with `lib_compat_mode`) has no way to
+    # opt out of the check. Warn instead of failing so the user isn't forced to
+    # fork the library to fix the manifest.
     framework = "arduino" if CORE.using_arduino else "espidf"
     valid_framework = "*" in frameworks or framework in frameworks
 
     if not valid_framework:
-        raise InvalidIDFComponent(f"Unsupported library frameworks: {frameworks}")
+        _LOGGER.warning(
+            "Library declares frameworks %s which does not include '%s'; including anyway",
+            frameworks,
+            framework,
+        )
 
 
 def _process_dependencies(component: IDFComponent):

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -261,9 +261,12 @@ def test_check_library_data_invalid_platform(esp32_idf_core):
         _check_library_data({"platforms": ["other"], "frameworks": "*"})
 
 
-def test_check_library_data_invalid_framework(esp32_idf_core):
-    with pytest.raises(InvalidIDFComponent):
-        _check_library_data({"platforms": "*", "frameworks": ["other"]})
+def test_check_library_data_invalid_framework(esp32_idf_core, caplog):
+    # Framework mismatch is a warning, not a hard skip: the library is still
+    # included so that PIO manifests that only list "arduino" (but actually
+    # compile under IDF) can be used without forking them.
+    _check_library_data({"name": "lib", "platforms": "*", "frameworks": ["other"]})
+    assert "does not include 'espidf'" in caplog.text
 
 
 def test_extra_script_captures_libpath_libs_and_defines(tmp_path):

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -266,7 +266,7 @@ def test_check_library_data_invalid_framework(esp32_idf_core, caplog):
     # included so that PIO manifests that only list "arduino" (but actually
     # compile under IDF) can be used without forking them.
     _check_library_data({"name": "lib", "platforms": "*", "frameworks": ["other"]})
-    assert "does not include 'espidf'" in caplog.text
+    assert "do not include 'espidf'" in caplog.text
 
 
 def test_extra_script_captures_libpath_libs_and_defines(tmp_path):

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -261,7 +261,9 @@ def test_check_library_data_invalid_platform(esp32_idf_core):
         _check_library_data({"platforms": ["other"], "frameworks": "*"})
 
 
-def test_check_library_data_invalid_framework(esp32_idf_core, caplog):
+def test_check_library_data_invalid_framework(
+    esp32_idf_core: None, caplog: pytest.LogCaptureFixture
+) -> None:
     # Framework mismatch is a warning, not a hard skip: the library is still
     # included so that PIO manifests that only list "arduino" (but actually
     # compile under IDF) can be used without forking them.


### PR DESCRIPTION
# What does this implement/fix?

Changes the framework-mismatch case in the IDF library-conversion path from a hard skip to a warning. The library is still added; the user just gets told that the PIO manifest doesn't list the active framework.

PIO library manifests commonly declare only `arduino` in their `frameworks` field even when the library compiles fine under ESP-IDF. On top of that, when a user manually pulls such a library in as an external component on a native IDF build, `CORE.using_arduino` is False, so the framework check evaluates the active framework as `espidf`, doesn't find it in the manifest, and filters the library out entirely.

PIO has [`lib_compat_mode`](https://docs.platformio.org/en/latest/projectconf/sections/env/options/library/lib_compat_mode.html) to relax this check; the IDF path in `_check_library_data` had no equivalent escape hatch. After this change the user sees a warning and can decide whether the library actually works, instead of being forced to fork the library to fix metadata.

The platform check (e.g. AVR-only libraries) is left as a hard skip — those are genuine "can't build on ESP32" cases.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

N/A — internal behavior change in the PIO-library → IDF-component conversion path.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).