### PR TITLE
[rp2040] Fix lwipopts template load on Windows extended-length paths

### DIFF
--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -501,18 +501,21 @@ def _generate_lwipopts_h() -> None:
     in the build directory, and a pre-build script injects this directory
     into the compiler include path before the framework's own include dir.
     """
-    from jinja2 import Environment, FileSystemLoader
+    from jinja2 import Environment
 
     lwip_defines = CORE.data[KEY_RP2040].get(KEY_LWIP_OPTS)
     if not lwip_defines:
         return
 
-    template_dir = Path(__file__).parent
-    jinja_env = Environment(
-        loader=FileSystemLoader(str(template_dir)),
-        keep_trailing_newline=True,
+    # Read the template via pathlib and render from a string rather than using
+    # FileSystemLoader. jinja2's loader joins the search path with posixpath, which
+    # breaks on Windows extended-length paths (\\?\C:\...) where forward slashes are
+    # not accepted, causing a spurious TemplateNotFound (see issue #16732).
+    template_text = (Path(__file__).parent / "lwipopts.h.jinja").read_text(
+        encoding="utf-8"
     )
-    template = jinja_env.get_template("lwipopts.h.jinja")
+    jinja_env = Environment(keep_trailing_newline=True)
+    template = jinja_env.from_string(template_text)
     content = template.render(**lwip_defines)
 
     lwip_dir = CORE.relative_build_path("lwip_override")


### PR DESCRIPTION
# What does this implement/fix?

On Windows, RP2040 builds fail during code generation with `jinja2.exceptions.TemplateNotFound: 'lwipopts.h.jinja'`, even though the template exists. This happens specifically when ESPHome runs from a Windows extended-length path (`\\?\C:\...`), as used by the **ESPHome Device Builder** app.

Root cause: `_generate_lwipopts_h()` loads the template with jinja2's `FileSystemLoader`. jinja2 joins the search path with the template name using `posixpath.join`, which inserts a forward slash:

```
\\?\C:\Users\...\rp2040  +  lwipopts.h.jinja  ->  \\?\C:\Users\...\rp2040/lwipopts.h.jinja
```

Windows does not normalize forward slashes inside `\\?\` extended-length paths, so the resulting path is rejected and the template is "not found". Normal Windows installs are unaffected because Windows accepts mixed `/` and `\` outside of `\\?\` paths.

Fix: read the template directly with `pathlib.Path.read_text()` (which uses native OS calls that handle extended-length paths correctly) and render it via `Environment.from_string()`, avoiding the loader's path joining entirely. This is platform-agnostic and removes the dependency on `FileSystemLoader`.

Reported and diagnosed in #16732.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16732

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
rp2040:
  board: rpipicow

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

> Note: no regression test is included because the failure only manifests on Windows extended-length (`\\?\`) paths, which cannot be reproduced on the Linux CI runners. The fix renders the existing template through `from_string`, which is exercised by any RP2040 build that enables lwIP tuning.