### PR TITLE
[nfc] Remove deprecated heap-allocating format helpers

### DIFF
--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -15,17 +15,6 @@ char *format_bytes_to(char *buffer, std::span<const uint8_t> bytes) {
   return format_hex_pretty_to(buffer, FORMAT_BYTES_BUFFER_SIZE, bytes.data(), bytes.size(), ' ');
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-// Deprecated wrappers intentionally use heap-allocating version for backward compatibility
-std::string format_uid(std::span<const uint8_t> uid) {
-  return format_hex_pretty(uid.data(), uid.size(), '-', false);  // NOLINT
-}
-std::string format_bytes(std::span<const uint8_t> bytes) {
-  return format_hex_pretty(bytes.data(), bytes.size(), ' ', false);  // NOLINT
-}
-#pragma GCC diagnostic pop
-
 uint8_t guess_tag_type(uint8_t uid_length) {
   if (uid_length == 4) {
     return TAG_TYPE_MIFARE_CLASSIC;

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -63,13 +63,6 @@ static constexpr size_t FORMAT_BYTES_BUFFER_SIZE = 192;
 /// Format bytes to buffer with ' ' separator (e.g., "04 11 22 33"). Returns buffer for inline use.
 char *format_bytes_to(char *buffer, std::span<const uint8_t> bytes);
 
-// Remove before 2026.6.0
-ESPDEPRECATED("Use format_uid_to() with stack buffer instead. Removed in 2026.6.0", "2025.12.0")
-std::string format_uid(std::span<const uint8_t> uid);
-// Remove before 2026.6.0
-ESPDEPRECATED("Use format_bytes_to() with stack buffer instead. Removed in 2026.6.0", "2025.12.0")
-std::string format_bytes(std::span<const uint8_t> bytes);
-
 uint8_t guess_tag_type(uint8_t uid_length);
 int8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data);
 bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_length, uint8_t &message_start_index);


### PR DESCRIPTION
# What does this implement/fix?

Removes `nfc::format_uid(span)` and `nfc::format_bytes(span)` (returning `std::string`). Both have been
`ESPDEPRECATED` since 2025.12.0 with a removal target of 2026.6.0. The stack-buffer variants
`nfc::format_uid_to(buf, span)` and `nfc::format_bytes_to(buf, span)` are the supported API and avoid heap
allocation on the hot path.

Every internal caller across `nfc`, `pn532`, and `pn7150` has already migrated to the `_to(buf, ...)` form;
zero remaining usages of the deprecated names in the tree.

Drops the matching `-Wdeprecated-declarations` `#pragma` block in `nfc.cpp` (it only existed to silence the
deprecated wrappers' own self-call).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Migration:**

```cpp
// Before
std::string s = nfc::format_uid(uid);

// After
char buf[nfc::FORMAT_UID_BUFFER_SIZE];
const char *s = nfc::format_uid_to(buf, uid);
```

(Same shape for `format_bytes_to` with `FORMAT_BYTES_BUFFER_SIZE`.)

**Related issue or feature (if applicable):**

- Scheduled removal per the 2025.12.0 `ESPDEPRECATED` cycle.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a (no documented user-facing change; helpers are C++-only).

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

(Removal is platform-independent — only affects `nfc` C++ helpers.)

## Example entry for `config.yaml`:

n/a (C++ API removal only).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).