### PR TITLE
DO NOT MERGE: prove memory impact no-common-platform fix in CI

### DIFF
--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -1,3 +1,5 @@
+// DNM: do not merge. Trivial touch to mark daikin changed; this is the working
+// esp8266-ard component that should generate memory impact (see PR #16788).
 #include "daikin.h"
 #include "esphome/components/remote_base/remote_base.h"
 

--- a/esphome/components/shelly_dimmer/shelly_dimmer.cpp
+++ b/esphome/components/shelly_dimmer/shelly_dimmer.cpp
@@ -1,3 +1,5 @@
+// DNM: do not merge. Trivial touch to mark shelly_dimmer changed so the
+// memory-impact CI job exercises the no-common-platform fix (see PR #16788).
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 

--- a/tests/components/const/common.yaml
+++ b/tests/components/const/common.yaml
@@ -1,0 +1,37 @@
+display:
+  - platform: qspi_dbi
+    model: RM690B0
+    data_rate: 80MHz
+    spi_mode: mode0
+    dimensions:
+      width: 450
+      height: 600
+      offset_width: 16
+    color_order: rgb
+    invert_colors: false
+    brightness: 255
+    cs_pin: 11
+    reset_pin: 13
+    enable_pin: 9
+
+  - platform: qspi_dbi
+    model: CUSTOM
+    id: main_lcd
+    draw_from_origin: true
+    dimensions:
+      height: 240
+      width: 536
+    transform:
+      mirror_x: true
+      swap_xy: true
+    color_order: rgb
+    brightness: 255
+    cs_pin: 6
+    reset_pin: 17
+    enable_pin: 38
+    init_sequence:
+      - [0x3A, 0x66]
+      - [0x11]
+      - delay 120ms
+      - [0x29]
+      - delay 20ms

--- a/tests/components/const/test-display.esp32-s3-idf.yaml
+++ b/tests/components/const/test-display.esp32-s3-idf.yaml
@@ -1,0 +1,7 @@
+# DNM proof: this is a VARIANT test (test-display.*) with no base test.*.yaml.
+# The memory-impact build runs --base-only, so const has nothing buildable and
+# must be excluded; it only contributes an esp32-s3-idf platform hint.
+packages:
+  qspi: !include ../../test_build_components/common/qspi/esp32-s3-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

DO NOT MERGE. This PR is chained on top of #16788 (its base is that branch, not `dev`) so CI runs the memory-impact fix and proves it in a real build.

It recreates the exact failure from https://github.com/esphome/esphome/actions/runs/26746938473/job/78830521340 using the two components that failed, `const` and `shelly_dimmer`, plus `daikin` as a working third component.

Changed components and their base test platforms:

- `const`: a variant only test (`test-display.esp32-s3-idf.yaml`, no base `test.*.yaml`). The memory build runs `--base-only`, so const has nothing buildable and must be excluded; it only contributes an esp32 platform hint.
- `shelly_dimmer`: base test on `esp8266-ard`, real C++.
- `daikin`: base test on `esp8266-ard`, real C++; this is the working third component.

Without the fix, the hint plus const's variant being counted as a supported platform select `esp32-idf`, which none of the three can build under `--base-only`; the build reports "0 passed, 0 failed" and memory extraction fails. With the fix, const is excluded, the unbuildable hint is ignored in favor of the common `esp8266-ard` platform, and `shelly_dimmer` and `daikin` generate memory impact.

Expected CI result on this PR: the memory-impact job picks `["daikin", "shelly_dimmer"]` on `esp8266-ard`, drops `const` (logged), and produces a memory report.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
