### PR TITLE
[esp32] Fix ESP-IDF compile when build path contains a space

### DIFF
--- a/.github/workflows/zz-windows-spaces-probe.yml
+++ b/.github/workflows/zz-windows-spaces-probe.yml
@@ -1,0 +1,49 @@
+# Temporary workflow: proves the ESP-IDF spaced-path compile bug on Windows.
+# Removed in the final commit of this PR; must never land on dev.
+name: zz Windows spaced-path probe (temporary)
+
+on:
+  push:
+    branches:
+      - esp32-idf-spaces-path-fix
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  esp-idf-spaced-path:
+    name: ESP-IDF compile from a path with a space
+    runs-on: windows-latest
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+      - name: Install esphome
+        shell: bash
+        run: |
+          python -m pip install -U pip
+          pip install -e .
+      - name: Write a minimal ESP-IDF config into a directory with a space
+        shell: bash
+        run: |
+          mkdir -p "first last"
+          cat > "first last/probe.yaml" <<'EOF'
+          esphome:
+            name: spaces-probe
+          esp32:
+            board: esp32dev
+            framework:
+              type: esp-idf
+          logger:
+          EOF
+          echo "Config dir (note the space):"
+          pwd
+          ls -la "first last"
+      - name: Compile from the spaced path
+        shell: bash
+        run: |
+          esphome compile "first last/probe.yaml"


### PR DESCRIPTION
# What does this implement/fix?

On Windows an ESP-IDF compile fails whenever the build path contains a space, which is very common since user profile dirs are usually like `C:\Users\First Last\...`. ESP-IDF embeds the build path verbatim into `-fdebug-prefix-map`, gated by `CONFIG_APP_REPRODUCIBLE_BUILD`; on Windows the compile command is routed through a gcc response file that splits on unquoted whitespace, so gcc receives a truncated path and rejects it:

```
cc1plus.exe: error: invalid argument 'C:/Users/.../First' to '-fdebug-prefix-map'
```

This disables reproducible-build path rewriting only when running on Windows and the build path contains a space, and warns the user so the cause is clear; space-free paths and other platforms keep the current behavior. The only cost in the spaced case is losing build-path hiding in the binary.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/device-builder/issues/1201

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: spaces-probe
esp32:
  board: esp32dev
  framework:
    type: esp-idf
logger:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
