### PR TITLE
[core] Enable ruff B (flake8-bugbear) lint family

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -608,7 +608,7 @@ def run_miniterm(config: ConfigType, port: str, args) -> int:
 
     try:
         module = importlib.import_module("esphome.components." + CORE.target_platform)
-        process_stacktrace = getattr(module, "process_stacktrace")
+        process_stacktrace = module.process_stacktrace
     except (AttributeError, ImportError):
         _LOGGER.info(
             'Stacktrace analysis is unavailable: no compatible analyzer found for target platform "%s".',
@@ -1101,7 +1101,7 @@ def upload_program(
     host = devices[0]
     try:
         module = importlib.import_module("esphome.components." + CORE.target_platform)
-        if getattr(module, "upload_program")(config, args, host):
+        if module.upload_program(config, args, host):
             return 0, host
     except AttributeError:
         pass
@@ -1353,7 +1353,7 @@ def _validate_bootloader_binary(binary: Path) -> None:
 def show_logs(config: ConfigType, args: ArgsProtocol, devices: list[str]) -> int | None:
     try:
         module = importlib.import_module("esphome.components." + CORE.target_platform)
-        if getattr(module, "show_logs")(config, args, devices):
+        if module.show_logs(config, args, devices):
             return 0
     except AttributeError:
         pass

--- a/esphome/analyze_memory/cli.py
+++ b/esphome/analyze_memory/cli.py
@@ -509,7 +509,7 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
             lines.append(
                 f"{_COMPONENT_CORE} Symbols > {self.SYMBOL_SIZE_THRESHOLD} B ({len(large_core_symbols)} symbols):"
             )
-            for i, (symbol, demangled, size) in enumerate(large_core_symbols):
+            for i, (_symbol, demangled, size) in enumerate(large_core_symbols):
                 # Core symbols only track (symbol, demangled, size) without section info,
                 # so we don't show section labels here
                 lines.append(
@@ -601,7 +601,7 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
                 lines.append(
                     f"{comp_name} Symbols > {self.SYMBOL_SIZE_THRESHOLD} B & storage ({len(large_symbols)} symbols):"
                 )
-                for i, (symbol, demangled, size, section) in enumerate(large_symbols):
+                for i, (_symbol, demangled, size, section) in enumerate(large_symbols):
                     lines.append(
                         f"{i + 1}. {self._format_symbol_with_section(demangled, size, section)}"
                     )
@@ -640,7 +640,7 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
                 lines.append(
                     f"  Symbols > {self.RAM_SYMBOL_SIZE_THRESHOLD} B ({len(large_ram_syms)}):"
                 )
-                for symbol, demangled, size, section in large_ram_syms[:10]:
+                for _symbol, demangled, size, section in large_ram_syms[:10]:
                     # Format section label consistently by stripping leading dot
                     section_label = section.lstrip(".") if section else ""
                     display_name = _format_pstorage_name(demangled)

--- a/esphome/analyze_memory/demangle.py
+++ b/esphome/analyze_memory/demangle.py
@@ -154,7 +154,7 @@ def batch_demangle(
     failed_count = 0
 
     for original, stripped, prefix, demangled in zip(
-        symbols, symbols_stripped, symbols_prefixes, demangled_lines
+        symbols, symbols_stripped, symbols_prefixes, demangled_lines, strict=True
     ):
         # Add back any prefix that was removed
         demangled = _restore_symbol_prefix(prefix, stripped, demangled)

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -108,7 +108,7 @@ async def async_run_logs(
     platform_process_stacktrace = None
     try:
         module = importlib.import_module("esphome.components." + CORE.target_platform)
-        platform_process_stacktrace = getattr(module, "process_stacktrace")
+        platform_process_stacktrace = module.process_stacktrace
     except (AttributeError, ImportError):
         _LOGGER.info(
             'Stacktrace analysis is unavailable: no compatible analyzer found for target platform "%s".',

--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -594,7 +594,9 @@ async def to_code(config):
             x.height,
         ]
         for (x, y) in zip(
-            glyph_args, list(accumulate([len(x.bitmap_data) for x in glyph_args]))
+            glyph_args,
+            list(accumulate([len(x.bitmap_data) for x in glyph_args])),
+            strict=True,
         )
     ]
 

--- a/esphome/components/lvgl/lv_validation.py
+++ b/esphome/components/lvgl/lv_validation.py
@@ -239,7 +239,7 @@ def color_retmapper(value):
         else:
             r, g, b, _ = from_rgbw(cval)
         return literal(f"lv_color_make({r}, {g}, {b})")
-    assert False
+    raise AssertionError(f"Unhandled lv_color value: {value!r}")
 
 
 def option_string(value):

--- a/esphome/components/lvgl/widgets/tabview.py
+++ b/esphome/components/lvgl/widgets/tabview.py
@@ -97,7 +97,7 @@ class TabviewType(WidgetType):
                 tab_bar = Widget(bar_obj, obj_spec)
                 await set_obj_properties(tab_bar, tab_style)
                 if tab_items_style:
-                    for index, tab_conf in enumerate(config[CONF_TABS]):
+                    for index, _tab_conf in enumerate(config[CONF_TABS]):
                         await set_obj_properties(
                             Widget(lv_obj.get_child(bar_obj, index), button_spec),
                             tab_items_style,

--- a/esphome/components/msa3xx/binary_sensor.py
+++ b/esphome/components/msa3xx/binary_sensor.py
@@ -26,7 +26,7 @@ CONFIG_SCHEMA = MSA_SENSOR_SCHEMA.extend(
             ),
             key=CONF_NAME,
         )
-        for event, icon in zip(EVENT_SENSORS, ICONS)
+        for event, icon in zip(EVENT_SENSORS, ICONS, strict=True)
     }
 )
 

--- a/esphome/components/opentherm/output/__init__.py
+++ b/esphome/components/opentherm/output/__init__.py
@@ -21,7 +21,7 @@ async def new_openthermoutput(
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await output.register_output(var, config)
-    cg.add(getattr(var, "set_id")(cg.RawExpression(f'"{key}_{config[CONF_ID]}"')))
+    cg.add(var.set_id(cg.RawExpression(f'"{key}_{config[CONF_ID]}"')))
     input.generate_setters(var, config)
     return var
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -1192,7 +1192,7 @@ def _std(x):
 
 def _correlation_coeff(x, y):
     m_x, m_y = _mean(x), _mean(y)
-    s_xy = sum((x_ - m_x) * (y_ - m_y) for x_, y_ in zip(x, y))
+    s_xy = sum((x_ - m_x) * (y_ - m_y) for x_, y_ in zip(x, y, strict=True))
     s_sq_x = sum((x_ - m_x) ** 2 for x_ in x)
     s_sq_y = sum((y_ - m_y) ** 2 for y_ in y)
     return s_xy / math.sqrt(s_sq_x * s_sq_y)
@@ -1228,7 +1228,7 @@ def _mat_copy(m):
 
 
 def _mat_transpose(m):
-    return _mat_copy(zip(*m))
+    return _mat_copy(zip(*m, strict=True))
 
 
 def _mat_identity(n):
@@ -1237,7 +1237,10 @@ def _mat_identity(n):
 
 def _mat_dot(a, b):
     b_t = _mat_transpose(b)
-    return [[sum(x * y for x, y in zip(row_a, col_b)) for col_b in b_t] for row_a in a]
+    return [
+        [sum(x * y for x, y in zip(row_a, col_b, strict=True)) for col_b in b_t]
+        for row_a in a
+    ]
 
 
 def _mat_inverse(m):

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -1081,7 +1081,7 @@ class EnumValue:
 
     @enum_value.setter
     def enum_value(self, value):
-        setattr(self, "_enum_value", value)
+        self._enum_value = value
 
 
 CORE = EsphomeCore()

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -115,7 +115,7 @@ class MDNSStatus:
             results = await asyncio.gather(
                 *(self.aiozc.async_resolve_host(name) for name in poll_names)
             )
-            for name, address_list in zip(poll_names, results):
+            for name, address_list in zip(poll_names, results, strict=True):
                 result = bool(address_list)
                 host_mdns_state[name] = result
                 for entry in poll_names[name]:

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -83,7 +83,7 @@ class PingStatus:
                     return_exceptions=True,
                 )
 
-                for entry, result in zip(ping_group, dns_results):
+                for entry, result in zip(ping_group, dns_results, strict=True):
                     if isinstance(result, Exception):
                         # Only update state if its unknown or from ping
                         # so we don't mark it as offline if we have a state
@@ -106,7 +106,7 @@ class PingStatus:
                     return_exceptions=True,
                 )
 
-                for entry_addresses, result in zip(entry_addresses, results):
+                for entry_address, result in zip(entry_addresses, results, strict=True):
                     if isinstance(result, Exception):
                         ping_result = False
                     elif isinstance(result, BaseException):
@@ -114,7 +114,7 @@ class PingStatus:
                     else:
                         host: Host = result
                         ping_result = host.is_alive
-                    entry: DashboardEntry = entry_addresses[0]
+                    entry: DashboardEntry = entry_address[0]
                     # If we can reach it via ping, we always set it
                     # online, however if we can't reach it via ping
                     # we only set it to offline if the state is unknown

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -1030,7 +1030,7 @@ class DownloadListRequestHandler(BaseHandler):
 
         try:
             module = importlib.import_module(f"esphome.components.{platform}")
-            get_download_types = getattr(module, "get_download_types")
+            get_download_types = module.get_download_types
         except AttributeError as exc:
             raise ValueError(f"Unknown platform {platform}") from exc
         downloads = get_download_types(storage_json)
@@ -1146,7 +1146,7 @@ class MainRequestHandler(BaseHandler):
         begin = bool(self.get_argument("begin", False))
         if settings.using_password:
             # Simply accessing the xsrf_token sets the cookie for us
-            self.xsrf_token  # pylint: disable=pointless-statement
+            self.xsrf_token  # pylint: disable=pointless-statement  # noqa: B018
         else:
             self.clear_cookie("_xsrf")
 
@@ -1519,7 +1519,10 @@ def get_static_file_url(name: str) -> str:
     return f"{base}?hash={hash_}"
 
 
-def make_app(debug=get_bool_env(ENV_DEV)) -> tornado.web.Application:
+def make_app(debug: bool | None = None) -> tornado.web.Application:
+    if debug is None:
+        debug = get_bool_env(ENV_DEV)
+
     def log_function(handler: tornado.web.RequestHandler) -> None:
         if handler.get_status() < 400:
             log_method = access_log.info

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -358,7 +358,7 @@ def copy_src_tree():
     platform = "esphome.components." + CORE.target_platform
     try:
         module = importlib.import_module(platform)
-        copy_files = getattr(module, "copy_files")
+        copy_files = module.copy_files
         copy_files()
     except AttributeError:
         pass

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -249,7 +249,7 @@ async def async_resolve_hosts(
             ),
             return_exceptions=True,
         )
