### PR TITLE
[network] move ipv6 enforcement to validation step

### DIFF
--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -108,9 +108,7 @@ def has_high_performance_networking() -> bool:
     return CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False)
 
 
-def validate_ipv6(value):
-    value = cv.boolean(value)
-
+def validate_ipv6(value: bool) -> bool:
     if CORE.is_nrf52 and not value:
         raise cv.Invalid("On nRF52, enable_ipv6 must be true")
 

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -108,6 +108,15 @@ def has_high_performance_networking() -> bool:
     return CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False)
 
 
+def validate_ipv6(value):
+    value = cv.boolean(value)
+
+    if CORE.is_nrf52 and not value:
+        raise cv.Invalid("On nRF52, enable_ipv6 must be true")
+
+    return value
+
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(NetworkComponent),
@@ -133,6 +142,7 @@ CONFIG_SCHEMA = cv.Schema(
                 ),
                 cv.boolean_false,
             ),
+            validate_ipv6,
         ),
         cv.Optional(CONF_MIN_IPV6_ADDR_COUNT, default=0): cv.positive_int,
         cv.Optional(CONF_ENABLE_HIGH_PERFORMANCE): cv.All(cv.boolean, cv.only_on_esp32),
@@ -209,13 +219,6 @@ async def to_code(config):
             add_idf_sdkconfig_option("CONFIG_LWIP_TCPIP_RECVMBOX_SIZE", 64)
 
     if CORE.is_nrf52:
-        enable_ipv6 = config.get(CONF_ENABLE_IPV6, True)
-        if not enable_ipv6:
-            _LOGGER.warning(
-                "IPv6 cannot be disabled on nRF52 because the Zephyr IPAddress implementation is IPv6-only. "
-                "Forcing CONFIG_NET_IPV6=y."
-            )
-            config[CONF_ENABLE_IPV6] = True
         zephyr_add_prj_conf("NETWORKING", True)
         zephyr_add_prj_conf("NET_IPV6", True)
         zephyr_add_prj_conf("NET_TCP", True)


### PR DESCRIPTION
# What does this implement/fix?

Follow up on https://github.com/esphome/esphome/pull/16336. Enforce ipv6 at config validation instead of warning at compilation time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
