### PR TITLE
[neopixelbus] Deprecate on ESP32

### DIFF
--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -24,6 +24,7 @@ from esphome.const import (
     Framework,
 )
 from esphome.core import CORE
+from esphome.types import ConfigType
 
 from ._methods import (
     METHOD_BIT_BANG,
@@ -138,7 +139,7 @@ def _validate(config):
     return config
 
 
-def _warn_esp32_deprecated(config):
+def _warn_esp32_deprecated(config: ConfigType) -> ConfigType:
     if CORE.is_esp32:
         _LOGGER.warning(
             "'neopixelbus' on ESP32 is deprecated. The upstream library "

--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -138,6 +138,17 @@ def _validate(config):
     return config
 
 
+def _warn_esp32_deprecated(config):
+    if CORE.is_esp32:
+        _LOGGER.warning(
+            "'neopixelbus' on ESP32 is deprecated. The upstream library "
+            "(makuna/NeoPixelBus) is no longer actively maintained. Migrate "
+            "to 'esp32_rmt_led_strip'. Removal is targeted for 2027.1 but "
+            "may happen sooner once ESPHome moves to ESP-IDF 6."
+        )
+    return config
+
+
 def _validate_method(value):
     if value is None:
         # default method is determined afterwards because it depends on the chip type chosen
@@ -199,6 +210,7 @@ CONFIG_SCHEMA = cv.All(
     ).extend(cv.COMPONENT_SCHEMA),
     _choose_default_method,
     _validate,
+    _warn_esp32_deprecated,
 )
 
 
@@ -245,12 +257,6 @@ async def to_code(config):
     # https://github.com/Makuna/NeoPixelBus/blob/master/library.json
     # Version Listed Here: https://registry.platformio.org/libraries/makuna/NeoPixelBus/versions
     if CORE.is_esp32:
-        _LOGGER.warning(
-            "'neopixelbus' on ESP32 is deprecated. The upstream library "
-            "(makuna/NeoPixelBus) is no longer actively maintained. Migrate "
-            "to 'esp32_rmt_led_strip'. Removal is targeted for 2027.1 but "
-            "may happen sooner once ESPHome moves to ESP-IDF 6."
-        )
         # disable built in rgb support as it uses the new RMT drivers and will
         # conflict with NeoPixelBus which uses the legacy drivers
         cg.add_build_flag("-DESP32_ARDUINO_NO_RGB_BUILTIN")

--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -1,3 +1,5 @@
+import logging
+
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import light
@@ -33,6 +35,8 @@ from ._methods import (
     METHODS,
 )
 from .const import CHIP_TYPES, CONF_ASYNC, CONF_BUS, ONE_WIRE_CHIPS
+
+_LOGGER = logging.getLogger(__name__)
 
 neopixelbus_ns = cg.esphome_ns.namespace("neopixelbus")
 NeoPixelBusLightOutputBase = neopixelbus_ns.class_(
@@ -241,6 +245,12 @@ async def to_code(config):
     # https://github.com/Makuna/NeoPixelBus/blob/master/library.json
     # Version Listed Here: https://registry.platformio.org/libraries/makuna/NeoPixelBus/versions
     if CORE.is_esp32:
+        _LOGGER.warning(
+            "'neopixelbus' on ESP32 is deprecated. The upstream library "
+            "(makuna/NeoPixelBus) is no longer actively maintained. Migrate "
+            "to 'esp32_rmt_led_strip'. Removal is targeted for 2027.1 but "
+            "may happen sooner once ESPHome moves to ESP-IDF 6."
+        )
         # disable built in rgb support as it uses the new RMT drivers and will
         # conflict with NeoPixelBus which uses the legacy drivers
         cg.add_build_flag("-DESP32_ARDUINO_NO_RGB_BUILTIN")


### PR DESCRIPTION
# What does this implement/fix?

Emit a deprecation warning when `neopixelbus` is used on ESP32 and direct users to
[`esp32_rmt_led_strip`](https://esphome.io/components/light/esp32_rmt_led_strip/). The upstream
[makuna/NeoPixelBus](https://github.com/Makuna/NeoPixelBus/) library is no longer actively maintained, and it
fails to build on top of ESP-IDF 6.

ESP8266 is not affected — the library still works there and there is no equivalent native ESPHome alternative.

Removal targeted for 2027.1; may happen sooner once ESPHome moves to ESP-IDF 6.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other (deprecation notice)

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6698

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

```yaml
# Any existing neopixelbus config on ESP32 will now emit:
#
#   WARNING 'neopixelbus' on ESP32 is deprecated. The upstream library
#   (makuna/NeoPixelBus) is no longer actively maintained. Migrate to
#   'esp32_rmt_led_strip'. Removal is targeted for 2027.1 but may happen
#   sooner once ESPHome moves to ESP-IDF 6.

light:
  - platform: neopixelbus
    type: GRB
    variant: WS2811
    pin: GPIO13
    num_leds: 60
    name: "NeoPixel Light"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).