### PR TITLE
[core] Enable ruff BLE (flake8-blind-except) lint family

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1800,7 +1800,7 @@ def command_analyze_memory(args: ArgsProtocol, config: ConfigType) -> int:
         ram_report = ram_analyzer.generate_report()
         print()
         print(ram_report)
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as e:  # noqa: BLE001  # pylint: disable=broad-except
         _LOGGER.warning("RAM strings analysis failed: %s", e)
 
     return 0

--- a/esphome/async_thread.py
+++ b/esphome/async_thread.py
@@ -45,7 +45,7 @@ class AsyncThreadRunner(threading.Thread, Generic[_T]):
     async def _runner(self) -> None:
         try:
             self.result = await self._coro_factory()
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
             # Capture all exceptions so ``event`` is always set — otherwise a
             # crash would hang the waiter forever.
             self.exception = exc

--- a/esphome/compiled_config.py
+++ b/esphome/compiled_config.py
@@ -43,7 +43,7 @@ def save_compiled_config(config: ConfigType) -> None:
     try:
         rendered = yaml_util.dump(config, show_secrets=True)
         write_file(compiled_config_path(CORE.config_filename), rendered, private=True)
-    except Exception as err:  # pylint: disable=broad-except
+    except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
         _LOGGER.debug("Skipping compiled config cache write: %s", err)
 
 
@@ -62,7 +62,7 @@ def load_compiled_config(conf_path: Path) -> ConfigType | None:
 
     try:
         config = yaml_util.load_yaml(cache_path, clear_secrets=False)
-    except Exception:  # pylint: disable=broad-except
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-except
         return None
 
     storage = StorageJSON.load(ext_storage_path(conf_path.name))

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2683,7 +2683,7 @@ def _decode_pc(config, addr):
     command = [str(addr2line_path), "-pfiaC", "-e", str(firmware_elf_path), addr]
     try:
         translation = subprocess.check_output(command, close_fds=False).decode().strip()
-    except Exception:  # pylint: disable=broad-except
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-except
         _LOGGER.debug("Caught exception for command %s", command, exc_info=1)
         return
 

--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -472,7 +472,7 @@ def _decode_pc(config, addr):
     command = [idedata.addr2line_path, "-pfiaC", "-e", idedata.firmware_elf_path, addr]
     try:
         translation = subprocess.check_output(command, close_fds=False).decode().strip()
-    except Exception:  # pylint: disable=broad-except
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-except
         _LOGGER.debug("Caught exception for command %s", command, exc_info=1)
         return
 

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -535,7 +535,7 @@ def _addr2line(addr2line: str, elf: Path, addr: str) -> str:
             check=True,
         )
         return result.stdout.strip().splitlines()[0]
-    except Exception as err:  # pylint: disable=broad-except
+    except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
         _LOGGER.error("Running command failed: %s", err)
     return ""
 

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -1379,7 +1379,7 @@ class LoginHandler(BaseHandler):
         loop = asyncio.get_running_loop()
         try:
             req = await loop.run_in_executor(None, self._make_supervisor_auth_request)
-        except Exception as err:  # pylint: disable=broad-except
+        except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
             _LOGGER.warning("Error during Hass.io auth request: %s", err)
             self.set_status(500)
             self.render_login_page(error="Internal server error")

