### PR TITLE
[core] Remove deprecated const char* mark_failed/status_set_error

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -32,10 +32,7 @@ static const char *const TAG = "component";
 namespace {
 struct ComponentErrorMessage {
   const Component *component;
-  const char *message;
-  // Track if message is flash pointer (needs LOG_STR_ARG) or RAM pointer
-  // Remove before 2026.6.0 when deprecated const char* API is removed
-  bool is_flash_ptr;
+  const LogString *message;
 };
 
 #ifdef USE_SETUP_PRIORITY_OVERRIDE
@@ -56,9 +53,8 @@ std::vector<ComponentPriorityOverride> *setup_priority_overrides = nullptr;
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::vector<ComponentErrorMessage> *component_error_messages = nullptr;
 
-// Helper to store error messages - reduces duplication between deprecated and new API
-// Remove before 2026.6.0 when deprecated const char* API is removed
-void store_component_error_message(const Component *component, const char *message, bool is_flash_ptr) {
+// Helper to store error messages
+void store_component_error_message(const Component *component, const LogString *message) {
   // Lazy allocate the error messages vector if needed
   if (!component_error_messages) {
     component_error_messages = new std::vector<ComponentErrorMessage>();
@@ -67,12 +63,11 @@ void store_component_error_message(const Component *component, const char *messa
   for (auto &entry : *component_error_messages) {
     if (entry.component == component) {
       entry.message = message;
-      entry.is_flash_ptr = is_flash_ptr;
       return;
     }
   }
   // Add new error message
-  component_error_messages->emplace_back(ComponentErrorMessage{component, message, is_flash_ptr});
+  component_error_messages->emplace_back(ComponentErrorMessage{component, message});
 }
 }  // namespace
 
@@ -209,21 +204,17 @@ void Component::call_dump_config_() {
   this->dump_config();
   if (this->is_failed()) {
     // Look up error message from global vector
-    const char *error_msg = nullptr;
-    bool is_flash_ptr = false;
+    const LogString *error_msg = nullptr;
     if (component_error_messages) {
       for (const auto &entry : *component_error_messages) {
         if (entry.component == this) {
           error_msg = entry.message;
-          is_flash_ptr = entry.is_flash_ptr;
           break;
         }
       }
     }
-    // Log with appropriate format based on pointer type
     ESP_LOGE(TAG, "  %s is marked FAILED: %s", LOG_STR_ARG(this->get_component_log_str()),
-             error_msg ? (is_flash_ptr ? LOG_STR_ARG((const LogString *) error_msg) : error_msg)
-                       : LOG_STR_LITERAL("unspecified"));
+             error_msg ? LOG_STR_ARG(error_msg) : LOG_STR_LITERAL("unspecified"));
   }
 }
 
@@ -390,23 +381,13 @@ void Component::status_set_warning(const LogString *message) {
            message ? LOG_STR_ARG(message) : LOG_STR_LITERAL("unspecified"));
 }
 void Component::status_set_error() { this->status_set_error((const LogString *) nullptr); }
-void Component::status_set_error(const char *message) {
-  if (!this->set_status_flag_(STATUS_LED_ERROR))
-    return;
-  ESP_LOGE(TAG, "%s set Error flag: %s", LOG_STR_ARG(this->get_component_log_str()),
-           message ? message : LOG_STR_LITERAL("unspecified"));
-  if (message != nullptr) {
-    store_component_error_message(this, message, false);
-  }
-}
 void Component::status_set_error(const LogString *message) {
   if (!this->set_status_flag_(STATUS_LED_ERROR))
     return;
   ESP_LOGE(TAG, "%s set Error flag: %s", LOG_STR_ARG(this->get_component_log_str()),
            message ? LOG_STR_ARG(message) : LOG_STR_LITERAL("unspecified"));
   if (message != nullptr) {
-    // Store the LogString pointer directly (safe because LogString is always in flash/static memory)
-    store_component_error_message(this, LOG_STR_ARG(message), true);
+    store_component_error_message(this, message);
   }
 }
 void Component::status_clear_warning_slow_path_() {

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -220,18 +220,6 @@ class Component {
    */
   void mark_failed();
 
-  // Remove before 2026.6.0
-  ESPDEPRECATED("Use mark_failed(LOG_STR(\"static string literal\")) instead. Do NOT use .c_str() from temporary "
-                "strings. Will stop working in 2026.6.0",
-                "2025.12.0")
-  void mark_failed(const char *message) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    this->status_set_error(message);
-#pragma GCC diagnostic pop
-    this->mark_failed();
-  }
-
   void mark_failed(const LogString *message) {
     this->status_set_error(message);
     this->mark_failed();
@@ -296,11 +284,6 @@ class Component {
   void status_set_warning(const LogString *message);
 
   void status_set_error();  // Set error flag without message
-  // Remove before 2026.6.0
-  ESPDEPRECATED("Use status_set_error(LOG_STR(\"static string literal\")) instead. Do NOT use .c_str() from temporary "
-                "strings. Will stop working in 2026.6.0",
-                "2025.12.0")
-  void status_set_error(const char *message);
   void status_set_error(const LogString *message);
 
   void status_clear_warning() {


### PR DESCRIPTION
# What does this implement/fix?

Drops the `const char *` overloads of `Component::mark_failed` and `Component::status_set_error`. Both have
been `ESPDEPRECATED` since 2025.12.0 with a removal target of 2026.6.0. The `const LogString *` overloads
(invoked via `LOG_STR("...")`) are the supported API.

While at it, simplify the failed-component error-message storage. Now that every stored pointer is a
`LogString`, change `ComponentErrorMessage::message` to `const LogString *` and drop the `is_flash_ptr`
discriminator field — saves one `bool` per failed component plus a branch in `call_dump_config_()`.

No internal callers of the deprecated overloads remain (verified with grep over `components/`, `core/` and
the codegen helpers).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Scheduled removal per the 2025.12.0 `ESPDEPRECATED` cycle.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a (no documented user-facing behavior change).

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

(Removal is platform-independent — only affects core C++ headers.)

## Example entry for `config.yaml`:

n/a (C++ API removal only). External components that still call the deprecated overloads must switch to:

```cpp
this->mark_failed(LOG_STR("static string literal"));
this->status_set_error(LOG_STR("static string literal"));
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).