### PR TITLE
[qmp6988] fix publishing bogus zero values on i2c error

### DIFF
--- a/esphome/components/qmp6988/qmp6988.cpp
+++ b/esphome/components/qmp6988/qmp6988.cpp
@@ -283,20 +283,21 @@ void QMP6988Component::calculate_altitude_(float pressure, float temp) {
   this->qmp6988_data_.altitude = altitude;
 }
 
-void QMP6988Component::calculate_pressure_() {
+bool QMP6988Component::calculate_pressure_() {
   uint8_t err = 0;
   uint32_t p_read, t_read;
   int32_t p_raw, t_raw;
   uint8_t a_data_uint8_tr[6] = {0};
   int32_t t_int, p_int;
-  this->qmp6988_data_.temperature = 0;
-  this->qmp6988_data_.pressure = 0;
 
   err = this->read_register(QMP6988_PRESSURE_MSB_REG, a_data_uint8_tr, 6);
   if (err != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Error reading raw pressure/temp values");
-    return;
+    this->status_set_warning();
+    return false;
   }
+  this->status_clear_warning();
+
   p_read = encode_uint24(a_data_uint8_tr[0], a_data_uint8_tr[1], a_data_uint8_tr[2]);
   p_raw = (int32_t) (p_read - SUBTRACTOR);
 
@@ -308,6 +309,7 @@ void QMP6988Component::calculate_pressure_() {
 
   this->qmp6988_data_.temperature = (float) t_int / 256.0f;
   this->qmp6988_data_.pressure = (float) p_int / 16.0f;
+  return true;
 }
 
 void QMP6988Component::setup() {
@@ -339,7 +341,10 @@ void QMP6988Component::dump_config() {
 }
 
 void QMP6988Component::update() {
-  this->calculate_pressure_();
+  if (!this->calculate_pressure_()) {
+    return;
+  }
+
   float pressurehectopascals = this->qmp6988_data_.pressure / 100;
   float temperature = this->qmp6988_data_.temperature;
 

--- a/esphome/components/qmp6988/qmp6988.h
+++ b/esphome/components/qmp6988/qmp6988.h
@@ -98,7 +98,7 @@ class QMP6988Component : public PollingComponent, public i2c::I2CDevice {
   void write_oversampling_temperature_(QMP6988Oversampling oversampling_t);
   void write_oversampling_pressure_(QMP6988Oversampling oversampling_p);
   void write_filter_(QMP6988IIRFilter filter);
-  void calculate_pressure_();
+  bool calculate_pressure_();
   void calculate_altitude_(float pressure, float temp);
 
   int32_t get_compensated_pressure_(qmp6988_ik_data_t *ik, int32_t dp, int16_t tx);


### PR DESCRIPTION
# What does this implement/fix?

Fixes (stops) the publishing of bogus zero values on i2c error

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16802

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io# N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: qmp6988
    i2c_id: ${i2c}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
