### PR TITLE
[usb_uart] Fix clang-tidy findings

### DIFF
--- a/esphome/components/usb_uart/ch34x.cpp
+++ b/esphome/components/usb_uart/ch34x.cpp
@@ -10,43 +10,43 @@ namespace esphome::usb_uart {
 using namespace bytebuffer;
 
 struct CH34xEntry {
+  const char *name;
   uint16_t pid;
   uint8_t byte_idx;  // which status.data[] byte to inspect
   uint8_t mask;      // bitmask applied before comparison
   uint8_t match;     // 0xFF = wildcard (default/fallthrough for this PID)
   CH34xChipType chiptype;
-  const char *name;
   uint8_t num_ports;
 };
 
 static const CH34xEntry CH34X_TABLE[] = {
-    {0x55D2, 1, 0xFF, 0x41, CHIP_CH342K, "CH342K", 2},
-    {0x55D2, 1, 0xFF, 0xFF, CHIP_CH342F, "CH342F", 2},
-    {0x55D3, 1, 0xFF, 0x02, CHIP_CH343J, "CH343J", 1},
-    {0x55D3, 1, 0xFF, 0x01, CHIP_CH343K, "CH343K", 1},
-    {0x55D3, 1, 0xFF, 0x18, CHIP_CH343G_AUTOBAUD, "CH343G_AUTOBAUD", 1},
-    {0x55D3, 1, 0xFF, 0xFF, CHIP_CH343GP, "CH343GP", 1},
-    {0x55D4, 1, 0xFF, 0x09, CHIP_CH9102X, "CH9102X", 1},
-    {0x55D4, 1, 0xFF, 0xFF, CHIP_CH9102F, "CH9102F", 1},
-    {0x55D5, 1, 0xFF, 0xC0, CHIP_CH344L, "CH344L", 4},  // CH344L vs CH344L_V2 resolved below
-    {0x55D5, 1, 0xFF, 0xFF, CHIP_CH344Q, "CH344Q", 4},
-    {0x55D7, 1, 0xFF, 0xFF, CHIP_CH9103M, "CH9103M", 2},
-    {0x55D8, 1, 0xFF, 0x0A, CHIP_CH9101RY, "CH9101RY", 1},
-    {0x55D8, 1, 0xFF, 0xFF, CHIP_CH9101UH, "CH9101UH", 1},
-    {0x55DB, 1, 0xFF, 0xFF, CHIP_CH347TF, "CH347TF", 1},
-    {0x55DD, 1, 0xFF, 0xFF, CHIP_CH347TF, "CH347TF", 1},
-    {0x55DA, 1, 0xFF, 0xFF, CHIP_CH347TF, "CH347TF", 2},
-    {0x55DE, 1, 0xFF, 0xFF, CHIP_CH347TF, "CH347TF", 2},
-    {0x55E7, 1, 0xFF, 0xFF, CHIP_CH339W, "CH339W", 1},
-    {0x55DF, 1, 0xFF, 0xFF, CHIP_CH9104L, "CH9104L", 4},
-    {0x55E9, 1, 0xFF, 0xFF, CHIP_CH9111L_M0, "CH9111L_M0", 1},
-    {0x55EA, 1, 0xFF, 0xFF, CHIP_CH9111L_M1, "CH9111L_M1", 1},
-    {0x55E8, 2, 0xFF, 0x48, CHIP_CH9114L, "CH9114L", 4},
-    {0x55E8, 2, 0xFF, 0x49, CHIP_CH9114W, "CH9114W", 4},
-    {0x55E8, 2, 0xFF, 0x4A, CHIP_CH9114F, "CH9114F", 4},
-    {0x55EB, 4, 0x01, 0x01, CHIP_CH346C_M1, "CH346C_M1", 1},
-    {0x55EB, 4, 0x01, 0xFF, CHIP_CH346C_M0, "CH346C_M0", 1},
-    {0x55EC, 1, 0xFF, 0xFF, CHIP_CH346C_M2, "CH346C_M2", 2},
+    {"CH342K", 0x55D2, 1, 0xFF, 0x41, CHIP_CH342K, 2},
+    {"CH342F", 0x55D2, 1, 0xFF, 0xFF, CHIP_CH342F, 2},
+    {"CH343J", 0x55D3, 1, 0xFF, 0x02, CHIP_CH343J, 1},
+    {"CH343K", 0x55D3, 1, 0xFF, 0x01, CHIP_CH343K, 1},
+    {"CH343G_AUTOBAUD", 0x55D3, 1, 0xFF, 0x18, CHIP_CH343G_AUTOBAUD, 1},
+    {"CH343GP", 0x55D3, 1, 0xFF, 0xFF, CHIP_CH343GP, 1},
+    {"CH9102X", 0x55D4, 1, 0xFF, 0x09, CHIP_CH9102X, 1},
+    {"CH9102F", 0x55D4, 1, 0xFF, 0xFF, CHIP_CH9102F, 1},
+    {"CH344L", 0x55D5, 1, 0xFF, 0xC0, CHIP_CH344L, 4},  // CH344L vs CH344L_V2 resolved below
+    {"CH344Q", 0x55D5, 1, 0xFF, 0xFF, CHIP_CH344Q, 4},
+    {"CH9103M", 0x55D7, 1, 0xFF, 0xFF, CHIP_CH9103M, 2},
+    {"CH9101RY", 0x55D8, 1, 0xFF, 0x0A, CHIP_CH9101RY, 1},
+    {"CH9101UH", 0x55D8, 1, 0xFF, 0xFF, CHIP_CH9101UH, 1},
+    {"CH347TF", 0x55DB, 1, 0xFF, 0xFF, CHIP_CH347TF, 1},
+    {"CH347TF", 0x55DD, 1, 0xFF, 0xFF, CHIP_CH347TF, 1},
+    {"CH347TF", 0x55DA, 1, 0xFF, 0xFF, CHIP_CH347TF, 2},
+    {"CH347TF", 0x55DE, 1, 0xFF, 0xFF, CHIP_CH347TF, 2},
+    {"CH339W", 0x55E7, 1, 0xFF, 0xFF, CHIP_CH339W, 1},
+    {"CH9104L", 0x55DF, 1, 0xFF, 0xFF, CHIP_CH9104L, 4},
+    {"CH9111L_M0", 0x55E9, 1, 0xFF, 0xFF, CHIP_CH9111L_M0, 1},
+    {"CH9111L_M1", 0x55EA, 1, 0xFF, 0xFF, CHIP_CH9111L_M1, 1},
+    {"CH9114L", 0x55E8, 2, 0xFF, 0x48, CHIP_CH9114L, 4},
+    {"CH9114W", 0x55E8, 2, 0xFF, 0x49, CHIP_CH9114W, 4},
+    {"CH9114F", 0x55E8, 2, 0xFF, 0x4A, CHIP_CH9114F, 4},
+    {"CH346C_M1", 0x55EB, 4, 0x01, 0x01, CHIP_CH346C_M1, 1},
+    {"CH346C_M0", 0x55EB, 4, 0x01, 0xFF, CHIP_CH346C_M0, 1},
+    {"CH346C_M2", 0x55EC, 1, 0xFF, 0xFF, CHIP_CH346C_M2, 2},
 };
 
 void USBUartTypeCH34X::enable_channels() {
@@ -157,7 +157,7 @@ void USBUartTypeCH34X::apply_line_settings_() {
     this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, cmd, value, (factor << 8) | divisor, callback);
     this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, cmd + 3, 0x80, 0, callback);
   }
