### PR TITLE
[ethernet] Bump espressif/dm9051 to 1.1.0

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -163,7 +163,7 @@ _IDF6_ETHERNET_COMPONENTS: dict[str, IDFRegistryComponent] = {
     "KSZ8081": IDFRegistryComponent("espressif/ksz80xx", "1.0.0"),
     "KSZ8081RNA": IDFRegistryComponent("espressif/ksz80xx", "1.0.0"),
     "W5500": IDFRegistryComponent("espressif/w5500", "1.0.1"),
-    "DM9051": IDFRegistryComponent("espressif/dm9051", "1.0.0"),
+    "DM9051": IDFRegistryComponent("espressif/dm9051", "1.1.0"),
     "ENC28J60": IDFRegistryComponent("espressif/enc28j60", "1.0.1"),
     "LAN8670": IDFRegistryComponent("espressif/lan867x", "2.0.0"),
 }

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -78,7 +78,7 @@ dependencies:
     rules:
       - if: "idf_version >=6.0.0"
   espressif/dm9051:
-    version: "1.0.0"
+    version: "1.1.0"
     rules:
       - if: "idf_version >=6.0.0"
   espressif/esp_tinyusb:


### PR DESCRIPTION
# What does this implement/fix?

Bumps the `espressif/dm9051` managed component pin from `1.0.0` to `1.1.0`.

arduino-esp32 4.0.0-alpha1 requires `espressif/dm9051 ^1.1.0` on ESP-IDF 6, but ESPHome pinned `1.0.0` in two places (the managed-component manifest `esphome/idf_component.yml` and the ethernet component's IDF 6 registry in `ethernet/__init__.py`). On an IDF 6 esp32-arduino build the two constraints (`1.0.0` vs `^1.1.0`) can't be reconciled and dependency solving fails. `1.1.0` satisfies arduino-esp32's `^1.1.0` and is the version already being resolved in practice.

The pin is gated to `idf_version >=6.0.0`, so IDF 5.x builds are unaffected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — internal managed-component version bump, no user-facing schema change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).