--- a/esphome/espidf/extra_script.py
+++ b/esphome/espidf/extra_script.py
@@ -120,7 +120,7 @@ def run_extra_script(
                 "__name__": "__pio_extra_script__",
             },
         )
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         _LOGGER.warning("PIO extra-script %s raised %s; skipping", script_path, e)
         return ExtraScriptResult()
     finally:

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -775,7 +775,7 @@ def download_from_mirrors(
                 f.seek(0)
                 return url
 
-            except Exception as e:  # pylint: disable=broad-exception-caught
+            except Exception as e:  # noqa: BLE001  # pylint: disable=broad-exception-caught
                 _LOGGER.debug("Failed to download %s: %s", url, str(e))
                 last_exception = e
 

--- a/esphome/platformio/runner.py
+++ b/esphome/platformio/runner.py
@@ -94,7 +94,7 @@ def patch_file_downloader() -> None:
                             self._http_response.close()
                         if hasattr(self, "_http_session"):
                             self._http_session.close()
-                    except Exception:
+                    except Exception:  # noqa: BLE001
                         pass
                     # pylint: enable=protected-access,broad-except
                     time.sleep(delay)

--- a/esphome/storage_json.py
+++ b/esphome/storage_json.py
@@ -267,7 +267,7 @@ class StorageJSON:
     def load(path: Path) -> StorageJSON | None:
         try:
             return StorageJSON._load_impl(path)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:  # noqa: BLE001  # pylint: disable=broad-except
             return None
 
     def apply_to_core(self) -> None:
@@ -339,7 +339,7 @@ class EsphomeStorageJSON:
     def last_update_check(self) -> datetime | None:
         try:
             return datetime.strptime(self.last_update_check_str, "%Y-%m-%dT%H:%M:%S")
-        except Exception:  # pylint: disable=broad-except
+        except Exception:  # noqa: BLE001  # pylint: disable=broad-except
             return None
 
     @last_update_check.setter
@@ -368,7 +368,7 @@ class EsphomeStorageJSON:
     def load(path: str) -> EsphomeStorageJSON | None:
         try:
             return EsphomeStorageJSON._load_impl(path)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:  # noqa: BLE001  # pylint: disable=broad-except
             return None
 
     @staticmethod

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -271,7 +271,7 @@ def run_external_command(
         raise
     except SystemExit as err:
         return err.args[0]
-    except Exception as err:  # pylint: disable=broad-except
+    except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
         _LOGGER.error("Running command failed: %s", err)
         _LOGGER.error("Please try running %s locally.", full_cmd)
         return 1
@@ -318,7 +318,7 @@ def run_external_process(*cmd: str, **kwargs: Any) -> int | str:
         return proc.stdout if capture_stdout else proc.returncode
     except KeyboardInterrupt:  # pylint: disable=try-except-raise
         raise
-    except Exception as err:  # pylint: disable=broad-except
+    except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
         _LOGGER.error("Running command failed: %s", err)
         _LOGGER.error("Please try running %s locally.", full_cmd)
         return 1

--- a/esphome/vscode.py
+++ b/esphome/vscode.py
@@ -134,13 +134,13 @@ def read_config(args):
         try:
             config = loader(file_name)
             res = validate_config(config, command_line_substitutions)
-        except Exception as err:  # pylint: disable=broad-except
+        except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
             vs.add_yaml_error(str(err))
         else:
             for err in res.errors:
                 try:
                     range_ = _get_invalid_range(res, err)
                     vs.add_validation_error(range_, _format_vol_invalid(err, res))
-                except Exception:  # pylint: disable=broad-except
+                except Exception:  # noqa: BLE001  # pylint: disable=broad-except
                     continue
         print(vs.dump())

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -342,7 +342,7 @@ async def async_discover_mdns_devices(
     )
     try:
         aiozc = AsyncEsphomeZeroconf()
-    except Exception as err:  # pylint: disable=broad-except
+    except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
         # Zeroconf init can raise OSError, NonUniqueNameException, etc.
         # Any failure here just means we can't discover — log and move on.
         _LOGGER.warning("mDNS discovery failed to initialize: %s", err)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ exclude = ['generated']
 [tool.ruff.lint]
 select = [
   "B",    # flake8-bugbear
+  "BLE",  # flake8-blind-except
   "C4",   # flake8-comprehensions
   "E",    # pycodestyle
   "EXE",  # flake8-executable

--- a/script/analyze_component_buses.py
+++ b/script/analyze_component_buses.py
@@ -128,7 +128,7 @@ def uses_local_file_references(component_dir: Path) -> bool:
 
     try:
         content = common_yaml.read_text()
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         return False
 
     # Pattern to match $component_dir or ${component_dir} references
@@ -164,7 +164,7 @@ def is_platform_component(component_dir: Path) -> bool:
     try:
         content = comp_init.read_text()
         return "IS_PLATFORM_COMPONENT = True" in content
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         return False
 
 
@@ -222,7 +222,7 @@ def analyze_yaml_file(yaml_file: Path) -> dict[str, Any]:
     try:
         data = yaml_util.load_yaml(yaml_file)
         result["loaded"] = True
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         return result
 
     # Check for Extend/Remove objects

--- a/script/build_helpers.py
+++ b/script/build_helpers.py
@@ -392,7 +392,7 @@ def compile_and_get_binary(
         if exit_code != 0:
             print(f"Error compiling {label} for {', '.join(components)}")
             return exit_code, None
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"Error compiling {label} for {', '.join(components)}: {e}")
         return EXIT_COMPILE_ERROR, None
 

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -312,7 +312,7 @@ def _is_clang_tidy_full_scan() -> bool:
         )
         # Exit 0 means hash changed (full scan needed)
         return result.returncode == 0
-    except Exception:
+    except Exception:  # noqa: BLE001
         # If hash check fails, run full scan to be safe
         return True
 

--- a/script/merge_component_configs.py
+++ b/script/merge_component_configs.py
@@ -437,7 +437,7 @@ def main() -> None:
             tests_dir=args.tests_dir,
             output_file=args.output,
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"Error merging configs: {e}", file=sys.stderr)
         import traceback
 

--- a/script/stress_test_connect.py
+++ b/script/stress_test_connect.py
@@ -21,7 +21,7 @@ async def connect_disconnect(client_id: int, iteration: int) -> tuple[int, bool,
         await asyncio.wait_for(cli.connect(login=True), timeout=10)
         await cli.disconnect()
         return iteration, True, ""
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return (
             iteration,
             False,

--- a/script/test_component_grouping.py
+++ b/script/test_component_grouping.py
@@ -63,7 +63,7 @@ def test_component_group(
     try:
         result = subprocess.run(cmd, check=False)
         return result.returncode == 0
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"Error running test: {e}")
         return False
 

--- a/tests/integration/test_syslog.py
+++ b/tests/integration/test_syslog.py
@@ -110,7 +110,7 @@ async def syslog_udp_listener() -> AsyncGenerator[tuple[int, SyslogReceiver]]:
                     receiver.on_message(msg)
             except BlockingIOError:
                 await asyncio.sleep(0.01)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 break
 
     task = asyncio.create_task(receive_messages())

--- a/tests/integration/test_udp.py
+++ b/tests/integration/test_udp.py
@@ -80,7 +80,7 @@ async def udp_listener(port: int = 0) -> AsyncGenerator[tuple[int, UDPReceiver]]
                     receiver.on_message(data)
             except BlockingIOError:
                 await asyncio.sleep(0.01)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 break
 
     task = asyncio.create_task(receive_messages())


### PR DESCRIPTION
# What does this implement/fix?

Enables the BLE ruff family; all 29 BLE001 sites in the tree are intentional broad-catch wrappers (most already carry `# pylint: disable=broad-except` or `# pylint: disable=broad-exception-caught`) so a single component failure does not bring down the tool. Each one gets an inline `# noqa: BLE001`, kept alongside the existing pylint disable where present, rather than narrowing the `except` clause.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
