### PR TITLE
[i2s_audio] Expose slot_bit_width to speaker YAML configuration

### DIFF
--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -46,6 +46,7 @@ CONF_SECONDARY = "secondary"
 
 CONF_USE_APLL = "use_apll"
 CONF_BITS_PER_CHANNEL = "bits_per_channel"
+CONF_SLOT_BIT_WIDTH = "slot_bit_width"
 CONF_MCLK_MULTIPLE = "mclk_multiple"
 CONF_MONO = "mono"
 CONF_LEFT = "left"
@@ -172,6 +173,10 @@ def i2s_audio_component_schema(
             cv.Optional(CONF_BITS_PER_SAMPLE, default=default_bits_per_sample): cv.All(
                 _validate_bits, cv.int_, cv.one_of(*I2S_BITS_PER_SAMPLE)
             ),
+            cv.Optional(CONF_SLOT_BIT_WIDTH, default="default"): cv.Any(
+                cv.one_of("default", lower=True),
+                cv.All(_validate_bits, cv.int_, cv.one_of(*I2S_SLOT_BIT_WIDTH)),
+            ),
             cv.Optional(CONF_I2S_MODE, default=CONF_PRIMARY): cv.one_of(
                 *I2S_MODE_OPTIONS, lower=True
             ),
@@ -192,7 +197,7 @@ async def register_i2s_audio_component(var, config):
         slot_mask = CONF_BOTH
     cg.add(var.set_slot_mode(I2S_SLOT_MODE[slot_mode]))
     cg.add(var.set_std_slot_mask(I2S_STD_SLOT_MASK[slot_mask]))
-    cg.add(var.set_slot_bit_width(I2S_SLOT_BIT_WIDTH[config[CONF_BITS_PER_SAMPLE]]))
+    cg.add(var.set_slot_bit_width(I2S_SLOT_BIT_WIDTH[config[CONF_SLOT_BIT_WIDTH]]))
     cg.add(var.set_sample_rate(config[CONF_SAMPLE_RATE]))
     cg.add(var.set_use_apll(config[CONF_USE_APLL]))
     cg.add(var.set_mclk_multiple(I2S_MCLK_MULTIPLE[config[CONF_MCLK_MULTIPLE]]))


### PR DESCRIPTION
# What does this implement/fix?

This PR exposes the `slot_bit_width` property to the YAML configuration for `i2s_audio` speakers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16624
- related https://github.com/orgs/esphome/discussions/3679

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6731

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
speaker:
  - platform: i2s_audio
    id: output_speaker
    ...
    slot_bit_width: 32bit # New property
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
