### PR TITLE
[audio] Deprecate unused scale_audio_samples helper

### DIFF
--- a/esphome/components/audio/audio.h
+++ b/esphome/components/audio/audio.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"  // for ESPDEPRECATED
 
 #include <cstddef>
 #include <cstdint>
@@ -143,6 +144,8 @@ AudioFileType detect_audio_file_type(const char *content_type, const char *url);
 /// @param output_buffer Buffer to store the scaled samples
 /// @param scale_factor Q15 fixed point scaling factor
 /// @param samples_to_scale Number of samples to scale
+// Remove before 2026.12.0
+ESPDEPRECATED("scale_audio_samples is unused and will be removed in 2026.12.0.", "2026.6.0")
 void scale_audio_samples(const int16_t *audio_samples, int16_t *output_buffer, int16_t scale_factor,
                          size_t samples_to_scale);
 

--- a/esphome/components/audio/audio.h
+++ b/esphome/components/audio/audio.h
@@ -145,7 +145,7 @@ AudioFileType detect_audio_file_type(const char *content_type, const char *url);
 /// @param scale_factor Q15 fixed point scaling factor
 /// @param samples_to_scale Number of samples to scale
 // Remove before 2026.12.0
-ESPDEPRECATED("scale_audio_samples is unused and will be removed in 2026.12.0.", "2026.6.0")
+ESPDEPRECATED("Use esp_audio_libs::gain::apply() (from <gain.h>) instead. Removed in 2026.12.0.", "2026.6.0")
 void scale_audio_samples(const int16_t *audio_samples, int16_t *output_buffer, int16_t scale_factor,
                          size_t samples_to_scale);
 


### PR DESCRIPTION
# What does this implement/fix?

The `scale_audio_samples` helper function in the `audio` component is no longer used anywhere in the codebase. This marks it as deprecated with `ESPDEPRECATED`, scheduled for removal in 2026.12.0.

The function declaration in `audio.h` now carries a deprecation attribute (emitting a compiler warning at any remaining call site) and a `// Remove before 2026.12.0` reminder. The definition in `audio.cpp` is left in place so existing code continues to link during the deprecation window. `audio.h` now also includes `esphome/core/helpers.h` for the `ESPDEPRECATED` macro.

### Migration guide

Any external component or lambda still calling `scale_audio_samples` should switch to `esp_audio_libs::gain::apply`, provided by the `esp-audio-libs` library that is already bundled with the `audio` component.

Include the header:

```cpp
// esp-audio-libs
#include <gain.h>
```

`gain::apply` takes a Q31 scale factor (not Q15), operates on raw byte buffers, and needs the sample width. Convert a Q15 factor to Q31 by left-shifting 16 bits (31 - 15):

```cpp
int32_t q31_scale = static_cast<int32_t>(q15_scale) << 16;
```

Like the old Q15 factor, the Q31 factor cannot amplify above unity (its max, `INT32_MAX`, corresponds to a gain of just under 1.0). Then replace the call:

```cpp
// Before (Q15 scale factor, int16 buffers)
esphome::audio::scale_audio_samples(samples, output, q15_scale, num_samples);

// After (Q31 scale factor, byte buffers + bytes_per_sample)
esp_audio_libs::gain::apply(reinterpret_cast<const uint8_t *>(samples),
                            reinterpret_cast<uint8_t *>(output), q31_scale, num_samples,
                            sizeof(int16_t));
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