-  this->start_channels();
+  this->start_channels_();
 }
 
 std::vector<CdcEps> USBUartTypeCH34X::parse_descriptors(usb_device_handle_t dev_hdl) {

--- a/esphome/components/usb_uart/cp210x.cpp
+++ b/esphome/components/usb_uart/cp210x.cpp
@@ -65,7 +65,7 @@ std::vector<CdcEps> USBUartTypeCP210X::parse_descriptors(usb_device_handle_t dev
   }
 
   for (uint8_t i = 0; i != config_desc->bNumInterfaces; i++) {
-    auto data_desc = usb_parse_interface_descriptor(config_desc, i, 0, &conf_offset);
+    const auto *data_desc = usb_parse_interface_descriptor(config_desc, i, 0, &conf_offset);
     if (!data_desc) {
       ESP_LOGE(TAG, "data_desc: usb_parse_interface_descriptor failed");
       break;
@@ -76,13 +76,13 @@ std::vector<CdcEps> USBUartTypeCP210X::parse_descriptors(usb_device_handle_t dev
       continue;
     }
     ep_offset = conf_offset;
-    auto out_ep = usb_parse_endpoint_descriptor_by_index(data_desc, 0, config_desc->wTotalLength, &ep_offset);
+    const auto *out_ep = usb_parse_endpoint_descriptor_by_index(data_desc, 0, config_desc->wTotalLength, &ep_offset);
     if (!out_ep) {
       ESP_LOGE(TAG, "out_ep: usb_parse_endpoint_descriptor_by_index failed");
       continue;
     }
     ep_offset = conf_offset;
-    auto in_ep = usb_parse_endpoint_descriptor_by_index(data_desc, 1, config_desc->wTotalLength, &ep_offset);
+    const auto *in_ep = usb_parse_endpoint_descriptor_by_index(data_desc, 1, config_desc->wTotalLength, &ep_offset);
     if (!in_ep) {
       ESP_LOGE(TAG, "in_ep: usb_parse_endpoint_descriptor_by_index failed");
       continue;
@@ -98,7 +98,7 @@ std::vector<CdcEps> USBUartTypeCP210X::parse_descriptors(usb_device_handle_t dev
 
 void USBUartTypeCP210X::enable_channels() {
   // enable the channels
-  for (auto channel : this->channels_) {
+  for (auto *channel : this->channels_) {
     if (!channel->initialised_.load())
       continue;
     usb_host::transfer_cb_t callback = [=](const usb_host::TransferStatus &status) {
@@ -118,7 +118,7 @@ void USBUartTypeCP210X::enable_channels() {
     this->control_transfer(USB_VENDOR_IFC | usb_host::USB_DIR_OUT, SET_BAUDRATE, 0, channel->index_, callback,
                            baud.get_data());
   }
-  this->start_channels();
+  this->start_channels_();
 }
 }  // namespace esphome::usb_uart
 

--- a/esphome/components/usb_uart/ft23xx.cpp
+++ b/esphome/components/usb_uart/ft23xx.cpp
@@ -125,7 +125,7 @@ static int ftdi_convert_baudrate(int baudrate, uint8_t chip_type, uint8_t channe
       best_baud = ftdi_to_clkbits(baudrate, H_CLK, 10, &encoded_divisor);
       encoded_divisor |= 0x20000; /* switch on CLK/10*/
     } else {
-      { best_baud = ftdi_to_clkbits(baudrate, C_CLK, 16, &encoded_divisor); }
+      best_baud = ftdi_to_clkbits(baudrate, C_CLK, 16, &encoded_divisor);
     }
   } else if ((chip_type == TYPE_BM) || (chip_type == TYPE_2232C) || (chip_type == TYPE_R) || (chip_type == TYPE_230X)) {
     best_baud = ftdi_to_clkbits(baudrate, C_CLK, 16, &encoded_divisor);
@@ -139,7 +139,7 @@ static int ftdi_convert_baudrate(int baudrate, uint8_t chip_type, uint8_t channe
     *index &= 0xFF00;
     *index |= (channel_index + 1);
   } else {
-    { *index = (uint16_t) (encoded_divisor >> 16); }
+    *index = (uint16_t) (encoded_divisor >> 16);
   }
 
   return best_baud;

--- a/esphome/components/usb_uart/ft23xx.cpp
+++ b/esphome/components/usb_uart/ft23xx.cpp
@@ -12,7 +12,7 @@ using namespace bytebuffer;
 
 // FTDI chip family identifiers. These map to USB device bcdDevice values
 // and determine how baudrate divisors and clock sources are calculated.
-enum ftdi_chip_type {
+enum FtdiChipType {
   TYPE_AM = 0,
   TYPE_BM = 1,
   TYPE_2232C = 2,
@@ -23,15 +23,15 @@ enum ftdi_chip_type {
   TYPE_230X = 7,
 };
 
-static int ftdi_to_clkbits_AM(int baudrate, unsigned long *encoded_divisor) {
-  static const char frac_code[8] = {0, 3, 2, 4, 1, 5, 6, 7};
-  static const char am_adjust_up[8] = {0, 0, 0, 1, 0, 3, 2, 1};
-  static const char am_adjust_dn[8] = {0, 0, 0, 1, 0, 1, 2, 3};
+static int ftdi_to_clkbits_am(int baudrate, uint32_t *encoded_divisor) {
+  static const char FRAC_CODE[8] = {0, 3, 2, 4, 1, 5, 6, 7};
+  static const char AM_ADJUST_UP[8] = {0, 0, 0, 1, 0, 3, 2, 1};
+  static const char AM_ADJUST_DN[8] = {0, 0, 0, 1, 0, 1, 2, 3};
   int divisor, best_divisor, best_baud, best_baud_diff;
   int i;
   divisor = 24000000 / baudrate;
 
-  divisor -= am_adjust_dn[divisor & 7];
+  divisor -= AM_ADJUST_DN[divisor & 7];
 
   best_divisor = 0;
   best_baud = 0;
@@ -46,7 +46,7 @@ static int ftdi_to_clkbits_AM(int baudrate, unsigned long *encoded_divisor) {
     } else if (divisor < 16) {
       try_divisor = 16;
     } else {
-      try_divisor += am_adjust_up[try_divisor & 7];
+      try_divisor += AM_ADJUST_UP[try_divisor & 7];
       if (try_divisor > 0x1FFF8) {
         // Round down to maximum supported divisor value (for AM)
         try_divisor = 0x1FFF8;
@@ -67,7 +67,7 @@ static int ftdi_to_clkbits_AM(int baudrate, unsigned long *encoded_divisor) {
       }
     }
   }
-  *encoded_divisor = (best_divisor >> 3) | (frac_code[best_divisor & 7] << 14);
+  *encoded_divisor = (best_divisor >> 3) | (FRAC_CODE[best_divisor & 7] << 14);
   if (*encoded_divisor == 1) {
     *encoded_divisor = 0;  // 3000000 baud
   } else if (*encoded_divisor == 0x4001) {
@@ -76,8 +76,8 @@ static int ftdi_to_clkbits_AM(int baudrate, unsigned long *encoded_divisor) {
   return best_baud;
 }
 
-static int ftdi_to_clkbits(int baudrate, unsigned int clk, int clk_div, unsigned long *encoded_divisor) {
-  static const char frac_code[8] = {0, 3, 2, 4, 1, 5, 6, 7};
+static int ftdi_to_clkbits(int baudrate, unsigned int clk, int clk_div, uint32_t *encoded_divisor) {
+  static const char FRAC_CODE[8] = {0, 3, 2, 4, 1, 5, 6, 7};
   int best_baud = 0;
   int divisor, best_divisor;
   if (baudrate >= clk / clk_div) {
@@ -91,26 +91,28 @@ static int ftdi_to_clkbits(int baudrate, unsigned int clk, int clk_div, unsigned
     best_baud = clk / (2 * clk_div);
   } else {
     divisor = clk * 16 / clk_div / baudrate;
-    if (divisor & 1)
+    if (divisor & 1) {
       best_divisor = divisor / 2 + 1;
-    else
+    } else {
       best_divisor = divisor / 2;
+    }
     if (best_divisor > 0x20000)
       best_divisor = 0x1ffff;
     best_baud = clk * 16 / clk_div / best_divisor;
-    if (best_baud & 1)
+    if (best_baud & 1) {
       best_baud = best_baud / 2 + 1;
-    else
+    } else {
       best_baud = best_baud / 2;
-    *encoded_divisor = (best_divisor >> 3) | (frac_code[best_divisor & 0x7] << 14);
+    }
+    *encoded_divisor = (best_divisor >> 3) | (FRAC_CODE[best_divisor & 0x7] << 14);
   }
   return best_baud;
 }
 
-static int ftdi_convert_baudrate(int baudrate, uint8_t chip_type, uint8_t channel_index, unsigned short *value,
-                                 unsigned short *index) {
+static int ftdi_convert_baudrate(int baudrate, uint8_t chip_type, uint8_t channel_index, uint16_t *value,
+                                 uint16_t *index) {
   int best_baud;
-  unsigned long encoded_divisor;
+  uint32_t encoded_divisor;
 
   if (baudrate <= 0) {
     return -1;
@@ -122,21 +124,23 @@ static int ftdi_convert_baudrate(int baudrate, uint8_t chip_type, uint8_t channe
     if (baudrate * 10 > H_CLK / 0x3fff) {
       best_baud = ftdi_to_clkbits(baudrate, H_CLK, 10, &encoded_divisor);
       encoded_divisor |= 0x20000; /* switch on CLK/10*/
-    } else
-      best_baud = ftdi_to_clkbits(baudrate, C_CLK, 16, &encoded_divisor);
+    } else {
+      { best_baud = ftdi_to_clkbits(baudrate, C_CLK, 16, &encoded_divisor); }
+    }
   } else if ((chip_type == TYPE_BM) || (chip_type == TYPE_2232C) || (chip_type == TYPE_R) || (chip_type == TYPE_230X)) {
     best_baud = ftdi_to_clkbits(baudrate, C_CLK, 16, &encoded_divisor);
   } else {
-    best_baud = ftdi_to_clkbits_AM(baudrate, &encoded_divisor);
+    best_baud = ftdi_to_clkbits_am(baudrate, &encoded_divisor);
   }
 
-  *value = (unsigned short) (encoded_divisor & 0xFFFF);
+  *value = (uint16_t) (encoded_divisor & 0xFFFF);
   if (chip_type == TYPE_2232H || chip_type == TYPE_4232H || chip_type == TYPE_232H) {
-    *index = (unsigned short) (encoded_divisor >> 8);
+    *index = (uint16_t) (encoded_divisor >> 8);
     *index &= 0xFF00;
     *index |= (channel_index + 1);
-  } else
-    *index = (unsigned short) (encoded_divisor >> 16);
+  } else {
+    { *index = (uint16_t) (encoded_divisor >> 16); }
+  }
 
   return best_baud;
 }
@@ -248,23 +252,23 @@ std::vector<CdcEps> USBUartTypeFT23XX::parse_descriptors(usb_device_handle_t dev
   }
 
   ESP_LOGD(TAG, "Found FTDI %s based device", type_string.c_str());
-  for (uint8_t intf_idx = 0; intf_idx < this->channels_.size(); intf_idx++) {
-    if (auto eps = get_uart(config_desc, intf_idx)) {
+  for (size_t intf_idx = 0; intf_idx < this->channels_.size(); intf_idx++) {
+    if (auto eps = get_uart(config_desc, static_cast<uint8_t>(intf_idx))) {
       cdc_devs.push_back(*eps);
-      ESP_LOGD(TAG, "Found CDC interface at USB interface index %d", intf_idx);
+      ESP_LOGD(TAG, "Found CDC interface at USB interface index %zu", intf_idx);
     }
   }
   return cdc_devs;
 }
 
-int USBUartTypeFT23XX::reset(USBUartChannel *channel) {
-  usb_host::transfer_cb_t callback = [=, this](const usb_host::TransferStatus &status) {
+int USBUartTypeFT23XX::reset_(USBUartChannel *channel) {
+  usb_host::transfer_cb_t callback = [channel, this](const usb_host::TransferStatus &status) {
     if (!status.success) {
       ESP_LOGE(TAG, "Reset failed, status=%s", esp_err_to_name(status.error_code));
       channel->initialised_.store(false);
     } else {
       ESP_LOGD(TAG, "Reset successful, setting baudrate...");
-      this->set_baudrate(channel);
+      this->set_baudrate_(channel);
     }
   };
   bool ok = this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, 0x00, 0x00,
@@ -277,20 +281,20 @@ int USBUartTypeFT23XX::reset(USBUartChannel *channel) {
   return 0;
 }
 
-int USBUartTypeFT23XX::set_baudrate(USBUartChannel *channel, uint32_t baudrate) {
-  usb_host::transfer_cb_t callback = [=, this](const usb_host::TransferStatus &status) {
+int USBUartTypeFT23XX::set_baudrate_(USBUartChannel *channel, uint32_t baudrate) {
+  usb_host::transfer_cb_t callback = [channel, this](const usb_host::TransferStatus &status) {
     if (!status.success) {
       ESP_LOGE(TAG, "Set baudrate failed, status=%s", esp_err_to_name(status.error_code));
       channel->initialised_.store(false);
     } else {
       ESP_LOGD(TAG, "Baudrate %d set, setting line properties...", channel->baud_rate_);
-      this->set_line_properties(channel);
+      this->set_line_properties_(channel);
     }
   };
   if (baudrate == 0) {
     baudrate = channel->baud_rate_;
   }
-  unsigned short value, ftdi_index;
+  uint16_t value, ftdi_index;
   ftdi_convert_baudrate(baudrate, this->chip_type_, channel->index_, &value, &ftdi_index);
   ESP_LOGD(TAG, "Baudrate: %d, value=0x%04X, ftdi_index=0x%04X", baudrate, value, ftdi_index);
   uint16_t usb_index = (ftdi_index & 0xFF00) | (channel->cdc_dev_.bulk_interface_number + 1);
@@ -303,18 +307,18 @@ int USBUartTypeFT23XX::set_baudrate(USBUartChannel *channel, uint32_t baudrate) 
   return 0;
 }
 
-int USBUartTypeFT23XX::set_line_properties(USBUartChannel *channel) {
-  usb_host::transfer_cb_t callback = [=, this](const usb_host::TransferStatus &status) {
+int USBUartTypeFT23XX::set_line_properties_(USBUartChannel *channel) {
+  usb_host::transfer_cb_t callback = [channel, this](const usb_host::TransferStatus &status) {
     if (!status.success) {
       ESP_LOGE(TAG, "Set line properties failed, status=%s", esp_err_to_name(status.error_code));
       channel->initialised_.store(false);
       return;
     }
     ESP_LOGD(TAG, "Line properties set, setting modem control...");
-    this->set_dtr_rts(channel);
+    this->set_dtr_rts_(channel);
   };
 
-  unsigned short value = channel->data_bits_;
+  uint16_t value = channel->data_bits_;
 
   switch (channel->parity_) {
     case UART_CONFIG_PARITY_NONE:
@@ -358,8 +362,8 @@ int USBUartTypeFT23XX::set_line_properties(USBUartChannel *channel) {
   return 0;
 }
 
-int USBUartTypeFT23XX::set_dtr_rts(USBUartChannel *channel) {
-  usb_host::transfer_cb_t callback = [=, this](const usb_host::TransferStatus &status) {
+int USBUartTypeFT23XX::set_dtr_rts_(USBUartChannel *channel) {
+  usb_host::transfer_cb_t callback = [channel, this](const usb_host::TransferStatus &status) {
     if (!status.success) {
       ESP_LOGE(TAG, "Set modem control failed, status=%s", esp_err_to_name(status.error_code));
       channel->initialised_.store(false);
@@ -372,7 +376,7 @@ int USBUartTypeFT23XX::set_dtr_rts(USBUartChannel *channel) {
     if (next_index < this->channels_.size()) {
       USBUartChannel *next_channel = this->channels_[next_index];
       ESP_LOGD(TAG, "Configuring next channel %d", next_channel->index_);
-      this->reset(next_channel);
+      this->reset_(next_channel);
       return;
     } else {
       ESP_LOGI(TAG, "All channels configured");
@@ -439,7 +443,7 @@ void USBUartTypeFT23XX::start_input(USBUartChannel *channel) {
 
 void USBUartTypeFT23XX::enable_channels() {
   if (!this->channels_.empty() && this->channels_[0]->initialised_.load()) {
-    this->reset(this->channels_[0]);
+    this->reset_(this->channels_[0]);
   }
 
   for (auto *channel : this->channels_) {

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -141,11 +141,11 @@ void USBUartChannel::write_array(const uint8_t *data, size_t len) {
   }
 #ifdef USE_UART_DEBUGGER
   if (this->debug_) {
-    constexpr size_t BATCH = 16;
-    char buf[4 + format_hex_pretty_size(BATCH)];  // ">>> " + "XX,XX,...,XX\0"
-    for (size_t off = 0; off < len; off += BATCH) {
-      size_t n = std::min(len - off, BATCH);
-      memcpy(buf, ">>> ", 4);
+    constexpr size_t batch = 16;
+    char buf[4 + format_hex_pretty_size(batch) + 1];  // ">>> " + "XX,XX,...,XX\0"
+    for (size_t off = 0; off < len; off += batch) {
+      size_t n = std::min(len - off, batch);
+      strcpy(buf, ">>> ");
       format_hex_pretty_to(buf + 4, sizeof(buf) - 4, data + off, n, ',');
       ESP_LOGD(TAG, "%s%s", this->debug_prefix_.c_str(), buf);
     }
@@ -222,8 +222,8 @@ void USBUartComponent::loop() {
 
 #ifdef USE_UART_DEBUGGER
     if (channel->debug_) {
-      char buf[4 + format_hex_pretty_size(usb_host::USB_MAX_PACKET_SIZE)];  // "<<< " + hex
-      memcpy(buf, "<<< ", 4);
+      char buf[4 + format_hex_pretty_size(usb_host::USB_MAX_PACKET_SIZE) + 1];  // "<<< " + hex
+      strcpy(buf, "<<< ");
       format_hex_pretty_to(buf + 4, sizeof(buf) - 4, chunk->data, chunk->length, ',');
       ESP_LOGD(TAG, "%s%s", channel->debug_prefix_.c_str(), buf);
     }
@@ -528,10 +528,10 @@ void USBUartTypeCdcAcm::enable_channels() {
                              }
                            });
   }
-  this->start_channels();
+  this->start_channels_();
 }
 
-void USBUartTypeCdcAcm::start_channels() {
+void USBUartTypeCdcAcm::start_channels_() {
   for (auto *channel : this->channels_) {
     if (!channel->initialised_.load())
       continue;

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -142,12 +142,11 @@ void USBUartChannel::write_array(const uint8_t *data, size_t len) {
 #ifdef USE_UART_DEBUGGER
   if (this->debug_) {
     constexpr size_t batch = 16;
-    char buf[4 + format_hex_pretty_size(batch) + 1];  // ">>> " + "XX,XX,...,XX\0"
+    char buf[format_hex_pretty_size(batch)];  // "XX,XX,...,XX\0"
     for (size_t off = 0; off < len; off += batch) {
       size_t n = std::min(len - off, batch);
-      strcpy(buf, ">>> ");
-      format_hex_pretty_to(buf + 4, sizeof(buf) - 4, data + off, n, ',');
-      ESP_LOGD(TAG, "%s%s", this->debug_prefix_.c_str(), buf);
+      format_hex_pretty_to(buf, data + off, n, ',');
+      ESP_LOGD(TAG, "%s>>> %s", this->debug_prefix_.c_str(), buf);
     }
   }
 #endif
@@ -222,10 +221,9 @@ void USBUartComponent::loop() {
 
 #ifdef USE_UART_DEBUGGER
     if (channel->debug_) {
-      char buf[4 + format_hex_pretty_size(usb_host::USB_MAX_PACKET_SIZE) + 1];  // "<<< " + hex
-      strcpy(buf, "<<< ");
-      format_hex_pretty_to(buf + 4, sizeof(buf) - 4, chunk->data, chunk->length, ',');
-      ESP_LOGD(TAG, "%s%s", channel->debug_prefix_.c_str(), buf);
+      char buf[format_hex_pretty_size(usb_host::USB_MAX_PACKET_SIZE)];  // "XX,XX,...,XX\0"
+      format_hex_pretty_to(buf, chunk->data, chunk->length, ',');
+      ESP_LOGD(TAG, "%s<<< %s", channel->debug_prefix_.c_str(), buf);
     }
 #endif
 

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -214,7 +214,7 @@ class USBUartTypeCdcAcm : public USBUartComponent {
   /// Resets per-channel transfer flags and posts the first bulk IN transfer.
   /// Called by enable_channels() and by vendor-specific subclass overrides that
   /// handle their own line-coding setup before starting data flow.
-  void start_channels();
+  void start_channels_();
 };
 
 class USBUartTypeCP210X : public USBUartTypeCdcAcm {
@@ -251,10 +251,10 @@ class USBUartTypeFT23XX : public USBUartTypeCdcAcm {
   std::vector<CdcEps> parse_descriptors(usb_device_handle_t dev_hdl) override;
   void enable_channels() override;
 
-  int reset(USBUartChannel *channel);
-  int set_baudrate(USBUartChannel *channel, uint32_t baudrate = 0);
-  int set_line_properties(USBUartChannel *channel);
-  int set_dtr_rts(USBUartChannel *channel);
+  int reset_(USBUartChannel *channel);
+  int set_baudrate_(USBUartChannel *channel, uint32_t baudrate = 0);
+  int set_line_properties_(USBUartChannel *channel);
+  int set_dtr_rts_(USBUartChannel *channel);
 
   uint8_t chip_type_{255};
 };


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy findings in the `usb_uart` component (including the newly-added FTDI `ft23xx` driver) that are surfaced by the upcoming ESP32 variant (S3/P4) clang-tidy scan. No behavior change.

- **ch34x**: reorder `CH34xEntry` struct fields (and its positional initializer table) to remove excessive padding (`clang-analyzer-optin.performance.Padding`).
- **ft23xx**: replace `unsigned short`/`unsigned long` with fixed-width `uint16_t`/`uint32_t` (`google-runtime-int`); widen the interface-index loop variable to `size_t` and cast at the call site (`bugprone-too-small-loop-variable`).
- **cp210x / usb_uart**: qualified-auto (`const auto *`), protected-method trailing-underscore naming, and brace-style fixes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).