### PR TITLE
[core] Use esp_rom_crc.h public API instead of legacy rom/crc.h

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -15,7 +15,7 @@
 #include <cstring>
 
 #ifdef USE_ESP32
-#include "rom/crc.h"
+#include "esp_rom_crc.h"
 #endif
 
 namespace esphome {
@@ -86,7 +86,7 @@ uint8_t crc8(const uint8_t *data, uint8_t len, uint8_t crc, uint8_t poly, bool m
 uint16_t crc16(const uint8_t *data, uint16_t len, uint16_t crc, uint16_t reverse_poly, bool refin, bool refout) {
 #ifdef USE_ESP32
   if (reverse_poly == 0x8408) {
-    crc = crc16_le(refin ? crc : (crc ^ 0xffff), data, len);
+    crc = esp_rom_crc16_le(refin ? crc : (crc ^ 0xffff), data, len);
     return refout ? crc : (crc ^ 0xffff);
   }
 #endif
@@ -126,7 +126,7 @@ uint16_t crc16(const uint8_t *data, uint16_t len, uint16_t crc, uint16_t reverse
 uint16_t crc16be(const uint8_t *data, uint16_t len, uint16_t crc, uint16_t poly, bool refin, bool refout) {
 #if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32S2)
   if (poly == 0x1021) {
-    crc = crc16_be(refin ? crc : (crc ^ 0xffff), data, len);
+    crc = esp_rom_crc16_be(refin ? crc : (crc ^ 0xffff), data, len);
     return refout ? crc : (crc ^ 0xffff);
   }
 #endif

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -47,7 +47,7 @@ static const uint16_t CRC16_8408_LE_LUT_H[] = {0x0000, 0x1081, 0x2102, 0x3183, 0
                                                0x8408, 0x9489, 0xa50a, 0xb58b, 0xc60c, 0xd68d, 0xe70e, 0xf78f};
 #endif
 
-#if !defined(USE_ESP32) || defined(USE_ESP32_VARIANT_ESP32S2)
+#ifndef USE_ESP32
 static const uint16_t CRC16_1021_BE_LUT_L[] = {0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
                                                0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef};
 static const uint16_t CRC16_1021_BE_LUT_H[] = {0x0000, 0x1231, 0x2462, 0x3653, 0x48c4, 0x5af5, 0x6ca6, 0x7e97,
@@ -124,7 +124,7 @@ uint16_t crc16(const uint8_t *data, uint16_t len, uint16_t crc, uint16_t reverse
 }
 
 uint16_t crc16be(const uint8_t *data, uint16_t len, uint16_t crc, uint16_t poly, bool refin, bool refout) {
-#if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32S2)
+#ifdef USE_ESP32
   if (poly == 0x1021) {
     crc = esp_rom_crc16_be(refin ? crc : (crc ^ 0xffff), data, len);
     return refout ? crc : (crc ^ 0xffff);
@@ -133,14 +133,15 @@ uint16_t crc16be(const uint8_t *data, uint16_t len, uint16_t crc, uint16_t poly,
   if (refin) {
     crc ^= 0xffff;
   }
-#if !defined(USE_ESP32) || defined(USE_ESP32_VARIANT_ESP32S2)
+#ifndef USE_ESP32
   if (poly == 0x1021) {
     while (len--) {
       uint8_t combo = (crc >> 8) ^ *data++;
       crc = (crc << 8) ^ CRC16_1021_BE_LUT_L[combo & 0x0F] ^ CRC16_1021_BE_LUT_H[combo >> 4];
     }
-  } else {
+  } else
 #endif
+  {
     while (len--) {
       crc ^= (((uint16_t) *data++) << 8);
       for (uint8_t i = 0; i < 8; i++) {
@@ -151,9 +152,7 @@ uint16_t crc16be(const uint8_t *data, uint16_t len, uint16_t crc, uint16_t poly,
         }
       }
     }
-#if !defined(USE_ESP32) || defined(USE_ESP32_VARIANT_ESP32S2)
   }
-#endif
   return refout ? (crc ^ 0xffff) : crc;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Two related changes that together let `esphome/core/helpers.cpp` build
cleanly on every current and future ESP32 variant.

**1. Switch from the legacy `rom/crc.h` header to the public
`esp_rom_crc.h` API.**

The per-variant `rom/crc.h` header (which exposes raw `crc16_le` /
`crc16_be` symbols) isn't shipped for newer variants in IDF 6.1 — the
`esp_rom/<variant>/include/<variant>/rom/` directory has no `crc.h` on
chips like ESP32-S31, ESP32-H21, and ESP32-H4, which breaks the build:

```
fatal error: rom/crc.h: No such file or directory
   18 | #include "rom/crc.h"
```

The unified `esp_rom_crc.h` API (`esp_rom_crc16_le` /
`esp_rom_crc16_be`) is part of the public component interface and is
declared for every variant.

**2. Drop the ESP32-S2 carve-out in `crc16be()`.**

ESP32-S2's ROM genuinely doesn't expose `crc16_be` (its
`esp32s2.rom.api.ld` only `PROVIDE`s `crc32_le` / `crc16_le` /
`crc8_le`). The old code worked around this by keeping a duplicated
software table loop and a `CRC16_1021_BE_LUT` table for S2.

However, IDF's `esp_rom` component already ships a software fallback at
`components/esp_rom/patches/esp_rom_crc.c`, gated on
`#if !ESP_ROM_HAS_CRC_BE`, so `esp_rom_crc16_be()` is callable on S2
(and any future chip whose ROM lacks BE crc) without ESPHome carrying
its own copy. Collapse the guards back to a plain
`USE_ESP32` / `!USE_ESP32` split, matching the style of `crc16()` (LE)
just above. The non-ESP32 path (esp8266/rp2040/libretiny) keeps the
table, so the only behavioral effect on S2 is that the software loop
moves from ESPHome to IDF.

Net result: pure portability + dedup. No CRC values change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

N/A — internal refactor of an existing helper.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).