### PR TITLE
[tuya] Fixed hysteresis bug for Tuya climate

### DIFF
--- a/esphome/components/tuya/climate/tuya_climate.cpp
+++ b/esphome/components/tuya/climate/tuya_climate.cpp
@@ -513,14 +513,14 @@ void TuyaClimate::compute_state_() {
   } else {
     // Fallback to active state calc based on temp and hysteresis
     const float temp_diff = this->target_temperature - this->current_temperature;
-    if (std::abs(temp_diff) > this->hysteresis_) {
-      if (this->supports_heat_ && temp_diff > 0) {
+    if ((this->supports_heat_ && temp_diff >= this->hysteresis_) ||
+        (this->action == climate::CLIMATE_ACTION_HEATING && temp_diff > 0)){
         target_action = climate::CLIMATE_ACTION_HEATING;
         this->mode = climate::CLIMATE_MODE_HEAT;
-      } else if (this->supports_cool_ && temp_diff < 0) {
+    } else if ((this->supports_cool_ && temp_diff <= -this->hysteresis_) ||
+               (this->action == climate::CLIMATE_ACTION_COOLING && temp_diff < 0)){
         target_action = climate::CLIMATE_ACTION_COOLING;
         this->mode = climate::CLIMATE_MODE_COOL;
-      }
     }
   }
 

--- a/esphome/components/tuya/climate/tuya_climate.cpp
+++ b/esphome/components/tuya/climate/tuya_climate.cpp
@@ -514,13 +514,13 @@ void TuyaClimate::compute_state_() {
     // Fallback to active state calc based on temp and hysteresis
     const float temp_diff = this->target_temperature - this->current_temperature;
     if ((this->supports_heat_ && temp_diff >= this->hysteresis_) ||
-        (this->action == climate::CLIMATE_ACTION_HEATING && temp_diff > 0)){
-        target_action = climate::CLIMATE_ACTION_HEATING;
-        this->mode = climate::CLIMATE_MODE_HEAT;
+        (this->action == climate::CLIMATE_ACTION_HEATING && temp_diff > 0)) {
+      target_action = climate::CLIMATE_ACTION_HEATING;
+      this->mode = climate::CLIMATE_MODE_HEAT;
     } else if ((this->supports_cool_ && temp_diff <= -this->hysteresis_) ||
-               (this->action == climate::CLIMATE_ACTION_COOLING && temp_diff < 0)){
-        target_action = climate::CLIMATE_ACTION_COOLING;
-        this->mode = climate::CLIMATE_MODE_COOL;
+               (this->action == climate::CLIMATE_ACTION_COOLING && temp_diff < 0)) {
+      target_action = climate::CLIMATE_ACTION_COOLING;
+      this->mode = climate::CLIMATE_MODE_COOL;
     }
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Fallback logic for target action calculation for Tuya Climate is not fitting to HW state. Hysteresis implementation was not matching actual behaviour.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes (https://github.com/esphome/esphome/issues/13270)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
