### PR TITLE
[lvgl] Support `rounded` property for meter arcs

### DIFF
--- a/esphome/components/lvgl/widgets/meter.py
+++ b/esphome/components/lvgl/widgets/meter.py
@@ -184,6 +184,7 @@ INDICATOR_ARC_SCHEMA = cv.Schema(
         cv.Optional(CONF_START_VALUE): lv_float,
         cv.Optional(CONF_END_VALUE): lv_float,
         cv.Optional(CONF_OPA, default=1.0): opacity,
+        cv.Optional(CONF_ROUNDED, default=False): cv.boolean,
     }
 ).add_extra(cv.has_at_most_one_key(CONF_VALUE, CONF_START_VALUE))
 
@@ -417,7 +418,7 @@ class MeterType(WidgetType):
                         "arc_width": v[CONF_WIDTH],
                         "arc_color": v[CONF_COLOR],
                         "arc_opa": v[CONF_OPA],
-                        "arc_rounded": v.get("arc_rounded", False),
+                        "arc_rounded": v[CONF_ROUNDED],
                     }
                     if CONF_R_MOD in v:
                         get_warnings().add(

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -1313,6 +1313,7 @@ lvgl:
                                 width: 6
                                 start_value: 0
                                 end_value: 360
+                                rounded: true
     - id: page3
       layout: Horizontal
       pad_all: 6px


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1508492635612909648

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6693

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

  - meter:
      id: temp_meter
      align: center
      height: 200
      width: 200
      border_width: 0
      bg_opa: 0
      scales:
        - angle_range: 270
          range_from: 50
          range_to: 90
          indicators:
            - arc:
                id: cooling_arc
                start_value: 75
                end_value: 80
                color: 0x5555bb
                width: 8
                rounded: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
