### PR TITLE
[clang-tidy] Support RISC-V targets natively

### DIFF
--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -28,12 +28,6 @@ from helpers import (
     temp_header_file,
 )
 
-# Limit the ESP-IDF tool install to esp32 for clang-tidy: the one xtensa-esp-elf
-# toolchain bundles the s2/s3 compilers too, so all xtensa tidy envs still
-# reconfigure while the large riscv32-esp-elf toolchain is skipped. Must be set
-# before esphome.espidf.framework is imported (lazily, via load_idedata).
-os.environ.setdefault("ESPHOME_IDF_DEFAULT_TARGETS", "esp32")
-
 
 def clang_options(idedata):
     cmd = []
@@ -46,7 +40,14 @@ def clang_options(idedata):
         cmd.append("-D__XTENSA__")
         cmd.append("-D_LIBC")
     else:
+        # RISC-V (and other non-Xtensa targets) have a real clang backend, so
+        # compile for the actual triplet. Espressif's RISC-V GCC -march adds
+        # vendor extensions (xesploop, xespv) upstream clang doesn't know; those
+        # are stripped from the copied cxx_flags below.
         cmd.append(f"--target={triplet}")
+        # The GCC build passes flags (e.g. -fno-plt) that clang accepts for some
+        # targets but not others; don't error on the ones unused for this target.
+        cmd.append("-Qunused-arguments")
 
     omit_flags = (
         "-free",
@@ -113,8 +114,15 @@ def clang_options(idedata):
     # ESP-IDF build defaults to gnu++2b, but ESPHome compiles with gnu++20 per
     # platformio.ini -- analyzing as C++23 flags code that doesn't build under
     # gnu++20). Force gnu++20 to match the real build.
+    # Strip Espressif's non-standard RISC-V -march extensions (e.g. xesploop,
+    # xespv); clang rejects the whole arch string otherwise.
+    def strip_esp_march(flag):
+        if flag.startswith("-march=") and triplet.startswith("riscv"):
+            return re.sub(r"_xesp\w+", "", flag)
+        return flag
+
     cmd.extend(
-        flag
+        strip_esp_march(flag)
         for flag in idedata["cxx_flags"]
         if flag not in omit_flags
         and not flag.startswith("-Werror")


### PR DESCRIPTION
# What does this implement/fix?

Make `script/clang-tidy` able to analyze RISC-V ESP32 variants (C3/C6/H2/P4, `riscv32-esp-elf`) with upstream clang's **native** RISC-V backend, rather than the 32-bit-x86 fake used for Xtensa. Two small adjustments to the non-Xtensa (`--target={triplet}`) path are enough:

- **Strip Espressif's non-standard `-march` extensions.** Their RISC-V GCC emits `-march=rv32imafc_zicsr_zifencei_xesploop_xespv`; the `xesploop`/`xespv` vendor extensions aren't known to upstream clang, which rejects the whole arch string. We drop the `_xesp*` parts, leaving the standard base ISA clang understands.
- **`-Qunused-arguments`.** The GCC build passes flags (e.g. `-fno-plt`) that clang accepts for some targets but not others; without this, the otherwise-unused ones trip `clang-diagnostic-unused-command-line-argument` under `-warnings-as-errors`.

Also drops the `ESPHOME_IDF_DEFAULT_TARGETS=esp32` limit, which skipped installing the `riscv32-esp-elf` toolchain — that toolchain is required for any RISC-V tidy run.

This is groundwork: it makes the helper RISC-V-capable. Wiring up an actual RISC-V tidy environment / CI job (and the findings it surfaces) is left to follow-up PRs. Verified locally by running `script/clang-tidy --environment esp32c3-idf-tidy` end to end — all files compile and analyze natively for `riscv32`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - tooling change (script/clang-tidy)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).