### PR TITLE
[usb_host][usb_cdc_acm][tinyusb] Fix clang-tidy findings

### DIFF
--- a/esphome/components/tinyusb/tinyusb_component.cpp
+++ b/esphome/components/tinyusb/tinyusb_component.cpp
@@ -6,7 +6,7 @@
 
 namespace esphome::tinyusb {
 
-static const char *TAG = "tinyusb";
+static const char *const TAG = "tinyusb";
 
 void TinyUSB::setup() {
   // Use the device's MAC address as its serial number if no serial number is defined

--- a/esphome/components/tinyusb/tinyusb_component.h
+++ b/esphome/components/tinyusb/tinyusb_component.h
@@ -17,7 +17,7 @@ enum USBDStringDescriptor : uint8_t {
   SIZE = 6,
 };
 
-static const char *DEFAULT_USB_STR = "ESPHome";
+static const char *const DEFAULT_USB_STR = "ESPHome";
 
 class TinyUSB : public Component {
  public:

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
@@ -96,9 +96,9 @@ static void tinyusb_cdc_line_coding_changed_callback(int itf, cdcacm_event_t *ev
 }
 
 static esp_err_t ringbuf_read_bytes(RingbufHandle_t ring_buf, uint8_t *out_buf, size_t out_buf_sz, size_t *rx_data_size,
-                                    TickType_t xTicksToWait) {
+                                    TickType_t x_ticks_to_wait) {
   size_t read_sz;
-  uint8_t *buf = static_cast<uint8_t *>(xRingbufferReceiveUpTo(ring_buf, &read_sz, xTicksToWait, out_buf_sz));
+  uint8_t *buf = static_cast<uint8_t *>(xRingbufferReceiveUpTo(ring_buf, &read_sz, x_ticks_to_wait, out_buf_sz));
 
   if (buf == nullptr) {
     return ESP_FAIL;
@@ -186,7 +186,7 @@ void USBCDCACMInstance::usb_tx_task() {
   uint8_t data[CONFIG_TINYUSB_CDC_TX_BUFSIZE] = {0};
   size_t tx_data_size = 0;
 
-  while (1) {
+  while (true) {
     // Wait for a notification from the bridge component
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
 

--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -167,7 +167,7 @@ class USBClient : public Component {
 
   // USB task management
   static void usb_task_fn(void *arg);
-  [[noreturn]] void usb_task_loop() const;
+  [[noreturn]] void usb_task_loop_() const;
 
   // Members ordered to minimize struct padding on 32-bit platforms
   TransferRequest requests_[MAX_REQUESTS]{};

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -236,9 +236,9 @@ void USBClient::setup() {
 
 void USBClient::usb_task_fn(void *arg) {
   auto *client = static_cast<USBClient *>(arg);
-  client->usb_task_loop();
+  client->usb_task_loop_();
 }
-void USBClient::usb_task_loop() const {
+void USBClient::usb_task_loop_() const {
   while (true) {
     usb_host_client_handle_events(this->handle_, portMAX_DELAY);
   }


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy findings in the USB host/device stack components, surfaced by the upcoming ESP32 variant (S3/P4) clang-tidy scan. No behavior change.

- **tinyusb**: make global string pointers const (`TAG`, `DEFAULT_USB_STR`).
- **usb_cdc_acm**: parameter naming (`xTicksToWait` -> `x_ticks_to_wait`), `while (1)` -> `while (true)`.
- **usb_host**: protected-method trailing-underscore naming (`usb_task_loop` -> `usb_task_loop_`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).