### PR TITLE
[esp32_camera] Enable PicolibC Newlib compatibility on IDF 6.0+

### DIFF
--- a/esphome/components/camera_encoder/__init__.py
+++ b/esphome/components/camera_encoder/__init__.py
@@ -1,8 +1,7 @@
 import esphome.codegen as cg
 from esphome.components.esp32 import (
     add_idf_component,
-    add_idf_sdkconfig_option,
-    idf_version,
+    require_libc_picolibc_newlib_compat,
 )
 import esphome.config_validation as cv
 from esphome.const import CONF_BUFFER_SIZE, CONF_ID, CONF_TYPE
@@ -55,10 +54,8 @@ async def to_code(config: ConfigType) -> None:
     cg.add(buffer.set_buffer_size(config[CONF_BUFFER_SIZE]))
     if config[CONF_TYPE] == ESP32_CAMERA_ENCODER:
         add_idf_component(name="espressif/esp32-camera", ref="2.1.5")
-        if idf_version() >= cv.Version(6, 0, 0):
-            # Enable PicolibC Newlib compatibility shim on IDF 6.0+ to fix missing type
-            # remove after updating to component version
-            add_idf_sdkconfig_option("CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY", True)
+        # esp32-camera 2.1.5 needs the Newlib shim on IDF 6.0+; remove when fixed upstream
+        require_libc_picolibc_newlib_compat()
         cg.add_define("USE_ESP32_CAMERA_JPEG_ENCODER")
         var = cg.new_Pvariable(
             config[CONF_ID],

--- a/esphome/components/camera_encoder/__init__.py
+++ b/esphome/components/camera_encoder/__init__.py
@@ -1,5 +1,9 @@
 import esphome.codegen as cg
-from esphome.components.esp32 import add_idf_component
+from esphome.components.esp32 import (
+    add_idf_component,
+    add_idf_sdkconfig_option,
+    idf_version,
+)
 import esphome.config_validation as cv
 from esphome.const import CONF_BUFFER_SIZE, CONF_ID, CONF_TYPE
 from esphome.types import ConfigType
@@ -51,6 +55,10 @@ async def to_code(config: ConfigType) -> None:
     cg.add(buffer.set_buffer_size(config[CONF_BUFFER_SIZE]))
     if config[CONF_TYPE] == ESP32_CAMERA_ENCODER:
         add_idf_component(name="espressif/esp32-camera", ref="2.1.5")
+        if idf_version() >= cv.Version(6, 0, 0):
+            # Enable PicolibC Newlib compatibility shim on IDF 6.0+ to fix missing type
+            # remove after updating to component version
+            add_idf_sdkconfig_option("CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY", True)
         cg.add_define("USE_ESP32_CAMERA_JPEG_ENCODER")
         var = cg.new_Pvariable(
             config[CONF_ID],

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1220,6 +1220,7 @@ KEY_MBEDTLS_PKCS7_REQUIRED = "mbedtls_pkcs7_required"
 KEY_FATFS_REQUIRED = "fatfs_required"
 KEY_MBEDTLS_SHA512_REQUIRED = "mbedtls_sha512_required"
 KEY_ADC_ONESHOT_IRAM_REQUIRED = "adc_oneshot_iram_required"
+KEY_LIBC_PICOLIBC_NEWLIB_COMPAT_REQUIRED = "libc_picolibc_newlib_compat_required"
 
 
 def require_vfs_select() -> None:
@@ -1326,6 +1327,15 @@ def require_adc_oneshot_iram() -> None:
     This sets CONFIG_ADC_ONESHOT_CTRL_FUNC_IN_IRAM.
     """
     CORE.data[KEY_ESP32][KEY_ADC_ONESHOT_IRAM_REQUIRED] = True
+
+
+def require_libc_picolibc_newlib_compat() -> None:
+    """Keep CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY enabled on IDF 6.0+.
+
+    Call this from components that link against precompiled Newlib binaries
+    referencing types/symbols the shim provides (e.g. esp32-camera).
+    """
+    CORE.data[KEY_ESP32][KEY_LIBC_PICOLIBC_NEWLIB_COMPAT_REQUIRED] = True
 
 
 def _parse_idf_component(value: str) -> ConfigType:
@@ -1730,6 +1740,22 @@ async def _write_arduino_libraries_sdkconfig() -> None:
     for lib in ARDUINO_DISABLED_LIBRARIES:
         # Enable if explicitly requested, disable otherwise
         add_idf_sdkconfig_option(f"CONFIG_ARDUINO_SELECTIVE_{lib}", lib in enabled_libs)
+
+
+@coroutine_with_priority(CoroPriority.FINAL)
+async def _set_libc_picolibc_newlib_compat() -> None:
+    """Apply the PicolibC Newlib compatibility shim option on IDF 6.0+.
+
+    IDF 6.0 switched from Newlib to PicolibC; the shim is disabled by default.
+    Runs at FINAL priority so every require_libc_picolibc_newlib_compat() call
+    (default priority) is seen before the option is written.
+    """
+    if idf_version() < cv.Version(6, 0, 0):
+        return
+    add_idf_sdkconfig_option(
+        "CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY",
+        CORE.data[KEY_ESP32].get(KEY_LIBC_PICOLIBC_NEWLIB_COMPAT_REQUIRED, False),
+    )
 
 
 @coroutine_with_priority(CoroPriority.FINAL)
@@ -2265,17 +2291,8 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA384_C", False)
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA512_C", False)
 
-    # Disable PicolibC Newlib compatibility shim on IDF 6.0+
-    # IDF 6.0 switched from Newlib to PicolibC. The shim provides thread-local
-    # stdin/stdout/stderr and getreent() for code compiled against Newlib.
-    # ESPHome doesn't link against Newlib-built libraries that use stdio.
-    # If a component needs it (e.g. precompiled Newlib binaries), re-enable via:
-    #   esp32:
-    #     framework:
-    #       sdkconfig_options:
-    #         CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY: "y"
-    if idf_version() >= cv.Version(6, 0, 0):
-        add_idf_sdkconfig_option("CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY", False)
+    # FINAL priority: runs after every require_libc_picolibc_newlib_compat() call
+    CORE.add_job(_set_libc_picolibc_newlib_compat)
 
     # Disable regi2c control functions in IRAM
     # Only needed if using analog peripherals (ADC, DAC, etc.) from ISRs while cache is disabled

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1748,12 +1748,16 @@ async def _set_libc_picolibc_newlib_compat() -> None:
 
     IDF 6.0 switched from Newlib to PicolibC; the shim is disabled by default.
     Runs at FINAL priority so every require_libc_picolibc_newlib_compat() call
-    (default priority) is seen before the option is written.
+    (default priority) is seen before the option is written. A user-supplied
+    sdkconfig_options value takes precedence.
     """
     if idf_version() < cv.Version(6, 0, 0):
         return
+    option = "CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY"
+    if option in CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]:
+        return
     add_idf_sdkconfig_option(
-        "CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY",
+        option,
         CORE.data[KEY_ESP32].get(KEY_LIBC_PICOLIBC_NEWLIB_COMPAT_REQUIRED, False),
     )
 

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -6,7 +6,7 @@ from esphome.components import i2c
 from esphome.components.esp32 import (
     add_idf_component,
     add_idf_sdkconfig_option,
-    idf_version,
+    require_libc_picolibc_newlib_compat,
 )
 from esphome.components.psram import DOMAIN as psram_domain
 import esphome.config_validation as cv
@@ -406,10 +406,8 @@ async def to_code(config):
     add_idf_component(name="espressif/esp32-camera", ref="2.1.5")
     add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_NEW", True)
     add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_LEGACY", False)
-    if idf_version() >= cv.Version(6, 0, 0):
-        # Enable PicolibC Newlib compatibility shim on IDF 6.0+ to fix missing type
-        # remove after updating to component version
-        add_idf_sdkconfig_option("CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY", True)
+    # esp32-camera 2.1.5 needs the Newlib shim on IDF 6.0+; remove when fixed upstream
+    require_libc_picolibc_newlib_compat()
 
     for conf in config.get(CONF_ON_STREAM_START, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -3,7 +3,11 @@ import logging
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import i2c
-from esphome.components.esp32 import add_idf_component, add_idf_sdkconfig_option
+from esphome.components.esp32 import (
+    add_idf_component,
+    add_idf_sdkconfig_option,
+    idf_version,
+)
 from esphome.components.psram import DOMAIN as psram_domain
 import esphome.config_validation as cv
 from esphome.const import (
@@ -402,6 +406,10 @@ async def to_code(config):
     add_idf_component(name="espressif/esp32-camera", ref="2.1.5")
     add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_NEW", True)
     add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_LEGACY", False)
+    if idf_version() >= cv.Version(6, 0, 0):
+        # Enable PicolibC Newlib compatibility shim on IDF 6.0+ to fix missing type
+        # remove after updating to component version
+        add_idf_sdkconfig_option("CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY", True)
 
     for conf in config.get(CONF_ON_STREAM_START, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)


### PR DESCRIPTION
# What does this implement/fix?

esp32-camera 2.1.5 references a libc type that the PicolibC variant shipped with ESP-IDF 6.0+ doesn't expose by default, so building against IDF 6 fails. Enable \`CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY\` on IDF 6.0+ to pull in the Newlib compatibility shim that provides the missing type.

This is gated on \`idf_version() >= cv.Version(6, 0, 0)\` so IDF 5.x builds are unaffected.

The fix is intentionally a stopgap (note in the comment): once an esp32-camera release lands that no longer needs the shim, this block should be removed. We do **not** bump esp32-camera's pin here — 2.1.5 stays in place to avoid the M5Stack CamS3 5MP / PY260 mega_ccm frame-capture regression that drove #16293's 2.1.6 → 2.1.5 downgrade.

Applied identically to both call sites:
- \`esphome/components/esp32_camera/__init__.py\`
- \`esphome/components/camera_encoder/__init__.py\`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

N/A — internal sdkconfig adjustment, no user-facing schema change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).