### PR TITLE
[core] Remove deprecated seq/gens templates

### DIFF
--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -13,27 +13,6 @@
 
 namespace esphome {
 
-// C++20 std::index_sequence is now used for tuple unpacking
-// Legacy seq<>/gens<> pattern deprecated but kept for backwards compatibility
-// https://stackoverflow.com/questions/7858817/unpacking-a-tuple-to-call-a-matching-function-pointer/7858971#7858971
-// Remove before 2026.6.0
-// NOLINTBEGIN(readability-identifier-naming)
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
-template<int...> struct ESPDEPRECATED("Use std::index_sequence instead. Removed in 2026.6.0", "2025.12.0") seq {};
-template<int N, int... S>
-struct ESPDEPRECATED("Use std::make_index_sequence instead. Removed in 2026.6.0", "2025.12.0") gens
-    : gens<N - 1, N - 1, S...> {};
-template<int... S> struct gens<0, S...> { using type = seq<S...>; };
-
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-// NOLINTEND(readability-identifier-naming)
-
 /// Function-pointer-only templatable storage (4 bytes on 32-bit).
 /// Used by the TEMPLATABLE_VALUE macro for codegen-managed fields.
 /// Codegen wraps constants in stateless lambdas so only a function pointer is needed.


### PR DESCRIPTION
# What does this implement/fix?

Removes the legacy `seq<>` and `gens<>` tuple-unpacking templates from `esphome/core/automation.h`. Both
have been `ESPDEPRECATED` since 2025.12.0 with a removal target of 2026.6.0. `std::index_sequence` /
`std::make_index_sequence` (C++14) are the standard replacement and have been in use across the core for a
while.

No internal callers remain (verified with grep across `*.cpp`/`*.h`/`*.hpp`/`*.tcc`).

Drops the templates plus the surrounding `-Wdeprecated-declarations` pragma block and the
`NOLINT(readability-identifier-naming)` guard.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Migration:**

```cpp
// Before
typename gens<sizeof...(Ts)>::type seq{};
// callee receiving seq<I...>

// After
std::index_sequence_for<Ts...>{}
// callee receiving std::index_sequence<I...>
```

**Related issue or feature (if applicable):**

- Scheduled removal per the 2025.12.0 `ESPDEPRECATED` cycle.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a (no documented user-facing change; templates were a C++-only internal helper).

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

(Removal is platform-independent — only affects a core C++ header.)

## Example entry for `config.yaml`:

n/a (C++ API removal only).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).