### PR TITLE
[router] Share a single I2S bus in test

### DIFF
--- a/tests/components/router/common.yaml
+++ b/tests/components/router/common.yaml
@@ -9,14 +9,12 @@ esphome:
           target_speaker: !lambda return id(speaker_a_id);
 
 i2s_audio:
-  - id: i2s_a
-    i2s_lrclk_pin: ${a_lrclk_pin}
-    i2s_bclk_pin: ${a_bclk_pin}
+  i2s_lrclk_pin: ${a_lrclk_pin}
+  i2s_bclk_pin: ${a_bclk_pin}
 
 speaker:
   - platform: i2s_audio
     id: speaker_a_id
-    i2s_audio_id: i2s_a
     dac_type: external
     i2s_dout_pin: ${a_dout_pin}
     sample_rate: 48000
@@ -24,7 +22,6 @@ speaker:
     channel: stereo
   - platform: i2s_audio
     id: speaker_b_id
-    i2s_audio_id: i2s_a
     dac_type: external
     i2s_dout_pin: ${b_dout_pin}
     spdif_mode: true

--- a/tests/components/router/common.yaml
+++ b/tests/components/router/common.yaml
@@ -12,7 +12,6 @@ i2s_audio:
   - id: i2s_a
     i2s_lrclk_pin: ${a_lrclk_pin}
     i2s_bclk_pin: ${a_bclk_pin}
-  - id: i2s_b
 
 speaker:
   - platform: i2s_audio
@@ -25,7 +24,7 @@ speaker:
     channel: stereo
   - platform: i2s_audio
     id: speaker_b_id
-    i2s_audio_id: i2s_b
+    i2s_audio_id: i2s_a
     dac_type: external
     i2s_dout_pin: ${b_dout_pin}
     spdif_mode: true


### PR DESCRIPTION
# What does this implement/fix?

The router speaker test used two `i2s_audio` buses, one per output speaker. There's no
need for that since the speakers share the same bus at runtime (the I2S component guards
access with a mutex, and only one output is active at a time). This drops the test to a
single bus.

The two-bus setup also limited CI grouping: ESP32 only has two I2S ports, so grouping the
router test with other I2S components risked exceeding that limit. One bus leaves headroom.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable, test-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
