### PR TITLE
[lvgl] Build automation_schema event validators lazily

### DIFF
--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -435,7 +435,7 @@ def _lazy_validate_automation(extra_schema: dict) -> Callable[[Any], Any]:
     return validator
 
 
-def automation_schema(typ: LvType):
+def automation_schema(typ: LvType) -> dict[Any, Any]:
     events = df.LV_EVENT_TRIGGERS + df.SWIPE_TRIGGERS
     if typ.has_on_value:
         events = events + (CONF_ON_VALUE, CONF_ON_UPDATE)

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -22,6 +22,7 @@ from esphome.const import (
 )
 from esphome.core import TimePeriod
 from esphome.core.config import StartupTrigger
+from esphome.schema_extractors import EnableSchemaExtraction
 
 from . import defines as df, lv_validation as lvalid
 from .defines import (
@@ -407,6 +408,33 @@ def part_schema(parts: tuple[str, ...] | list[str]) -> cv.Schema:
     return cv.Schema(part_dict(parts))
 
 
+def _lazy_validate_automation(extra_schema: dict) -> Callable[[Any], Any]:
+    """Return a validator that defers building the validate_automation schema.
+
+    validate_automation() runs AUTOMATION_SCHEMA.extend(extra_schema), which
+    voluptuous compiles eagerly. automation_schema() builds ~60 of these per
+    widget type, and the vast majority of slots are never invoked by a given
+    user config. Deferring the build to first use removes that work from
+    schema-construction time.
+
+    When EnableSchemaExtraction is set (build_language_schema.py), fall back
+    to eager construction so the @schema_extractor("automation") decoration
+    inside validate_automation is registered.
+    """
+    if EnableSchemaExtraction:
+        return validate_automation(extra_schema)
+
+    cached: Callable[[Any], Any] | None = None
+
+    def validator(value: Any) -> Any:
+        nonlocal cached
+        if cached is None:
+            cached = validate_automation(extra_schema)
+        return cached(value)
+
+    return validator
+
+
 def automation_schema(typ: LvType):
     events = df.LV_EVENT_TRIGGERS + df.SWIPE_TRIGGERS
     if typ.has_on_value:
@@ -422,7 +450,7 @@ def automation_schema(typ: LvType):
 
     return {
         **{
-            cv.Optional(event): validate_automation(
+            cv.Optional(event): _lazy_validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
                         Trigger.template(*get_trigger_args(event))
@@ -431,7 +459,7 @@ def automation_schema(typ: LvType):
             )
             for event in events
         },
-        cv.Optional(CONF_ON_BOOT): validate_automation(
+        cv.Optional(CONF_ON_BOOT): _lazy_validate_automation(
             {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(StartupTrigger)}
         ),
     }

--- a/tests/component_tests/lvgl/test_automation_schema_lazy.py
+++ b/tests/component_tests/lvgl/test_automation_schema_lazy.py
@@ -1,0 +1,70 @@
+"""Tests for lvgl automation_schema lazy validate_automation build."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import esphome.components.lvgl  # noqa: F401
+from esphome.components.lvgl import schemas as lvgl_schemas
+from esphome.components.lvgl.schemas import (
+    WIDGET_TYPES,
+    _lazy_validate_automation,
+    automation_schema,
+)
+from esphome.config_validation import GenerateID, declare_id
+from esphome.const import CONF_TRIGGER_ID
+from esphome.core.config import StartupTrigger
+
+
+def _widget_type(name: str = "obj"):
+    wt = WIDGET_TYPES.get(name)
+    assert wt is not None, f"widget type {name!r} not registered"
+    return wt
+
+
+def _trigger_extra_schema() -> dict:
+    return {GenerateID(CONF_TRIGGER_ID): declare_id(StartupTrigger)}
+
+
+def test_lazy_validator_defers_build_until_first_call() -> None:
+    with patch(
+        "esphome.components.lvgl.schemas.validate_automation",
+        wraps=lvgl_schemas.validate_automation,
+    ) as va_mock:
+        validator = _lazy_validate_automation(_trigger_extra_schema())
+        assert va_mock.call_count == 0
+        validator({"then": []})
+        assert va_mock.call_count == 1
+        validator({"then": []})
+        assert va_mock.call_count == 1
+
+
+def test_eager_build_when_schema_extraction_enabled() -> None:
+    with (
+        patch("esphome.components.lvgl.schemas.EnableSchemaExtraction", True),
+        patch(
+            "esphome.components.lvgl.schemas.validate_automation",
+            wraps=lvgl_schemas.validate_automation,
+        ) as va_mock,
+    ):
+        _lazy_validate_automation(_trigger_extra_schema())
+        assert va_mock.call_count == 1
+
+
+def test_lazy_and_eager_produce_equivalent_validation() -> None:
+    extra = _trigger_extra_schema()
+    with patch("esphome.components.lvgl.schemas.EnableSchemaExtraction", True):
+        eager = _lazy_validate_automation(extra)
+    lazy = _lazy_validate_automation(_trigger_extra_schema())
+    sample = {"then": []}
+    assert lazy(sample) == eager(sample)
+
+
+def test_automation_schema_uses_lazy_validators() -> None:
+    wt = _widget_type("obj")
+    with patch(
+        "esphome.components.lvgl.schemas.validate_automation",
+        wraps=lvgl_schemas.validate_automation,
+    ) as va_mock:
+        automation_schema(wt.w_type)
+        assert va_mock.call_count == 0

--- a/tests/component_tests/lvgl/test_automation_schema_lazy.py
+++ b/tests/component_tests/lvgl/test_automation_schema_lazy.py
@@ -11,12 +11,13 @@ from esphome.components.lvgl.schemas import (
     _lazy_validate_automation,
     automation_schema,
 )
+from esphome.components.lvgl.widgets import WidgetType
 from esphome.config_validation import GenerateID, declare_id
 from esphome.const import CONF_TRIGGER_ID
 from esphome.core.config import StartupTrigger
 
 
-def _widget_type(name: str = "obj"):
+def _widget_type(name: str = "obj") -> WidgetType:
     wt = WIDGET_TYPES.get(name)
     assert wt is not None, f"widget type {name!r} not registered"
     return wt


### PR DESCRIPTION
# What does this implement/fix?

Follow-on to the LVGL schema-construction series (#16567, #16569, #16614, #16615). The new device builder UI re-validates the configuration on every save, so `esphome config` latency is paid on every edit; LVGL configs remain one of the worst offenders.

Profile of a real LVGL config shows `lvgl/schemas.py:automation_schema()` is the largest remaining hot spot the prior PRs did not touch. `obj_dict()` (built lazily and memoized per widget type) drives ~60 `validate_automation()` calls per widget type the first time each widget is seen, and `validate_automation()` runs `AUTOMATION_SCHEMA.extend(extra_schema)` eagerly, which voluptuous compiles on construction. A user config typically only uses a handful of those event slots, so most of that work is thrown away.

This PR wraps each per-event slot in `automation_schema()` with `_lazy_validate_automation()`, which defers the `validate_automation()` build until the validator is first invoked. When `schema_extractors.EnableSchemaExtraction` is on, build is eager so `script/build_language_schema.py` still sees the full mapping, matching the pattern from #16569.

Local microbench, 5 passes over 29 widget types calling `automation_schema(wt.w_type)`:

```
dev baseline: 281.3 ms
this PR:       63.0 ms
```

About a 4.5x reduction in the per-call cost; `_theme_schema` time drops accordingly because it builds one `obj_dict()` per widget. `script/test_build_components -c lvgl -e config` passes across host, esp32-idf, and esp32-p4-idf.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).