### PR TITLE
[ci] Exclude device-builder slow e2e tests from downstream CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,9 +189,12 @@ jobs:
       - name: Run device-builder pytest
         # ``-n auto`` runs under pytest-xdist (matches device-builder's
         # own CI). No ``--cov`` here -- this is purely a downstream
-        # smoke check against this PR's esphome code.
+        # smoke check against this PR's esphome code. ``tests/e2e/slow``
+        # is excluded: those are real multi-minute toolchain compiles
+        # (LibreTiny SDK clone, native ESP-IDF install) that device-builder
+        # runs in its own dedicated jobs, not this smoke check.
         working-directory: device-builder
-        run: pytest -q -n auto --maxfail=5 --durations=30 --no-cov --ignore=tests/benchmarks
+        run: pytest -q -n auto --maxfail=5 --durations=30 --no-cov --ignore=tests/benchmarks --ignore=tests/e2e/slow
 
   pytest:
     name: Run pytest


### PR DESCRIPTION
# What does this implement/fix?

The downstream `device-builder` CI job runs device-builder's pytest suite against the PR's esphome to catch breakage. Two of device-builder's e2e tests are real multi-minute toolchain compiles (a LibreTiny SDK clone plus build, and a native ESP-IDF install plus build); device-builder runs those in its own dedicated per-toolchain jobs, so they don't belong in this fast downstream smoke check.

device-builder moved both into a single `tests/e2e/slow/` tree, so this excludes them with one `--ignore=tests/e2e/slow` rather than listing each file. The ignore is a no-op until that move lands on device-builder `main` (see esphome/device-builder#1193), so this can merge in either order.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- esphome/device-builder#1193

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable; CI workflow change only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