-        for host, result in zip(pending, results):
+        for host, result in zip(pending, results, strict=True):
             if isinstance(result, BaseException):
                 _LOGGER.debug("Failed to resolve %s: %s", host, result)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ exclude = ['generated']
 
 [tool.ruff.lint]
 select = [
+  "B",    # flake8-bugbear
   "C4",   # flake8-comprehensions
   "E",    # pycodestyle
   "EXE",  # flake8-executable

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -3551,7 +3551,7 @@ static const char *const TAG = "api.service";
         if id_ is not None and not mt.options.deprecated:
             id_to_msg_name[id_] = mt.name
 
-    for id_, (_, _, case_label) in cases:
+    for id_, (_, _, _case_label) in cases:
         msg_name = id_to_msg_name.get(id_, "")
         if msg_name in message_auth_map:
             needs_auth = message_auth_map[msg_name]
@@ -3614,7 +3614,7 @@ static const char *const TAG = "api.service";
 
     # Dispatch switch
     out += "  switch (msg_type) {\n"
-    for i, (case, ifdef, case_label) in cases:
+    for _i, (case, ifdef, case_label) in cases:
         if ifdef is not None:
             out += _make_ifdef_line(ifdef) + "\n"
 

--- a/script/build_language_schema.py
+++ b/script/build_language_schema.py
@@ -972,7 +972,7 @@ def convert(schema, config_var, path):
             }
         elif schema_type == "use_id":
             if inspect.ismodule(data):
