### PR TITLE
[ci] Fix auto label platform restructure false positive

### DIFF
--- a/.github/scripts/auto-label-pr/detectors.js
+++ b/.github/scripts/auto-label-pr/detectors.js
@@ -107,12 +107,18 @@ async function detectNewPlatforms(github, context, prFiles, apiData) {
     /^esphome\/components\/([^\/]+)\/([^\/]+)\/__init__\.py$/,
   ];
 
+  const removedFiles = new Set(prFiles.filter(file => file.status === 'removed').map(file => file.filename));
+
   for (const file of addedFiles) {
     for (const re of platformPathPatterns) {
       const match = file.match(re);
       if (!match) continue;
       const platform = match[2];
       if (!apiData.platformComponents.includes(platform)) break;
+
+      // Skip if this is a restructure: <component>/<platform>.py -> <component>/<platform>/__init__.py
+      const flatEquivalent = `esphome/components/${match[1]}/${platform}.py`;
+      if (removedFiles.has(flatEquivalent)) break;
 
       labels.add('new-platform');
       const content = await fetchPrFileContent(github, context, file);

--- a/.github/scripts/auto-label-pr/detectors.js
+++ b/.github/scripts/auto-label-pr/detectors.js
@@ -116,9 +116,11 @@ async function detectNewPlatforms(github, context, prFiles, apiData) {
       const platform = match[2];
       if (!apiData.platformComponents.includes(platform)) break;
 
-      // Skip if this is a restructure: <component>/<platform>.py -> <component>/<platform>/__init__.py
+      // Skip if this is a restructure between flat and subdirectory forms (either direction):
+      //   <component>/<platform>.py  <->  <component>/<platform>/__init__.py
       const flatEquivalent = `esphome/components/${match[1]}/${platform}.py`;
-      if (removedFiles.has(flatEquivalent)) break;
+      const subdirEquivalent = `esphome/components/${match[1]}/${platform}/__init__.py`;
+      if (removedFiles.has(flatEquivalent) || removedFiles.has(subdirEquivalent)) break;
 
       labels.add('new-platform');
       const content = await fetchPrFileContent(github, context, file);

--- a/.github/scripts/auto-label-pr/package.json
+++ b/.github/scripts/auto-label-pr/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "auto-label-pr",
+  "private": true,
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  }
+}

--- a/.github/scripts/auto-label-pr/tests/detectors.test.js
+++ b/.github/scripts/auto-label-pr/tests/detectors.test.js
@@ -1,0 +1,148 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { detectNewPlatforms, detectNewComponents } = require('../detectors');
+
+// Minimal GitHub API mock — only repos.getContent is called by detectNewPlatforms/detectNewComponents
+// to check for CONFIG_SCHEMA in newly added files.
+function makeGithub(content = '') {
+  return {
+    rest: {
+      repos: {
+        getContent: async () => ({
+          data: { content: Buffer.from(content).toString('base64') }
+        })
+      }
+    }
+  };
+}
+
+const CONTEXT = {
+  repo: { owner: 'esphome', repo: 'esphome' },
+  payload: { pull_request: { head: { sha: 'abc123' }, base: { ref: 'dev' } } }
+};
+
+const API_DATA = {
+  targetPlatforms: ['esp32', 'esp8266', 'rp2040'],
+  platformComponents: ['cover', 'sensor', 'binary_sensor', 'switch', 'light', 'fan', 'climate', 'valve']
+};
+
+const WITH_SCHEMA = 'CONFIG_SCHEMA = cv.Schema({})';
+const WITHOUT_SCHEMA = 'CODEOWNERS = ["@esphome/core"]';
+
+// ---------------------------------------------------------------------------
+// detectNewPlatforms
+// ---------------------------------------------------------------------------
+
+describe('detectNewPlatforms', () => {
+  describe('restructure detection (no false positives)', () => {
+    it('flat .py -> subdir __init__.py is not a new platform', async () => {
+      const prFiles = [
+        { filename: 'esphome/components/endstop/cover.py', status: 'removed' },
+        { filename: 'esphome/components/endstop/cover/__init__.py', status: 'added' },
+      ];
+      const result = await detectNewPlatforms(makeGithub(WITH_SCHEMA), CONTEXT, prFiles, API_DATA);
+      assert.equal(result.labels.size, 0);
+      assert.equal(result.hasYamlLoadable, false);
+    });
+
+    it('subdir __init__.py -> flat .py is not a new platform', async () => {
+      const prFiles = [
+        { filename: 'esphome/components/endstop/cover/__init__.py', status: 'removed' },
+        { filename: 'esphome/components/endstop/cover.py', status: 'added' },
+      ];
+      const result = await detectNewPlatforms(makeGithub(WITH_SCHEMA), CONTEXT, prFiles, API_DATA);
+      assert.equal(result.labels.size, 0);
+      assert.equal(result.hasYamlLoadable, false);
+    });
+  });
+
+  describe('genuine new platforms', () => {
+    it('new subdir platform with CONFIG_SCHEMA sets new-platform and hasYamlLoadable', async () => {
+      const prFiles = [
+        { filename: 'esphome/components/my_sensor/cover/__init__.py', status: 'added' },
+      ];
+      const result = await detectNewPlatforms(makeGithub(WITH_SCHEMA), CONTEXT, prFiles, API_DATA);
+      assert.ok(result.labels.has('new-platform'));
+      assert.equal(result.hasYamlLoadable, true);
+    });
+
+    it('new flat platform with CONFIG_SCHEMA sets new-platform and hasYamlLoadable', async () => {
+      const prFiles = [
+        { filename: 'esphome/components/my_sensor/cover.py', status: 'added' },
+      ];
+      const result = await detectNewPlatforms(makeGithub(WITH_SCHEMA), CONTEXT, prFiles, API_DATA);
+      assert.ok(result.labels.has('new-platform'));
+      assert.equal(result.hasYamlLoadable, true);
+    });
+
+    it('new platform without CONFIG_SCHEMA sets new-platform but not hasYamlLoadable', async () => {
+      const prFiles = [
+        { filename: 'esphome/components/my_sensor/cover.py', status: 'added' },
+      ];
+      const result = await detectNewPlatforms(makeGithub(WITHOUT_SCHEMA), CONTEXT, prFiles, API_DATA);
+      assert.ok(result.labels.has('new-platform'));
+      assert.equal(result.hasYamlLoadable, false);
+    });
+
+    it('non-platform file addition produces no labels', async () => {
+      const prFiles = [
+        { filename: 'esphome/components/my_sensor/sensor.py', status: 'added' },
+      ];
+      // 'sensor' is not in platformComponents as a *platform* name here — but actually
+      // it IS in our test API_DATA. Let's use a name that isn't a platform component.
+      const nonPlatformApiData = { ...API_DATA, platformComponents: ['cover'] };
+      const result = await detectNewPlatforms(makeGithub(WITH_SCHEMA), CONTEXT, prFiles, nonPlatformApiData);
+      assert.equal(result.labels.size, 0);
+      assert.equal(result.hasYamlLoadable, false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectNewComponents
+// ---------------------------------------------------------------------------
+
+describe('detectNewComponents', () => {
+  it('new top-level __init__.py sets new-component', async () => {
+    const prFiles = [
+      { filename: 'esphome/components/actuator/__init__.py', status: 'added', },
+    ];
+    const result = await detectNewComponents(makeGithub(WITHOUT_SCHEMA), CONTEXT, prFiles);
+    assert.ok(result.labels.has('new-component'));
+    assert.equal(result.hasYamlLoadable, false);
+  });
+
+  it('new top-level __init__.py with CONFIG_SCHEMA sets hasYamlLoadable', async () => {
+    const prFiles = [
+      { filename: 'esphome/components/my_component/__init__.py', status: 'added' },
+    ];
+    const result = await detectNewComponents(makeGithub(WITH_SCHEMA), CONTEXT, prFiles);
+    assert.ok(result.labels.has('new-component'));
+    assert.equal(result.hasYamlLoadable, true);
+  });
+
+  it('new top-level __init__.py with IS_TARGET_PLATFORM sets new-target-platform', async () => {
+    const prFiles = [
+      { filename: 'esphome/components/my_platform/__init__.py', status: 'added' },
+    ];
+    const result = await detectNewComponents(makeGithub('IS_TARGET_PLATFORM = True'), CONTEXT, prFiles);
+    assert.ok(result.labels.has('new-component'));
+    assert.ok(result.labels.has('new-target-platform'));
+  });
+
+  it('modified __init__.py does not set new-component', async () => {
+    const prFiles = [
+      { filename: 'esphome/components/existing/__init__.py', status: 'modified' },
+    ];
+    const result = await detectNewComponents(makeGithub(WITH_SCHEMA), CONTEXT, prFiles);
+    assert.equal(result.labels.size, 0);
+  });
+
+  it('nested __init__.py does not set new-component', async () => {
+    const prFiles = [
+      { filename: 'esphome/components/endstop/cover/__init__.py', status: 'added' },
+    ];
+    const result = await detectNewComponents(makeGithub(WITH_SCHEMA), CONTEXT, prFiles);
+    assert.equal(result.labels.size, 0);
+  });
+});

--- a/.github/scripts/auto-label-pr/tests/detectors.test.js
+++ b/.github/scripts/auto-label-pr/tests/detectors.test.js
@@ -88,8 +88,7 @@ describe('detectNewPlatforms', () => {
       const prFiles = [
         { filename: 'esphome/components/my_sensor/sensor.py', status: 'added' },
       ];
-      // 'sensor' is not in platformComponents as a *platform* name here — but actually
-      // it IS in our test API_DATA. Let's use a name that isn't a platform component.
+      // Override platformComponents so 'sensor' is not a recognized platform -> no label expected.
       const nonPlatformApiData = { ...API_DATA, platformComponents: ['cover'] };
       const result = await detectNewPlatforms(makeGithub(WITH_SCHEMA), CONTEXT, prFiles, nonPlatformApiData);
       assert.equal(result.labels.size, 0);

--- a/.github/workflows/ci-github-scripts.yml
+++ b/.github/workflows/ci-github-scripts.yml
@@ -1,0 +1,25 @@
+name: CI - GitHub Scripts
+
+on:
+  push:
+    branches: [dev, beta, release]
+    paths:
+      - ".github/scripts/**"
+  pull_request:
+    paths:
+      - ".github/scripts/**"
+
+permissions:
+  contents: read
+
+jobs:
+  test-auto-label-pr:
+    name: Test auto-label-pr scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run tests
+        working-directory: .github/scripts/auto-label-pr
+        run: npm test

--- a/.github/workflows/ci-github-scripts.yml
+++ b/.github/workflows/ci-github-scripts.yml
@@ -5,9 +5,11 @@ on:
     branches: [dev, beta, release]
     paths:
       - ".github/scripts/**"
+      - ".github/workflows/ci-github-scripts.yml"
   pull_request:
     paths:
       - ".github/scripts/**"
+      - ".github/workflows/ci-github-scripts.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes labeling new-platforms to exclude situations where a file is moved to a subfolder (e.g. `endstop/cover.py` to `endstop/cover/__init__.py`)

- Avoids labeling as new-platform for moves in both directions
- Tests added to workflow script to avoid regressions in future
- Avoids labeling as needs-docs when not needed

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
