### PR TITLE
[multiple] Avoid float-to-double promotion in math calls

### DIFF
--- a/esphome/components/daikin_arc/daikin_arc.cpp
+++ b/esphome/components/daikin_arc/daikin_arc.cpp
@@ -216,7 +216,7 @@ uint8_t DaikinArcClimate::temperature_() {
       return 0xc0;
     default:
       float new_temp = clamp<float>(this->target_temperature, DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX);
-      uint8_t temperature = (uint8_t) floor(new_temp);
+      uint8_t temperature = (uint8_t) std::floor(new_temp);
       return temperature << 1 | (new_temp - temperature > 0 ? 0x01 : 0);
   }
 }

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -1,4 +1,5 @@
 #include "display.h"
+#include <cmath>
 #include <utility>
 #include <numbers>
 #include "display_color_utils.h"
@@ -238,7 +239,7 @@ void Display::filled_gauge(int center_x, int center_y, int radius1, int radius2,
       int lhline_width = -(dxmax - dxmin) + 1;
       if (progress >= 50) {
         if (float(dymax) < float(-dxmax) * tan_a) {
-          upd_dxmax = ceil(float(dymax) / tan_a);
+          upd_dxmax = std::ceil(float(dymax) / tan_a);
         } else {
           upd_dxmax = -dxmax;
         }
@@ -253,7 +254,7 @@ void Display::filled_gauge(int center_x, int center_y, int radius1, int radius2,
         }
       } else {
         if (float(dymin) > float(-dxmin) * tan_a) {
-          upd_dxmin = ceil(float(dymin) / tan_a);
+          upd_dxmin = std::ceil(float(dymin) / tan_a);
         } else {
           upd_dxmin = -dxmin;
         }
@@ -268,12 +269,12 @@ void Display::filled_gauge(int center_x, int center_y, int radius1, int radius2,
       int hline_width = 2 * (-dxmax) + 1;
       if (progress >= 50) {
         if (dymax < float(-dxmax) * tan_a) {
-          upd_dxmax = ceil(float(dymax) / tan_a);
+          upd_dxmax = std::ceil(float(dymax) / tan_a);
           hline_width = -dxmax + upd_dxmax + 1;
         }
       } else {
         if (dymax < float(-dxmax) * tan_a) {
-          upd_dxmax = ceil(float(dymax) / tan_a);
+          upd_dxmax = std::ceil(float(dymax) / tan_a);
           hline_width = -dxmax - upd_dxmax + 1;
         } else {
           hline_width = 0;
@@ -452,8 +453,8 @@ void HOT Display::get_regular_polygon_vertex(int vertex_id, int *vertex_x, int *
     rotation_radians -= (variation == VARIATION_FLAT_TOP) ? std::numbers::pi / edges : 0.0;
 
     float vertex_angle = ((float) vertex_id) / edges * 2 * std::numbers::pi + rotation_radians;
-    *vertex_x = (int) round(cos(vertex_angle) * radius) + center_x;
-    *vertex_y = (int) round(sin(vertex_angle) * radius) + center_y;
+    *vertex_x = (int) std::round(std::cos(vertex_angle) * radius) + center_x;
+    *vertex_y = (int) std::round(std::sin(vertex_angle) * radius) + center_y;
   }
 }
 

--- a/esphome/components/esp32/core.cpp
+++ b/esphome/components/esp32/core.cpp
@@ -8,7 +8,9 @@
 
 void setup();  // NOLINT(readability-redundant-declaration)
 
-// Weak stub for initArduino - overridden when the Arduino component is present
+// Weak stub for initArduino - overridden when the Arduino component is present.
+// Name must match the Arduino framework's entry point, so the naming check is suppressed.
+// NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" __attribute__((weak)) void initArduino() {}
 
 namespace esphome {

--- a/esphome/components/nau7802/nau7802.cpp
+++ b/esphome/components/nau7802/nau7802.cpp
@@ -1,4 +1,5 @@
 #include "nau7802.h"
+#include <cmath>
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
@@ -76,7 +77,7 @@ void NAU7802Sensor::setup() {
     return;
   }
 
-  uint32_t gcal = (uint32_t) (round(this->gain_calibration_ * (1 << GCAL1_FRACTIONAL)));
+  uint32_t gcal = (uint32_t) (std::round(this->gain_calibration_ * (1 << GCAL1_FRACTIONAL)));
   this->write_value_(OCAL1_B2_REG, 3, this->offset_calibration_);
   this->write_value_(GCAL1_B3_REG, 4, gcal);
 

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -3,6 +3,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 #include <cinttypes>
+#include <cmath>
 
 namespace esphome::sgp4x {
 
@@ -199,7 +200,7 @@ void SGP4xComponent::measure_raw_() {
       response_words = 2;
     }
   }
-  uint16_t rhticks = (uint16_t) llround((humidity * 65535) / 100);
+  uint16_t rhticks = (uint16_t) std::llround((humidity * 65535) / 100);
   uint16_t tempticks = (uint16_t) (((temperature + 45) * 65535) / 175);
   // first parameter are the relative humidity ticks
   data[0] = rhticks;

--- a/esphome/components/thermopro_ble/thermopro_ble.cpp
+++ b/esphome/components/thermopro_ble/thermopro_ble.cpp
@@ -1,4 +1,5 @@
 #include "thermopro_ble.h"
+#include <cmath>
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -136,7 +137,7 @@ static inline uint32_t read_uint32(const uint8_t *data, std::size_t offset) {
 // A*tanh(B*x+C)+D
 // Where A,B,C,D are the variables to optimize for. This yielded the below function
 static float tp96_battery(uint16_t voltage) {
-  float level = 52.317286f * tanh(static_cast<float>(voltage) / 273.624277936f - 8.76485439394f) + 51.06925f;
+  float level = 52.317286f * std::tanh(static_cast<float>(voltage) / 273.624277936f - 8.76485439394f) + 51.06925f;
   return std::max(0.0f, std::min(level, 100.0f));
 }
 

--- a/esphome/components/tuya/number/tuya_number.cpp
+++ b/esphome/components/tuya/number/tuya_number.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include "esphome/core/log.h"
 #include "tuya_number.h"
 
@@ -63,7 +65,7 @@ void TuyaNumber::setup() {
 void TuyaNumber::control(float value) {
   ESP_LOGV(TAG, "Setting number %u: %f", this->number_id_, value);
   if (this->type_ == TuyaDatapointType::INTEGER) {
-    int integer_value = lround(value * multiply_by_);
+    int integer_value = std::lround(value * multiply_by_);
     this->parent_->set_integer_datapoint_value(this->number_id_, integer_value);
   } else if (this->type_ == TuyaDatapointType::ENUM) {
     this->parent_->set_enum_datapoint_value(this->number_id_, value);


### PR DESCRIPTION
# What does this implement/fix?

Running `script/clang-tidy` against the native ESP-IDF toolchain (an esp32 RISC-V variant) surfaced a batch of `performance-type-promotion-in-math-fn` findings: code calling the C `<math.h>` functions (`floor`, `ceil`, `round`, `lround`, `llround`, `cos`, `sin`, `tanh`) with a `float` argument. Those C functions are `double`-only, so the `float` is promoted to `double`, the work is done in double precision, and a `double` comes back — wasteful on a 32-bit MCU.

This switches the flagged call sites to the overloaded `std::` versions from `<cmath>`, which select the `float` overload and keep the math in float. Only sites with a genuinely `float` argument are changed; calls whose argument is already `double` (e.g. `round(data[j] / 10.)` in daikin_arc, or the `M_PI`-based `cos`/`sin` in display) are left as-is since they don't promote.

Per component:
- **daikin_arc** — `floor` → `std::floor`.
- **display** — `ceil` → `std::ceil` (4 sites); `cos`/`sin` → `std::` at the float-argument sites, and the wrapping `round` → `std::round` too (qualifying the inner call makes its result `float`, which would otherwise cascade a fresh promotion onto `round`).
- **nau7802** — `round` → `std::round`.
- **sgp4x** — `llround` → `std::llround`.
- **thermopro_ble** — `tanh` → `std::tanh`.
- **tuya** — `lround` → `std::lround`.
- **esp32** — `initArduino` keeps its name (it's the Arduino framework entry point) and gets a `NOLINT(readability-identifier-naming)`.

`#include <cmath>` is added where it wasn't already present. These don't trip the existing `esp32-arduino-tidy` job because the Arduino headers pull the `std` float overloads into the global namespace, so `floor(float)` already resolves cleanly there; they only appear on the IDF path. Each changed file was verified to analyze cleanly under the esp32 IDF toolchain.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal code-quality fixes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).