### PR TITLE
[light] Pass light reference into lambda light effect

### DIFF
--- a/esphome/components/light/base_light_effects.h
+++ b/esphome/components/light/base_light_effects.h
@@ -111,7 +111,7 @@ class RandomLightEffect : public LightEffect {
 
 class LambdaLightEffect : public LightEffect {
  public:
-  LambdaLightEffect(const char *name, void (*f)(bool initial_run), uint32_t update_interval)
+  LambdaLightEffect(const char *name, void (*f)(LightState &, bool initial_run), uint32_t update_interval)
       : LightEffect(name), f_(f), update_interval_(update_interval) {}
 
   void start() override { this->initial_run_ = true; }
@@ -119,7 +119,7 @@ class LambdaLightEffect : public LightEffect {
     const uint32_t now = millis();
     if (now - this->last_run_ >= this->update_interval_ || this->initial_run_) {
       this->last_run_ = now;
-      this->f_(this->initial_run_);
+      this->f_(*this->state_, this->initial_run_);
       this->initial_run_ = false;
     }
   }
@@ -129,7 +129,7 @@ class LambdaLightEffect : public LightEffect {
   uint32_t get_current_index() const { return this->get_index(); }
 
  protected:
-  void (*f_)(bool initial_run);
+  void (*f_)(LightState &, bool initial_run);
   uint32_t update_interval_;
   uint32_t last_run_{0};
   bool initial_run_;

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -51,6 +51,7 @@ from .types import (
     FlickerLightEffect,
     LambdaLightEffect,
     LightColorValues,
+    LightStateRef,
     PulseLightEffect,
     RandomLightEffect,
     StrobeLightEffect,
@@ -175,7 +176,9 @@ def register_addressable_effect(
 )
 async def lambda_effect_to_code(config, effect_id):
     lambda_ = await cg.process_lambda(
-        config[CONF_LAMBDA], [(bool, "initial_run")], return_type=cg.void
+        config[CONF_LAMBDA],
+        [(LightStateRef, "it"), (bool, "initial_run")],
+        return_type=cg.void,
     )
     return cg.new_Pvariable(
         effect_id, config[CONF_NAME], lambda_, config[CONF_UPDATE_INTERVAL]

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -4,6 +4,7 @@ import esphome.codegen as cg
 # Base
 light_ns = cg.esphome_ns.namespace("light")
 LightState = light_ns.class_("LightState", cg.EntityBase, cg.Component)
+LightStateRef = LightState.operator("ref")
 AddressableLightState = light_ns.class_("AddressableLightState", LightState)
 LightOutput = light_ns.class_("LightOutput")
 AddressableLight = light_ns.class_("AddressableLight", LightOutput, cg.Component)

--- a/tests/components/light/common.yaml
+++ b/tests/components/light/common.yaml
@@ -182,6 +182,9 @@ light:
             state += 1;
             if (state == 4)
               state = 0;
+            if (initial_run) {
+              ESP_LOGD("custom_effect", "Effect %s started", it.get_name().c_str());
+            }
       - pulse:
           transition_length: 10s
           update_interval: 20s


### PR DESCRIPTION
# What does this implement/fix?

The `AddressableLambdaLightEffect` exposes the light to the lambda as `it`, but the regular `LambdaLightEffect` did not. This passes the effect's `LightState` into the lambda as `it`, so users can reference the light directly inside a `lambda:` effect without needing to look it up by `id()`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6737

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
light:
  - platform: monochromatic
    output: my_output
    id: my_light
    effects:
      - lambda:
          name: My Custom Effect
          update_interval: 1s
          lambda: |-
            // Reference the light directly via `it` instead of id(my_light)
            auto call = it.turn_on();
            call.set_brightness(0.5);
            call.perform();
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).