### PR TITLE
[vscode] Mark the component key for "Component not found" errors

### DIFF
--- a/esphome/vscode.py
+++ b/esphome/vscode.py
@@ -13,9 +13,13 @@ from esphome.yaml_util import parse_yaml
 
 
 def _get_invalid_range(res: Config, invalid: cv.Invalid) -> DocumentRange | None:
-    return res.get_deepest_document_range_for_path(
-        invalid.path, invalid.error_message == "extra keys not allowed"
-    )
+    # Errors about the key itself (an unknown option, an unknown component)
+    # mark the key, not its value mapping — otherwise the range lands on the
+    # component's children instead of the offending key.
+    mark_key = invalid.error_message == "extra keys not allowed" or (
+        invalid.error_message or ""
+    ).startswith("Component not found:")
+    return res.get_deepest_document_range_for_path(invalid.path, mark_key)
 
 
 def _dump_range(range: DocumentRange | None) -> dict | None:

--- a/tests/unit_tests/test_vscode.py
+++ b/tests/unit_tests/test_vscode.py
@@ -97,6 +97,39 @@ esp8266:
     assert range["end_col"] == 7
 
 
+def test_component_not_found_marks_key():
+    source_path = str(Path("dir_path", "x.yaml"))
+    output_lines = _run_repl_test(
+        [
+            _validate(source_path),
+            # read_file x.yaml
+            _file_response("""esphome:
+  name: test1
+esp8266:
+  board: esp01_1m
+
+apccci:
+  id: foo
+"""),
+        ]
+    )
+
+    error = json.loads(output_lines[-1])
+    not_found = next(
+        e
+        for e in error["validation_errors"]
+        if e["message"].startswith("Component not found:")
+    )
+    assert not_found["message"] == "Component not found: apccci."
+    # Range covers the ``apccci`` key, not its child mapping.
+    range = not_found["range"]
+    assert range["document"] == source_path
+    assert range["start_line"] == 5
+    assert range["start_col"] == 0
+    assert range["end_line"] == 5
+    assert range["end_col"] == 6
+
+
 def test_shows_correct_loaded_file_error():
     source_path = str(Path("dir_path", "x.yaml"))
     output_lines = _run_repl_test(


### PR DESCRIPTION
# What does this implement/fix?

The `esphome vscode --ace` validator resolves each config error's range
with `Config.get_deepest_document_range_for_path`, which lands on the
*deepest* matching node. For a `Component not found: <domain>` error the
deepest node is the component's value mapping, so the returned range
starts at the component's **first child** rather than the offending
top-level key. An editor (the ESPHome Device Builder dashboard) then
underlines the children — e.g. for

```yaml
apccci:
  id: api_server
  encryption:
    key: "…"
```

the range covers the `id:` / `encryption:` / `key:` lines instead of
`apccci:`.

This requests the **key's** range for `Component not found` errors,
exactly as already done for `extra keys not allowed`. The error's path is
the single component domain, so `get_deepest_document_range_for_path(...,
get_key=True)` returns the key node directly.

Backward compatible: only the range emitted for this error type changes
(value mapping → key); every other error path is untouched. Adds a unit
test pinning the key range for an unknown top-level component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced by the ESPHome Device Builder dashboard: esphome/device-builder-frontend#574

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
