### PR TITLE
[improv_serial] Fix build on ESP32-C5/P4 and simplify variant guards

### DIFF
--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -68,7 +68,7 @@ optional<uint8_t> ImprovSerialComponent::read_byte_() {
   switch (logger::global_logger->get_uart()) {
     case logger::UART_SELECTION_UART0:
     case logger::UART_SELECTION_UART1:
-#if defined(USE_LIBRETINY) || defined(USE_ESP32_VARIANT_ESP32)
+#if defined(USE_ESP32_VARIANT_ESP32)
     case logger::UART_SELECTION_UART2:
 #endif
       if (this->uart_num_ >= 0) {
@@ -134,7 +134,7 @@ void ImprovSerialComponent::write_data_(const uint8_t *data, const size_t size) 
   switch (logger::global_logger->get_uart()) {
     case logger::UART_SELECTION_UART0:
     case logger::UART_SELECTION_UART1:
-#if defined(USE_LIBRETINY) || defined(USE_ESP32_VARIANT_ESP32)
+#if defined(USE_ESP32_VARIANT_ESP32)
     case logger::UART_SELECTION_UART2:
 #endif
       uart_write_bytes(this->uart_num_, this->tx_header_, header_tx_len);

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -68,11 +68,9 @@ optional<uint8_t> ImprovSerialComponent::read_byte_() {
   switch (logger::global_logger->get_uart()) {
     case logger::UART_SELECTION_UART0:
     case logger::UART_SELECTION_UART1:
-#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && \
-    !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32S2) && !defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_LIBRETINY) || defined(USE_ESP32_VARIANT_ESP32)
     case logger::UART_SELECTION_UART2:
-#endif  // !USE_ESP32_VARIANT_ESP32C3 && !USE_ESP32_VARIANT_ESP32C6 && !USE_ESP32_VARIANT_ESP32C61 &&
-        // !USE_ESP32_VARIANT_ESP32S2 && !USE_ESP32_VARIANT_ESP32S3
+#endif
       if (this->uart_num_ >= 0) {
         size_t available;
         uart_get_buffered_data_len(this->uart_num_, &available);
@@ -136,8 +134,7 @@ void ImprovSerialComponent::write_data_(const uint8_t *data, const size_t size) 
   switch (logger::global_logger->get_uart()) {
     case logger::UART_SELECTION_UART0:
     case logger::UART_SELECTION_UART1:
-#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && \
-    !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32S2) && !defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_LIBRETINY) || defined(USE_ESP32_VARIANT_ESP32)
     case logger::UART_SELECTION_UART2:
 #endif
       uart_write_bytes(this->uart_num_, this->tx_header_, header_tx_len);

--- a/esphome/components/improv_serial/improv_serial_component.h
+++ b/esphome/components/improv_serial/improv_serial_component.h
@@ -11,8 +11,7 @@
 
 #ifdef USE_ESP32
 #include <driver/uart.h>
-#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C6) || defined(USE_ESP32_VARIANT_ESP32C61) || \
-    defined(USE_ESP32_VARIANT_ESP32H2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#ifdef USE_LOGGER_USB_SERIAL_JTAG
 #include <driver/usb_serial_jtag.h>
 #include <hal/usb_serial_jtag_ll.h>
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fixes a build break for `improv_serial` on newer ESP32 variants and simplifies the variant guards to reuse macros that already express the same intent.

The header gated the `usb_serial_jtag` includes on a hand-maintained list of variants:

```
USE_ESP32_VARIANT_ESP32C3 || ESP32C6 || ESP32C61 || ESP32H2 || ESP32S3
```

But the logger enables USB-serial-JTAG (and defines `USE_LOGGER_USB_SERIAL_JTAG`) for a wider set — **C3, C5, C6, C61, H2, P4, S3**. The list omitted the newer **ESP32-C5** and **ESP32-P4**, so on those variants `improv_serial_component.cpp` compiled its `#ifdef USE_LOGGER_USB_SERIAL_JTAG` body without ever including `driver/usb_serial_jtag.h` / `hal/usb_serial_jtag_ll.h`, breaking the build.

Changes:

- Header: gate the `usb_serial_jtag` includes on `#ifdef USE_LOGGER_USB_SERIAL_JTAG` — the exact macro the logger defines for this capability — so the includes always match the code that uses them, on every current and future variant.
- `read_byte_()` / `write_data_()`: replace the negated variant list guarding the `UART_SELECTION_UART2` case with `#if defined(USE_LIBRETINY) || defined(USE_ESP32_VARIANT_ESP32)`, matching how `logger.h` already gates `UART_SELECTION_UART2`.

No functional change on variants that already built; deriving the guards from the centrally-maintained logger macros also stops them drifting as new variants are added.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).