### PR TITLE
[ci] Add codecov.yml to enforce 100% patch coverage on PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%
+        threshold: 0%
+    project:
+      default:
+        informational: true
+
+ignore:
+  - "esphome/components/**/*"
+  - "esphome/analyze_memory/**/*"
+  - "tests/integration/**/*"
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true


### PR DESCRIPTION
# What does this implement/fix?

Adds a `codecov.yml` so Codecov runs against an explicit configuration instead of its defaults. The key change is enforcing 100% patch coverage: every line changed in a PR must be covered by tests for the patch status check to pass.

To avoid penalising contributors for pre-existing untested code, the project-level status is set to `informational` (it still reports, but never blocks). The `ignore` list mirrors the `omit` paths in `.coveragerc` (`esphome/components`, `esphome/analyze_memory`, `tests/integration`) so coverage gating stays consistent with what is actually measured.

The config was validated against Codecov's `https://codecov.io/validate` endpoint.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).