### PR TITLE
[ci] Share a cached native ESP-IDF install across clang-tidy and build jobs

### DIFF
--- a/.github/actions/cache-esp-idf/action.yml
+++ b/.github/actions/cache-esp-idf/action.yml
@@ -1,0 +1,35 @@
+name: Cache ESP-IDF
+description: >
+  Resolve the pinned ESP-IDF version and cache the native ESP-IDF install
+  (toolchains + source) at ~/.esphome-idf. Every job that installs ESP-IDF
+  natively (clang-tidy for IDF/Arduino and the native-IDF component build)
+  shares one cache, since the install is identical (ESPHOME_IDF_DEFAULT_TARGETS
+  defaults to "all", so all toolchains are present regardless of the chip).
+  Callers must set env ESPHOME_ESP_IDF_PREFIX: ~/.esphome-idf and have the
+  Python venv already restored.
+inputs:
+  framework:
+    description: 'Which pinned IDF version to key on: "espidf" (recommended) or "arduino".'
+    default: espidf
+runs:
+  using: composite
+  steps:
+    - name: Resolve ESP-IDF version for cache key
+      # The native-IDF version is pinned in code, not in any file that feeds the
+      # other cache keys, so resolve it explicitly. Keying on it means the cache
+      # invalidates on a version bump (actions/cache never overwrites a key).
+      id: version
+      shell: bash
+      run: |
+        . venv/bin/activate
+        if [ "${{ inputs.framework }}" = "arduino" ]; then
+          version=$(python -c 'from esphome.components.esp32 import ARDUINO_FRAMEWORK_VERSION_LOOKUP as A, ARDUINO_IDF_VERSION_LOOKUP as L; print(L[A["recommended"]])')
+        else
+          version=$(python -c 'from esphome.components.esp32 import ESP_IDF_FRAMEWORK_VERSION_LOOKUP as L; print(L["recommended"])')
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+    - name: Cache ESP-IDF install
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.esphome-idf
+        key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}

--- a/.github/actions/cache-esp-idf/action.yml
+++ b/.github/actions/cache-esp-idf/action.yml
@@ -28,8 +28,19 @@ runs:
           version=$(python -c 'from esphome.components.esp32 import ESP_IDF_FRAMEWORK_VERSION_LOOKUP as L; print(L["recommended"])')
         fi
         echo "version=$version" >> "$GITHUB_OUTPUT"
-    - name: Cache ESP-IDF install
+    # Mirror the adjacent PlatformIO cache: only dev-branch runs write the
+    # shared cache (so it lives in the default-branch scope readable by all
+    # PRs), and PRs are restore-only -- they never push multi-GB artifacts into
+    # their own scope / the repo quota (e.g. on a version-bump PR).
+    - name: Cache ESP-IDF install (write on dev)
+      if: github.ref == 'refs/heads/dev'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.esphome-idf
+        key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}
+    - name: Cache ESP-IDF install (restore-only off dev)
+      if: github.ref != 'refs/heads/dev'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.esphome-idf
         key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,8 +486,6 @@ jobs:
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 Arduino
             options: --environment esp32-arduino-tidy --grep USE_ARDUINO
-            # esp32-arduino-tidy installs ESP-IDF natively; gate the Cache ESP-IDF
-            # step to this entry (ESP8266/Zephyr don't install IDF).
             cache_idf: true
           - id: clang-tidy
             name: Run script/clang-tidy for ZEPHYR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,10 +488,8 @@ jobs:
             name: Run script/clang-tidy for ESP32 IDF
             options: --environment esp32-idf-tidy --grep USE_ESP_IDF
             pio_cache_key: tidyesp32-idf
-            # esp32-idf-tidy installs ESP-IDF natively. The install carries all
-            # target toolchains (ESPHOME_IDF_DEFAULT_TARGETS=all), so a single
-            # version-keyed cache is reused by every native-IDF tidy target.
-            # This flag gates the Resolve/Cache ESP-IDF steps to this entry only.
+            # esp32-idf-tidy installs ESP-IDF natively; this flag gates the
+            # Cache ESP-IDF step to this entry (ESP8266/Zephyr don't install IDF).
             cache_idf: true
           - id: clang-tidy
             name: Run script/clang-tidy for ZEPHYR
@@ -526,29 +524,10 @@ jobs:
           path: ~/.platformio
           key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
 
-      - name: Resolve ESP-IDF version for cache key
-        # The native-IDF tidy version is pinned in code, not in any cache-key
-        # input file; resolve it so the IDF cache invalidates on a version bump.
+      - name: Cache ESP-IDF install
+        # Shared with the Arduino tidy jobs and the native-IDF build (same install).
         if: matrix.cache_idf
