### PR TITLE
[esp8266] Loop delay() until the full interval elapses

### DIFF
--- a/esphome/components/esp8266/hal.cpp
+++ b/esphome/components/esp8266/hal.cpp
@@ -72,22 +72,25 @@ uint32_t IRAM_ATTR HOT millis() {
   return result;
 }
 
-// Delegate to Arduino's 1-arg esp_delay(), which uses os_timer + esp_suspend to
-// suspend the cont task for `ms` milliseconds without polling millis(). This
-// matches pre-2026.5.0 behavior (when esphome::delay() forwarded to ::delay())
-// and lets the SDK run freely while we wait, which timing-sensitive
-// interrupt-driven code (e.g. ESP8266 software-serial RX in components like
-// fingerprint_grow) depends on. The poll-based busy-wait that this replaced
-// rarely yielded inside short waits like delay(1), starving WiFi/SDK tasks and
-// extending interrupt latency. Unlike ::delay(), esp_delay()'s 1-arg form does
-// not call millis(), so the slow Arduino millis() body is not pulled into IRAM
-// by this path (the --wrap=millis goal of #15662 is preserved).
+// Wait at least `ms` milliseconds while letting the SDK run. The 1-arg esp_delay()
+// suspends the cont task via os_timer + esp_suspend so WiFi/SDK tasks run freely
+// (which timing-sensitive interrupt-driven code like ESP8266 software-serial RX in
+// fingerprint_grow depends on), but it is a single suspend: esp_suspend() resumes
+// on ANY esp_schedule() (not just our delay timer) and no-ops entirely when the
+// cont can't suspend, so a lone esp_delay(ms) can return well before `ms` elapses.
+// Loop on the wrapped fast millis() until the full interval has actually passed so
+// callers get at least the delay they asked for, matching Arduino ::delay(). Using
+// the wrapped millis() keeps the slow Arduino millis() body out of IRAM (the
+// --wrap=millis goal of #15662 is preserved); millis() is hardware-backed, so it
+// still advances on the rare path where esp_delay() can't suspend and busy-waits.
 void HOT delay(uint32_t ms) {
   if (ms == 0) {
     optimistic_yield(1000);
     return;
   }
-  esp_delay(ms);
+  uint32_t start = millis();
+  for (uint32_t elapsed = 0; elapsed < ms; elapsed = millis() - start)
+    esp_delay(ms - elapsed);
 }
 
 void arch_restart() {


### PR DESCRIPTION
# What does this implement/fix?

On ESP8266 `delay()` called the 1-arg `esp_delay()`, which suspends the cont task only once and resumes on any `esp_schedule()`, not just its own timer; it also no-ops entirely when the cont can't suspend. As a result `delay(ms)` could return well before `ms` had actually elapsed, particularly during WiFi activity when the SDK posts the loop task frequently. This loops on the hardware-backed `millis()` until the full interval has passed, matching Arduino's `::delay()` semantics, while still using the wrapped fast `millis()` so the slow Arduino `millis()` body stays out of IRAM.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16738

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No configuration change; this is a core ESP8266 HAL fix.
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
