### PR TITLE
[zigbee][openthread][esp32_hosted] Fix clang-tidy findings

### DIFF
--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -56,7 +56,10 @@ static bool parse_version(const std::string &version_str, int &major, int &minor
   major = minor = patch = 0;
   const char *ptr = version_str.c_str();
 
-  if (!parse_int(ptr, major) || *ptr++ != '.' || !parse_int(ptr, minor))
+  if (!parse_int(ptr, major) || *ptr != '.')
+    return false;
+  ++ptr;
+  if (!parse_int(ptr, minor))
     return false;
   if (*ptr == '.')
     parse_int(++ptr, patch);

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -9,6 +9,7 @@
 #include <openthread/tasklet.h>
 
 #include <cstring>
+#include <utility>
 
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
@@ -43,7 +44,7 @@ void OpenThreadComponent::dump_config() {
   }
 }
 
-void OpenThreadComponent::on_state_changed_(otChangedFlags flags, void *context) {
+void OpenThreadComponent::on_state_changed(otChangedFlags flags, void *context) {
   if (flags & OT_CHANGED_THREAD_ROLE) {
     auto *self = static_cast<OpenThreadComponent *>(context);
     // This runs on the OpenThread task thread with the OT lock held,
@@ -241,7 +242,7 @@ bool OpenThreadComponent::teardown() {
 }
 
 void OpenThreadComponent::on_factory_reset(std::function<void()> callback) {
-  factory_reset_external_callback_ = callback;
+  factory_reset_external_callback_ = std::move(callback);
   ESP_LOGD(TAG, "Start Removal SRP Host and Services");
   otError error;
   InstanceLock lock = InstanceLock::acquire();

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -242,7 +242,7 @@ bool OpenThreadComponent::teardown() {
 }
 
 void OpenThreadComponent::on_factory_reset(std::function<void()> callback) {
-  factory_reset_external_callback_ = std::move(callback);
+  this->factory_reset_external_callback_ = std::move(callback);
   ESP_LOGD(TAG, "Start Removal SRP Host and Services");
   otError error;
   InstanceLock lock = InstanceLock::acquire();

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -46,7 +46,7 @@ class OpenThreadComponent : public Component {
 
  protected:
   std::optional<otIp6Address> get_omr_address_(InstanceLock &lock);
-  static void on_state_changed_(otChangedFlags flags, void *context);
+  static void on_state_changed(otChangedFlags flags, void *context);
   otInstance *get_openthread_instance_();
   int openthread_stop_();
   std::function<void()> factory_reset_external_callback_;

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -179,7 +179,10 @@ void OpenThreadComponent::ot_main() {
   ESP_ERROR_CHECK(esp_openthread_auto_start(dataset.mLength > 0 ? &dataset : nullptr));
 
   // Register state change callback to update connected_ reactively instead of polling
-  otSetStateChangedCallback(instance, OpenThreadComponent::on_state_changed_, this);
+  otError ot_err = otSetStateChangedCallback(instance, OpenThreadComponent::on_state_changed, this);
+  if (ot_err != OT_ERROR_NONE) {
+    ESP_LOGW(TAG, "Failed to register state change callback: %d", ot_err);
+  }
 
   esp_openthread_launch_mainloop();
 

--- a/esphome/components/zigbee/zigbee_esp32.cpp
+++ b/esphome/components/zigbee/zigbee_esp32.cpp
@@ -42,7 +42,9 @@ static void bdb_start_top_level_commissioning_cb(uint8_t mode_mask) {
   }
 }
 
-void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
+// Defined with C linkage: the ESP Zigbee stack calls this as a weak C symbol.
+// (The redundant extern "C" forward declaration was removed; keep the linkage here.)
+extern "C" void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
   static uint8_t steering_retry_count = 0;
   uint32_t *p_sg_p = signal_struct->p_app_signal;
   esp_err_t err_status = signal_struct->esp_err_status;

--- a/esphome/components/zigbee/zigbee_esp32.cpp
+++ b/esphome/components/zigbee/zigbee_esp32.cpp
@@ -183,21 +183,21 @@ esp_err_t ZigbeeComponent::create_endpoint(uint8_t endpoint_id, zb_ha_standard_d
                                            esp_zb_cluster_list_t *esp_zb_cluster_list) {
   esp_zb_endpoint_config_t endpoint_config = {.endpoint = endpoint_id,
                                               .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID,
-                                              .app_device_id = device_id,
+                                              .app_device_id = static_cast<uint16_t>(device_id),
                                               .app_device_version = 0};
   return esp_zb_ep_list_add_ep(this->esp_zb_ep_list_, esp_zb_cluster_list, endpoint_config);
 }
 
-static void esp_zb_task_(void *pvParameters) {
+static void esp_zb_task(void *pv_parameters) {
   if (esp_zb_start(false) != ESP_OK) {
     ESP_LOGE(TAG, "Could not setup Zigbee");
     vTaskDelete(NULL);
   }
   if (global_zigbee->is_battery_powered()) {
     ESP_LOGD(TAG, "Battery powered!");
-    esp_zb_set_node_descriptor_power_source(0);
+    esp_zb_set_node_descriptor_power_source(false);
   } else {
-    esp_zb_set_node_descriptor_power_source(1);
+    esp_zb_set_node_descriptor_power_source(true);
   }
   esp_zb_stack_main_loop();
 }
@@ -218,20 +218,20 @@ void ZigbeeComponent::setup() {
     return;
   }
 
-  esp_zb_zed_cfg_t zb_zed_cfg = {
-      .ed_timeout = ESP_ZB_ED_AGING_TIMEOUT_64MIN,
-      .keep_alive = ED_KEEP_ALIVE,
-  };
-  esp_zb_zczr_cfg_t zb_zczr_cfg = {
-      .max_children = MAX_CHILDREN,
-  };
   esp_zb_cfg_t zb_nwk_cfg = {
       .esp_zb_role = this->device_role_,
       .install_code_policy = false,
   };
 #ifdef ZB_ROUTER_ROLE
+  esp_zb_zczr_cfg_t zb_zczr_cfg = {
+      .max_children = MAX_CHILDREN,
+  };
   zb_nwk_cfg.nwk_cfg.zczr_cfg = zb_zczr_cfg;
 #else
+  esp_zb_zed_cfg_t zb_zed_cfg = {
+      .ed_timeout = ESP_ZB_ED_AGING_TIMEOUT_64MIN,
+      .keep_alive = ED_KEEP_ALIVE,
+  };
   zb_nwk_cfg.nwk_cfg.zed_cfg = zb_zed_cfg;
 #endif
   esp_zb_init(&zb_nwk_cfg);
@@ -290,7 +290,7 @@ void ZigbeeComponent::setup() {
       }
     }
   }
-  xTaskCreate(esp_zb_task_, "Zigbee_main", 4096, NULL, 24, NULL);
+  xTaskCreate(esp_zb_task, "Zigbee_main", 4096, NULL, 24, NULL);
   this->disable_loop();  // loop is only needed for processing events, so disable until we join a network
 }
 

--- a/esphome/components/zigbee/zigbee_esp32.cpp
+++ b/esphome/components/zigbee/zigbee_esp32.cpp
@@ -42,8 +42,6 @@ static void bdb_start_top_level_commissioning_cb(uint8_t mode_mask) {
   }
 }
 
-// Defined with C linkage: the ESP Zigbee stack calls this as a weak C symbol.
-// (The redundant extern "C" forward declaration was removed; keep the linkage here.)
 extern "C" void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
   static uint8_t steering_retry_count = 0;
   uint32_t *p_sg_p = signal_struct->p_app_signal;

--- a/esphome/components/zigbee/zigbee_esp32.h
+++ b/esphome/components/zigbee/zigbee_esp32.h
@@ -13,7 +13,6 @@
 #include "ha/esp_zigbee_ha_standard.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
-#include "esphome/core/defines.h"
 #include "zigbee_helpers_esp32.h"
 
 #ifdef USE_BINARY_SENSOR
@@ -99,8 +98,6 @@ class ZigbeeComponent : public Component {
   CallbackManager<void(bool)> join_cb_{};
 };
 
-extern "C" void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct);
-
 template<typename T>
 void ZigbeeComponent::add_attr(uint8_t endpoint_id, uint16_t cluster_id, uint8_t role, uint16_t attr_id,
                                uint8_t max_size, T value) {
@@ -129,7 +126,7 @@ template<typename T>
 void ZigbeeComponent::add_attr_(ZigbeeAttribute *attr, uint8_t endpoint_id, uint16_t cluster_id, uint8_t role,
                                 uint16_t attr_id, T *value_p) {
   esp_zb_attribute_list_t *attr_list = this->attribute_list_[{endpoint_id, cluster_id, role}];
-  esp_err_t ret = esphome_zb_cluster_add_or_update_attr(cluster_id, attr_list, attr_id, value_p);
+  esphome_zb_cluster_add_or_update_attr(cluster_id, attr_list, attr_id, value_p);
 
   if (attr != nullptr) {
     this->attributes_[{endpoint_id, cluster_id, role, attr_id}] = attr;


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy findings in the 802.15.4 / coprocessor radio components, surfaced by the upcoming ESP32 variant (C6/P4) clang-tidy scan. No behavior change.

- **zigbee**: scope the `zed`/`zczr` config structs to their respective role `#ifdef` branch (`unused-variable`), drop a redundant `esp_zb_app_signal_handler` declaration and an unused `ret`, remove a duplicate `defines.h` include.
- **openthread**: check the `otSetStateChangedCallback` return value (`warn_unused_result`), `std::move` the external callback (`performance-unnecessary-value-param`), public static-method naming.
- **esp32_hosted**: split `*ptr++` out of a complex `||` condition (`bugprone-inc-dec-in-conditions`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).