-        id: idf_version
-        run: |
-          . venv/bin/activate
-          version=$(python -c 'from esphome.components.esp32 import ESP_IDF_FRAMEWORK_VERSION_LOOKUP as L; print(L["recommended"])')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Cache ESP-IDF
-        if: matrix.cache_idf && github.ref == 'refs/heads/dev'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.esphome-idf
-          key: ${{ runner.os }}-esphome-idf-tidy-idf${{ steps.idf_version.outputs.version }}
-
-      - name: Cache ESP-IDF
-        if: matrix.cache_idf && github.ref != 'refs/heads/dev'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.esphome-idf
-          key: ${{ runner.os }}-esphome-idf-tidy-idf${{ steps.idf_version.outputs.version }}
+        uses: ./.github/actions/cache-esp-idf
 
       - name: Register problem matchers
         run: |
@@ -608,6 +587,8 @@ jobs:
     if: needs.determine-jobs.outputs.clang-tidy-mode == 'nosplit'
     env:
       GH_TOKEN: ${{ github.token }}
+      # esp32-arduino-tidy builds on ESP-IDF; share the native IDF install cache.
+      ESPHOME_ESP_IDF_PREFIX: ~/.esphome-idf
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -634,6 +615,12 @@ jobs:
         with:
           path: ~/.platformio
           key: platformio-tidyesp32-${{ hashFiles('platformio.ini') }}
+
+      - name: Cache ESP-IDF install
+        # Shared with the IDF tidy job and the native-IDF build (same install).
+        uses: ./.github/actions/cache-esp-idf
+        with:
+          framework: arduino
 
       - name: Register problem matchers
         run: |
@@ -685,6 +672,8 @@ jobs:
     if: needs.determine-jobs.outputs.clang-tidy-mode == 'split'
     env:
       GH_TOKEN: ${{ github.token }}
+      # esp32-arduino-tidy builds on ESP-IDF; share the native IDF install cache.
+      ESPHOME_ESP_IDF_PREFIX: ~/.esphome-idf
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -729,6 +718,12 @@ jobs:
         with:
           path: ~/.platformio
           key: platformio-tidyesp32-${{ hashFiles('platformio.ini') }}
+
+      - name: Cache ESP-IDF install
+        # Shared with the IDF tidy job and the native-IDF build (same install).
+        uses: ./.github/actions/cache-esp-idf
+        with:
+          framework: arduino
 
       - name: Register problem matchers
         run: |
@@ -932,33 +927,20 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
 
-      - name: Cache ESPHome
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.esphome-idf
-          key: ${{ runner.os }}-esphome-${{ needs.common.outputs.cache-key }}
-
-      - name: Run native ESP-IDF compile test
+      - name: Prepare build storage on /mnt
+        # Bind-mount the larger /mnt disk over the IDF install + build dirs BEFORE
+        # restoring the cache, so the ~4.5GB restore lands on the roomier volume
+        # instead of being shadowed by a mount set up later in the run step.
         run: |
-          . venv/bin/activate
-
-          # Check if /mnt has more free space than / before bind mounting
-          # Extract available space in KB for comparison
           root_avail=$(df -k / | awk 'NR==2 {print $4}')
           mnt_avail=$(df -k /mnt 2>/dev/null | awk 'NR==2 {print $4}')
-
           echo "Available space: / has ${root_avail}KB, /mnt has ${mnt_avail}KB"
-
-          # Only use /mnt if it has more space than /
           if [ -n "$mnt_avail" ] && [ "$mnt_avail" -gt "$root_avail" ]; then
             echo "Using /mnt for build files (more space available)"
-            # Bind mount PlatformIO directory to /mnt (tools, packages, build cache all go there)
             sudo mkdir -p /mnt/esphome-idf
             sudo chown $USER:$USER /mnt/esphome-idf
             mkdir -p ~/.esphome-idf
             sudo mount --bind /mnt/esphome-idf ~/.esphome-idf
-
-            # Bind mount test build directory to /mnt
             sudo mkdir -p /mnt/test_build_components_build
             sudo chown $USER:$USER /mnt/test_build_components_build
             mkdir -p tests/test_build_components/build
@@ -967,10 +949,19 @@ jobs:
             echo "Using / for build files (more space available than /mnt or /mnt unavailable)"
           fi
 
