### PR TITLE
[esp32] Stub arduino-esp32 with INTERFACE re-export to framework

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2596,7 +2596,7 @@ def _write_idf_component_yml():
                 arduino_stub / "CMakeLists.txt",
                 "idf_component_register()\n"
                 "target_link_libraries(${COMPONENT_LIB} "
-                "INTERFACE idf::framework-arduinoespressif32)\n",
+                f"INTERFACE idf::{ARDUINO_FRAMEWORK_NAME})\n",
             )
             dependencies[ARDUINO_ESP32_COMPONENT_NAME] = {
                 "version": "*",

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2583,6 +2583,26 @@ def _write_idf_component_yml():
                 "override_path": str(stub_path),
             }
 
+        # On the PlatformIO toolchain, framework-arduinoespressif32 already
+        # ships arduino-esp32. Stub the managed component so anything that
+        # `REQUIRES arduino-esp32` (e.g. third-party FastLED) resolves to a
+        # CMake target that re-exports the framework's INTERFACE properties
+        # (INCLUDE_DIRS, public compile options like -DESP32, transitive
+        # REQUIRES) instead of triggering a duplicate download/rebuild.
+        if CORE.using_toolchain_platformio:
+            arduino_stub = stubs_dir / "arduino-esp32"
+            arduino_stub.mkdir(exist_ok=True)
+            write_file_if_changed(
+                arduino_stub / "CMakeLists.txt",
+                "idf_component_register()\n"
+                "target_link_libraries(${COMPONENT_LIB} "
+                "INTERFACE idf::framework-arduinoespressif32)\n",
+            )
+            dependencies[ARDUINO_ESP32_COMPONENT_NAME] = {
+                "version": "*",
+                "override_path": str(arduino_stub),
+            }
+
         # Remove stubs for components that are now required by enabled libraries
         for component_name in required_idf_components:
             stub_path = stubs_dir / _idf_component_stub_name(component_name)


### PR DESCRIPTION
# What does this implement/fix?

On the PlatformIO toolchain, `framework-arduinoespressif32` already ships arduino-esp32 (cores,
libraries, prebuilt libs). If a project pulls in a managed component whose CMakeLists says
`REQUIRES arduino-esp32`, the IDF Component Manager tries to download arduino-esp32 from the
component registry too -- duplicating what PlatformIO already provides.

This PR generates an `override_path` stub for `arduino-esp32` that re-exports the framework's
INTERFACE via:

```cmake
idf_component_register()
target_link_libraries(${COMPONENT_LIB} INTERFACE idf::framework-arduinoespressif32)
```

The INTERFACE link propagates everything the real arduino-esp32 component would have exported --
`cores/esp32/` + variant INCLUDE_DIRS, public compile options (`-DESP32`, `-DARDUINO_ARCH_ESP32`,
`-DARDUINO=...`), and the full transitive REQUIRES list -- without recompiling any sources.

The new block is gated on `CORE.using_toolchain_platformio`. On the ESP-IDF toolchain
arduino-esp32 is fetched as a real managed component already (handled elsewhere in this file), so
the stub is not needed there.

## Context

Surfaced while adding FastLED as an ESP-IDF managed component on the idf6-test branch -- FastLED's
`CMakeLists.txt` declares `REQUIRES arduino-esp32`, which previously either tried to download a
duplicate copy of the component or, if stubbed empty, left Arduino headers / `-DESP32` out of scope
for FastLED's compilation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a -- internal build-system fix.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a (build-system change, not user-facing).

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

n/a (no user-facing config change).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).