### PR TITLE
[ota][logger][esp32][internal_temperature] Fix clang-tidy findings surfaced by RISC-V analysis

### DIFF
--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -41,6 +41,7 @@ static inline bool is_return_addr(uint32_t addr) {
   // Use memcpy for alignment safety — RISC-V C extension means code addresses
   // are only 2-byte aligned, so addr-4 may not be 4-byte aligned.
   uint32_t inst;
+  // NOLINTNEXTLINE(performance-no-int-to-ptr) - reading code memory at a raw address is the point
   memcpy(&inst, (const void *) (addr - 4), sizeof(inst));
   // RISC-V instruction encoding: bits [6:0] = opcode, bits [11:7] = rd
   uint32_t opcode = inst & 0x7f;  // Extract 7-bit opcode
@@ -51,6 +52,7 @@ static inline bool is_return_addr(uint32_t addr) {
   // Check for 2-byte compressed c.jalr before this address (C extension).
   // c.jalr saves to ra implicitly: funct4=1001, rs1!=0, rs2=0, op=10
   if (addr >= 2) {
+    // NOLINTNEXTLINE(performance-no-int-to-ptr) - reading code memory at a raw address is the point
     uint16_t c_inst = *(uint16_t *) (addr - 2);
     if ((c_inst & 0xf07f) == 0x9002 && (c_inst & 0x0f80) != 0)
       return true;
@@ -101,6 +103,7 @@ static uint8_t IRAM_ATTR capture_riscv_backtrace(RvExcFrame *frame, uint32_t *ou
     out[count++] = frame->ra;
   }
   *reg_count = count;
+  // NOLINTNEXTLINE(performance-no-int-to-ptr) - walking the raw stack by address is the point
   auto *scan_start = (uint32_t *) frame->sp;
   for (uint32_t i = 0; i < 64 && count < max; i++) {
     uint32_t val = scan_start[i];
@@ -354,6 +357,8 @@ void crash_handler_log() {
 #if SOC_CPU_CORES_NUM > 1
   append_addrs_to_hint(hint, sizeof(hint), pos, s_raw_crash_data.other_backtrace,
                        s_raw_crash_data.other_backtrace_count, s_raw_crash_data.other_reg_frame_count);
+#else
+  (void) pos;  // single-core: pos is only consumed by the second-core append above
 #endif
   ESP_LOGE(TAG, "%s", hint);
 }

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -358,7 +358,7 @@ void crash_handler_log() {
   append_addrs_to_hint(hint, sizeof(hint), pos, s_raw_crash_data.other_backtrace,
                        s_raw_crash_data.other_backtrace_count, s_raw_crash_data.other_reg_frame_count);
 #else
-  (void) pos;  // single-core: pos is only consumed by the second-core append above
+  (void) pos;  // There is no second-core append on single-core targets, so pos would otherwise be unread.
 #endif
   ESP_LOGE(TAG, "%s", hint);
 }

--- a/esphome/components/internal_temperature/internal_temperature.h
+++ b/esphome/components/internal_temperature/internal_temperature.h
@@ -3,6 +3,12 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 
+// Every ESP32 variant except the original one exposes the on-chip sensor through
+// the IDF temperature_sensor driver (the original uses the legacy temprature_sens_read).
+#if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32)
+#include "driver/temperature_sensor.h"
+#endif
+
 namespace esphome::internal_temperature {
 
 class InternalTemperatureSensor : public sensor::Sensor, public PollingComponent {
@@ -13,6 +19,11 @@ class InternalTemperatureSensor : public sensor::Sensor, public PollingComponent
   void dump_config() override;
 
   void update() override;
+
+#if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32)
+ protected:
+  temperature_sensor_handle_t tsens_{nullptr};
+#endif
 };
 
 }  // namespace esphome::internal_temperature

--- a/esphome/components/internal_temperature/internal_temperature_esp32.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_esp32.cpp
@@ -19,12 +19,6 @@ namespace esphome::internal_temperature {
 
 static const char *const TAG = "internal_temperature.esp32";
 
-#if defined(USE_ESP32_VARIANT_ESP32C2) || defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C5) || \
-    defined(USE_ESP32_VARIANT_ESP32C6) || defined(USE_ESP32_VARIANT_ESP32C61) || defined(USE_ESP32_VARIANT_ESP32H2) || \
-    defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
-static temperature_sensor_handle_t tsensNew = NULL;
-#endif  // USE_ESP32_VARIANT
-
 void InternalTemperatureSensor::update() {
   float temperature = NAN;
   bool success = false;
@@ -37,7 +31,7 @@ void InternalTemperatureSensor::update() {
     defined(USE_ESP32_VARIANT_ESP32C5) || defined(USE_ESP32_VARIANT_ESP32C6) || defined(USE_ESP32_VARIANT_ESP32C61) || \
     defined(USE_ESP32_VARIANT_ESP32H2) || defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || \
     defined(USE_ESP32_VARIANT_ESP32S3)
-  esp_err_t result = temperature_sensor_get_celsius(tsensNew, &temperature);
+  esp_err_t result = temperature_sensor_get_celsius(this->tsens_, &temperature);
   success = (result == ESP_OK);
   if (!success) {
     ESP_LOGE(TAG, "Reading failed (%d)", result);
@@ -60,14 +54,14 @@ void InternalTemperatureSensor::setup() {
     defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
   temperature_sensor_config_t tsens_config = TEMPERATURE_SENSOR_CONFIG_DEFAULT(-10, 80);
 
-  esp_err_t result = temperature_sensor_install(&tsens_config, &tsensNew);
+  esp_err_t result = temperature_sensor_install(&tsens_config, &this->tsens_);
   if (result != ESP_OK) {
     ESP_LOGE(TAG, "Install failed (%d)", result);
     this->mark_failed();
     return;
   }
 
-  result = temperature_sensor_enable(tsensNew);
+  result = temperature_sensor_enable(this->tsens_);
   if (result != ESP_OK) {
     ESP_LOGE(TAG, "Enabling failed (%d)", result);
     this->mark_failed();

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -30,7 +30,7 @@ namespace esphome::logger {
 static const char *const TAG = "logger";
 
 #ifdef USE_LOGGER_UART_SELECTION_USB_SERIAL_JTAG
-static void init_usb_serial_jtag_() {
+static void init_usb_serial_jtag() {
   setvbuf(stdin, NULL, _IONBF, 0);  // Disable buffering on stdin
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
@@ -109,7 +109,7 @@ void Logger::pre_setup() {
 #ifdef USE_LOGGER_USB_SERIAL_JTAG
       case UART_SELECTION_USB_SERIAL_JTAG:
 #ifdef USE_LOGGER_UART_SELECTION_USB_SERIAL_JTAG
-        init_usb_serial_jtag_();
+        init_usb_serial_jtag();
 #endif
         break;
 #endif

--- a/esphome/components/ota/ota_backend_esp_idf.h
+++ b/esphome/components/ota/ota_backend_esp_idf.h
@@ -54,7 +54,7 @@ class IDFOTABackend final {
 #endif
 
  private:
-  // md5_ first: its digest_ is alignas(32) on DMA-SHA variants (md5_set_ stays last so buf_ packs tightly).
+  // Keep md5_ first since its digest_ is alignas(32) on DMA-SHA variants; md5_set_ stays last so buf_ packs tightly.
   md5::MD5Digest md5_{};
   esp_ota_handle_t update_handle_{0};
   const esp_partition_t *partition_;

--- a/esphome/components/ota/ota_backend_esp_idf.h
+++ b/esphome/components/ota/ota_backend_esp_idf.h
@@ -54,9 +54,11 @@ class IDFOTABackend final {
 #endif
 
  private:
+  // md5_ first: on esp32 variants with DMA hardware SHA its digest_ buffer is alignas(32), so
+  // leading it avoids a large alignment gap (and md5_set_ stays last so buf_ below packs tightly).
+  md5::MD5Digest md5_{};
   esp_ota_handle_t update_handle_{0};
   const esp_partition_t *partition_;
-  md5::MD5Digest md5_{};
   char expected_bin_md5_[32];
   bool md5_set_{false};
 #ifdef USE_OTA_PARTITIONS

--- a/esphome/components/ota/ota_backend_esp_idf.h
+++ b/esphome/components/ota/ota_backend_esp_idf.h
@@ -54,8 +54,7 @@ class IDFOTABackend final {
 #endif
 
  private:
-  // md5_ first: on esp32 variants with DMA hardware SHA its digest_ buffer is alignas(32), so
-  // leading it avoids a large alignment gap (and md5_set_ stays last so buf_ below packs tightly).
+  // md5_ first: its digest_ is alignas(32) on DMA-SHA variants (md5_set_ stays last so buf_ packs tightly).
   md5::MD5Digest md5_{};
   esp_ota_handle_t update_handle_{0};
   const esp_partition_t *partition_;


### PR DESCRIPTION
# What does this implement/fix?

Running `script/clang-tidy` natively against a RISC-V ESP32 variant (esp32c3) compiles code paths and a data model that the Xtensa `-m32` fake never exercises, which surfaced a handful of genuine findings. This fixes them — all are real improvements independent of the analysis platform:

- **`ota`** — reorder `IDFOTABackend` fields so the `md5_` member leads. On every ESP32 variant except the original, `md5::MD5Digest`'s `digest_` buffer is `alignas(32)` (DMA hardware SHA), so with `md5_` sitting third the layout wasted 55 padding bytes (where 23 is optimal). `md5_set_` is kept last so the `USE_OTA_PARTITIONS` staging buffer still packs tightly. (`clang-analyzer-optin.performance.Padding`)
- **`logger`** — drop the trailing underscore from the free function `init_usb_serial_jtag_`; trailing underscores are for members, not functions. (`readability-identifier-naming`)
- **`esp32`** (crash_handler) — fix a conditional dead store (`pos` was reassigned then never read on single-core targets), and mark the three deliberate raw-address reads in the backtrace scanner `NOLINT(performance-no-int-to-ptr)` — reading code/stack memory by address is the whole point of a crash handler.
- **`internal_temperature`** — promote the file-static `tsensNew` handle to a `tsens_` member of `InternalTemperatureSensor`, fixing both the camelCase name and the non-const global. (`readability-identifier-naming`, `cppcoreguidelines-avoid-non-const-global-variables`)

Each touched file was verified to analyze cleanly under the esp32c3 toolchain. Depends conceptually on #16809 (which teaches `script/clang-tidy` to target RISC-V natively) to reproduce, but the fixes themselves are platform-independent.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal code-quality fixes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).