+      - name: Cache ESP-IDF install
+        # Shared with the IDF/Arduino clang-tidy jobs (same install); restores
+        # into the /mnt bind-mount prepared above when present.
+        uses: ./.github/actions/cache-esp-idf
+
+      - name: Run native ESP-IDF compile test
+        run: |
+          . venv/bin/activate
+
           echo "Testing components: $TEST_COMPONENTS"
           echo ""
 
-          # Show disk space before validation (after bind mounts setup)
+          # Show disk space before validation
           echo "Disk space before config validation:"
           df -h
           echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,9 @@ jobs:
     if: needs.determine-jobs.outputs.clang-tidy == 'true'
     env:
       GH_TOKEN: ${{ github.token }}
+      # The esp32-idf-tidy entry installs ESP-IDF natively; point it at a stable,
+      # cacheable location (other entries ignore this -- see Cache ESP-IDF below).
+      ESPHOME_ESP_IDF_PREFIX: ~/.esphome-idf
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -485,6 +488,11 @@ jobs:
             name: Run script/clang-tidy for ESP32 IDF
             options: --environment esp32-idf-tidy --grep USE_ESP_IDF
             pio_cache_key: tidyesp32-idf
+            # esp32-idf-tidy installs ESP-IDF natively. The install carries all
+            # target toolchains (ESPHOME_IDF_DEFAULT_TARGETS=all), so a single
+            # version-keyed cache is reused by every native-IDF tidy target.
+            # This flag gates the Resolve/Cache ESP-IDF steps to this entry only.
+            cache_idf: true
           - id: clang-tidy
             name: Run script/clang-tidy for ZEPHYR
             options: --environment nrf52-tidy --grep USE_ZEPHYR --grep USE_NRF52
@@ -517,6 +525,30 @@ jobs:
         with:
           path: ~/.platformio
           key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
+
+      - name: Resolve ESP-IDF version for cache key
+        # The native-IDF tidy version is pinned in code, not in any cache-key
+        # input file; resolve it so the IDF cache invalidates on a version bump.
+        if: matrix.cache_idf
+        id: idf_version
+        run: |
+          . venv/bin/activate
+          version=$(python -c 'from esphome.components.esp32 import ESP_IDF_FRAMEWORK_VERSION_LOOKUP as L; print(L["recommended"])')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache ESP-IDF
+        if: matrix.cache_idf && github.ref == 'refs/heads/dev'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.esphome-idf
+          key: ${{ runner.os }}-esphome-idf-tidy-idf${{ steps.idf_version.outputs.version }}
+
+      - name: Cache ESP-IDF
+        if: matrix.cache_idf && github.ref != 'refs/heads/dev'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.esphome-idf
+          key: ${{ runner.os }}-esphome-idf-tidy-idf${{ steps.idf_version.outputs.version }}
 
       - name: Register problem matchers
         run: |


### PR DESCRIPTION
# What does this implement/fix?

Several CI jobs install ESP-IDF natively (toolchain + source, ~4.5GB) on every run and currently don't share that work:
- `esp32-idf-tidy` clang-tidy (`script/helpers.py` routes any `esp32` env through `esphome.espidf.clang_tidy`)
- `esp32-arduino-tidy` clang-tidy (both the `nosplit` and `split` jobs — Arduino builds on ESP-IDF)
- the native-IDF component build (`test-native-idf`)

They all install the **same** IDF version (5.5.4 — the Arduino recommended framework 3.3.8 also maps to 5.5.4) with **all** target toolchains (`ESPHOME_IDF_DEFAULT_TARGETS` defaults to `all`), so the `~/.esphome-idf` install is identical across them. This makes them share a single cache.

## How

- New composite action `.github/actions/cache-esp-idf` resolves the pinned IDF version and caches `~/.esphome-idf` under one key (`<os>-esphome-idf-<version>`). Used by all four job types.
- All those jobs set `ESPHOME_ESP_IDF_PREFIX: ~/.esphome-idf` so the install goes to the cacheable path.
- The version is **resolved from code** (`ESP_IDF_FRAMEWORK_VERSION_LOOKUP["recommended"]`, or the Arduino-mapped equivalent), not hashed from a file. It's pinned in `esp32/__init__.py`, which feeds none of the existing cache keys; resolving it means the cache invalidates exactly on a version bump (important since `actions/cache` never overwrites an existing key, so a non-version-aware key would silently go stale).
- `test-native-idf` bind-mounts `/mnt` (more disk) over `~/.esphome-idf`; that mount is moved **ahead of** the cache restore so the restore lands on the roomier volume instead of being shadowed by a mount set up later in the run step (previously its cache restore was effectively inert).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# CI-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).