### PR TITLE
[esp32_ble_server] Fix duplicate Device Information Service with string UUIDs

### DIFF
--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -62,6 +62,26 @@ MANUFACTURER_NAME_CHARACTERISTIC_UUID = 0x2A29
 MODEL_CHARACTERISTIC_UUID = 0x2A24
 FIRMWARE_VERSION_CHARACTERISTIC_UUID = 0x2A26
 
+# Suffix of the Bluetooth Base UUID used to expand 16/32 bit UUIDs to 128 bit.
+_BASE_UUID_SUFFIX = "-0000-1000-8000-00805F9B34FB"
+
+
+def uuid_is(uuid, uuid16: int) -> bool:
+    """Return True if a validated UUID refers to the given 16-bit short UUID.
+
+    A service/characteristic UUID may be an ``int`` (from ``cv.hex_uint32_t``) or an
+    uppercase string in 16, 32 or 128 bit form (from ``bt_uuid``), so every
+    representation of the same UUID must be considered equivalent.
+    """
+    if isinstance(uuid, int):
+        return uuid == uuid16
+    return uuid.upper() in (
+        f"{uuid16:04X}",
+        f"{uuid16:08X}",
+        f"{uuid16:08X}{_BASE_UUID_SUFFIX}",
+    )
+
+
 # Core key to store the global configuration
 KEY_NOTIFY_REQUIRED = "notify_required"
 KEY_SET_VALUE = "set_value"
@@ -244,7 +264,7 @@ def create_device_information_service(config):
     # If there is already a device information service,
     # there cannot be CONF_MODEL, CONF_MANUFACTURER or CONF_FIRMWARE_VERSION properties
     for service in config[CONF_SERVICES]:
-        if service[CONF_UUID] == DEVICE_INFORMATION_SERVICE_UUID:
+        if uuid_is(service[CONF_UUID], DEVICE_INFORMATION_SERVICE_UUID):
             if (
                 CONF_MODEL in config
                 or CONF_MANUFACTURER in config
@@ -592,7 +612,7 @@ async def to_code(config):
         )
         for char_conf in service_config[CONF_CHARACTERISTICS]:
             await to_code_characteristic(service_var, char_conf)
-        if service_config[CONF_UUID] == DEVICE_INFORMATION_SERVICE_UUID:
+        if uuid_is(service_config[CONF_UUID], DEVICE_INFORMATION_SERVICE_UUID):
             cg.add(var.set_device_information_service(service_var))
         else:
             cg.add(var.enqueue_start_service(service_var))

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -66,7 +66,7 @@ FIRMWARE_VERSION_CHARACTERISTIC_UUID = 0x2A26
 _BASE_UUID_SUFFIX = "-0000-1000-8000-00805F9B34FB"
 
 
