### PR TITLE
[core] Mark canonical sensitive fields with cv.sensitive

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -234,7 +234,7 @@ ACTIONS_SCHEMA = automation.validate_automation(
 
 ENCRYPTION_SCHEMA = cv.Schema(
     {
-        cv.Optional(CONF_KEY): validate_encryption_key,
+        cv.Optional(CONF_KEY): cv.sensitive(validate_encryption_key),
     }
 )
 

--- a/esphome/components/esphome/ota/__init__.py
+++ b/esphome/components/esphome/ota/__init__.py
@@ -133,7 +133,7 @@ CONFIG_SCHEMA = cv.All(
                 host=8082,
             ): cv.port,
             cv.Optional(CONF_ALLOW_PARTITION_ACCESS, default=False): cv.boolean,
-            cv.Optional(CONF_PASSWORD): cv.string,
+            cv.Optional(CONF_PASSWORD): cv.sensitive(),
             cv.Optional(CONF_NUM_ATTEMPTS): cv.invalid(
                 f"'{CONF_SAFE_MODE}' (and its related configuration variables) has moved from 'ota' to its own component. See https://esphome.io/components/safe_mode"
             ),

--- a/esphome/components/http_request/ota/__init__.py
+++ b/esphome/components/http_request/ota/__init__.py
@@ -57,7 +57,7 @@ OTA_HTTP_REQUEST_FLASH_ACTION_SCHEMA = cv.All(
             cv.Optional(CONF_MD5): cv.templatable(
                 cv.All(cv.string, cv.Length(min=32, max=32))
             ),
-            cv.Optional(CONF_PASSWORD): cv.templatable(cv.string),
+            cv.Optional(CONF_PASSWORD): cv.sensitive(cv.templatable(cv.string)),
             cv.Optional(CONF_USERNAME): cv.templatable(cv.string),
             cv.Required(CONF_URL): cv.templatable(cv.url),
         }

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -232,7 +232,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
             cv.Optional(CONF_PORT, default=1883): cv.port,
             cv.Optional(CONF_USERNAME, default=""): cv.string,
-            cv.Optional(CONF_PASSWORD, default=""): cv.string,
+            cv.Optional(CONF_PASSWORD, default=""): cv.sensitive(),
             cv.Optional(CONF_CLEAN_SESSION, default=False): cv.boolean,
             cv.Optional(CONF_CLIENT_ID): cv.string,
             cv.SplitDefault(CONF_IDF_SEND_ASYNC, esp32=False): cv.All(

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -193,8 +193,8 @@ CONFIG_SCHEMA = cv.All(
                     cv.Required(CONF_USERNAME): cv.All(
                         cv.string_strict, cv.Length(min=1)
                     ),
-                    cv.Required(CONF_PASSWORD): cv.All(
-                        cv.string_strict, cv.Length(min=1)
+                    cv.Required(CONF_PASSWORD): cv.sensitive(
+                        cv.All(cv.string_strict, cv.Length(min=1))
                     ),
                 }
             ),

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -251,7 +251,7 @@ EAP_AUTH_SCHEMA = cv.All(
         {
             cv.Optional(CONF_IDENTITY): cv.string_strict,
             cv.Optional(CONF_USERNAME): cv.string_strict,
-            cv.Optional(CONF_PASSWORD): cv.string_strict,
+            cv.Optional(CONF_PASSWORD): cv.sensitive(cv.string_strict),
             cv.Optional(CONF_CERTIFICATE_AUTHORITY): wpa2_eap.validate_certificate,
             cv.SplitDefault(CONF_TTLS_PHASE_2, esp32="mschapv2"): cv.All(
                 cv.enum(TTLS_PHASE_2), cv.only_on_esp32
@@ -272,7 +272,7 @@ WIFI_NETWORK_BASE = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(WiFiAP),
         cv.Optional(CONF_SSID): cv.ssid,
-        cv.Optional(CONF_PASSWORD): validate_password,
+        cv.Optional(CONF_PASSWORD): cv.sensitive(validate_password),
         cv.Optional(CONF_CHANNEL): validate_channel,
         cv.Optional(CONF_MANUAL_IP): STA_MANUAL_IP_SCHEMA,
     }
@@ -449,7 +449,7 @@ CONFIG_SCHEMA = cv.All(
                 cv.ensure_list(WIFI_NETWORK_STA), cv.Length(max=MAX_WIFI_NETWORKS)
             ),
             cv.Optional(CONF_SSID): cv.ssid,
-            cv.Optional(CONF_PASSWORD): validate_password,
+            cv.Optional(CONF_PASSWORD): cv.sensitive(validate_password),
             cv.Optional(CONF_MANUAL_IP): STA_MANUAL_IP_SCHEMA,
             cv.Optional(CONF_EAP): EAP_AUTH_SCHEMA,
             cv.Optional(CONF_AP): wifi_network_ap,
@@ -865,7 +865,7 @@ async def final_step():
     cv.Schema(
         {
             cv.Required(CONF_SSID): cv.templatable(cv.ssid),
-            cv.Required(CONF_PASSWORD): cv.templatable(validate_password),
+            cv.Required(CONF_PASSWORD): cv.sensitive(cv.templatable(validate_password)),
             cv.Optional(CONF_SAVE, default=True): cv.templatable(cv.boolean),
             cv.Optional(CONF_TIMEOUT, default="30000ms"): cv.templatable(
                 cv.positive_time_period_milliseconds


### PR DESCRIPTION
# What does this implement/fix?

Migrates the most obvious secret-bearing fields in core components to use the `cv.sensitive(...)` marker added in #16673, so the schema JSON dump emits `"sensitive": true, "sensitive_source": "explicit"` for them. The device builder UI can then mask these inputs deterministically without falling back to the key-name heuristic.

Fields tagged in this PR:

- `api.encryption.key`
- `wifi.password`, `wifi.ap.password`, `wifi.networks[].password`, `wifi.networks[].eap.password`
- `wifi.configure` action `password`
- `ota.password` for the `esphome` and `http_request` OTA platforms

Validation semantics are unchanged; `cv.sensitive` is a transparent wrapper that delegates to the inner validator.

A note on `api.encryption.key`: the marker is correctly placed on the validator, but the dump can't currently traverse the `_encryption_schema` function wrapper to surface it as `sensitive_source: explicit` in the JSON. That's a pre-existing schema-dump visibility limitation on the api component; the marker is still useful for any runtime introspection and is in place for when that gets fixed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- follow-up to #16673

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Existing user YAML is unchanged. Internally these fields now carry the
# cv.sensitive marker so the schema dump tags them as explicitly sensitive.
api:
  encryption:
    key: !secret api_encryption_key

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  ap:
    ssid: "Fallback"
    password: !secret fallback_password

ota:
  - platform: esphome
    password: !secret ota_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).