### PR TITLE
[core] Schema-aware redaction in esphome config output

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1414,13 +1414,49 @@ def command_config(args: ArgsProtocol, config: ConfigType) -> int | None:
     output = yaml_util.dump(config, args.show_secrets)
     # add the console decoration so the front-end can hide the secrets
     if not args.show_secrets:
-        output = re.sub(
-            r"(password|key|psk|ssid)\: (.+)", r"\1: \\033[8m\2\\033[28m", output
-        )
+        output = _redact_sensitive(output)
     if not CORE.quiet:
         safe_print(output)
     _LOGGER.info("Configuration is valid!")
     return 0
+
+
+# Substring fallbacks preserved from the previous regex so existing behavior
+# (redacting fields with names like ``ssid`` or ``encryption_key``) is not
+# regressed. Explicit names from ``cv.sensitive`` are added on top.
+_REDACTION_FALLBACK_FRAGMENTS: frozenset[str] = frozenset({"key", "ssid"})
+
+
+def _collect_loaded_sensitive_keys() -> set[str]:
+    import esphome.config_validation as cv
+    from esphome.loader import get_component
+
+    explicit: set[str] = set()
+    for domain in CORE.loaded_integrations:
+        manifest = get_component(domain)
+        if manifest is None:
+            continue
+        schema = manifest.config_schema
+        if schema is not None:
+            cv.collect_sensitive_keys(schema, explicit)
+    return explicit
+
+
+def _build_redaction_pattern(explicit_names: set[str]) -> re.Pattern[str]:
+    import esphome.config_validation as cv
+
+    alternation = "|".join(
+        re.escape(n)
+        for n in sorted(
+            explicit_names | cv.SENSITIVE_KEY_FRAGMENTS | _REDACTION_FALLBACK_FRAGMENTS
+        )
+    )
+    return re.compile(rf"({alternation})\: (.+)")
+
+
+def _redact_sensitive(output: str) -> str:
+    pattern = _build_redaction_pattern(_collect_loaded_sensitive_keys())
+    return pattern.sub(r"\1: \\033[8m\2\\033[28m", output)
 
 
 def command_config_hash(args: ArgsProtocol, config: ConfigType) -> int | None:

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -534,6 +534,56 @@ def sensitive(
     return SensitiveValidator(inner)
 
 
+def _validator_has_sensitive_marker(validator: typing.Any) -> bool:
+    """Return True when ``validator`` is wrapped in ``cv.sensitive`` at the top."""
+    if isinstance(validator, SensitiveValidator):
+        return True
+    if isinstance(validator, (vol.All, vol.Any)) and hasattr(validator, "validators"):
+        return any(_validator_has_sensitive_marker(v) for v in validator.validators)
+    return False
+
+
+def collect_sensitive_keys(schema: typing.Any, out: set[str]) -> None:
+    """Walk a voluptuous schema and add field names wrapped in ``cv.sensitive`` to ``out``.
+
+    Recurses through ``vol.Schema``, ``vol.All``, ``vol.Any``, ``SensitiveValidator``,
+    and dict literals. Only string field names are collected; non-string keys
+    (callable validators) and nested function-wrapped schemas are skipped, matching
+    the limits of static voluptuous introspection.
+    """
+    _collect_sensitive_keys_inner(schema, out, set())
+
+
+def _collect_sensitive_keys_inner(
+    schema: typing.Any, out: set[str], seen: set[int]
+) -> None:
+    sid = id(schema)
+    if sid in seen:
+        return
+    seen.add(sid)
+    if isinstance(schema, SensitiveValidator):
+        _collect_sensitive_keys_inner(schema.inner, out, seen)
+        return
+    if isinstance(schema, vol.Schema):
+        _collect_sensitive_keys_inner(schema.schema, out, seen)
+        return
+    if isinstance(schema, (vol.All, vol.Any)) and hasattr(schema, "validators"):
+        for v in schema.validators:
+            _collect_sensitive_keys_inner(v, out, seen)
+        return
+    if isinstance(schema, dict):
+        for k, v in schema.items():
+            if (
+                isinstance(
+                    k, (vol.Required, vol.Optional, vol.Inclusive, vol.Exclusive)
+                )
+                and isinstance(k.schema, str)
+                and _validator_has_sensitive_marker(v)
+            ):
+                out.add(k.schema)
+            _collect_sensitive_keys_inner(v, out, seen)
+
+
 def icon(value):
     """Validate that a given config value is a valid icon."""
     from esphome.core.config import ICON_MAX_LENGTH

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -170,6 +170,76 @@ def test_sensitive_key_fragments__covers_common_terms() -> None:
         assert term in config_validation.SENSITIVE_KEY_FRAGMENTS
 
 
+def test_collect_sensitive_keys__direct_marker() -> None:
+    cv = config_validation
+    schema = cv.Schema(
+        {
+            cv.Required("password"): cv.sensitive(),
+            cv.Optional("hostname"): cv.string,
+        }
+    )
+    out: set[str] = set()
+    cv.collect_sensitive_keys(schema, out)
+    assert out == {"password"}
+
+
+def test_collect_sensitive_keys__nested_schema() -> None:
+    cv = config_validation
+    inner = cv.Schema({cv.Required("token"): cv.sensitive(cv.string_strict)})
+    schema = cv.Schema({cv.Optional("auth"): inner})
+    out: set[str] = set()
+    cv.collect_sensitive_keys(schema, out)
+    assert out == {"token"}
+
+
+def test_collect_sensitive_keys__inside_all_chain() -> None:
+    cv = config_validation
+    # Sensitive marker wrapped in cv.All; the helper should still pick it up.
+    schema = cv.Schema(
+        {cv.Required("key"): cv.All(cv.sensitive(cv.string), cv.Length(min=1))}
+    )
+    out: set[str] = set()
+    cv.collect_sensitive_keys(schema, out)
+    assert out == {"key"}
+
+
+def test_collect_sensitive_keys__ignores_unmarked() -> None:
+    cv = config_validation
+    schema = cv.Schema(
+        {
+            cv.Optional("password"): cv.string,
+            cv.Optional("token"): cv.string,
+        }
+    )
+    out: set[str] = set()
+    cv.collect_sensitive_keys(schema, out)
+    assert out == set()
+
+
+def test_collect_sensitive_keys__skips_non_string_keys() -> None:
+    cv = config_validation
+    # Key whose .schema is a callable rather than a string should be skipped.
+    schema = cv.Schema(
+        {
+            cv.Required(cv.string): cv.sensitive(),
+            cv.Required("password"): cv.sensitive(),
+        }
+    )
+    out: set[str] = set()
+    cv.collect_sensitive_keys(schema, out)
+    assert out == {"password"}
+
+
+def test_collect_sensitive_keys__deduplicates_across_calls() -> None:
+    cv = config_validation
+    schema_a = cv.Schema({cv.Required("password"): cv.sensitive()})
+    schema_b = cv.Schema({cv.Required("password"): cv.sensitive()})
+    out: set[str] = set()
+    cv.collect_sensitive_keys(schema_a, out)
+    cv.collect_sensitive_keys(schema_b, out)
+    assert out == {"password"}
+
+
 @given(
     builds(
         lambda v: "mdi:" + v,

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -20,6 +20,7 @@ from zeroconf import ServiceStateChange
 
 from esphome.__main__ import (
     Purpose,
+    _build_redaction_pattern,
     _get_configured_xtal_freq,
     _make_crystal_freq_callback,
     _resolve_network_devices,
@@ -338,6 +339,34 @@ def mock_ram_strings_analyzer() -> Generator[Mock]:
         mock_analyzer.generate_report.return_value = "Mock RAM Strings Report"
         mock_class.return_value = mock_analyzer
         yield mock_class
+
+
+def test_build_redaction_pattern__includes_fragments_and_fallbacks() -> None:
+    pattern = _build_redaction_pattern(set())
+    # Fragment set (cv.SENSITIVE_KEY_FRAGMENTS) members are matched.
+    assert pattern.search("password: secret_value") is not None
+    assert pattern.search("token: abc") is not None
+    # Pre-existing wildcard fallbacks (key, ssid) are still matched.
+    assert pattern.search("key: foo") is not None
+    assert pattern.search("ssid: MyNetwork") is not None
+    # Non-sensitive fields are left alone.
+    assert pattern.search("hostname: server") is None
+
+
+def test_build_redaction_pattern__honors_explicit_names() -> None:
+    # A field name that isn't a fragment or fallback only matches when
+    # supplied as an explicit name from cv.sensitive.
+    no_explicit = _build_redaction_pattern(set())
+    assert no_explicit.search("auth_string: abc") is None
+
+    with_explicit = _build_redaction_pattern({"auth_string"})
+    assert with_explicit.search("auth_string: abc") is not None
+
+
+def test_build_redaction_pattern__substitution_wraps_value() -> None:
+    pattern = _build_redaction_pattern(set())
+    out = pattern.sub(r"\1: \\033[8m\2\\033[28m", "password: hunter2")
+    assert out == "password: \\033[8mhunter2\\033[28m"
 
 
 def test_choose_upload_log_host_with_string_default() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Phase 2 of the `cv.sensitive` rollout. `esphome config` used to redact secrets with a hardcoded regex `(password|key|psk|ssid)`; this PR makes the alternation dynamic so it also includes every field name marked `cv.sensitive(...)` in a loaded component's schema.

Pieces:

- `cv.collect_sensitive_keys(schema, out)` walks a voluptuous schema (handles `vol.Schema`, `vol.All`, `vol.Any`, `SensitiveValidator`, nested dicts, with cycle guard) and adds explicitly marked field names to a set; non-string keys and function-wrapped sub-schemas are skipped, matching the limits of static introspection.
- `command_config` collects names from every loaded component manifest and builds the redaction regex via `_build_redaction_pattern`, layering explicit names on top of `cv.SENSITIVE_KEY_FRAGMENTS` plus `{"key", "ssid"}` as legacy substring fallbacks; behavior for the fallback set is unchanged so existing redaction of `encryption_key`, SSID, etc. is preserved.
- `--show-secrets` still bypasses redaction entirely.

With #16677 merged the explicit name set is non-empty in practice; the marker now drives runtime redaction in addition to the schema dump consumed by the device builder.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- follow-up to #16673 and #16677

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config change. Running esphome config now redacts the
# values of every cv.sensitive field as well as the prior substring
# fallbacks; --show-secrets is unchanged.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).