-def uuid_is(uuid, uuid16: int) -> bool:
+def uuid_is(uuid: int | str, uuid16: int) -> bool:
     """Return True if a validated UUID refers to the given 16-bit short UUID.
 
     A service/characteristic UUID may be an ``int`` (from ``cv.hex_uint32_t``) or an
@@ -215,7 +215,7 @@ def create_description_cud(char_config):
         return char_config
     # If the config displays a description, there cannot be a descriptor with the CUD UUID
     for desc in char_config[CONF_DESCRIPTORS]:
-        if desc[CONF_UUID] == CUD_DESCRIPTOR_UUID:
+        if uuid_is(desc[CONF_UUID], CUD_DESCRIPTOR_UUID):
             raise cv.Invalid(
                 f"Characteristic {char_config[CONF_UUID]} has a description, but a CUD descriptor is already present"
             )
@@ -238,7 +238,7 @@ def create_notify_cccd(char_config):
         return char_config
     # If the CCCD descriptor is already present, return the config
     for desc in char_config[CONF_DESCRIPTORS]:
-        if desc[CONF_UUID] == CCCD_DESCRIPTOR_UUID:
+        if uuid_is(desc[CONF_UUID], CCCD_DESCRIPTOR_UUID):
             # Check if the WRITE property is set
             if not desc[CONF_WRITE]:
                 raise cv.Invalid(

--- a/tests/component_tests/esp32_ble_server/test_esp32_ble_server.py
+++ b/tests/component_tests/esp32_ble_server/test_esp32_ble_server.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from esphome.components.esp32_ble_server import DEVICE_INFORMATION_SERVICE_UUID, uuid_is
+from esphome.components.esp32_ble_server import (
+    CCCD_DESCRIPTOR_UUID,
+    CUD_DESCRIPTOR_UUID,
+    DEVICE_INFORMATION_SERVICE_UUID,
+    uuid_is,
+)
 
 
 @pytest.mark.parametrize(
@@ -32,3 +37,11 @@ def test_uuid_is_matches_all_representations(uuid) -> None:
 def test_uuid_is_rejects_other_uuids(uuid) -> None:
     """A different UUID must not be mistaken for the device information service."""
     assert not uuid_is(uuid, DEVICE_INFORMATION_SERVICE_UUID)
+
+
+@pytest.mark.parametrize("uuid16", [CUD_DESCRIPTOR_UUID, CCCD_DESCRIPTOR_UUID])
+def test_uuid_is_matches_descriptor_short_strings(uuid16) -> None:
+    """Reserved descriptor UUIDs match whether given as int or short string."""
+    assert uuid_is(uuid16, uuid16)
+    assert uuid_is(f"{uuid16:04X}", uuid16)
+    assert uuid_is(f"{uuid16:08X}", uuid16)

--- a/tests/component_tests/esp32_ble_server/test_esp32_ble_server.py
+++ b/tests/component_tests/esp32_ble_server/test_esp32_ble_server.py
@@ -1,0 +1,34 @@
+"""Tests for esp32_ble_server configuration helpers."""
+
+import pytest
+
+from esphome.components.esp32_ble_server import DEVICE_INFORMATION_SERVICE_UUID, uuid_is
+
+
+@pytest.mark.parametrize(
+    "uuid",
+    [
+        DEVICE_INFORMATION_SERVICE_UUID,  # int form (cv.hex_uint32_t)
+        "180A",  # 16 bit short form (bt_uuid)
+        "180a",  # lowercase is normalized by bt_uuid but guard anyway
+        "0000180A",  # 32 bit form
+        "0000180A-0000-1000-8000-00805F9B34FB",  # full 128 bit form
+    ],
+)
+def test_uuid_is_matches_all_representations(uuid) -> None:
+    """All representations of the same 16 bit UUID must compare equal."""
+    assert uuid_is(uuid, DEVICE_INFORMATION_SERVICE_UUID)
+
+
+@pytest.mark.parametrize(
+    "uuid",
+    [
+        0x1818,  # Cycling Power Service (different int)
+        "1818",  # different 16 bit short form
+        "0000180B",  # adjacent UUID
+        "0000180A-0000-1000-8000-00805F9B34FC",  # wrong base UUID suffix
+    ],
+)
+def test_uuid_is_rejects_other_uuids(uuid) -> None:
+    """A different UUID must not be mistaken for the device information service."""
+    assert not uuid_is(uuid, DEVICE_INFORMATION_SERVICE_UUID)


### PR DESCRIPTION
# What does this implement/fix?

When a user declares their own Device Information Service (`0x180A`) **and** sets `manufacturer`/`model`/`firmware_version` on the server, ESPHome is supposed to either reuse the user's service or raise a clear error. Instead it silently creates a **second** `0x180A` service, producing a malformed GATT table with two Device Information Services.

Root cause: the de-duplication compares the validated service UUID directly against the int `0x180A`:

```python
if service[CONF_UUID] == DEVICE_INFORMATION_SERVICE_UUID:  # DEVICE_INFORMATION_SERVICE_UUID = 0x180A
```

But `bt_uuid("180A")` returns the **string** `"180A"`, and `"180A" == 0x180A` is always `False`. The comparison only matches when the UUID is written as an integer (`uuid: 0x180A`), not the normal short/long string form. So with `uuid: "180A"` the guard silently fails: the auto-generated DIS is appended (and registered via `set_device_information_service`) while the user's own service is started as a regular service — two `0x180A` services.

This shows up in the reported logs as:

```
Creating BLE service - 0x180A      <- user's manually-declared service
Creating BLE service - 0x0000180A  <- second, auto-generated Device Information Service
```

(The `0x180A` vs `0x0000180A` difference comes from the string UUID going through `from_raw` and the int through `from_uint32`.)

## Fix

Introduce a `uuid_is()` helper that recognizes a UUID as the target short UUID across every validated representation — `int` (from `cv.hex_uint32_t`) and 16-, 32-, and 128-bit string forms (from `bt_uuid`) — using the Bluetooth Base UUID to expand short forms. Both comparison sites (the dedup guard and the `set_device_information_service` branch in `to_code`) use it.

After the fix:
- Manual `"180A"` service **+** `manufacturer`/`model` → raises the intended `"Device information service already present, cannot add manufacturer, model or firmware version"` error (no more silent duplicate).
- Manual `"180A"` service, no `manufacturer`/`model` → valid, no duplicate.
- No manual DIS + `manufacturer`/`model` → valid, auto-DIS added (unchanged).

A unit test covering all matching/non-matching UUID representations is included.

> Note: this fixes the duplicate-Device-Information-Service bug. The watch-specific connection failure in the report also involves BLE bonding (`auth_req_mode: bond`), which is a separate matter and not addressed here.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/16694

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32_ble:

esp32_ble_server:
  manufacturer: "Custom Ergo"
  model: "ESP32 Bridge"
  services:
    # Declaring the Device Information Service as a string UUID alongside
    # manufacturer/model now correctly raises a validation error instead of
    # silently creating a duplicate 0x180A service.
    - uuid: "1818" # Cycling Power Service
      advertise: true
      characteristics:
        - uuid: "2A65"
          read: true
          value:
            type: uint32_t
            data: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).