### PR TITLE
[core] Enable ruff PGH (pygrep-hooks) lint family

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -56,7 +56,7 @@ from esphome.types import ConfigType
 from esphome.writer import clean_build, clean_cmake_cache
 
 from .boards import BOARDS, STANDARD_BOARDS
-from .const import (  # noqa
+from .const import (
     KEY_ARDUINO_LIBRARIES,
     KEY_BOARD,
     KEY_COMPONENTS,
@@ -86,7 +86,7 @@ from .const import (  # noqa
 )
 
 # force import gpio to register pin schema
-from .gpio import esp32_pin_to_code  # noqa
+from .gpio import esp32_pin_to_code  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)
 AUTO_LOAD = ["preferences"]

--- a/esphome/components/host/__init__.py
+++ b/esphome/components/host/__init__.py
@@ -14,7 +14,7 @@ from esphome.core import CORE
 from .const import KEY_HOST
 
 # force import gpio to register pin schema
-from .gpio import host_pin_to_code  # noqa
+from .gpio import host_pin_to_code  # noqa: F401
 
 CODEOWNERS = ["@esphome/core", "@clydebarrow"]
 AUTO_LOAD = ["network", "preferences"]

--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -28,7 +28,7 @@ from esphome.core.config import BOARD_MAX_LENGTH
 from esphome.helpers import copy_file_if_changed
 from esphome.storage_json import StorageJSON
 
-from . import gpio  # noqa
+from . import gpio  # noqa: F401
 from .const import (
     COMPONENT_BK72XX,
     CONF_GPIO_RECOVER,

--- a/esphome/components/libretiny/generate_components.py
+++ b/esphome/components/libretiny/generate_components.py
@@ -1,7 +1,7 @@
 # Copyright (c) Kuba Szczodrzyński 2023-06-01.
 
 # pylint: skip-file
-# flake8: noqa
+# ruff: noqa: C408, I001
 
 import json
 import re
@@ -313,8 +313,12 @@ def write_const(
     # build component constants
     comp_str = "\n".join(f'COMPONENT_{f} = "{f.lower()}"' for f in components)
     # replace the 2nd regex group only
-    repl = lambda m: m.group(1) + comp_str + m.group(3)
-    code = re.sub(comp_regex, repl, code, flags=re.DOTALL | re.MULTILINE)
+    code = re.sub(
+        comp_regex,
+        lambda m: m.group(1) + comp_str + m.group(3),
+        code,
+        flags=re.DOTALL | re.MULTILINE,
+    )
 
     # regex for finding the family list block
     fam_regex = r"(# FAMILIES.+?\n)(.*?)(\n# FAMILIES)"
@@ -337,8 +341,12 @@ def write_const(
     ]
     var_str = "\n".join(fam_lines)
     # replace the 2nd regex group only
-    repl = lambda m: m.group(1) + var_str + m.group(3)
-    code = re.sub(fam_regex, repl, code, flags=re.DOTALL | re.MULTILINE)
+    code = re.sub(
+        fam_regex,
+        lambda m: m.group(1) + var_str + m.group(3),
+        code,
+        flags=re.DOTALL | re.MULTILINE,
+    )
 
     # format with black
     code = format_str(code, mode=FileMode())

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -58,7 +58,7 @@ from .effects import (
     RGB_EFFECTS,
     validate_effects,
 )
-from .types import (  # noqa
+from .types import (  # noqa: F401
     AddressableLight,
     AddressableLightState,
     ColorMode,

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -514,7 +514,7 @@ def validate_printf(value):
     (?:hh|h|ll|l|j|z|t|L|w|I|I32|I64)?  # size
     [cCdiouxXeEfgGaAnpsSZ]              # type
     )
-    """  # noqa
+    """
     matches = re.findall(cfmt, value[CONF_FORMAT], flags=re.VERBOSE)
     if len(matches) != len(value[CONF_ARGS]):
         raise cv.Invalid(

--- a/esphome/components/lvgl/helpers.py
+++ b/esphome/components/lvgl/helpers.py
@@ -6,7 +6,6 @@ from esphome.const import CONF_ARGS, CONF_FORMAT
 CONF_IF_NAN = "if_nan"
 
 
-# noqa
 f_regex = re.compile(
     r"""
     (                                   # start of capture group 1
@@ -20,7 +19,6 @@ f_regex = re.compile(
     """,
     flags=re.VERBOSE,
 )
-# noqa
 c_regex = re.compile(
     r"""
     (                                   # start of capture group 1

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -65,7 +65,7 @@ from .const import (
 )
 
 # force import gpio to register pin schema
-from .gpio import nrf52_pin_to_code  # noqa
+from .gpio import nrf52_pin_to_code  # noqa: F401
 
 CODEOWNERS = ["@tomaszduda23"]
 AUTO_LOAD = ["zephyr", "preferences"]

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -50,7 +50,7 @@ from .const import (
 )
 
 # force import gpio to register pin schema
-from .gpio import rp2040_pin_to_code  # noqa
+from .gpio import rp2040_pin_to_code  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)
 CODEOWNERS = ["@jesserockz"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ select = [
   "LOG",  # flake8-logging
   "NPY",  # numpy-specific rules
   "PERF", # performance
+  "PGH",  # pygrep-hooks
   "PL",   # pylint
   "PYI",  # flake8-pyi
   "Q",    # flake8-quotes


### PR DESCRIPTION
# What does this implement/fix?

Enables the PGH ruff family; 11 PGH004 violations existed. Bare `# noqa` directives are replaced with the specific code they suppress (mostly `F401` on side-effect gpio imports, plus the `# noqa: F401` on the `esphome/components/light/__init__.py` re-exports), the dead ones are dropped, and the file-level `# flake8: noqa` in `esphome/components/libretiny/generate_components.py` becomes `# ruff: noqa: C408, I001` (the two `repl = lambda m: ...` assignments are inlined into the `re.sub(...)` call so E731 no longer fires, leaving C408 from the `dict(KEY=value, ...)` substitution-builders and I001 from the import sort the generator wants).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
