### PR TITLE
[core] Enable ruff RSE (flake8-raise) lint family

### DIFF
--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -81,7 +81,7 @@ def _process_single_config(config: dict[str, Any]) -> None:
     elif conf[CONF_TYPE] == TYPE_LOCAL:
         components_dir = Path(CORE.relative_config_path(conf[CONF_PATH]))
     else:
-        raise NotImplementedError()
+        raise NotImplementedError
 
     if config[CONF_COMPONENTS] == "all":
         num_components = len(list(components_dir.glob("*/__init__.py")))

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -236,7 +236,7 @@ async def to_code(config):
         rhs = model.new()
         var = cg.Pvariable(config[CONF_ID], rhs, model)
     else:
-        raise NotImplementedError()
+        raise NotImplementedError
 
     await display.register_display(var, config)
     await spi.register_spi_device(var, config, write_only=True)

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1862,7 +1862,7 @@ def extract_keys(schema):
         elif isinstance(skey, vol.Marker) and isinstance(skey.schema, str):
             keys.append(skey.schema)
         else:
-            raise ValueError()
+            raise ValueError
     keys.sort()
     return keys
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -893,7 +893,7 @@ class MockObj(Expression):
     def __getattr__(self, attr: str) -> "MockObj":
         # prevent python dunder methods being replaced by mock objects
         if attr.startswith("__"):
-            raise AttributeError()
+            raise AttributeError
         next_op = "."
         if attr.startswith("P") and self.op not in ["::", ""]:
             attr = attr[1:]

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -55,7 +55,7 @@ ESPHOME_DATA_EXTRA_CMAKE_KEY = "EXTRA_CMAKE"
 
 class Source:
     def download(self, dir_suffix: str, force: bool = False) -> Path:
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class URLSource(Source):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ select = [
   "PERF", # performance
   "PL",   # pylint
   "Q",    # flake8-quotes
+  "RSE",  # flake8-raise
   "SIM",  # flake8-simplify
   "RET",  # flake8-ret
   "T10",  # flake8-debugger


### PR DESCRIPTION
# What does this implement/fix?

Enables the RSE ruff family; five RSE102 violations existed where exceptions were raised with empty parentheses. The fix is the ruff auto-fix; behavior is unchanged since Python constructs the exception object whether the parentheses are present or not.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).