### PR TITLE
[ci] Make ESP32 IDF the comprehensive clang-tidy pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,13 +525,6 @@ jobs:
           echo "::add-matcher::.github/workflows/matchers/gcc.json"
           echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
 
-      - name: Run 'pio run --list-targets -e esp32-idf-tidy'
-        if: matrix.name == 'Run script/clang-tidy for ESP32 IDF'
-        run: |
-          . venv/bin/activate
-          mkdir -p .temp
-          pio run --list-targets -e esp32-idf-tidy
-
       - name: Check if full clang-tidy scan needed
         id: check_full_scan
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,6 @@ jobs:
       integration-tests: ${{ steps.determine.outputs.integration-tests }}
       integration-test-buckets: ${{ steps.determine.outputs.integration-test-buckets }}
       clang-tidy: ${{ steps.determine.outputs.clang-tidy }}
-      clang-tidy-mode: ${{ steps.determine.outputs.clang-tidy-mode }}
       clang-tidy-full-scan: ${{ steps.determine.outputs.clang-tidy-full-scan }}
       python-linters: ${{ steps.determine.outputs.python-linters }}
       import-time: ${{ steps.determine.outputs.import-time }}
@@ -318,7 +317,6 @@ jobs:
           echo "integration-tests=$(echo "$output" | jq -r '.integration_tests')" >> $GITHUB_OUTPUT
           echo "integration-test-buckets=$(echo "$output" | jq -c '.integration_test_buckets')" >> $GITHUB_OUTPUT
           echo "clang-tidy=$(echo "$output" | jq -r '.clang_tidy')" >> $GITHUB_OUTPUT
-          echo "clang-tidy-mode=$(echo "$output" | jq -r '.clang_tidy_mode')" >> $GITHUB_OUTPUT
           echo "clang-tidy-full-scan=$(echo "$output" | jq -r '.clang_tidy_full_scan')" >> $GITHUB_OUTPUT
           echo "python-linters=$(echo "$output" | jq -r '.python_linters')" >> $GITHUB_OUTPUT
           echo "import-time=$(echo "$output" | jq -r '.import_time')" >> $GITHUB_OUTPUT
@@ -483,8 +481,12 @@ jobs:
             pio_cache_key: tidyesp8266
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 IDF
-            options: --environment esp32-idf-tidy --grep USE_ESP_IDF
+            options: --environment esp32-idf-tidy
             pio_cache_key: tidyesp32-idf
+          - id: clang-tidy
+            name: Run script/clang-tidy for ESP32 Arduino
+            options: --environment esp32-arduino-tidy --grep USE_ARDUINO
+            pio_cache_key: tidyesp32-arduino
           - id: clang-tidy
             name: Run script/clang-tidy for ZEPHYR
             options: --environment nrf52-tidy --grep USE_ZEPHYR --grep USE_NRF52
@@ -565,178 +567,6 @@ jobs:
       - name: Suggested changes
         run: script/ci-suggest-changes ${{ matrix.ignore_errors && '|| true' || '' }}
         # yamllint disable-line rule:line-length
