### PR TITLE
[renogy_inverter_ble] Add Renogy inverter BLE sensor component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -432,6 +432,7 @@ esphome/components/rc522/* @glmnet
 esphome/components/rc522_i2c/* @glmnet
 esphome/components/rc522_spi/* @glmnet
 esphome/components/rd03d/* @jasstrong
+esphome/components/renogy_inverter_ble/* @emilioaray-dev
 esphome/components/resampler/speaker/* @kahrendt
 esphome/components/restart/* @esphome/core
 esphome/components/rf_bridge/* @jesserockz

--- a/esphome/components/renogy_inverter_ble/__init__.py
+++ b/esphome/components/renogy_inverter_ble/__init__.py
@@ -6,7 +6,7 @@ RIV1230PU-126); applies to the RNGRIU family.
 The inverter speaks Modbus-over-BLE but requires a proprietary init read on characteristic
 0xFFD4 before it answers (the reason a generic modbus_controller times out). This hub connects
 via ble_client, performs that init, then reads holding registers 4000 (main) and 4408 (load),
-publishing the values to the configured sensors. Goal v1.31; built PR-ready for ESPHome upstream.
+publishing the values to the configured sensors.
 """
 
 import esphome.codegen as cg

--- a/esphome/components/renogy_inverter_ble/__init__.py
+++ b/esphome/components/renogy_inverter_ble/__init__.py
@@ -1,0 +1,49 @@
+"""ESPHome component: read a Renogy inverter with built-in Bluetooth over BLE → sensors.
+
+Tested against the Renogy PUH 12V 3000W Pure Sine Wave Inverter (UPS transfer switch, SKU
+RIV1230PU-126); applies to the RNGRIU family.
+
+The inverter speaks Modbus-over-BLE but requires a proprietary init read on characteristic
+0xFFD4 before it answers (the reason a generic modbus_controller times out). This hub connects
+via ble_client, performs that init, then reads holding registers 4000 (main) and 4408 (load),
+publishing the values to the configured sensors. Goal v1.31; built PR-ready for ESPHome upstream.
+"""
+
+import esphome.codegen as cg
+from esphome.components import ble_client
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+CODEOWNERS = ["@emilioaray-dev"]
+DEPENDENCIES = ["ble_client"]
+AUTO_LOAD = ["sensor"]
+MULTI_CONF = True
+
+CONF_RENOGY_INVERTER_BLE_ID = "renogy_inverter_ble_id"
+
+renogy_inverter_ble_ns = cg.esphome_ns.namespace("renogy_inverter_ble")
+RenogyInverterBle = renogy_inverter_ble_ns.class_(
+    "RenogyInverterBle", ble_client.BLEClientNode, cg.PollingComponent
+)
+
+RENOGY_INVERTER_BLE_COMPONENT_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_RENOGY_INVERTER_BLE_ID): cv.use_id(RenogyInverterBle),
+    }
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(RenogyInverterBle),
+        }
+    )
+    .extend(ble_client.BLE_CLIENT_SCHEMA)
+    .extend(cv.polling_component_schema("30s"))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await ble_client.register_ble_node(var, config)

--- a/esphome/components/renogy_inverter_ble/renogy_inverter_ble.cpp
+++ b/esphome/components/renogy_inverter_ble/renogy_inverter_ble.cpp
@@ -23,6 +23,10 @@ static const uint16_t REG_LOAD = 4408;
 static const uint16_t REG_LOAD_WORDS = 6;
 // Largest expected response: 3 header + 2*32 data + 2 CRC = 69 bytes.
 static const size_t MAX_FRAME = 80;
+// Watchdog for one read cycle. A healthy init->main->load exchange finishes well under a second;
+// 3 s is generous headroom. If it elapses the state machine is wedged (silent device, lost
+// notification) and we reset so the next poll retries.
+static const uint32_t CYCLE_TIMEOUT_MS = 3000;
 
 static uint16_t modbus_crc16(const uint8_t *data, uint16_t len) {
   uint16_t crc = 0xFFFF;
@@ -66,6 +70,13 @@ void RenogyInverterBle::reset_frame_() {
   this->expected_len_ = 0;
 }
 
+void RenogyInverterBle::abort_cycle_() {
+  this->cancel_timeout("rng_cycle");
+  this->cancel_timeout("rng_load");
+  this->reset_frame_();
+  this->state_ = State::IDLE;
+}
+
 static bool crc_valid(const uint8_t *data, uint16_t len) {
   if (len < 5) {
     return false;
@@ -94,19 +105,26 @@ void RenogyInverterBle::read_register_(uint16_t start_register, uint16_t word_co
                                req.size(), req.data(), ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (status != ESP_OK) {
     ESP_LOGW(TAG, "write_char (reg %u) failed, status=%d", start_register, status);
-    this->state_ = State::IDLE;
+    this->abort_cycle_();
   }
 }
 
 void RenogyInverterBle::start_cycle_() {
   this->reset_frame_();
+  // Arm the cycle watchdog. The YAML mqtt/wifi reboot_timeout cannot rescue a wedged read cycle:
+  // MQTT stays alive while only this state machine is stuck, so the device would publish stale
+  // values forever. This timer guarantees the cycle always returns to IDLE.
+  this->set_timeout("rng_cycle", CYCLE_TIMEOUT_MS, [this]() {
+    ESP_LOGW(TAG, "Read cycle timed out (state=%u); resetting", static_cast<uint8_t>(this->state_));
+    this->abort_cycle_();
+  });
   if (this->init_handle_ != 0) {
     this->state_ = State::INIT;
     const esp_err_t status = esp_ble_gattc_read_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(),
                                                      this->init_handle_, ESP_GATT_AUTH_REQ_NONE);
     if (status != ESP_OK) {
       ESP_LOGW(TAG, "init read_char failed, status=%d", status);
-      this->state_ = State::IDLE;
+      this->abort_cycle_();
     }
   } else {
     // No init characteristic discovered — try the main read directly (best effort).
@@ -131,8 +149,14 @@ void RenogyInverterBle::on_frame_complete_() {
   const uint16_t len = this->expected_len_;
   if (!crc_valid(this->frame_.data(), len)) {
     ESP_LOGW(TAG, "CRC mismatch (state=%u, len=%u)", static_cast<uint8_t>(this->state_), len);
-    this->reset_frame_();
-    this->state_ = State::IDLE;
+    this->abort_cycle_();
+    return;
+  }
+  // Modbus exception response: the function code echoes back with the high bit set (e.g. 0x83 for
+  // a read). The third byte is the exception code, not a byte count — bail before parsing data.
+  if ((this->frame_[1] & 0x80) != 0) {
+    ESP_LOGW(TAG, "Modbus exception 0x%02X (state=%u)", this->frame_[2], static_cast<uint8_t>(this->state_));
+    this->abort_cycle_();
     return;
   }
   const uint8_t word_count = this->frame_[2] / 2;
@@ -145,8 +169,7 @@ void RenogyInverterBle::on_frame_complete_() {
   if (this->state_ == State::MAIN) {
     if (word_count < 10) {
       ESP_LOGW(TAG, "Main response too short: %u words", word_count);
-      this->reset_frame_();
-      this->state_ = State::IDLE;
+      this->abort_cycle_();
       return;
     }
     publish(this->ac_input_voltage_sensor_, reg16(0) * 0.1f);
@@ -170,11 +193,9 @@ void RenogyInverterBle::on_frame_complete_() {
       publish(this->load_active_power_sensor_, static_cast<float>(reg16(1)));
       publish(this->load_apparent_power_sensor_, static_cast<float>(reg16(2)));
     }
-    this->reset_frame_();
-    this->state_ = State::IDLE;
+    this->abort_cycle_();
   } else {
-    this->reset_frame_();
-    this->state_ = State::IDLE;
+    this->abort_cycle_();
   }
 }
 
@@ -183,11 +204,10 @@ void RenogyInverterBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt
   switch (event) {
     case ESP_GATTC_DISCONNECT_EVT: {
       this->established_ = false;
-      this->state_ = State::IDLE;
       this->notify_handle_ = 0;
       this->write_handle_ = 0;
       this->init_handle_ = 0;
-      this->reset_frame_();
+      this->abort_cycle_();
       this->node_state = espbt::ClientState::IDLE;
       break;
     }
@@ -241,7 +261,9 @@ void RenogyInverterBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt
       }
       this->frame_.insert(this->frame_.end(), param->notify.value, param->notify.value + param->notify.value_len);
       if (this->expected_len_ == 0 && this->frame_.size() >= 3) {
-        this->expected_len_ = 3 + this->frame_[2] + 2;
+        // Exception frame ([id][func|0x80][exc][crc][crc]) is 5 bytes; a normal response is
+        // [id][func][byte_count][...data][crc][crc]. Pick the expected length by the function code.
+        this->expected_len_ = ((this->frame_[1] & 0x80) != 0) ? 5 : (3 + this->frame_[2] + 2);
       }
       if (this->expected_len_ != 0 && this->frame_.size() >= this->expected_len_) {
         this->on_frame_complete_();

--- a/esphome/components/renogy_inverter_ble/renogy_inverter_ble.cpp
+++ b/esphome/components/renogy_inverter_ble/renogy_inverter_ble.cpp
@@ -1,0 +1,258 @@
+#include "renogy_inverter_ble.h"
+#include "esphome/core/log.h"
+
+#ifdef USE_ESP32
+
+namespace esphome::renogy_inverter_ble {
+
+static const char *const TAG = "renogy_inverter_ble";
+
+// GATT UUIDs (16-bit). Notify svc/char and write svc/char + the proprietary init char.
+static const uint16_t SERVICE_NOTIFY_UUID = 0xFFF0;
+static const uint16_t CHAR_NOTIFY_UUID = 0xFFF1;
+static const uint16_t SERVICE_WRITE_UUID = 0xFFD0;
+static const uint16_t CHAR_WRITE_UUID = 0xFFD1;
+static const uint16_t CHAR_INIT_UUID = 0xFFD4;
+
+// Modbus over BLE.
+static const uint8_t MODBUS_DEVICE_ID = 0x20;
+static const uint8_t MODBUS_READ_HOLDING = 0x03;
+static const uint16_t REG_MAIN = 4000;
+static const uint16_t REG_MAIN_WORDS = 32;
+static const uint16_t REG_LOAD = 4408;
+static const uint16_t REG_LOAD_WORDS = 6;
+// Largest expected response: 3 header + 2*32 data + 2 CRC = 69 bytes.
+static const size_t MAX_FRAME = 80;
+
+static uint16_t modbus_crc16(const uint8_t *data, uint16_t len) {
+  uint16_t crc = 0xFFFF;
+  for (uint16_t i = 0; i < len; i++) {
+    crc ^= data[i];
+    for (uint8_t bit = 0; bit < 8; bit++) {
+      if ((crc & 0x0001) != 0) {
+        crc = (crc >> 1) ^ 0xA001;
+      } else {
+        crc >>= 1;
+      }
+    }
+  }
+  return crc;  // serialized low byte first
+}
+
+void RenogyInverterBle::setup() { this->frame_.reserve(MAX_FRAME); }
+
+void RenogyInverterBle::dump_config() {
+  ESP_LOGCONFIG(TAG, "Renogy Inverter BLE:");
+  LOG_SENSOR("  ", "AC input voltage", this->ac_input_voltage_sensor_);
+  LOG_SENSOR("  ", "AC output voltage", this->ac_output_voltage_sensor_);
+  LOG_SENSOR("  ", "AC output current", this->ac_output_current_sensor_);
+  LOG_SENSOR("  ", "AC output frequency", this->ac_output_frequency_sensor_);
+  LOG_SENSOR("  ", "Input frequency", this->input_frequency_sensor_);
+  LOG_SENSOR("  ", "Battery voltage", this->battery_voltage_sensor_);
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+  LOG_SENSOR("  ", "Load current", this->load_current_sensor_);
+  LOG_SENSOR("  ", "Load active power", this->load_active_power_sensor_);
+  LOG_SENSOR("  ", "Load apparent power", this->load_apparent_power_sensor_);
+}
+
+static void publish(sensor::Sensor *s, float value) {
+  if (s != nullptr) {
+    s->publish_state(value);
+  }
+}
+
+void RenogyInverterBle::reset_frame_() {
+  this->frame_.clear();
+  this->expected_len_ = 0;
+}
+
+static bool crc_valid(const uint8_t *data, uint16_t len) {
+  if (len < 5) {
+    return false;
+  }
+  const uint16_t crc = modbus_crc16(data, len - 2);
+  const uint8_t crc_lo = crc & 0xFF;
+  const uint8_t crc_hi = (crc >> 8) & 0xFF;
+  return data[len - 2] == crc_lo && data[len - 1] == crc_hi;
+}
+
+void RenogyInverterBle::read_register_(uint16_t start_register, uint16_t word_count) {
+  std::array<uint8_t, 8> req{};
+  req[0] = MODBUS_DEVICE_ID;
+  req[1] = MODBUS_READ_HOLDING;
+  req[2] = (start_register >> 8) & 0xFF;
+  req[3] = start_register & 0xFF;
+  req[4] = (word_count >> 8) & 0xFF;
+  req[5] = word_count & 0xFF;
+  const uint16_t crc = modbus_crc16(req.data(), 6);
+  req[6] = crc & 0xFF;
+  req[7] = (crc >> 8) & 0xFF;
+
+  this->reset_frame_();
+  const esp_err_t status =
+      esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->write_handle_,
+                               req.size(), req.data(), ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
+  if (status != ESP_OK) {
+    ESP_LOGW(TAG, "write_char (reg %u) failed, status=%d", start_register, status);
+    this->state_ = State::IDLE;
+  }
+}
+
+void RenogyInverterBle::start_cycle_() {
+  this->reset_frame_();
+  if (this->init_handle_ != 0) {
+    this->state_ = State::INIT;
+    const esp_err_t status = esp_ble_gattc_read_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(),
+                                                     this->init_handle_, ESP_GATT_AUTH_REQ_NONE);
+    if (status != ESP_OK) {
+      ESP_LOGW(TAG, "init read_char failed, status=%d", status);
+      this->state_ = State::IDLE;
+    }
+  } else {
+    // No init characteristic discovered — try the main read directly (best effort).
+    this->state_ = State::MAIN;
+    this->read_register_(REG_MAIN, REG_MAIN_WORDS);
+  }
+}
+
+void RenogyInverterBle::update() {
+  if (!this->established_) {
+    ESP_LOGD(TAG, "Not connected yet; skipping poll");
+    return;
+  }
+  if (this->state_ != State::IDLE) {
+    ESP_LOGD(TAG, "Previous read cycle still in progress; skipping");
+    return;
+  }
+  this->start_cycle_();
+}
+
+void RenogyInverterBle::on_frame_complete_() {
+  const uint16_t len = this->expected_len_;
+  if (!crc_valid(this->frame_.data(), len)) {
+    ESP_LOGW(TAG, "CRC mismatch (state=%u, len=%u)", static_cast<uint8_t>(this->state_), len);
+    this->reset_frame_();
+    this->state_ = State::IDLE;
+    return;
+  }
+  const uint8_t word_count = this->frame_[2] / 2;
+  // NOTE: do NOT name this `word` — Arduino.h defines a `word(...)` macro that expands the calls
+  // to makeWord() and silently returns the argument (every word(i) became i → all values wrong).
+  auto reg16 = [this](uint8_t i) -> uint16_t {
+    return static_cast<uint16_t>((this->frame_[3 + 2 * i] << 8) | this->frame_[3 + 2 * i + 1]);
+  };
+
+  if (this->state_ == State::MAIN) {
+    if (word_count < 10) {
+      ESP_LOGW(TAG, "Main response too short: %u words", word_count);
+      this->reset_frame_();
+      this->state_ = State::IDLE;
+      return;
+    }
+    publish(this->ac_input_voltage_sensor_, reg16(0) * 0.1f);
+    publish(this->ac_output_voltage_sensor_, reg16(2) * 0.1f);
+    publish(this->ac_output_current_sensor_, reg16(3) * 0.01f);
+    publish(this->ac_output_frequency_sensor_, reg16(4) * 0.01f);
+    publish(this->battery_voltage_sensor_, reg16(5) * 0.1f);
+    publish(this->temperature_sensor_, reg16(6) * 0.1f);
+    publish(this->input_frequency_sensor_, reg16(9) * 0.01f);
+    this->reset_frame_();
+    // Inter-command delay, then read the load register.
+    this->set_timeout("rng_load", 300, [this]() {
+      this->state_ = State::LOAD;
+      this->read_register_(REG_LOAD, REG_LOAD_WORDS);
+    });
+  } else if (this->state_ == State::LOAD) {
+    if (word_count < 3) {
+      ESP_LOGW(TAG, "Load response too short: %u words", word_count);
+    } else {
+      publish(this->load_current_sensor_, reg16(0) * 0.01f);
+      publish(this->load_active_power_sensor_, static_cast<float>(reg16(1)));
+      publish(this->load_apparent_power_sensor_, static_cast<float>(reg16(2)));
+    }
+    this->reset_frame_();
+    this->state_ = State::IDLE;
+  } else {
+    this->reset_frame_();
+    this->state_ = State::IDLE;
+  }
+}
+
+void RenogyInverterBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                                            esp_ble_gattc_cb_param_t *param) {
+  switch (event) {
+    case ESP_GATTC_DISCONNECT_EVT: {
+      this->established_ = false;
+      this->state_ = State::IDLE;
+      this->notify_handle_ = 0;
+      this->write_handle_ = 0;
+      this->init_handle_ = 0;
+      this->reset_frame_();
+      this->node_state = espbt::ClientState::IDLE;
+      break;
+    }
+    case ESP_GATTC_SEARCH_CMPL_EVT: {
+      auto *notify_chr = this->parent_->get_characteristic(espbt::ESPBTUUID::from_uint16(SERVICE_NOTIFY_UUID),
+                                                           espbt::ESPBTUUID::from_uint16(CHAR_NOTIFY_UUID));
+      auto *write_chr = this->parent_->get_characteristic(espbt::ESPBTUUID::from_uint16(SERVICE_WRITE_UUID),
+                                                          espbt::ESPBTUUID::from_uint16(CHAR_WRITE_UUID));
+      auto *init_chr = this->parent_->get_characteristic(espbt::ESPBTUUID::from_uint16(SERVICE_WRITE_UUID),
+                                                         espbt::ESPBTUUID::from_uint16(CHAR_INIT_UUID));
+      if (notify_chr == nullptr || write_chr == nullptr) {
+        ESP_LOGE(TAG, "Required characteristics not found — not a Renogy inverter?");
+        break;
+      }
+      this->notify_handle_ = notify_chr->handle;
+      this->write_handle_ = write_chr->handle;
+      this->init_handle_ = (init_chr != nullptr) ? init_chr->handle : 0;
+      ESP_LOGI(TAG, "handles: notify=%u write=%u init=%u", this->notify_handle_, this->write_handle_,
+               this->init_handle_);
+      const esp_err_t status = esp_ble_gattc_register_for_notify(this->parent_->get_gattc_if(),
+                                                                 this->parent_->get_remote_bda(), this->notify_handle_);
+      if (status != ESP_OK) {
+        ESP_LOGW(TAG, "register_for_notify failed, status=%d", status);
+      }
+      break;
+    }
+    case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
+      this->established_ = true;
+      this->state_ = State::IDLE;
+      this->node_state = espbt::ClientState::ESTABLISHED;
+      ESP_LOGI(TAG, "Connected; will poll the inverter every update interval");
+      break;
+    }
+    case ESP_GATTC_READ_CHAR_EVT: {
+      if (this->state_ == State::INIT && param->read.handle == this->init_handle_) {
+        // Init handshake done — now the inverter answers Modbus reads.
+        this->state_ = State::MAIN;
+        this->read_register_(REG_MAIN, REG_MAIN_WORDS);
+      }
+      break;
+    }
+    case ESP_GATTC_NOTIFY_EVT: {
+      if (param->notify.handle != this->notify_handle_) {
+        break;
+      }
+      if (this->frame_.size() + param->notify.value_len > MAX_FRAME) {
+        ESP_LOGW(TAG, "Frame overflow; resetting");
+        this->reset_frame_();
+        this->state_ = State::IDLE;
+        break;
+      }
+      this->frame_.insert(this->frame_.end(), param->notify.value, param->notify.value + param->notify.value_len);
+      if (this->expected_len_ == 0 && this->frame_.size() >= 3) {
+        this->expected_len_ = 3 + this->frame_[2] + 2;
+      }
+      if (this->expected_len_ != 0 && this->frame_.size() >= this->expected_len_) {
+        this->on_frame_complete_();
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+}  // namespace esphome::renogy_inverter_ble
+
+#endif  // USE_ESP32

--- a/esphome/components/renogy_inverter_ble/renogy_inverter_ble.h
+++ b/esphome/components/renogy_inverter_ble/renogy_inverter_ble.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <array>
+#include <vector>
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/sensor/sensor.h"
+
+#ifdef USE_ESP32
+#include "esphome/components/ble_client/ble_client.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include <esp_gattc_api.h>
+namespace espbt = esphome::esp32_ble_tracker;
+#endif
+
+namespace esphome::renogy_inverter_ble {
+
+// Renogy inverter BLE GATT (RIV1230PU). Notify char 0xFFF1 (svc 0xFFF0), write char 0xFFD1
+// (svc 0xFFD0), init char 0xFFD4 (svc 0xFFD0). Modbus device id 0x20, function 0x03.
+class RenogyInverterBle :
+#ifdef USE_ESP32
+    public ble_client::BLEClientNode,
+#endif
+    public PollingComponent {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+#ifdef USE_ESP32
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                           esp_ble_gattc_cb_param_t *param) override;
+#endif
+
+  void set_ac_input_voltage_sensor(sensor::Sensor *s) { this->ac_input_voltage_sensor_ = s; }
+  void set_ac_output_voltage_sensor(sensor::Sensor *s) { this->ac_output_voltage_sensor_ = s; }
+  void set_ac_output_current_sensor(sensor::Sensor *s) { this->ac_output_current_sensor_ = s; }
+  void set_ac_output_frequency_sensor(sensor::Sensor *s) { this->ac_output_frequency_sensor_ = s; }
+  void set_input_frequency_sensor(sensor::Sensor *s) { this->input_frequency_sensor_ = s; }
+  void set_battery_voltage_sensor(sensor::Sensor *s) { this->battery_voltage_sensor_ = s; }
+  void set_temperature_sensor(sensor::Sensor *s) { this->temperature_sensor_ = s; }
+  void set_load_current_sensor(sensor::Sensor *s) { this->load_current_sensor_ = s; }
+  void set_load_active_power_sensor(sensor::Sensor *s) { this->load_active_power_sensor_ = s; }
+  void set_load_apparent_power_sensor(sensor::Sensor *s) { this->load_apparent_power_sensor_ = s; }
+
+ protected:
+#ifdef USE_ESP32
+  // Read cycle: IDLE → (update) INIT read(0xFFD4) → MAIN read(4000) → LOAD read(4408) → IDLE.
+  enum class State : uint8_t { IDLE, INIT, MAIN, LOAD };
+
+  void start_cycle_();
+  void read_register_(uint16_t start_register, uint16_t word_count);
+  void on_frame_complete_();
+  void reset_frame_();
+
+  bool established_{false};
+  State state_{State::IDLE};
+  uint16_t notify_handle_{0};
+  uint16_t write_handle_{0};
+  uint16_t init_handle_{0};
+  // Reassembly buffer for the Modbus response (arrives in MTU-sized notification chunks).
+  std::vector<uint8_t> frame_;
+  uint16_t expected_len_{0};
+#endif
+
+  sensor::Sensor *ac_input_voltage_sensor_{nullptr};
+  sensor::Sensor *ac_output_voltage_sensor_{nullptr};
+  sensor::Sensor *ac_output_current_sensor_{nullptr};
+  sensor::Sensor *ac_output_frequency_sensor_{nullptr};
+  sensor::Sensor *input_frequency_sensor_{nullptr};
+  sensor::Sensor *battery_voltage_sensor_{nullptr};
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *load_current_sensor_{nullptr};
+  sensor::Sensor *load_active_power_sensor_{nullptr};
+  sensor::Sensor *load_apparent_power_sensor_{nullptr};
+};
+
+}  // namespace esphome::renogy_inverter_ble

--- a/esphome/components/renogy_inverter_ble/renogy_inverter_ble.h
+++ b/esphome/components/renogy_inverter_ble/renogy_inverter_ble.h
@@ -53,6 +53,8 @@ class RenogyInverterBle :
   void read_register_(uint16_t start_register, uint16_t word_count);
   void on_frame_complete_();
   void reset_frame_();
+  // Cancel the in-flight read cycle (watchdog + load timers), drop the partial frame, go IDLE.
+  void abort_cycle_();
 
   bool established_{false};
   State state_{State::IDLE};

--- a/esphome/components/renogy_inverter_ble/sensor.py
+++ b/esphome/components/renogy_inverter_ble/sensor.py
@@ -1,0 +1,60 @@
+"""Sensor platform for renogy_inverter_ble — the inverter's live electrical values."""
+
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_FREQUENCY,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLTAGE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_AMPERE,
+    UNIT_CELSIUS,
+    UNIT_HERTZ,
+    UNIT_VOLT,
+    UNIT_WATT,
+)
+
+from . import CONF_RENOGY_INVERTER_BLE_ID, RENOGY_INVERTER_BLE_COMPONENT_SCHEMA
+
+DEPENDENCIES = ["renogy_inverter_ble"]
+CODEOWNERS = ["@emilioaray-dev"]
+
+UNIT_VOLT_AMPS = "VA"
+
+# (config key, setter, unit, accuracy decimals, device_class). Names chosen so the ESPHome MQTT
+# object_id matches the backend ingester's field map (infrastructure/mqtt/inverter_ingester.py).
+SENSORS = [
+    ("ac_input_voltage", UNIT_VOLT, 1, DEVICE_CLASS_VOLTAGE),
+    ("ac_output_voltage", UNIT_VOLT, 1, DEVICE_CLASS_VOLTAGE),
+    ("ac_output_current", UNIT_AMPERE, 2, DEVICE_CLASS_CURRENT),
+    ("ac_output_frequency", UNIT_HERTZ, 2, DEVICE_CLASS_FREQUENCY),
+    ("input_frequency", UNIT_HERTZ, 2, DEVICE_CLASS_FREQUENCY),
+    ("battery_voltage", UNIT_VOLT, 1, DEVICE_CLASS_VOLTAGE),
+    ("temperature", UNIT_CELSIUS, 1, DEVICE_CLASS_TEMPERATURE),
+    ("load_current", UNIT_AMPERE, 2, DEVICE_CLASS_CURRENT),
+    ("load_active_power", UNIT_WATT, 0, DEVICE_CLASS_POWER),
+    ("load_apparent_power", UNIT_VOLT_AMPS, 0, DEVICE_CLASS_POWER),
+]
+
+CONFIG_SCHEMA = RENOGY_INVERTER_BLE_COMPONENT_SCHEMA.extend(
+    {
+        cv.Optional(key): sensor.sensor_schema(
+            unit_of_measurement=unit,
+            accuracy_decimals=decimals,
+            device_class=device_class,
+            state_class=STATE_CLASS_MEASUREMENT,
+        )
+        for key, unit, decimals, device_class in SENSORS
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_RENOGY_INVERTER_BLE_ID])
+    for key, _unit, _decimals, _device_class in SENSORS:
+        if key in config:
+            sens = await sensor.new_sensor(config[key])
+            cg.add(getattr(hub, f"set_{key}_sensor")(sens))

--- a/esphome/components/renogy_inverter_ble/sensor.py
+++ b/esphome/components/renogy_inverter_ble/sensor.py
@@ -4,6 +4,7 @@ import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import (
+    DEVICE_CLASS_APPARENT_POWER,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_FREQUENCY,
     DEVICE_CLASS_POWER,
@@ -24,8 +25,7 @@ CODEOWNERS = ["@emilioaray-dev"]
 
 UNIT_VOLT_AMPS = "VA"
 
-# (config key, setter, unit, accuracy decimals, device_class). Names chosen so the ESPHome MQTT
-# object_id matches the backend ingester's field map (infrastructure/mqtt/inverter_ingester.py).
+# (config key, unit, accuracy decimals, device_class) for each measurement the inverter exposes.
 SENSORS = [
     ("ac_input_voltage", UNIT_VOLT, 1, DEVICE_CLASS_VOLTAGE),
     ("ac_output_voltage", UNIT_VOLT, 1, DEVICE_CLASS_VOLTAGE),
@@ -36,7 +36,7 @@ SENSORS = [
     ("temperature", UNIT_CELSIUS, 1, DEVICE_CLASS_TEMPERATURE),
     ("load_current", UNIT_AMPERE, 2, DEVICE_CLASS_CURRENT),
     ("load_active_power", UNIT_WATT, 0, DEVICE_CLASS_POWER),
-    ("load_apparent_power", UNIT_VOLT_AMPS, 0, DEVICE_CLASS_POWER),
+    ("load_apparent_power", UNIT_VOLT_AMPS, 0, DEVICE_CLASS_APPARENT_POWER),
 ]
 
 CONFIG_SCHEMA = RENOGY_INVERTER_BLE_COMPONENT_SCHEMA.extend(

--- a/tests/components/renogy_inverter_ble/common.yaml
+++ b/tests/components/renogy_inverter_ble/common.yaml
@@ -1,0 +1,32 @@
+ble_client:
+  - mac_address: 14:9C:EF:01:02:03
+    id: inverter_client
+
+renogy_inverter_ble:
+  - id: inv0
+    ble_client_id: inverter_client
+    update_interval: 30s
+
+sensor:
+  - platform: renogy_inverter_ble
+    renogy_inverter_ble_id: inv0
+    ac_input_voltage:
+      name: AC input voltage
+    ac_output_voltage:
+      name: AC output voltage
+    ac_output_current:
+      name: AC output current
+    ac_output_frequency:
+      name: AC output frequency
+    input_frequency:
+      name: Input frequency
+    battery_voltage:
+      name: Battery voltage
+    temperature:
+      name: Temperature
+    load_current:
+      name: Load current
+    load_active_power:
+      name: Load active power
+    load_apparent_power:
+      name: Load apparent power

--- a/tests/components/renogy_inverter_ble/test.esp32-ard.yaml
+++ b/tests/components/renogy_inverter_ble/test.esp32-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  ble: !include ../../test_build_components/common/ble/esp32-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/renogy_inverter_ble/test.esp32-idf.yaml
+++ b/tests/components/renogy_inverter_ble/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  ble: !include ../../test_build_components/common/ble/esp32-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# Add `renogy_inverter_ble` component

## What does this implement/fix?

Adds a new sensor component, `renogy_inverter_ble`, that reads live data from **Renogy inverters with built-in Bluetooth** over Bluetooth Low Energy via `ble_client` — tested against the **Renogy PUH 12V 3000W Pure Sine Wave Inverter** (UPS transfer switch, SKU `RIV1230PU-126`), part of the `RNGRIU` family.

These inverters speak Modbus over BLE but require a proprietary "wake" read on characteristic `0xFFD4` before they answer any request — which is why a generic `modbus_controller` over a BLE bridge times out against them. This component performs that init read, then polls holding registers `4000` (main) and `4408` (load), reassembles the multi-notification Modbus response, validates the CRC, and publishes the values.

Exposed sensors: `ac_input_voltage`, `ac_output_voltage`, `ac_output_current`, `ac_output_frequency`, `input_frequency`, `battery_voltage`, `temperature`, `load_current`, `load_active_power`, `load_apparent_power`.

The hub/sensor split is intentional: the inverter also exposes a model string (reg `4311`) and status flags, so a future `text_sensor`/`binary_sensor` platform can attach to the same hub without restructuring.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Related issue or feature (if applicable)

Implements BLE support for Renogy inverters (related to the long-standing requests for Renogy BLE in esphome/feature-requests#2200).

## Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable)

- esphome-docs PR: esphome/esphome-docs#6717

## Test Environment

- [x] ESP32 (Arduino) — tested on an ESP32-D0WDQ6 reading a live RIV1230PU
- [ ] ESP32 IDF

## Checklist

- [x] The code change is tested and works locally (live values: AC output ~124 V, battery ~14.6 V, input frequency ~60 Hz, temperature ~27 °C — matching the vendor app).
- [x] Tests added under `tests/components/renogy_inverter_ble/` (esp32-ard + esp32-idf).
- [x] `CODEOWNERS` updated via `script/build_codeowners.py`.
- [x] `script/quicklint` passes (ci-custom, ruff, clang-format).

## Notes

- No external libraries: the Modbus-over-BLE framing and CRC16 are implemented in-component.
- `frame_` is the only heap buffer; it is `reserve()`d once in `setup()` and never grows after.