### PR TITLE
[qmp6988] fix false report of software reset error

### DIFF
--- a/esphome/components/qmp6988/qmp6988.cpp
+++ b/esphome/components/qmp6988/qmp6988.cpp
@@ -216,10 +216,7 @@ int32_t QMP6988Component::get_compensated_pressure_(qmp6988_ik_data_t *ik, int32
 }
 
 void QMP6988Component::software_reset_() {
-  uint8_t ret = 0;
-
-  ret = this->write_byte(QMP6988_RESET_REG, 0xe6);
-  if (ret != i2c::ERROR_OK) {
+  if (!this->write_byte(QMP6988_RESET_REG, 0xe6)) {
     ESP_LOGE(TAG, "Software Reset (0xe6) failed");
   }
   delay(10);


### PR DESCRIPTION
# What does this implement/fix?

qmp6988 falsely reports an error on software reset

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16842

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io# N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: qmp6988
    i2c_id: ${i2c}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

----

difference:

 void QMP6988Component::software_reset_() {
-  uint8_t ret = 0; -
-  ret = this->write_byte(QMP6988_RESET_REG, 0xe6);
-  if (ret != i2c::ERROR_OK) {
+  if (!this->write_byte(QMP6988_RESET_REG, 0xe6)) {

i2c.h:

  bool write_bytes(uint8_t a_register, const uint8_t *data, uint8_t len) const {
    return write_register(a_register, data, len) == ERROR_OK;
  }

  bool write_byte(uint8_t a_register, uint8_t data) const { return write_bytes(a_register, &data, 1); }

----

while write_register returns an error code,
write_bytes (and, therefore, write_byte) returns a boolean: true if ERROR_OK

software_reset was treating the write_byte return value wrongly