-        if: always()
-
-  clang-tidy-nosplit:
-    name: Run script/clang-tidy for ESP32 Arduino
-    runs-on: ubuntu-24.04
-    needs:
-      - common
-      - determine-jobs
-    if: needs.determine-jobs.outputs.clang-tidy-mode == 'nosplit'
-    env:
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          # Need history for HEAD~1 to work for checking changed files
-          fetch-depth: 2
-
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-
-      - name: Cache platformio
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.platformio
-          key: platformio-tidyesp32-${{ hashFiles('platformio.ini') }}
-
-      - name: Cache platformio
-        if: github.ref != 'refs/heads/dev'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.platformio
-          key: platformio-tidyesp32-${{ hashFiles('platformio.ini') }}
-
-      - name: Register problem matchers
-        run: |
-          echo "::add-matcher::.github/workflows/matchers/gcc.json"
-          echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
-
-      - name: Check if full clang-tidy scan needed
-        id: check_full_scan
-        run: |
-          . venv/bin/activate
-          # determine-jobs.clang-tidy-full-scan is true when core C++ changed
-          # OR the ci-run-all label forced --force-all. Independent of the
-          # hash check, both must produce a full scan in the job itself.
-          if [ "${{ needs.determine-jobs.outputs.clang-tidy-full-scan }}" = "true" ]; then
-            echo "full_scan=true" >> $GITHUB_OUTPUT
-            echo "reason=determine_jobs" >> $GITHUB_OUTPUT
-          elif python script/clang_tidy_hash.py --check; then
-            echo "full_scan=true" >> $GITHUB_OUTPUT
-            echo "reason=hash_changed" >> $GITHUB_OUTPUT
-          else
-            echo "full_scan=false" >> $GITHUB_OUTPUT
-            echo "reason=normal" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Run clang-tidy
-        run: |
-          . venv/bin/activate
-          if [ "${{ steps.check_full_scan.outputs.full_scan }}" = "true" ]; then
-            echo "Running FULL clang-tidy scan (reason: ${{ steps.check_full_scan.outputs.reason }})"
-            script/clang-tidy --all-headers --fix --environment esp32-arduino-tidy
-          else
-            echo "Running clang-tidy on changed files only"
-            script/clang-tidy --all-headers --fix --changed --environment esp32-arduino-tidy
-          fi
-        env:
-          # Also cache libdeps, store them in a ~/.platformio subfolder
-          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
-
-      - name: Suggested changes
-        run: script/ci-suggest-changes
-        if: always()
-
-  clang-tidy-split:
-    name: ${{ matrix.name }}
-    runs-on: ubuntu-24.04
-    needs:
-      - common
-      - determine-jobs
-    if: needs.determine-jobs.outputs.clang-tidy-mode == 'split'
-    env:
-      GH_TOKEN: ${{ github.token }}
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        include:
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 1/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 1
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 2/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 2
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 3/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 3
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 4/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 4
-
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          # Need history for HEAD~1 to work for checking changed files
-          fetch-depth: 2
-
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-
-      - name: Cache platformio
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.platformio
-          key: platformio-tidyesp32-${{ hashFiles('platformio.ini') }}
-
-      - name: Cache platformio
-        if: github.ref != 'refs/heads/dev'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.platformio
-          key: platformio-tidyesp32-${{ hashFiles('platformio.ini') }}
-
-      - name: Register problem matchers
-        run: |
-          echo "::add-matcher::.github/workflows/matchers/gcc.json"
-          echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
-
-      - name: Check if full clang-tidy scan needed
-        id: check_full_scan
-        run: |
-          . venv/bin/activate
-          # determine-jobs.clang-tidy-full-scan is true when core C++ changed
-          # OR the ci-run-all label forced --force-all. Independent of the
-          # hash check, both must produce a full scan in the job itself.
-          if [ "${{ needs.determine-jobs.outputs.clang-tidy-full-scan }}" = "true" ]; then
-            echo "full_scan=true" >> $GITHUB_OUTPUT
-            echo "reason=determine_jobs" >> $GITHUB_OUTPUT
-          elif python script/clang_tidy_hash.py --check; then
-            echo "full_scan=true" >> $GITHUB_OUTPUT
-            echo "reason=hash_changed" >> $GITHUB_OUTPUT
-          else
-            echo "full_scan=false" >> $GITHUB_OUTPUT
-            echo "reason=normal" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Run clang-tidy
-        run: |
-          . venv/bin/activate
-          if [ "${{ steps.check_full_scan.outputs.full_scan }}" = "true" ]; then
-            echo "Running FULL clang-tidy scan (reason: ${{ steps.check_full_scan.outputs.reason }})"
-            script/clang-tidy --all-headers --fix ${{ matrix.options }}
-          else
-            echo "Running clang-tidy on changed files only"
-            script/clang-tidy --all-headers --fix --changed ${{ matrix.options }}
-          fi
-        env:
-          # Also cache libdeps, store them in a ~/.platformio subfolder
-          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
-
-      - name: Suggested changes
-        run: script/ci-suggest-changes
         if: always()
 
   test-build-components-split:
@@ -1292,8 +1122,6 @@ jobs:
       - pytest
       - integration-tests
       - clang-tidy-single
-      - clang-tidy-nosplit
-      - clang-tidy-split
       - determine-jobs
       - device-builder
       - test-build-components-split

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,20 +582,6 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
 
-      - name: Cache platformio
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.platformio
-          key: platformio-tidyesp32-idf-${{ hashFiles('platformio.ini') }}
-
-      - name: Cache platformio
-        if: github.ref != 'refs/heads/dev'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.platformio
-          key: platformio-tidyesp32-idf-${{ hashFiles('platformio.ini') }}
-
       - name: Register problem matchers
         run: |
           echo "::add-matcher::.github/workflows/matchers/gcc.json"
