### PR TITLE
[core] Enable additional zero-violation ruff lint families

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,14 +113,22 @@ exclude = ['generated']
 select = [
   "E",    # pycodestyle
   "F",    # pyflakes/autoflake
+  "FA",   # flake8-future-annotations
   "FLY",  # flynt: convert string formatting to f-strings
   "FURB", # refurb
   "I",    # isort
+  "ICN",  # flake8-import-conventions
+  "LOG",  # flake8-logging
+  "NPY",  # numpy-specific rules
   "PERF", # performance
   "PL",   # pylint
+  "Q",    # flake8-quotes
   "SIM",  # flake8-simplify
   "RET",  # flake8-ret
+  "T10",  # flake8-debugger
   "UP",   # pyupgrade
+  "W",    # pycodestyle warnings
+  "YTT",  # flake8-2020
 ]
 
 ignore = [


### PR DESCRIPTION
# What does this implement/fix?

Enables eight extra ruff lint families that aioesphomeapi already uses and that currently report zero violations against the esphome tree; FA, ICN, LOG, NPY, Q, T10, W, YTT. No source changes are needed, only the select list in pyproject.toml.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).