### PR TITLE
[wifi] Default ESP8266 min_auth_mode to WPA2

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -326,23 +326,9 @@ def validate_variant(_):
 
 
 def _apply_min_auth_mode_default(config):
-    """Apply platform-specific default for min_auth_mode and warn ESP8266 users."""
-    # Only apply defaults for platforms that support min_auth_mode
+    """Apply platform-specific default for min_auth_mode."""
     if CONF_MIN_AUTH_MODE not in config and (CORE.is_esp8266 or CORE.is_esp32):
-        if CORE.is_esp8266:
-            _LOGGER.warning(
-                "The minimum WiFi authentication mode (wifi -> min_auth_mode) is not set. "
-                "This controls the weakest encryption your device will accept when connecting to WiFi. "
-                "Currently defaults to WPA (less secure), but will change to WPA2 (more secure) in 2026.6.0. "
-                "WPA uses TKIP encryption which has known security vulnerabilities and should be avoided. "
-                "WPA2 uses AES encryption which is significantly more secure. "
-                "To silence this warning, explicitly set min_auth_mode under 'wifi:'. "
-                "If your router supports WPA2 or WPA3, set 'min_auth_mode: WPA2'. "
-                "If your router only supports WPA, set 'min_auth_mode: WPA'."
-            )
-            config[CONF_MIN_AUTH_MODE] = VALIDATE_WIFI_MIN_AUTH_MODE("WPA")
-        elif CORE.is_esp32:
-            config[CONF_MIN_AUTH_MODE] = VALIDATE_WIFI_MIN_AUTH_MODE("WPA2")
+        config[CONF_MIN_AUTH_MODE] = VALIDATE_WIFI_MIN_AUTH_MODE("WPA2")
     return config
 
 


### PR DESCRIPTION
# What does this implement/fix?

The 2026.1 deprecation warning on ESP8266 wifi configurations missing an explicit `min_auth_mode` flagged that
the default would flip from `WPA` to `WPA2` in 2026.6.0. Land the flip and drop the warning. ESP32 already
defaults to `WPA2`, so the two platforms now match.

Users on legacy WPA-only (TKIP) routers can still opt back in explicitly:

```yaml
wifi:
  min_auth_mode: WPA
```

The warning has been telling them how to do this for two release cycles.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**User impact:** existing ESP8266 configurations that omit `min_auth_mode` and connect to a WPA-only (TKIP)
network will stop associating after upgrade. Either upgrade the AP to WPA2, or pin the YAML to
`min_auth_mode: WPA`. The 2026.1 → 2026.5 warning has called this out at every config validation.

**Related issue or feature (if applicable):**

- Follow-up to the 2026.1 deprecation warning in `wifi/__init__.py:_apply_min_auth_mode_default`.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6699

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Change is ESP8266-only in effect; ESP32 default was already `WPA2`.)

## Example entry for `config.yaml`:

```yaml
# No change required for users on WPA2/WPA3 networks.

# Users on WPA-only routers must pin:
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  min_auth_mode: WPA
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).