@@ -673,20 +659,6 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
-
-      - name: Cache platformio
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.platformio
-          key: platformio-tidyesp32-idf-${{ hashFiles('platformio.ini') }}
-
-      - name: Cache platformio
-        if: github.ref != 'refs/heads/dev'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.platformio
-          key: platformio-tidyesp32-idf-${{ hashFiles('platformio.ini') }}
 
       - name: Register problem matchers
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,9 +502,6 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
 
-      # Only the PlatformIO-based env (esp8266) populates ~/.platformio; the esp32*
-      # and zephyr envs go through the native ESP-IDF / west generators, so they
-      # have no pio_cache_key and skip these steps.
       - name: Cache platformio
         if: github.ref == 'refs/heads/dev' && matrix.pio_cache_key
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,11 +484,9 @@ jobs:
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 Arduino
             options: --environment esp32-arduino-tidy --grep USE_ARDUINO
-            pio_cache_key: tidyesp32-arduino
           - id: clang-tidy
             name: Run script/clang-tidy for ZEPHYR
             options: --environment nrf52-tidy --grep USE_ZEPHYR --grep USE_NRF52
-            pio_cache_key: tidy-zephyr
             ignore_errors: false
 
     steps:
@@ -504,15 +502,18 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
 
+      # Only the PlatformIO-based env (esp8266) populates ~/.platformio; the esp32*
+      # and zephyr envs go through the native ESP-IDF / west generators, so they
+      # have no pio_cache_key and skip these steps.
       - name: Cache platformio
-        if: github.ref == 'refs/heads/dev'
+        if: github.ref == 'refs/heads/dev' && matrix.pio_cache_key
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.platformio
           key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
 
       - name: Cache platformio
-        if: github.ref != 'refs/heads/dev'
+        if: github.ref != 'refs/heads/dev' && matrix.pio_cache_key
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.platformio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,7 @@ jobs:
       integration-tests: ${{ steps.determine.outputs.integration-tests }}
       integration-test-buckets: ${{ steps.determine.outputs.integration-test-buckets }}
       clang-tidy: ${{ steps.determine.outputs.clang-tidy }}
+      clang-tidy-mode: ${{ steps.determine.outputs.clang-tidy-mode }}
       clang-tidy-full-scan: ${{ steps.determine.outputs.clang-tidy-full-scan }}
       python-linters: ${{ steps.determine.outputs.python-linters }}
       import-time: ${{ steps.determine.outputs.import-time }}
@@ -317,6 +318,7 @@ jobs:
           echo "integration-tests=$(echo "$output" | jq -r '.integration_tests')" >> $GITHUB_OUTPUT
           echo "integration-test-buckets=$(echo "$output" | jq -c '.integration_test_buckets')" >> $GITHUB_OUTPUT
           echo "clang-tidy=$(echo "$output" | jq -r '.clang_tidy')" >> $GITHUB_OUTPUT
+          echo "clang-tidy-mode=$(echo "$output" | jq -r '.clang_tidy_mode')" >> $GITHUB_OUTPUT
           echo "clang-tidy-full-scan=$(echo "$output" | jq -r '.clang_tidy_full_scan')" >> $GITHUB_OUTPUT
           echo "python-linters=$(echo "$output" | jq -r '.python_linters')" >> $GITHUB_OUTPUT
           echo "import-time=$(echo "$output" | jq -r '.import_time')" >> $GITHUB_OUTPUT
@@ -480,10 +482,6 @@ jobs:
             options: --environment esp8266-arduino-tidy --grep USE_ESP8266
             pio_cache_key: tidyesp8266
           - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 IDF
-            options: --environment esp32-idf-tidy
-            pio_cache_key: tidyesp32-idf
-          - id: clang-tidy
             name: Run script/clang-tidy for ESP32 Arduino
             options: --environment esp32-arduino-tidy --grep USE_ARDUINO
             pio_cache_key: tidyesp32-arduino
@@ -560,6 +558,175 @@ jobs:
       - name: Suggested changes
         run: script/ci-suggest-changes ${{ matrix.ignore_errors && '|| true' || '' }}
         # yamllint disable-line rule:line-length
