### PR TITLE
[core] Remove cv.only_with_esp_idf and CORE.using_esp_idf

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -855,8 +855,6 @@ only_on_esp8266 = only_on(PLATFORM_ESP8266)
 only_on_nrf52 = only_on(PLATFORM_NRF52)
 only_on_rp2040 = only_on(PLATFORM_RP2040)
 only_with_arduino = only_with_framework(Framework.ARDUINO)
-# Legacy alias; prefer only_on_esp32.
-only_with_esp_idf = only_on_esp32
 
 
 # Adapted from:

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -855,9 +855,7 @@ only_on_esp8266 = only_on(PLATFORM_ESP8266)
 only_on_nrf52 = only_on(PLATFORM_NRF52)
 only_on_rp2040 = only_on(PLATFORM_RP2040)
 only_with_arduino = only_with_framework(Framework.ARDUINO)
-# Legacy alias. ESP32 Arduino now builds on top of ESP-IDF, so ESP-IDF features
-# are available in both frameworks; the "pure IDF framework" gate has been
-# folded into "is ESP32". Prefer cv.only_on_esp32 directly.
+# Legacy alias; prefer only_on_esp32.
 only_with_esp_idf = only_on_esp32
 
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -855,16 +855,10 @@ only_on_esp8266 = only_on(PLATFORM_ESP8266)
 only_on_nrf52 = only_on(PLATFORM_NRF52)
 only_on_rp2040 = only_on(PLATFORM_RP2040)
 only_with_arduino = only_with_framework(Framework.ARDUINO)
-
-
-def only_with_esp_idf(obj):
-    """Deprecated: use only_on_esp32 instead."""
-    _LOGGER.warning(
-        "cv.only_with_esp_idf was deprecated in 2026.1, will change behavior in 2026.6. "
-        "ESP32 Arduino builds on top of ESP-IDF, so ESP-IDF features are available in both frameworks. "
-        "Use cv.only_on_esp32 and/or cv.only_with_arduino instead."
-    )
-    return only_with_framework(Framework.ESP_IDF)(obj)
+# Legacy alias. ESP32 Arduino now builds on top of ESP-IDF, so ESP-IDF features
+# are available in both frameworks; the "pure IDF framework" gate has been
+# folded into "is ESP32". Prefer cv.only_on_esp32 directly.
+only_with_esp_idf = only_on_esp32
 
 
 # Adapted from:

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -861,12 +861,11 @@ class EsphomeCore:
 
     @property
     def using_esp_idf(self):
-        _LOGGER.warning(
-            "CORE.using_esp_idf was deprecated in 2026.1, will change behavior in 2026.6. "
-            "ESP32 Arduino builds on top of ESP-IDF, so ESP-IDF features are available in both frameworks. "
-            "Use CORE.is_esp32 and/or CORE.using_arduino instead."
-        )
-        return self.target_framework == "esp-idf"
+        # Legacy alias. ESP32 Arduino now builds on top of ESP-IDF, so the
+        # "pure IDF framework" check has been folded into "is ESP32". Prefer
+        # CORE.is_esp32 (or CORE.using_toolchain_esp_idf for the actual
+        # toolchain question) in new code.
+        return self.is_esp32
 
     @property
     def using_toolchain_esp_idf(self):

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -860,11 +860,6 @@ class EsphomeCore:
         return self.target_framework == "arduino"
 
     @property
-    def using_esp_idf(self):
-        # Legacy alias; prefer is_esp32.
-        return self.is_esp32
-
-    @property
     def using_toolchain_esp_idf(self):
         return self.toolchain == Toolchain.ESP_IDF
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -861,10 +861,7 @@ class EsphomeCore:
 
     @property
     def using_esp_idf(self):
-        # Legacy alias. ESP32 Arduino now builds on top of ESP-IDF, so the
-        # "pure IDF framework" check has been folded into "is ESP32". Prefer
-        # CORE.is_esp32 (or CORE.using_toolchain_esp_idf for the actual
-        # toolchain question) in new code.
+        # Legacy alias; prefer is_esp32 (or using_toolchain_esp_idf).
         return self.is_esp32
 
     @property

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -861,7 +861,7 @@ class EsphomeCore:
 
     @property
     def using_esp_idf(self):
-        # Legacy alias; prefer is_esp32 (or using_toolchain_esp_idf).
+        # Legacy alias; prefer is_esp32.
         return self.is_esp32
 
     @property

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -693,19 +693,6 @@ def lint_esphome_h(fname, line, col, content):
     )
 
 
-@lint_content_find_check(
-    "CORE.using_esp_idf",
-    include=py_include,
-    exclude=["esphome/core/__init__.py", "script/ci-custom.py"],
-)
-def lint_using_esp_idf_deprecated(fname, line, col, content):
-    return (
-        f"{highlight('CORE.using_esp_idf')} is deprecated and will change behavior in 2026.6. "
-        "ESP32 Arduino builds on top of ESP-IDF, so ESP-IDF features are available in both frameworks. "
-        f"Please use {highlight('CORE.is_esp32')} and/or {highlight('CORE.using_arduino')} instead."
-    )
-
-
 @lint_content_check(include=["*.h"], exclude=["esphome/core/entity_types.h"])
 def lint_pragma_once(fname, content):
     if "#pragma once" not in content:


### PR DESCRIPTION
# What does this implement/fix?

Removes `cv.only_with_esp_idf` and `CORE.using_esp_idf`, both deprecated in 2026.1 (via #12673) with a
removal cycle target of 2026.6.

With ESP32 Arduino now building on top of ESP-IDF (Arduino-as-component), the historic "pure ESP-IDF
framework" gate is no longer the right check for external component authors -- ESP-IDF features are
available in both frameworks. The 2026.1 → 2026.5 runtime warning has been telling users to migrate to
`cv.only_on_esp32` and `CORE.is_esp32` for two release cycles.

Drops:

- `cv.only_with_esp_idf` (in `esphome/config_validation.py`)
- `CORE.using_esp_idf` property (in `esphome/core/__init__.py`)
- the matching `lint_using_esp_idf_deprecated` ci-custom lint (no targets to flag any more)

No internal callers remain. External components still using the old names will get a clean `AttributeError`
at import time -- the warning has been visible since 2026.1.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Migration:**

```python
# Before
import esphome.config_validation as cv
from esphome.core import CORE

cv.only_with_esp_idf            # -> cv.only_on_esp32
CORE.using_esp_idf              # -> CORE.is_esp32
```

Components that truly need the toolchain check (the rare actual "pure IDF" question) can use
`CORE.using_toolchain_esp_idf`.

**Related issue or feature (if applicable):**

- Follow-up to #12673 (`[core] Replace USE_ESP_IDF with USE_ESP32 across components`), which added the
  2026.1 deprecation warning with a 2026.6 removal target.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a (no documented user-facing config change; both symbols are internal to component authors).

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

(Removal is platform-independent — only affects Python helpers.)

## Example entry for `config.yaml`:

n/a (Python helper removal only).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).