### PR TITLE
[dsmr] Force BearSSL on ESP8266 to avoid mbedtls link failure

### DIFF
--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -16,9 +16,14 @@
 #include <span>
 #include <vector>
 
+// On ESP8266 Arduino, BearSSL is the native crypto. The mbedtls headers can
+// still be in scope when a sibling component (e.g. wireguard) pulls in
+// esp_mbedtls_esp8266, but that build leaves MBEDTLS_GCM_C disabled so the
+// gcm.h symbols are unresolved at link time. Force BearSSL on ESP8266 to
+// avoid that linker error.
 #if __has_include(<psa/crypto.h>)
 #include <dsmr_parser/decryption/aes128gcm_tfpsa.h>
-#elif __has_include(<mbedtls/gcm.h>)
+#elif !defined(USE_ESP8266) && __has_include(<mbedtls/gcm.h>)
 #if __has_include(<mbedtls/esp_config.h>)
 #include <mbedtls/esp_config.h>
 #endif
@@ -33,7 +38,7 @@ namespace esphome::dsmr {
 
 #if __has_include(<psa/crypto.h>)
 using Aes128GcmDecryptorImpl = dsmr_parser::Aes128GcmTfPsa;
-#elif __has_include(<mbedtls/gcm.h>)
+#elif !defined(USE_ESP8266) && __has_include(<mbedtls/gcm.h>)
 using Aes128GcmDecryptorImpl = dsmr_parser::Aes128GcmMbedTls;
 #else
 using Aes128GcmDecryptorImpl = dsmr_parser::Aes128GcmBearSsl;


### PR DESCRIPTION
# What does this implement/fix?

Fixes an `esp8266-ard` link failure that occurs whenever both `dsmr` and `wireguard` are configured (or
batched together in CI).

`wireguard`'s `esp_mbedtls_esp8266` library ships `mbedtls/gcm.h` headers but builds with `MBEDTLS_GCM_C`
disabled (`config-esp_wireguard-esp8266.h:2649` -- `//#define MBEDTLS_GCM_C`). Since #15875, `dsmr.h`'s
`__has_include(<mbedtls/gcm.h>)` probe matches in that environment and selects `Aes128GcmMbedTls`, leading
to undefined references at link time:

```
undefined reference to `mbedtls_gcm_init`
undefined reference to `mbedtls_gcm_setkey`
undefined reference to `mbedtls_gcm_auth_decrypt`
undefined reference to `mbedtls_gcm_free`
```

Exclude `USE_ESP8266` from the mbedtls branch in both selection chains so the fall-through to BearSSL fires.
BearSSL is the native crypto on ESP8266 Arduino and was the only option prior to #15875.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Reproducer:**

```
./script/test_build_components -e compile -c dsmr,wireguard -t esp8266-ard
```

Before this PR: linker error on the symbols listed above.
After: clean build (verified locally).

**Related issue or feature (if applicable):**

- Regression from #15875 (`[dsmr] Improve performance. Add missing sensors. Remove Crypto-no-arduino.`).
  Surfaces on CI batches that group `dsmr` and `wireguard` on `esp8266-ard`.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any config combining dsmr + wireguard on esp8266 was failing to link.
dsmr:
  decryption_key: "0123456789abcdef0123456789abcdef"

wireguard:
  address: 10.0.0.2
  netmask: 255.255.255.0
  private_key: "..."
  peer_endpoint: vpn.example.com
  peer_public_key: "..."
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).