+        if: always()
+
+  clang-tidy-nosplit:
+    name: Run script/clang-tidy for ESP32 IDF
+    runs-on: ubuntu-24.04
+    needs:
+      - common
+      - determine-jobs
+    if: needs.determine-jobs.outputs.clang-tidy-mode == 'nosplit'
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Need history for HEAD~1 to work for checking changed files
+          fetch-depth: 2
+
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+
+      - name: Cache platformio
+        if: github.ref == 'refs/heads/dev'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.platformio
+          key: platformio-tidyesp32-idf-${{ hashFiles('platformio.ini') }}
+
+      - name: Cache platformio
+        if: github.ref != 'refs/heads/dev'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.platformio
+          key: platformio-tidyesp32-idf-${{ hashFiles('platformio.ini') }}
+
+      - name: Register problem matchers
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/gcc.json"
+          echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
+
+      - name: Check if full clang-tidy scan needed
+        id: check_full_scan
+        run: |
+          . venv/bin/activate
+          # determine-jobs.clang-tidy-full-scan is true when core C++ changed
+          # OR the ci-run-all label forced --force-all. Independent of the
+          # hash check, both must produce a full scan in the job itself.
+          if [ "${{ needs.determine-jobs.outputs.clang-tidy-full-scan }}" = "true" ]; then
+            echo "full_scan=true" >> $GITHUB_OUTPUT
+            echo "reason=determine_jobs" >> $GITHUB_OUTPUT
+          elif python script/clang_tidy_hash.py --check; then
+            echo "full_scan=true" >> $GITHUB_OUTPUT
+            echo "reason=hash_changed" >> $GITHUB_OUTPUT
+          else
+            echo "full_scan=false" >> $GITHUB_OUTPUT
+            echo "reason=normal" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run clang-tidy
+        run: |
+          . venv/bin/activate
+          if [ "${{ steps.check_full_scan.outputs.full_scan }}" = "true" ]; then
+            echo "Running FULL clang-tidy scan (reason: ${{ steps.check_full_scan.outputs.reason }})"
+            script/clang-tidy --all-headers --fix --environment esp32-idf-tidy
+          else
+            echo "Running clang-tidy on changed files only"
+            script/clang-tidy --all-headers --fix --changed --environment esp32-idf-tidy
+          fi
+        env:
+          # Also cache libdeps, store them in a ~/.platformio subfolder
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
+
+      - name: Suggested changes
+        run: script/ci-suggest-changes
+        if: always()
+
+  clang-tidy-split:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-24.04
+    needs:
+      - common
+      - determine-jobs
+    if: needs.determine-jobs.outputs.clang-tidy-mode == 'split'
+    env:
+      GH_TOKEN: ${{ github.token }}
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        include:
+          - id: clang-tidy
+            name: Run script/clang-tidy for ESP32 IDF 1/3
+            options: --environment esp32-idf-tidy --split-num 3 --split-at 1
+          - id: clang-tidy
+            name: Run script/clang-tidy for ESP32 IDF 2/3
+            options: --environment esp32-idf-tidy --split-num 3 --split-at 2
+          - id: clang-tidy
+            name: Run script/clang-tidy for ESP32 IDF 3/3
+            options: --environment esp32-idf-tidy --split-num 3 --split-at 3
+
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Need history for HEAD~1 to work for checking changed files
+          fetch-depth: 2
+
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+
+      - name: Cache platformio
+        if: github.ref == 'refs/heads/dev'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.platformio
+          key: platformio-tidyesp32-idf-${{ hashFiles('platformio.ini') }}
+
+      - name: Cache platformio
+        if: github.ref != 'refs/heads/dev'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.platformio
+          key: platformio-tidyesp32-idf-${{ hashFiles('platformio.ini') }}
+
+      - name: Register problem matchers
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/gcc.json"
+          echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
+
+      - name: Check if full clang-tidy scan needed
+        id: check_full_scan
+        run: |
+          . venv/bin/activate
+          # determine-jobs.clang-tidy-full-scan is true when core C++ changed
+          # OR the ci-run-all label forced --force-all. Independent of the
+          # hash check, both must produce a full scan in the job itself.
+          if [ "${{ needs.determine-jobs.outputs.clang-tidy-full-scan }}" = "true" ]; then
+            echo "full_scan=true" >> $GITHUB_OUTPUT
+            echo "reason=determine_jobs" >> $GITHUB_OUTPUT
+          elif python script/clang_tidy_hash.py --check; then
+            echo "full_scan=true" >> $GITHUB_OUTPUT
+            echo "reason=hash_changed" >> $GITHUB_OUTPUT
+          else
+            echo "full_scan=false" >> $GITHUB_OUTPUT
+            echo "reason=normal" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run clang-tidy
+        run: |
+          . venv/bin/activate
+          if [ "${{ steps.check_full_scan.outputs.full_scan }}" = "true" ]; then
+            echo "Running FULL clang-tidy scan (reason: ${{ steps.check_full_scan.outputs.reason }})"
+            script/clang-tidy --all-headers --fix ${{ matrix.options }}
+          else
+            echo "Running clang-tidy on changed files only"
+            script/clang-tidy --all-headers --fix --changed ${{ matrix.options }}
+          fi
+        env:
+          # Also cache libdeps, store them in a ~/.platformio subfolder
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
+
+      - name: Suggested changes
+        run: script/ci-suggest-changes
         if: always()
 
   test-build-components-split:
