### PR TITLE
[text_sensor] Remove deprecated public raw_state member

### DIFF
--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -39,16 +39,13 @@ void TextSensor::publish_state(const char *state, size_t len) {
 #ifdef USE_TEXT_SENSOR_FILTER
   } else {
     // Has filters: need separate raw storage
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     // Only assign if changed to avoid heap allocation
-    if (len != this->raw_state.size() || memcmp(state, this->raw_state.data(), len) != 0) {
-      this->raw_state.assign(state, len);
+    if (len != this->raw_state_.size() || memcmp(state, this->raw_state_.data(), len) != 0) {
+      this->raw_state_.assign(state, len);
     }
-    this->raw_callback_.call(this->raw_state);
-    ESP_LOGV(TAG, "'%s': Received new state %s", this->name_.c_str(), this->raw_state.c_str());
-    this->filter_list_->input(this->raw_state);
-#pragma GCC diagnostic pop
+    this->raw_callback_.call(this->raw_state_);
+    ESP_LOGV(TAG, "'%s': Received new state %s", this->name_.c_str(), this->raw_state_.c_str());
+    this->filter_list_->input(this->raw_state_);
   }
 #endif
 }
@@ -89,11 +86,7 @@ const std::string &TextSensor::get_state() const { return this->state; }
 const std::string &TextSensor::get_raw_state() const {
 #ifdef USE_TEXT_SENSOR_FILTER
   if (this->filter_list_ != nullptr) {
-    // Suppress deprecation warning - get_raw_state() is the replacement API
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    return this->raw_state;
-#pragma GCC diagnostic pop
+    return this->raw_state_;
   }
 #endif
   return this->state;  // No filters, raw == filtered

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -29,19 +29,12 @@ class TextSensor : public EntityBase {
  public:
   std::string state;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  /// @deprecated Use get_raw_state() instead. This member will be removed in ESPHome 2026.6.0.
-  ESPDEPRECATED("Use get_raw_state() instead of .raw_state. Will be removed in 2026.6.0", "2025.12.0")
-  std::string raw_state;
-
   TextSensor() = default;
   ~TextSensor() = default;
-#pragma GCC diagnostic pop
 
   /// Getter-syntax for .state.
   const std::string &get_state() const;
-  /// Getter-syntax for .raw_state
+  /// Returns the raw (pre-filter) state.
   const std::string &get_raw_state() const;
 
   void publish_state(const std::string &state);
@@ -84,6 +77,7 @@ class TextSensor : public EntityBase {
   /// Notify frontend that state has changed (assumes this->state is already set)
   void notify_frontend_();
 #ifdef USE_TEXT_SENSOR_FILTER
+  std::string raw_state_;  ///< Backing storage for the raw (pre-filter) value. Only used when a filter is attached.
   LazyCallbackManager<void(const std::string &)> raw_callback_;  ///< Storage for raw state callbacks.
 #endif
   LazyCallbackManager<void(const std::string &)> callback_;  ///< Storage for filtered state callbacks.


### PR DESCRIPTION
# What does this implement/fix?

The public `std::string raw_state` member on `text_sensor::TextSensor` has been `ESPDEPRECATED` since 2025.12.0
with a removal target of 2026.6.0; the supported accessor is `TextSensor::get_raw_state()`.

Drops the public member and moves its backing storage into a protected `raw_state_` field. The field is only
present when `USE_TEXT_SENSOR_FILTER` is enabled (the only code path that actually needs separate raw
storage; without filters, raw == filtered and we just reuse `state`).

Two `-Wdeprecated-declarations` `#pragma` blocks go away too — they only existed to silence the class's own
internal use of the deprecated member.

No internal callers of the public member outside `text_sensor.cpp` itself.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Migration:**

```cpp
// Before
sensor->raw_state;          // -> sensor->get_raw_state();
sensor->raw_state.empty();  // -> sensor->get_raw_state().empty();
```

**Related issue or feature (if applicable):**

- Scheduled removal per the 2025.12.0 `ESPDEPRECATED` cycle.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a (no documented user-facing change; member was a C++ implementation detail).

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

(Removal is platform-independent — only C++ class layout changes.)

## Example entry for `config.yaml`:

n/a (C++ API removal only).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).