-                m_attr_obj = getattr(data, "CONFIG_SCHEMA")
+                m_attr_obj = data.CONFIG_SCHEMA
                 use_schema = known_schemas.get(repr(m_attr_obj))
                 if use_schema:
                     [output_module, output_name] = use_schema[0][1].split(".")

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -342,8 +342,8 @@ def lint_const_ordered(fname, content):
             (i + 1, line) for i, line in enumerate(lines) if line.startswith(start)
         ]
         ordered = sorted(matching, key=lambda x: x[1].replace("_", " "))
-        ordered = [(mi, ol) for (mi, _), (_, ol) in zip(matching, ordered)]
-        for (mi, mline), (_, ol) in zip(matching, ordered):
+        ordered = [(mi, ol) for (mi, _), (_, ol) in zip(matching, ordered, strict=True)]
+        for (mi, mline), (_, ol) in zip(matching, ordered, strict=True):
             if mline == ol:
                 continue
             target = next(i for i, line in ordered if line == mline)

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -1047,7 +1047,7 @@ def detect_memory_impact_config(
     # Find common platforms supported by ALL components
     # This ensures we can build all components together in a merged config
     common_platforms = set(MEMORY_IMPACT_PLATFORM_PREFERENCE)
-    for component, platforms in component_platforms_map.items():
+    for platforms in component_platforms_map.values():
         common_platforms &= platforms
 
     # Select the most preferred platform from the common set

--- a/script/split_components_for_ci.py
+++ b/script/split_components_for_ci.py
@@ -295,7 +295,7 @@ def main() -> int:
     # Sort groups by signature for readability
     groupable_groups = []
     isolated_groups = []
-    for (platform, signature), group_comps in sorted(signature_groups.items()):
+    for (_platform, signature), group_comps in sorted(signature_groups.items()):
         if signature.startswith(ISOLATED_SIGNATURE_PREFIX):
             isolated_groups.append((signature, group_comps))
         else:

--- a/script/test_build_components.py
+++ b/script/test_build_components.py
@@ -890,7 +890,7 @@ def run_grouped_component_tests(
     print("=" * 80 + "\n")
 
     # Execute grouped tests
-    for (platform, signature), components in grouped_components.items():
+    for (platform, _signature), components in grouped_components.items():
         # Only group if we have multiple components with same signature
         if len(components) <= 1:
             continue
@@ -1055,7 +1055,7 @@ def test_components(
 
         # Create empty test files for each platform (or filtered platform)
         reference_tests: list[Path] = []
-        for platform_name, base_file in platform_bases.items():
+        for platform_name in platform_bases:
             if platform_filter and not platform_name.startswith(platform_filter):
                 continue
             # Create an empty test file named to match the platform

--- a/tests/component_tests/display/test_display_metadata.py
+++ b/tests/component_tests/display/test_display_metadata.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from esphome.components.display import (
     DisplayMetaData,
     add_metadata,
@@ -74,8 +76,5 @@ def test_add_metadata_overwrites_existing():
 def test_metadata_is_frozen():
     """Test that DisplayMetaData instances are immutable (frozen dataclass)."""
     meta = DisplayMetaData(320, 240, True, False)
-    try:
+    with pytest.raises(AttributeError):
         meta.width = 640
-        assert False, "Expected FrozenInstanceError"
-    except AttributeError:
-        pass

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -510,15 +510,9 @@ def test_package_merge_by_missing_id() -> None:
         ],
     }
 
-    error_raised = False
-    try:
+    with pytest.raises(cv.Invalid) as exc_info:
         packages_pass(config)
-        assert False, "Expected validation error for missing ID"
-    except cv.Invalid as err:
-        error_raised = True
-        assert err.path == [CONF_SENSOR, 2]
-
-    assert error_raised
+    assert exc_info.value.path == [CONF_SENSOR, 2]
 
 
 def test_package_list_remove_by_id() -> None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -407,8 +407,10 @@ async def wait_and_connect_api_client(
         # Wait for connection with timeout
         try:
             await asyncio.wait_for(connected_future, timeout=timeout)
-        except TimeoutError:
-            raise TimeoutError(f"Failed to connect to API after {timeout} seconds")
+        except TimeoutError as err:
+            raise TimeoutError(
+                f"Failed to connect to API after {timeout} seconds"
+            ) from err
 
         if return_disconnect_event:
             yield client, disconnect_event

--- a/tests/unit_tests/test_config_normalization.py
+++ b/tests/unit_tests/test_config_normalization.py
@@ -67,7 +67,7 @@ def test_iter_component_configs_with_multi_conf(mock_get_component: Mock) -> Non
     configs = list(config.iter_component_configs(test_config))
     assert len(configs) == 2
 
-    for domain, component, conf in configs:
+    for domain, _component, conf in configs:
         assert domain == "switch"
         assert "name" in conf
 


### PR DESCRIPTION
# What does this implement/fix?

Enables the B ruff family; 39 violations cleaned up. Auto-fix swaps 9 getattr/setattr-on-constant calls for direct attribute access, 11 unused loop variables get an underscore prefix (two of those then prefer .values() / iter-over-keys to satisfy PERF102), and 12 zip() loops gain explicit strict=True since both sides are derived from the same source. The lvgl color helper assert False is replaced with raise AssertionError; the two test-side assert False patterns become pytest.raises. The integration conftest raises with from err inside its TimeoutError handler, the shadowed entry_addresses loop variable in the dashboard ping watcher is renamed, the xsrf_token side-effect access in the dashboard handler gets a # noqa: B018 with the existing pylint comment kept, and make_app now resolves the ENV_DEV default inside the function rather than at module-import time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).