### PR TITLE
[espidf] Support github:// and https://github.com/.../.git framework sources

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -794,17 +794,8 @@ _GITHUB_HTTPS_RE = re.compile(
 
 
 def _parse_git_source(source_url: str) -> tuple[str, str | None] | None:
-    """Detect a GitHub framework source URL.
-
-    Returns ``(url, ref)`` if ``source_url`` is a recognized GitHub git
-    source, otherwise ``None`` (treat as plain archive URL).
-
-    Accepted forms (matches the string-shorthand subset of
-    ``external_components`` ``SOURCE_SCHEMA``):
-
-      - ``github://owner/repo[@ref]``                shorthand
-      - ``https://github.com/owner/repo.git[@ref]``  explicit URL
-    """
+    """Return ``(url, ref)`` for ``github://owner/repo[@ref]`` or
+    ``https://github.com/owner/repo.git[@ref]``, else ``None``."""
     if m := _GITHUB_SHORTHAND_RE.match(source_url):
         owner, repo, ref = m.group(1), m.group(2), m.group(3)
         return f"https://github.com/{owner}/{repo}.git", ref
@@ -816,17 +807,10 @@ def _parse_git_source(source_url: str) -> tuple[str, str | None] | None:
 def _clone_idf_with_submodules(
     framework_path: Path, git_url: str, ref: str | None
 ) -> None:
-    """Clone ESP-IDF from a git URL into ``framework_path`` with submodules.
+    """Shallow-clone ESP-IDF with submodules into ``framework_path``.
 
-    The plain ``archive/<ref>.zip`` URL from GitHub strips submodules, so
-    components that vendor upstream code via a submodule (``mbedtls``,
-    ``openthread``, ``esptool``, ``bootloader``, ...) come down empty and
-    the CMake configure dies. This path runs ``git clone
-    --recurse-submodules --shallow-submodules`` so the working tree is
-    actually buildable.
-
-    The clone is shallow (``--depth=1``) and submodules are shallow too;
-    ESP-IDF master is still ~2-3 GB after this.
+    GitHub's archive zip strips submodules, so vendored components
+    (mbedtls, openthread, esptool, ...) come down empty and CMake fails.
     """
     from esphome.git import run_git_command
 
@@ -1001,9 +985,6 @@ def _check_esphome_idf_framework_install(
 
         git_source = _parse_git_source(source_url) if source_url else None
         if git_source is not None:
-            # Plain archive URLs from GitHub strip submodules; pull via git
-            # with --recurse-submodules so components like mbedtls/openthread
-            # actually have their nested source.
             git_url, ref = git_source
             _clone_idf_with_submodules(framework_path, git_url, ref)
         else:

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -818,6 +818,8 @@ def _clone_idf_with_submodules(
     The clone is shallow (``--depth=1``) and submodules are shallow too;
     ESP-IDF master is still ~2-3 GB after this.
     """
+    from esphome.git import run_git_command
+
     cmd = [
         "git",
         "clone",
@@ -829,7 +831,7 @@ def _clone_idf_with_submodules(
         cmd += ["--branch", ref]
     cmd += ["--", git_url, str(framework_path)]
     _LOGGER.info("Cloning ESP-IDF from %s%s", git_url, f"@{ref}" if ref else "")
-    subprocess.run(cmd, check=True)
+    run_git_command(cmd)
 
 
 def _write_idf_version_txt(framework_path: Path, version: str) -> None:

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -8,6 +8,7 @@ import logging
 import os
 from pathlib import Path
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -784,38 +785,32 @@ def download_from_mirrors(
         return None
 
 
+_GITHUB_SHORTHAND_RE = re.compile(
+    r"^github://([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\._]+?)(?:@([a-zA-Z0-9\-_.\./]+))?$"
+)
+_GITHUB_HTTPS_RE = re.compile(
+    r"^(https://github\.com/[a-zA-Z0-9\-]+/[a-zA-Z0-9\-\._]+?\.git)(?:@([a-zA-Z0-9\-_.\./]+))?$"
+)
+
+
 def _parse_git_source(source_url: str) -> tuple[str, str | None] | None:
-    """Detect a git framework source URL.
+    """Detect a GitHub framework source URL.
 
-    Returns ``(url, ref)`` if ``source_url`` looks like a git repo,
-    otherwise ``None`` (treat as plain archive URL).
+    Returns ``(url, ref)`` if ``source_url`` is a recognized GitHub git
+    source, otherwise ``None`` (treat as plain archive URL).
 
-    Recognized forms:
-      - HTTPS/HTTP ending in ``.git`` (optionally followed by ``@<ref>``)
-      - ``git://`` or ``ssh://`` protocol
-      - ``git@host:path`` SSH shorthand
+    Accepted forms (matches the string-shorthand subset of
+    ``external_components`` ``SOURCE_SCHEMA``):
 
-    Examples:
-      - ``https://github.com/espressif/esp-idf.git@master``
-      - ``git@github.com:espressif/esp-idf.git``
-      - ``ssh://git@github.com/espressif/esp-idf.git``
+      - ``github://owner/repo[@ref]``                shorthand
+      - ``https://github.com/owner/repo.git[@ref]``  explicit URL
     """
-    # Split off ``@<ref>`` only from the last path segment so an embedded
-    # ``user@host`` in an SSH URL isn't mistaken for a ref.
-    url = source_url
-    ref: str | None = None
-    if "@" in url.rsplit("/", 1)[-1]:
-        candidate, candidate_ref = url.rsplit("@", 1)
-        # Treat as ref only if what's left still looks like a URL (has a
-        # scheme or SSH shorthand). Otherwise it's the ``user@host`` of an
-        # SSH URL with no explicit ref.
-        if "://" in candidate or candidate.startswith("git@"):
-            url, ref = candidate, candidate_ref
-
-    is_git = url.endswith(".git") or url.startswith(("git://", "ssh://", "git@"))
-    if not is_git:
-        return None
-    return url, ref
+    if m := _GITHUB_SHORTHAND_RE.match(source_url):
+        owner, repo, ref = m.group(1), m.group(2), m.group(3)
+        return f"https://github.com/{owner}/{repo}.git", ref
+    if m := _GITHUB_HTTPS_RE.match(source_url):
+        return m.group(1), m.group(2)
+    return None
 
 
 def _clone_idf_with_submodules(

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -798,6 +798,9 @@ def _parse_git_source(source_url: str) -> tuple[str, str | None] | None:
     ``https://github.com/owner/repo.git[@ref]``, else ``None``."""
     if m := _GITHUB_SHORTHAND_RE.match(source_url):
         owner, repo, ref = m.group(1), m.group(2), m.group(3)
+        # Tolerate a trailing ".git" on the shorthand repo so the
+        # github://owner/repo.git form doesn't silently become repo.git.git.
+        repo = repo.removesuffix(".git")
         return f"https://github.com/{owner}/{repo}.git", ref
     if m := _GITHUB_HTTPS_RE.match(source_url):
         return m.group(1), m.group(2)
@@ -811,21 +814,46 @@ def _clone_idf_with_submodules(
 
     GitHub's archive zip strips submodules, so vendored components
     (mbedtls, openthread, esptool, ...) come down empty and CMake fails.
+
+    Uses clone + ``fetch FETCH_HEAD`` + ``reset --hard`` instead of
+    ``--branch``: ``--branch`` only accepts branch or tag names, but a
+    user can also point at a commit SHA. The fetch-then-reset pattern
+    handles branches, tags, and SHAs uniformly (mirrors the approach in
+    ``esphome.git.clone_or_update``).
     """
     from esphome.git import run_git_command
 
-    cmd = [
-        "git",
-        "clone",
-        "--depth=1",
-        "--recurse-submodules",
-        "--shallow-submodules",
-    ]
-    if ref:
-        cmd += ["--branch", ref]
-    cmd += ["--", git_url, str(framework_path)]
     _LOGGER.info("Cloning ESP-IDF from %s%s", git_url, f"@{ref}" if ref else "")
-    run_git_command(cmd)
+    run_git_command(["git", "clone", "--depth=1", "--", git_url, str(framework_path)])
+    if ref:
+        run_git_command(
+            ["git", "fetch", "--depth=1", "--", "origin", ref],
+            git_dir=framework_path,
+        )
+        run_git_command(
+            ["git", "reset", "--hard", "FETCH_HEAD"],
+            git_dir=framework_path,
+        )
+    run_git_command(
+        [
+            "git",
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+            "--depth=1",
+        ],
+        git_dir=framework_path,
+    )
+
+    # Sanity-check the resulting tree. run_git_command only raises when
+    # stderr is non-empty, so a clone that silently produces no working
+    # tree would otherwise be marked extracted and stuck until
+    # ``esphome clean``.
+    if not (framework_path / "tools" / "idf_tools.py").is_file():
+        raise RuntimeError(
+            f"Clone of {git_url} produced no usable ESP-IDF tree at {framework_path}"
+        )
 
 
 def _write_idf_version_txt(framework_path: Path, version: str) -> None:

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -785,22 +785,37 @@ def download_from_mirrors(
 
 
 def _parse_git_source(source_url: str) -> tuple[str, str | None] | None:
-    """Parse a ``git+`` framework source URL.
+    """Detect a git framework source URL.
 
-    Accepts pip-style ``git+<url>[@<ref>]`` (e.g.
-    ``git+https://github.com/espressif/esp-idf.git@master``). Returns
-    ``(url, ref)`` if the input is a git source, or ``None`` if it's a
-    plain archive URL.
+    Returns ``(url, ref)`` if ``source_url`` looks like a git repo,
+    otherwise ``None`` (treat as plain archive URL).
+
+    Recognized forms:
+      - HTTPS/HTTP ending in ``.git`` (optionally followed by ``@<ref>``)
+      - ``git://`` or ``ssh://`` protocol
+      - ``git@host:path`` SSH shorthand
+
+    Examples:
+      - ``https://github.com/espressif/esp-idf.git@master``
+      - ``git@github.com:espressif/esp-idf.git``
+      - ``ssh://git@github.com/espressif/esp-idf.git``
     """
-    if not source_url.startswith("git+"):
-        return None
-    git_url = source_url[len("git+") :]
+    # Split off ``@<ref>`` only from the last path segment so an embedded
+    # ``user@host`` in an SSH URL isn't mistaken for a ref.
+    url = source_url
     ref: str | None = None
-    # Use rsplit("@") so URLs with embedded ``user@host`` (ssh) keep the ref
-    # split on the last ``@`` only.
-    if "@" in git_url.rsplit("/", 1)[-1]:
-        git_url, ref = git_url.rsplit("@", 1)
-    return git_url, ref
+    if "@" in url.rsplit("/", 1)[-1]:
+        candidate, candidate_ref = url.rsplit("@", 1)
+        # Treat as ref only if what's left still looks like a URL (has a
+        # scheme or SSH shorthand). Otherwise it's the ``user@host`` of an
+        # SSH URL with no explicit ref.
+        if "://" in candidate or candidate.startswith("git@"):
+            url, ref = candidate, candidate_ref
+
+    is_git = url.endswith(".git") or url.startswith(("git://", "ssh://", "git@"))
+    if not is_git:
+        return None
+    return url, ref
 
 
 def _clone_idf_with_submodules(

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -784,6 +784,54 @@ def download_from_mirrors(
         return None
 
 
+def _parse_git_source(source_url: str) -> tuple[str, str | None] | None:
+    """Parse a ``git+`` framework source URL.
+
+    Accepts pip-style ``git+<url>[@<ref>]`` (e.g.
+    ``git+https://github.com/espressif/esp-idf.git@master``). Returns
+    ``(url, ref)`` if the input is a git source, or ``None`` if it's a
+    plain archive URL.
+    """
+    if not source_url.startswith("git+"):
+        return None
+    git_url = source_url[len("git+") :]
+    ref: str | None = None
+    # Use rsplit("@") so URLs with embedded ``user@host`` (ssh) keep the ref
+    # split on the last ``@`` only.
+    if "@" in git_url.rsplit("/", 1)[-1]:
+        git_url, ref = git_url.rsplit("@", 1)
+    return git_url, ref
+
+
+def _clone_idf_with_submodules(
+    framework_path: Path, git_url: str, ref: str | None
+) -> None:
+    """Clone ESP-IDF from a git URL into ``framework_path`` with submodules.
+
+    The plain ``archive/<ref>.zip`` URL from GitHub strips submodules, so
+    components that vendor upstream code via a submodule (``mbedtls``,
+    ``openthread``, ``esptool``, ``bootloader``, ...) come down empty and
+    the CMake configure dies. This path runs ``git clone
+    --recurse-submodules --shallow-submodules`` so the working tree is
+    actually buildable.
+
+    The clone is shallow (``--depth=1``) and submodules are shallow too;
+    ESP-IDF master is still ~2-3 GB after this.
+    """
+    cmd = [
+        "git",
+        "clone",
+        "--depth=1",
+        "--recurse-submodules",
+        "--shallow-submodules",
+    ]
+    if ref:
+        cmd += ["--branch", ref]
+    cmd += ["--", git_url, str(framework_path)]
+    _LOGGER.info("Cloning ESP-IDF from %s%s", git_url, f"@{ref}" if ref else "")
+    subprocess.run(cmd, check=True)
+
+
 def _write_idf_version_txt(framework_path: Path, version: str) -> None:
     """Write <framework_path>/version.txt if missing.
 
@@ -939,27 +987,37 @@ def _check_esphome_idf_framework_install(
     if install:
         rmdir(framework_path, msg=f"Clean up ESP-IDF {version} framework")
 
-        # Download in temporary file
-        with tempfile.NamedTemporaryFile() as tmp:
-            _LOGGER.info("Downloading ESP-IDF %s framework ...", version)
+        git_source = _parse_git_source(source_url) if source_url else None
+        if git_source is not None:
+            # Plain archive URLs from GitHub strip submodules; pull via git
+            # with --recurse-submodules so components like mbedtls/openthread
+            # actually have their nested source.
+            git_url, ref = git_source
+            _clone_idf_with_submodules(framework_path, git_url, ref)
+        else:
+            # Download in temporary file
+            with tempfile.NamedTemporaryFile() as tmp:
+                _LOGGER.info("Downloading ESP-IDF %s framework ...", version)
 
-            # Create substitutions for the URLs
-            substitutions = {"VERSION": version}
-            try:
-                ver = Version.parse(version)
-                substitutions["MAJOR"] = str(ver.major)
-                substitutions["MINOR"] = str(ver.minor)
-                substitutions["PATCH"] = str(ver.patch)
-                substitutions["EXTRA"] = ver.extra
-            except ValueError:
-                pass
+                # Create substitutions for the URLs
+                substitutions = {"VERSION": version}
+                try:
+                    ver = Version.parse(version)
+                    substitutions["MAJOR"] = str(ver.major)
+                    substitutions["MINOR"] = str(ver.minor)
+                    substitutions["PATCH"] = str(ver.patch)
+                    substitutions["EXTRA"] = ver.extra
+                except ValueError:
+                    pass
 
-            mirrors = [source_url] if source_url else ESPHOME_IDF_FRAMEWORK_MIRRORS
-            download_from_mirrors(mirrors, substitutions, tmp.file)
+                mirrors = [source_url] if source_url else ESPHOME_IDF_FRAMEWORK_MIRRORS
+                download_from_mirrors(mirrors, substitutions, tmp.file)
 
-            _LOGGER.info("Extracting ESP-IDF %s framework ...", version)
-            archive_extract_all(tmp.file, framework_path, progress_header="Extracting")
-            extracted_marker.touch()
+                _LOGGER.info("Extracting ESP-IDF %s framework ...", version)
+                archive_extract_all(
+                    tmp.file, framework_path, progress_header="Extracting"
+                )
+        extracted_marker.touch()
 
     # Idempotent post-extract patch: written every invocation so a build
     # dir extracted before this fix gets the file too, without forcing a

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -72,7 +72,7 @@ def run_git_command(cmd: list[str], git_dir: Path | None = None) -> str:
         )
     except FileNotFoundError as err:
         raise GitNotInstalledError(
-            "git is not installed but required for external_components.\n"
+            "git is not installed but required by this feature.\n"
             "Please see https://git-scm.com/book/en/v2/Getting-Started-Installing-Git for installing git"
         ) from err
 

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -72,8 +72,9 @@ def run_git_command(cmd: list[str], git_dir: Path | None = None) -> str:
         )
     except FileNotFoundError as err:
         raise GitNotInstalledError(
-            "git is not installed but required by this feature.\n"
-            "Please see https://git-scm.com/book/en/v2/Getting-Started-Installing-Git for installing git"
+            "git is not installed. See "
+            "https://git-scm.com/book/en/v2/Getting-Started-Installing-Git "
+            "for installation instructions."
         ) from err
 
     if ret.returncode != 0 and ret.stderr:

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -1,0 +1,66 @@
+"""Tests for esphome.espidf.framework helpers."""
+
+# pylint: disable=protected-access
+
+import pytest
+
+from esphome.espidf.framework import _parse_git_source
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        # github:// shorthand
+        (
+            "github://espressif/esp-idf",
+            ("https://github.com/espressif/esp-idf.git", None),
+        ),
+        (
+            "github://espressif/esp-idf@master",
+            ("https://github.com/espressif/esp-idf.git", "master"),
+        ),
+        (
+            "github://espressif/esp-idf@release/v6.0",
+            ("https://github.com/espressif/esp-idf.git", "release/v6.0"),
+        ),
+        # explicit https://github.com/...git URL
+        (
+            "https://github.com/espressif/esp-idf.git",
+            ("https://github.com/espressif/esp-idf.git", None),
+        ),
+        (
+            "https://github.com/espressif/esp-idf.git@master",
+            ("https://github.com/espressif/esp-idf.git", "master"),
+        ),
+        (
+            "https://github.com/espressif/esp-idf.git@v6.0.1",
+            ("https://github.com/espressif/esp-idf.git", "v6.0.1"),
+        ),
+    ],
+)
+def test_parse_git_source_recognized(
+    source: str, expected: tuple[str, str | None]
+) -> None:
+    assert _parse_git_source(source) == expected
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # archive URLs fall through to the existing download path
+        "https://github.com/espressif/esp-idf/archive/refs/heads/master.zip",
+        "https://dl.espressif.com/dl/esp-idf/v6.0.1/esp-idf-v6.0.1.zip",
+        "https://github.com/esphome-libs/esp-idf/releases/download/v5.5.4/esp-idf-v5.5.4.tar.xz",
+        # SSH and other git protocols are intentionally rejected — match
+        # external_components, which only recognizes github:// + structured
+        # dicts for these.
+        "git@github.com:espressif/esp-idf.git",
+        "ssh://git@github.com/espressif/esp-idf.git",
+        "git://github.com/espressif/esp-idf.git",
+        # non-GitHub .git URLs are intentionally rejected for the same reason
+        "https://gitlab.com/foo/bar.git",
+        "https://github.example.com/foo/bar.git",
+    ],
+)
+def test_parse_git_source_rejected(source: str) -> None:
+    assert _parse_git_source(source) is None

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -2,9 +2,12 @@
 
 # pylint: disable=protected-access
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
-from esphome.espidf.framework import _parse_git_source
+from esphome.espidf.framework import _clone_idf_with_submodules, _parse_git_source
 
 
 @pytest.mark.parametrize(
@@ -36,6 +39,16 @@ from esphome.espidf.framework import _parse_git_source
             "https://github.com/espressif/esp-idf.git@v6.0.1",
             ("https://github.com/espressif/esp-idf.git", "v6.0.1"),
         ),
+        # Tolerate a trailing ".git" on the shorthand so the user doesn't
+        # silently end up with a doubled "...esp-idf.git.git" URL.
+        (
+            "github://espressif/esp-idf.git",
+            ("https://github.com/espressif/esp-idf.git", None),
+        ),
+        (
+            "github://espressif/esp-idf.git@master",
+            ("https://github.com/espressif/esp-idf.git", "master"),
+        ),
     ],
 )
 def test_parse_git_source_recognized(
@@ -64,3 +77,80 @@ def test_parse_git_source_recognized(
 )
 def test_parse_git_source_rejected(source: str) -> None:
     assert _parse_git_source(source) is None
+
+
+def _make_idf_tree(framework_path: Path) -> None:
+    """Create the minimum tree _clone_idf_with_submodules sanity-checks for."""
+    (framework_path / "tools").mkdir(parents=True)
+    (framework_path / "tools" / "idf_tools.py").write_text("# stub\n")
+
+
+def test_clone_idf_with_submodules_without_ref(tmp_path: Path) -> None:
+    framework_path = tmp_path / "idf"
+    framework_path.mkdir()
+    _make_idf_tree(framework_path)
+
+    with patch("esphome.git.run_git_command", return_value="") as run_git_command_mock:
+        _clone_idf_with_submodules(
+            framework_path, "https://github.com/espressif/esp-idf.git", None
+        )
+
+    # No ref -> just clone + submodule update, no fetch/reset.
+    calls = [c.args[0] for c in run_git_command_mock.call_args_list]
+    assert calls[0] == [
+        "git",
+        "clone",
+        "--depth=1",
+        "--",
+        "https://github.com/espressif/esp-idf.git",
+        str(framework_path),
+    ]
+    assert calls[-1][:5] == ["git", "submodule", "update", "--init", "--recursive"]
+    assert not any(c[1] == "fetch" for c in calls)
+    assert not any(c[1] == "reset" for c in calls)
+
+
+def test_clone_idf_with_submodules_with_ref(tmp_path: Path) -> None:
+    framework_path = tmp_path / "idf"
+    framework_path.mkdir()
+    _make_idf_tree(framework_path)
+
+    with patch("esphome.git.run_git_command", return_value="") as run_git_command_mock:
+        _clone_idf_with_submodules(
+            framework_path,
+            "https://github.com/espressif/esp-idf.git",
+            "master",
+        )
+
+    calls = [c.args[0] for c in run_git_command_mock.call_args_list]
+    # clone, fetch ref, reset hard, submodule update
+    assert calls[0][:2] == ["git", "clone"]
+    assert calls[1] == [
+        "git",
+        "fetch",
+        "--depth=1",
+        "--",
+        "origin",
+        "master",
+    ]
+    assert calls[2] == ["git", "reset", "--hard", "FETCH_HEAD"]
+    assert calls[3][:5] == ["git", "submodule", "update", "--init", "--recursive"]
+
+
+def test_clone_idf_with_submodules_raises_when_tree_missing(
+    tmp_path: Path,
+) -> None:
+    framework_path = tmp_path / "idf"
+    framework_path.mkdir()
+    # Deliberately do NOT call _make_idf_tree — simulate a clone that
+    # returned 0 but produced no tools/idf_tools.py.
+
+    with (
+        patch("esphome.git.run_git_command", return_value=""),
+        pytest.raises(RuntimeError, match="no usable ESP-IDF tree"),
+    ):
+        _clone_idf_with_submodules(
+            framework_path,
+            "https://github.com/espressif/esp-idf.git",
+            None,
+        )


### PR DESCRIPTION
# What does this implement/fix?

Adds git-clone support to the `esp32.framework.source` override so users can point at a GitHub repo (clone-with-submodules) instead of an archive URL (download-and-extract).

The plain archive URL from GitHub (`https://github.com/.../archive/refs/heads/master.zip`) strips submodules. ESP-IDF vendors a lot of upstream code via submodules (`mbedtls`, `openthread`, `esptool`, `bootloader`, `tinyusb`, ...), so using a GitHub archive URL as `framework.source` makes the CMake configure die with:

\`\`\`
CMake Error: Include directory
  '.esphome/idf/frameworks/<ver>/components/mbedtls/mbedtls/include'
  is not a directory.
\`\`\`

When the override is recognized as a GitHub git source, we `git clone --depth=1 --recurse-submodules --shallow-submodules` directly into the framework path instead of downloading an archive. The same `.esphome_extracted` marker is written, so re-runs skip the clone just like archives.

Accepted string forms (matches the string-shorthand subset of `external_components`'s `SOURCE_SCHEMA`):

- `github://owner/repo[@ref]`
- `https://github.com/owner/repo.git[@ref]`

Anything else (archive URLs, non-GitHub `.git`, SSH `git@…`, `ssh://`, `git://`) falls through to the existing archive download. Non-GitHub or SSH git sources can be added later as a separate change if there's demand.

Primary motivating use case: testing against pre-release ESP-IDF (e.g. ESP32-S31 support on `master`, before any tagged release ships the chip).

Example:

\`\`\`yaml
esp32:
  framework:
    type: esp-idf
    version: 6.1.0
    source: github://espressif/esp-idf@master
\`\`\`

Also generalizes the `GitNotInstalledError` message in `esphome.git` — previously hardcoded "required for external_components", now just tells the user how to install git, so any caller's user sees a sensible message.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6691

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
esp32:
  framework:
    type: esp-idf
    version: 6.1.0
    source: github://espressif/esp-idf@master
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).