@@ -1115,6 +1282,8 @@ jobs:
       - pytest
       - integration-tests
       - clang-tidy-single
+      - clang-tidy-nosplit
+      - clang-tidy-split
       - determine-jobs
       - device-builder
       - test-build-components-split

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,6 +487,7 @@ jobs:
           - id: clang-tidy
             name: Run script/clang-tidy for ZEPHYR
             options: --environment nrf52-tidy --grep USE_ZEPHYR --grep USE_NRF52
+            pio_cache_key: tidy-zephyr
             ignore_errors: false
 
     steps:

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -2,6 +2,7 @@
 
 #if defined(USE_ARDUINO) || defined(USE_ESP32)
 
+#include <cmath>
 #include <map>
 #include <IRSender.h>
 #include <HeatpumpIRFactory.h>
@@ -113,7 +114,7 @@ void HeatpumpIRClimate::setup() {
       this->current_temperature = state;
 
       IRSenderESPHome esp_sender(this->transmitter_);
-      this->heatpump_ir_->send(esp_sender, uint8_t(lround(this->current_temperature)));
+      this->heatpump_ir_->send(esp_sender, uint8_t(std::lround(this->current_temperature)));
 
       // current temperature changed, publish state
       this->publish_state();


### PR DESCRIPTION
# What does this implement/fix?

Flips which ESP32 clang-tidy environment does the comprehensive (un-grepped) pass.

**Before:** `esp32-arduino-tidy` ran with **no grep** (the comprehensive pass, split 4 ways on full scans); `esp32-idf-tidy` ran narrowed to `--grep USE_ESP_IDF` (~4 files).

**After:**
- **`esp32-idf-tidy` — no grep → the comprehensive pass**, on the native ESP-IDF toolchain. It keeps the existing mode-gated splitting (just moved from arduino to idf): a single `clang-tidy-nosplit` job for small/changed PRs, and a **3-way** `clang-tidy-split` (`--split-num 3`, `max-parallel: 3`) for full scans. (Was 4-way on arduino; the IDF full scan ran ~30 min as a single job, hence the split.)
- **`esp32-arduino-tidy` — `--grep USE_ARDUINO` → the Arduino-specific delta** (~25 files), now a single entry in the `clang-tidy-single` matrix alongside esp8266 and zephyr.
- **esp8266 / zephyr** — unchanged.

`determine-jobs.py` is untouched: it already computes `clang_tidy_mode` (nosplit `<65` changed files / split otherwise), which now drives the IDF split instead of the arduino one.

## Why

The Arduino toolchain has a blind spot: its headers pull the `std` float math overloads into the global namespace, so `floor(float)` etc. resolve cleanly and `performance-type-promotion-in-math-fn` never fires there. The native IDF toolchain sees the real semantics and catches those (and other toolchain-specific) issues. Making IDF the comprehensive pass lints the shared codebase against the toolchain that more closely matches real firmware, and clang now analyzes the RISC-V IDF variants natively.

## Also in this PR

- **Drop the obsolete `pio run --list-targets -e esp32-idf-tidy` warmup step** — clang-tidy runs through the native ESP-IDF toolchain now, not a raw PlatformIO invocation.
- **Drop the `~/.platformio` cache from the IDF jobs** — the native-IDF path never populates `~/.platformio`, so caching it was dead weight. The PlatformIO-based jobs (esp8266/arduino/zephyr) keep their cache.
- **`[heatpumpir]`** float→double `lround` fix — one finding the new IDF pass surfaces that #16812 didn't cover.

## Notes

- `script/clang-tidy --all-headers` is still added by the job step for every env, so the full unity-header compile still runs on both the IDF and Arduino toolchains; only the per-file scan is grep-narrowed for Arduino.
- A full comprehensive IDF scan only triggers on a config-hash/core change or the **`ci-run-all`** label — add that label to this PR to exercise the full no-grep IDF split.
- Follow-up idea (not in this PR): with the 3-way split each shard installs the ESP-IDF toolchain independently (~2 min), so caching the IDF toolchain (`IDF_TOOLS_PATH` / `.esphome/idf`) would be the higher-value CI speedup.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Developer breaking change
- [ ] Undocumented C++ API change
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI tooling change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).