### PR TITLE
[core] Remove deprecated custom_components folder loading

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -1005,7 +1005,6 @@ def validate_config(
     CORE.skip_external_update = skip_external_update
 
     loader.clear_component_meta_finders()
-    loader.install_custom_components_meta_finder()
 
     # 0. Load packages
     if CONF_PACKAGES in config:

--- a/esphome/loader.py
+++ b/esphome/loader.py
@@ -12,7 +12,6 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any
 
 from esphome.const import SOURCE_FILE_EXTENSIONS
-from esphome.core import CORE
 from esphome.types import ConfigType
 
 if TYPE_CHECKING:
@@ -204,18 +203,6 @@ def install_meta_finder(
     components_path: Path, allowed_components: list[str] | None = None
 ):
     sys.meta_path.insert(0, ComponentMetaFinder(components_path, allowed_components))
-
-
-def install_custom_components_meta_finder():
-    # Remove before 2026.6.0
-    custom_components_dir = (Path(CORE.config_dir) / "custom_components").resolve()
-    if custom_components_dir.is_dir() and any(custom_components_dir.iterdir()):
-        _LOGGER.warning(
-            "The 'custom_components' folder is deprecated and will be removed in 2026.6.0. "
-            "Please use 'external_components' instead. "
-            "See https://esphome.io/components/external_components.html for more information."
-        )
-    install_meta_finder(custom_components_dir)
 
 
 def _lookup_module(domain: str, exception: bool) -> ComponentManifest | None:

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -200,8 +200,8 @@ ESPHome automatically populates the build directory, and any
 changes to this directory will be removed the next time esphome is
 run.
 
-For modifying esphome's core files, please use a development esphome install,
-the custom_components folder or the external_components feature.
+For modifying esphome's core files, please use a development esphome install
+or the external_components feature.
 """
 
 


### PR DESCRIPTION
# What does this implement/fix?

Removes the `custom_components/` folder auto-loader, deprecated since 2025.6 with a removal target of 2026.6.0
(see `loader.py` deprecation warning). Users should use the
[`external_components`](https://esphome.io/components/external_components.html) feature.

- Drop `install_custom_components_meta_finder()` from `esphome/loader.py` and its single call site in
  `esphome/config.py`.
- Drop the now-unused `CORE` import in `esphome/loader.py`.
- Drop the `custom_components` mention from the generated build-directory README in `esphome/writer.py`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Scheduled removal per the 2025.12.0 `ESPDEPRECATED` cycle.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a (the migration target — `external_components` — is already documented).

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

(Removal is platform-independent — it only affects the Python config-loader path.)

## Example entry for `config.yaml`:

n/a (removal only).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).