### PR TITLE
[mixer] Give mixer test its own speaker id to avoid CI grouping collision

### DIFF
--- a/tests/components/mixer/common.yaml
+++ b/tests/components/mixer/common.yaml
@@ -13,13 +13,13 @@ i2s_audio:
 
 speaker:
   - platform: i2s_audio
-    id: speaker_id
+    id: mixer_output_speaker_id
     dac_type: external
     i2s_dout_pin: ${dout_pin}
     bits_per_sample: 32bit
     channel: stereo
   - platform: mixer
-    output_speaker: speaker_id
+    output_speaker: mixer_output_speaker_id
     bits_per_sample: 32
     num_channels: 2
     source_speakers:


### PR DESCRIPTION
# What does this implement/fix?

Fixes a CI config-validation failure in the grouped component test build, e.g.:

```
Invalid configuration for the mixer component. The bits_per_sample value must be at most 16.
```

The `mixer` test fixture (`tests/components/mixer/common.yaml`) declared its 32-bit i2s_audio output speaker as `speaker_id` — the same id the generic `speaker` test fixture uses for a default **16-bit, primary-mode** i2s_audio speaker. When CI groups these components into one build, `script/merge_component_configs.py`'s `deduplicate_by_id` keeps the **first** entry seen for a given id and silently drops the rest. In a group where `speaker` merges first, the mixer's `output_speaker: speaker_id` then resolves to the 16-bit speaker, and the mixer's `bits_per_sample: 32` fails the audio-compatibility check.

This was latent until #16672 ("[i2s_audio] Fix speaker DMA buffer sizing and validate bit depth at compile time") made a primary-mode i2s_audio speaker advertise `max_bits_per_sample = bits_per_sample` (16 by default) instead of a fixed 32. The speaker behavior in #16672 is correct — a 16-bit primary speaker genuinely can't accept a 32-bit stream — so the fix belongs in the test fixture, not the component.

Renaming the mixer fixture's output speaker to `mixer_output_speaker_id` makes the mixer own its ids, so dedup can no longer substitute an incompatible speaker. The fix is order-independent.

Verified locally: reproduced the exact `must be at most 16` failure with the colliding ids, and confirmed the renamed fixture reports `Configuration is valid!`. The standalone `mixer` config test (`script/test_build_components.py -e config -c mixer`) passes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (regression surfaced by #16672)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Test-fixture only change; no user-facing config.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).