### PR TITLE
[ledc] Adapt to LEDC LL API changes in ESP-IDF 6.1

### DIFF
--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -53,7 +53,11 @@ static_assert(
     "re-evaluate for this target");
 
 static bool ledc_duty_update_pending(ledc_mode_t speed_mode, ledc_channel_t chan_num) {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0)
+  auto *hw = LEDC_LL_GET_HW(0);
+#else
   auto *hw = LEDC_LL_GET_HW();
+#endif
   return hw->channel_group[speed_mode].channel[chan_num].conf1.duty_start != 0;
 }
 #endif
@@ -161,7 +165,9 @@ void LEDCOutput::write_state(float state) {
 void LEDCOutput::setup() {
   if (!ledc_peripheral_reset_done) {
     ESP_LOGV(TAG, "Resetting LEDC peripheral to clear stale state after reboot");
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0)
+    PERIPH_RCC_ATOMIC() { ledc_ll_reset_register(0); }
+#elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
     PERIPH_RCC_ATOMIC() {
       ledc_ll_enable_reset_reg(true);
       ledc_ll_enable_reset_reg(false);


### PR DESCRIPTION
# What does this implement/fix?

Fixes two compile errors that surface when building the LEDC component against ESP-IDF 6.1:

```
.../components/esp_hal_ledc/esp32/include/hal/ledc_ll.h:21:55:
  error: expected primary-expression before '==' token
  #define LEDC_LL_GET_HW(group_id) ((group_id == 0) ? &LEDC : NULL)

.../components/ledc/ledc_output.cpp:166:7:
  error: 'ledc_ll_enable_reset_reg' was not declared in this scope
```

IDF 6.1 changed two LL pieces that LEDC uses directly:

- **`LEDC_LL_GET_HW()` → `LEDC_LL_GET_HW(group_id)`** -- macro now takes a group ID argument. No ESP32 variant ships more than one LEDC group (no `SOC_LEDC_GROUPS_NUM` exists), so `0` is the correct call.
- **`ledc_ll_enable_reset_reg(bool)` removed** -- replaced by a single-shot `ledc_ll_reset_register(int group_id)`. Use it on 6.1+ and keep the previous enable/disable pair on 6.0.

Pre-6.0 paths (`periph_module_reset(PERIPH_LEDC_MODULE)` and bare `LEDC_LL_GET_HW()`) are untouched.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Surfaced while testing against `esp-idf` master @ 6.1.0.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a (internal C++ adaptation, no user-facing change).

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

n/a -- no config surface changed.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).