### PR TITLE
[mipi_dsi][mipi_rgb][st7701s][rpi_dpi_rgb] Fix clang-tidy findings

### DIFF
--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -65,7 +65,7 @@ DOMAIN = "mipi_dsi"
 
 LOGGER = logging.getLogger(DOMAIN)
 
-MIPI_DSI = mipi_dsi_ns.class_("MIPI_DSI", display.Display, cg.Component)
+MipiDsi = mipi_dsi_ns.class_("MipiDsi", display.Display, cg.Component)
 ColorOrder = display.display_ns.enum("ColorMode")
 ColorBitness = display.display_ns.enum("ColorBitness")
 
@@ -114,7 +114,7 @@ def model_schema(config):
     schema = display.FULL_DISPLAY_SCHEMA.extend(
         {
             model.option(CONF_RESET_PIN, cv.UNDEFINED): pins.gpio_output_pin_schema,
-            cv.GenerateID(): cv.declare_id(MIPI_DSI),
+            cv.GenerateID(): cv.declare_id(MipiDsi),
             cv_dimensions(CONF_DIMENSIONS): dimension_schema(
                 model.get_default(CONF_DRAW_ROUNDING, 1)
             ),

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -9,7 +9,7 @@ namespace esphome::mipi_dsi {
 static constexpr size_t MIPI_DSI_MAX_CMD_LOG_BYTES = 64;
 
 static bool notify_refresh_ready(esp_lcd_panel_handle_t panel, esp_lcd_dpi_panel_event_data_t *edata, void *user_ctx) {
-  auto *sem = static_cast<SemaphoreHandle_t>(user_ctx);
+  SemaphoreHandle_t sem = static_cast<SemaphoreHandle_t>(user_ctx);
   BaseType_t need_yield = pdFALSE;
   xSemaphoreGiveFromISR(sem, &need_yield);
   return (need_yield == pdTRUE);

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -9,18 +9,18 @@ namespace esphome::mipi_dsi {
 static constexpr size_t MIPI_DSI_MAX_CMD_LOG_BYTES = 64;
 
 static bool notify_refresh_ready(esp_lcd_panel_handle_t panel, esp_lcd_dpi_panel_event_data_t *edata, void *user_ctx) {
-  auto sem = static_cast<SemaphoreHandle_t>(user_ctx);
+  auto *sem = static_cast<SemaphoreHandle_t>(user_ctx);
   BaseType_t need_yield = pdFALSE;
   xSemaphoreGiveFromISR(sem, &need_yield);
   return (need_yield == pdTRUE);
 }
 
-void MIPI_DSI::smark_failed(const LogString *message, esp_err_t err) {
+void MipiDsi::smark_failed(const LogString *message, esp_err_t err) {
   ESP_LOGE(TAG, "%s: %s", LOG_STR_ARG(message), esp_err_to_name(err));
   this->mark_failed(message);
 }
 
-void MIPI_DSI::setup() {
+void MipiDsi::setup() {
   ESP_LOGCONFIG(TAG, "Running Setup");
 
   if (!this->enable_pins_.empty()) {
@@ -175,7 +175,7 @@ void MIPI_DSI::setup() {
   ESP_LOGCONFIG(TAG, "MIPI DSI setup complete");
 }
 
-void MIPI_DSI::update() {
+void MipiDsi::update() {
   if (this->auto_clear_enabled_) {
     this->clear();
   }
@@ -202,8 +202,8 @@ void MIPI_DSI::update() {
   this->y_high_ = 0;
 }
 
-void MIPI_DSI::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
-                              display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) {
+void MipiDsi::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
+                             display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) {
   if (w <= 0 || h <= 0)
     return;
   // if color mapping is required, pass the buck.
@@ -216,8 +216,8 @@ void MIPI_DSI::draw_pixels_at(int x_start, int y_start, int w, int h, const uint
   this->write_to_display_(x_start, y_start, w, h, ptr, x_offset, y_offset, x_pad);
 }
 
-void MIPI_DSI::write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
-                                 int x_pad) {
+void MipiDsi::write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
+                                int x_pad) {
   esp_err_t err = ESP_OK;
   auto bytes_per_pixel = 3 - this->color_depth_;
   auto stride = (x_offset + w + x_pad) * bytes_per_pixel;
@@ -241,7 +241,7 @@ void MIPI_DSI::write_to_display_(int x_start, int y_start, int w, int h, const u
     ESP_LOGE(TAG, "lcd_lcd_panel_draw_bitmap failed: %s", esp_err_to_name(err));
 }
 
-bool MIPI_DSI::check_buffer_() {
+bool MipiDsi::check_buffer_() {
   if (this->is_failed())
     return false;
   if (this->buffer_ != nullptr)
@@ -257,7 +257,7 @@ bool MIPI_DSI::check_buffer_() {
   return true;
 }
 
-void MIPI_DSI::draw_pixel_at(int x, int y, Color color) {
+void MipiDsi::draw_pixel_at(int x, int y, Color color) {
   if (!this->get_clipping().inside(x, y))
     return;
 
@@ -280,7 +280,6 @@ void MIPI_DSI::draw_pixel_at(int x, int y, Color color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0) {
     return;
   }
-  auto pixel = convert_big_endian(display::ColorUtil::color_to_565(color));
   if (!this->check_buffer_())
     return;
   size_t pos = (y * this->width_) + x;
@@ -319,7 +318,7 @@ void MIPI_DSI::draw_pixel_at(int x, int y, Color color) {
   if (y > this->y_high_)
     this->y_high_ = y;
 }
-void MIPI_DSI::fill(Color color) {
+void MipiDsi::fill(Color color) {
   if (!this->check_buffer_())
     return;
 
@@ -359,7 +358,7 @@ void MIPI_DSI::fill(Color color) {
   }
 }
 
-int MIPI_DSI::get_width() {
+int MipiDsi::get_width() {
   switch (this->rotation_) {
     case display::DISPLAY_ROTATION_90_DEGREES:
     case display::DISPLAY_ROTATION_270_DEGREES:
@@ -371,7 +370,7 @@ int MIPI_DSI::get_width() {
   }
 }
 
-int MIPI_DSI::get_height() {
+int MipiDsi::get_height() {
   switch (this->rotation_) {
     case display::DISPLAY_ROTATION_0_DEGREES:
     case display::DISPLAY_ROTATION_180_DEGREES:
@@ -385,7 +384,7 @@ int MIPI_DSI::get_height() {
 
 static const uint8_t PIXEL_MODES[] = {0, 16, 18, 24};
 
-void MIPI_DSI::dump_config() {
+void MipiDsi::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "MIPI_DSI RGB LCD"
                 "\n  Model: %s"

--- a/esphome/components/mipi_dsi/mipi_dsi.h
+++ b/esphome/components/mipi_dsi/mipi_dsi.h
@@ -35,9 +35,9 @@ const uint8_t MADCTL_MV = 0x20;     // row/column swap
 const uint8_t MADCTL_XFLIP = 0x02;  // Mirror the display horizontally
 const uint8_t MADCTL_YFLIP = 0x01;  // Mirror the display vertically
 
-class MIPI_DSI : public display::Display {
+class MipiDsi : public display::Display {
  public:
-  MIPI_DSI(size_t width, size_t height, display::ColorBitness color_depth, uint8_t pixel_mode)
+  MipiDsi(size_t width, size_t height, display::ColorBitness color_depth, uint8_t pixel_mode)
       : width_(width), height_(height), color_depth_(color_depth), pixel_mode_(pixel_mode) {}
   display::ColorOrder get_color_mode() { return this->color_mode_; }
   void set_color_mode(display::ColorOrder color_mode) { this->color_mode_ = color_mode; }

--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -202,8 +202,8 @@ void MipiRgb::update() {
   ESP_LOGV(TAG, "x_low %d, y_low %d, x_high %d, y_high %d", this->x_low_, this->y_low_, this->x_high_, this->y_high_);
   int w = this->x_high_ - this->x_low_ + 1;
   int h = this->y_high_ - this->y_low_ + 1;
-  this->write_to_display(this->x_low_, this->y_low_, w, h, reinterpret_cast<const uint8_t *>(this->buffer_),
-                         this->x_low_, this->y_low_, this->width_ - w - this->x_low_);
+  this->write_to_display_(this->x_low_, this->y_low_, w, h, reinterpret_cast<const uint8_t *>(this->buffer_),
+                          this->x_low_, this->y_low_, this->width_ - w - this->x_low_);
   // invalidate watermarks
   this->x_low_ = this->width_;
   this->y_low_ = this->height_;
@@ -219,15 +219,15 @@ void MipiRgb::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8
   // note that endianness is not considered here - it is assumed to match!
   if (bitness != display::COLOR_BITNESS_565) {
     Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset, x_pad);
-    this->write_to_display(x_start, y_start, w, h, reinterpret_cast<const uint8_t *>(this->buffer_), x_start, y_start,
-                           this->width_ - w - x_start);
+    this->write_to_display_(x_start, y_start, w, h, reinterpret_cast<const uint8_t *>(this->buffer_), x_start, y_start,
+                            this->width_ - w - x_start);
   } else {
-    this->write_to_display(x_start, y_start, w, h, ptr, x_offset, y_offset, x_pad);
+    this->write_to_display_(x_start, y_start, w, h, ptr, x_offset, y_offset, x_pad);
   }
 }
 
-void MipiRgb::write_to_display(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
-                               int x_pad) {
+void MipiRgb::write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
+                                int x_pad) {
   esp_err_t err = ESP_OK;
   auto stride = (x_offset + w + x_pad) * 2;
   ptr += y_offset * stride + x_offset * 2;  // skip to the first pixel
@@ -247,7 +247,7 @@ void MipiRgb::write_to_display(int x_start, int y_start, int w, int h, const uin
     ESP_LOGE(TAG, "lcd_lcd_panel_draw_bitmap failed: %s", esp_err_to_name(err));
 }
 
-bool MipiRgb::check_buffer() {
+bool MipiRgb::check_buffer_() {
   if (this->is_failed())
     return false;
   if (this->buffer_ != nullptr)
@@ -285,7 +285,7 @@ void MipiRgb::draw_pixel_at(int x, int y, Color color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0) {
     return;
   }
-  if (!this->check_buffer())
+  if (!this->check_buffer_())
     return;
   size_t pos = (y * this->width_) + x;
   uint16_t new_color = convert_big_endian(display::ColorUtil::color_to_565(color));
@@ -303,7 +303,7 @@ void MipiRgb::draw_pixel_at(int x, int y, Color color) {
     this->y_high_ = y;
 }
 void MipiRgb::fill(Color color) {
-  if (!this->check_buffer())
+  if (!this->check_buffer_())
     return;
 
   // If clipping is active, fall back to base implementation
@@ -352,7 +352,7 @@ static const char *get_pin_name(GPIOPin *pin, std::span<char, GPIO_SUMMARY_MAX_L
   return buffer.data();
 }
 
-void MipiRgb::dump_pins(uint8_t start, uint8_t end, const char *name, uint8_t offset) {
+void MipiRgb::dump_pins_(uint8_t start, uint8_t end, const char *name, uint8_t offset) {
   char pin_summary[GPIO_SUMMARY_MAX_LEN];
   for (uint8_t i = start; i != end; i++) {
     this->data_pins_[i]->dump_summary(pin_summary, sizeof(pin_summary));
@@ -393,10 +393,10 @@ void MipiRgb::dump_config() {
                 get_pin_name(this->de_pin_, de_buf), get_pin_name(this->pclk_pin_, pclk_buf),
                 get_pin_name(this->hsync_pin_, hsync_buf), get_pin_name(this->vsync_pin_, vsync_buf));
 
-  this->dump_pins(8, 13, "Blue", 0);
-  this->dump_pins(13, 16, "Green", 0);
-  this->dump_pins(0, 3, "Green", 3);
-  this->dump_pins(3, 8, "Red", 0);
+  this->dump_pins_(8, 13, "Blue", 0);
+  this->dump_pins_(13, 16, "Green", 0);
+  this->dump_pins_(0, 3, "Green", 3);
+  this->dump_pins_(3, 8, "Red", 0);
 }
 
 }  // namespace esphome::mipi_rgb

--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -202,8 +202,8 @@ void MipiRgb::update() {
   ESP_LOGV(TAG, "x_low %d, y_low %d, x_high %d, y_high %d", this->x_low_, this->y_low_, this->x_high_, this->y_high_);
   int w = this->x_high_ - this->x_low_ + 1;
   int h = this->y_high_ - this->y_low_ + 1;
-  this->write_to_display_(this->x_low_, this->y_low_, w, h, reinterpret_cast<const uint8_t *>(this->buffer_),
-                          this->x_low_, this->y_low_, this->width_ - w - this->x_low_);
+  this->write_to_display(this->x_low_, this->y_low_, w, h, reinterpret_cast<const uint8_t *>(this->buffer_),
+                         this->x_low_, this->y_low_, this->width_ - w - this->x_low_);
   // invalidate watermarks
   this->x_low_ = this->width_;
   this->y_low_ = this->height_;
@@ -219,15 +219,15 @@ void MipiRgb::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8
   // note that endianness is not considered here - it is assumed to match!
   if (bitness != display::COLOR_BITNESS_565) {
     Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset, x_pad);
-    this->write_to_display_(x_start, y_start, w, h, reinterpret_cast<const uint8_t *>(this->buffer_), x_start, y_start,
-                            this->width_ - w - x_start);
+    this->write_to_display(x_start, y_start, w, h, reinterpret_cast<const uint8_t *>(this->buffer_), x_start, y_start,
+                           this->width_ - w - x_start);
   } else {
-    this->write_to_display_(x_start, y_start, w, h, ptr, x_offset, y_offset, x_pad);
+    this->write_to_display(x_start, y_start, w, h, ptr, x_offset, y_offset, x_pad);
   }
 }
 
-void MipiRgb::write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
-                                int x_pad) {
+void MipiRgb::write_to_display(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
+                               int x_pad) {
   esp_err_t err = ESP_OK;
   auto stride = (x_offset + w + x_pad) * 2;
   ptr += y_offset * stride + x_offset * 2;  // skip to the first pixel
@@ -247,7 +247,7 @@ void MipiRgb::write_to_display_(int x_start, int y_start, int w, int h, const ui
     ESP_LOGE(TAG, "lcd_lcd_panel_draw_bitmap failed: %s", esp_err_to_name(err));
 }
 
-bool MipiRgb::check_buffer_() {
+bool MipiRgb::check_buffer() {
   if (this->is_failed())
     return false;
   if (this->buffer_ != nullptr)
@@ -285,7 +285,7 @@ void MipiRgb::draw_pixel_at(int x, int y, Color color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0) {
     return;
   }
-  if (!this->check_buffer_())
+  if (!this->check_buffer())
     return;
   size_t pos = (y * this->width_) + x;
   uint16_t new_color = convert_big_endian(display::ColorUtil::color_to_565(color));
@@ -303,7 +303,7 @@ void MipiRgb::draw_pixel_at(int x, int y, Color color) {
     this->y_high_ = y;
 }
 void MipiRgb::fill(Color color) {
-  if (!this->check_buffer_())
+  if (!this->check_buffer())
     return;
 
   // If clipping is active, fall back to base implementation
@@ -352,7 +352,7 @@ static const char *get_pin_name(GPIOPin *pin, std::span<char, GPIO_SUMMARY_MAX_L
   return buffer.data();
 }
 
-void MipiRgb::dump_pins_(uint8_t start, uint8_t end, const char *name, uint8_t offset) {
+void MipiRgb::dump_pins(uint8_t start, uint8_t end, const char *name, uint8_t offset) {
   char pin_summary[GPIO_SUMMARY_MAX_LEN];
   for (uint8_t i = start; i != end; i++) {
     this->data_pins_[i]->dump_summary(pin_summary, sizeof(pin_summary));
@@ -393,10 +393,10 @@ void MipiRgb::dump_config() {
                 get_pin_name(this->de_pin_, de_buf), get_pin_name(this->pclk_pin_, pclk_buf),
                 get_pin_name(this->hsync_pin_, hsync_buf), get_pin_name(this->vsync_pin_, vsync_buf));
 
-  this->dump_pins_(8, 13, "Blue", 0);
-  this->dump_pins_(13, 16, "Green", 0);
-  this->dump_pins_(0, 3, "Green", 3);
-  this->dump_pins_(3, 8, "Red", 0);
+  this->dump_pins(8, 13, "Blue", 0);
+  this->dump_pins(13, 16, "Green", 0);
+  this->dump_pins(0, 3, "Green", 3);
+  this->dump_pins(3, 8, "Red", 0);
 }
 
 }  // namespace esphome::mipi_rgb

--- a/esphome/components/mipi_rgb/mipi_rgb.h
+++ b/esphome/components/mipi_rgb/mipi_rgb.h
@@ -30,9 +30,9 @@ class MipiRgb : public display::Display {
   void fill(Color color) override;
   void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
                       display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
-  void write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
-                         int x_pad);
-  bool check_buffer_();
+  void write_to_display(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
+                        int x_pad);
+  bool check_buffer();
 
   display::ColorOrder get_color_mode() { return this->color_mode_; }
   void set_color_mode(display::ColorOrder color_mode) { this->color_mode_ = color_mode; }
@@ -60,7 +60,7 @@ class MipiRgb : public display::Display {
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
   int get_width_internal() override { return this->width_; }
   int get_height_internal() override { return this->height_; }
-  void dump_pins_(uint8_t start, uint8_t end, const char *name, uint8_t offset);
+  void dump_pins(uint8_t start, uint8_t end, const char *name, uint8_t offset);
   void dump_config() override;
   void draw_pixel_at(int x, int y, Color color) override;
 

--- a/esphome/components/mipi_rgb/mipi_rgb.h
+++ b/esphome/components/mipi_rgb/mipi_rgb.h
@@ -30,9 +30,6 @@ class MipiRgb : public display::Display {
   void fill(Color color) override;
   void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
                       display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
-  void write_to_display(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
-                        int x_pad);
-  bool check_buffer();
 
   display::ColorOrder get_color_mode() { return this->color_mode_; }
   void set_color_mode(display::ColorOrder color_mode) { this->color_mode_ = color_mode; }
@@ -60,12 +57,15 @@ class MipiRgb : public display::Display {
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
   int get_width_internal() override { return this->width_; }
   int get_height_internal() override { return this->height_; }
-  void dump_pins(uint8_t start, uint8_t end, const char *name, uint8_t offset);
   void dump_config() override;
   void draw_pixel_at(int x, int y, Color color) override;
 
   // this will be horribly slow.
  protected:
+  void write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
+                         int x_pad);
+  bool check_buffer_();
+  void dump_pins_(uint8_t start, uint8_t end, const char *name, uint8_t offset);
   void setup_enables_();
   void common_setup_();
   InternalGPIOPin *de_pin_{nullptr};

--- a/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
+++ b/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
@@ -54,8 +54,9 @@ void RpiDpiRgb::draw_pixels_at(int x_start, int y_start, int w, int h, const uin
   // if color mapping is required, pass the buck.
   // note that endianness is not considered here - it is assumed to match!
   if (bitness != display::COLOR_BITNESS_565) {
-    return display::Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset,
-                                            x_pad);
+    display::Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset,
+                                     x_pad);
+    return;
   }
   x_start += this->offset_x_;
   y_start += this->offset_y_;

--- a/esphome/components/st7701s/st7701s.cpp
+++ b/esphome/components/st7701s/st7701s.cpp
@@ -57,8 +57,9 @@ void ST7701S::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8
   // if color mapping is required, pass the buck.
   // note that endianness is not considered here - it is assumed to match!
   if (bitness != display::COLOR_BITNESS_565) {
-    return display::Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset,
-                                            x_pad);
+    display::Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset,
+                                     x_pad);
+    return;
   }
   x_start += this->offset_x_;
   y_start += this->offset_y_;

--- a/esphome/components/st7701s/st7701s.h
+++ b/esphome/components/st7701s/st7701s.h
@@ -32,7 +32,6 @@ class ST7701S : public display::Display,
  public:
   void update() override { this->do_update_(); }
   void setup() override;
-  void complete_setup();
   void loop() override;
   void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
                       display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;

--- a/esphome/components/st7701s/st7701s.h
+++ b/esphome/components/st7701s/st7701s.h
@@ -32,7 +32,7 @@ class ST7701S : public display::Display,
  public:
   void update() override { this->do_update_(); }
   void setup() override;
-  void complete_setup_();
+  void complete_setup();
   void loop() override;
   void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
                       display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;

--- a/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
+++ b/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
@@ -124,15 +124,15 @@ def test_code_generation(
 
     main_cpp = generate_main(component_fixture_path("mipi_dsi.yaml"))
     assert (
-        "alignas(mipi_dsi::MIPI_DSI) static unsigned char mipi_dsi__p4_nano__pstorage[sizeof(mipi_dsi::MIPI_DSI)];"
+        "alignas(mipi_dsi::MipiDsi) static unsigned char mipi_dsi__p4_nano__pstorage[sizeof(mipi_dsi::MipiDsi)];"
         in main_cpp
     )
     assert (
-        "static mipi_dsi::MIPI_DSI *const p4_nano = reinterpret_cast<mipi_dsi::MIPI_DSI *>(mipi_dsi__p4_nano__pstorage);"
+        "static mipi_dsi::MipiDsi *const p4_nano = reinterpret_cast<mipi_dsi::MipiDsi *>(mipi_dsi__p4_nano__pstorage);"
         in main_cpp
     )
     assert (
-        "new(p4_nano) mipi_dsi::MIPI_DSI(800, 1280, display::COLOR_BITNESS_565, 16);"
+        "new(p4_nano) mipi_dsi::MipiDsi(800, 1280, display::COLOR_BITNESS_565, 16);"
         in main_cpp
     )
     assert "set_init_sequence({224, 1, 0, 225, 1, 147, 226, 1," in main_cpp


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy findings in the MIPI/RGB display components, surfaced by the upcoming ESP32 variant (S3/P4) clang-tidy scan. No runtime behavior change.

- **mipi_dsi**: rename the `MIPI_DSI` class to `MipiDsi` (UpperCamelCase) in both C++ and codegen (`display.py`), remove a dead `pixel` variable, qualified-auto.
- **mipi_rgb / st7701s / rpi_dpi_rgb**: qualified-auto (`const auto *`), brace style; keep internal helpers (`write_to_display_`, `check_buffer_`, `dump_pins_`) `protected`; drop the unused, never-defined `st7701s::complete_setup` declaration.

> **Note — undocumented C++ API change:** the display class `mipi_dsi::MIPI_DSI` is renamed to `mipi_dsi::MipiDsi`. Runtime behavior is unchanged, but any user lambda that referenced the old type name will need to use `MipiDsi`. Migration: `mipi_dsi::MIPI_DSI` -> `mipi_dsi::MipiDsi`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).