### PR TITLE
[espidf] Keep cmake output filter working when IDF writes raw bytes

### DIFF
--- a/esphome/espidf/runner.py
+++ b/esphome/espidf/runner.py
@@ -162,13 +162,9 @@ def main() -> int:
             else:
                 self._filter_pattern = None
             self._line_buffer = ""
-            # Force IDF 6.1+ RunTool.write_stdout_bytes (in
-            # tools/idf_py_actions/tools.py) to take the text
-            # ``output_stream.write(...)`` path instead of writing raw bytes
-            # directly to ``output_stream.buffer.write(...)``. The buffer
-            # path bypasses our text-level filter entirely, so cmake output
-            # like ``-- Components: ...`` and ``-- Component paths: ...``
-            # would otherwise reach the terminal unfiltered on IDF 6.1.
+            # IDF 6.1+ writes raw bytes to ``stream.buffer`` if present,
+            # bypassing our text-level filter. Mask it so IDF falls back
+            # to ``stream.write()``.
             self.buffer = None
 
         def __getattr__(self, name: str):

--- a/esphome/espidf/runner.py
+++ b/esphome/espidf/runner.py
@@ -162,6 +162,14 @@ def main() -> int:
             else:
                 self._filter_pattern = None
             self._line_buffer = ""
+            # Force IDF 6.1+ RunTool.write_stdout_bytes (in
+            # tools/idf_py_actions/tools.py) to take the text
+            # ``output_stream.write(...)`` path instead of writing raw bytes
+            # directly to ``output_stream.buffer.write(...)``. The buffer
+            # path bypasses our text-level filter entirely, so cmake output
+            # like ``-- Components: ...`` and ``-- Component paths: ...``
+            # would otherwise reach the terminal unfiltered on IDF 6.1.
+            self.buffer = None
 
         def __getattr__(self, name: str):
             return getattr(self._stream, name)

--- a/esphome/espidf/runner.py
+++ b/esphome/espidf/runner.py
@@ -162,12 +162,14 @@ def main() -> int:
             else:
                 self._filter_pattern = None
             self._line_buffer = ""
-            # IDF 6.1+ writes raw bytes to ``stream.buffer`` if present,
-            # bypassing our text-level filter. Mask it so IDF falls back
-            # to ``stream.write()``.
-            self.buffer = None
 
         def __getattr__(self, name: str):
+            # Hide ``buffer`` so consumers that use either
+            # ``getattr(stream, 'buffer', None)`` or
+            # ``hasattr(stream, 'buffer')`` see this as a text-only stream
+            # and skip writing raw bytes (which would bypass the filter).
+            if name == "buffer":
+                raise AttributeError(name)
             return getattr(self._stream, name)
 
         def isatty(self) -> bool:


### PR DESCRIPTION
# What does this implement/fix?

Restores ESPHome's existing IDF cmake-output line filter when running against ESP-IDF master.

`runner.py`'s `_FilteringTTYStream` wraps `sys.stdout` / `sys.stderr` and runs `FILTER_IDF_LINES` regex patterns against each line in `write(str)`. IDF commit [`6e4ed2c204`](https://github.com/espressif/esp-idf/commit/6e4ed2c204) — *"fix(tools): Forward build subprocess stdout as UTF-8 bytes on Windows"* (Jakub Kocka, 2026-04-20) — reworked `RunTool` to bypass `output_stream.write()` whenever the stream exposes a binary `buffer`:

```python
def write_stdout_bytes(data: bytes) -> None:
    """Write raw subprocess bytes to the underlying binary stream (UTF-8 from CMake, no TextIO re-encode)."""
    binary_buf = getattr(output_stream, 'buffer', None)
    if binary_buf is not None:
        binary_buf.write(data)        # skips our filter
        binary_buf.flush()
    else:
        write_text_maybe_illencoded(output_stream, data.decode('utf-8', errors='replace'))  # runs our filter
```
([tools/idf_py_actions/tools.py:549-556](https://github.com/espressif/esp-idf/blob/master/tools/idf_py_actions/tools.py#L549-L556))

When `output_stream` is our wrapped `sys.stdout`, `getattr(output_stream, 'buffer', None)` resolves via `_FilteringTTYStream.__getattr__` to the real `sys.stdout.buffer`. IDF then writes cmake's raw bytes directly to FD 1, completely bypassing our `write()` method. Patterns like `-- Components:`, `-- Component paths:`, `-- Adding linker script`, and `-- git rev-parse returned` reach the user's terminal unfiltered.

Fix: set `self.buffer = None` on the wrapper. Instance attributes shadow `__getattr__`, so `getattr(filtering_stream, 'buffer', None)` returns `None` and IDF's branch falls back to `write_text_maybe_illencoded(output_stream, data.decode(...))`, which calls our `.write()`, which runs the filter.

## Scope of the regression

The IDF commit is **only on master** as of writing. It is not in any tagged release:

| IDF ref | Has the buffer-write path? |
|---|---|
| `master` | yes |
| `release/v6.0` (latest tag `v6.0.1`, 2026-04-27) | no |
| `release/v5.5` (latest tag `v5.5.4`, 2026-03-27) | no |
| all earlier | no |

So users on stable IDF (the default `recommended` / `latest` flow) are not currently affected. Users hitting this today are those who override `esp32.framework.source` to track IDF master — e.g. for early ESP32-S31 testing via #16639. The fix is forward-looking and will keep working once this IDF commit lands in a tagged 6.x release.

Verified locally on an ESP32-P4 build against IDF master: the `-- Components: …` / `-- Component paths: …` / `-- Adding linker script …` / `-- git rev-parse returned …` lines are filtered out, matching the IDF 5.5 / 6.0 behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

N/A — internal output-handling fix in the native IDF runner.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).