### PR TITLE
Exit nginx bypass placeholder cleanly on SIGTERM

### DIFF
--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -6,11 +6,15 @@
 # ==============================================================================
 
 # The new device builder handles HA ingress itself, so nginx is bypassed.
-# Block the longrun forever so s6 keeps the dependency satisfied and does
-# not respawn it.
+# Block the longrun so s6 keeps the dependency satisfied, but exit 0 on
+# SIGTERM instead of being signal-killed; a 256/15 exit makes nginx/finish
+# stamp the container exit 143, which trips the Supervisor's SIGTERM check.
 if bashio::config.true 'use_new_device_builder'; then
     bashio::log.info "NGINX bypassed: new device builder serves ingress directly."
-    exec sleep infinity
+    trap 'exit 0' TERM
+    sleep infinity &
+    wait
+    exit 0
 fi
 
 bashio::log.info "Waiting for ESPHome dashboard to come up..."


### PR DESCRIPTION
# What does this implement/fix?

When `use_new_device_builder` is enabled, nginx is bypassed and its longrun just blocks on `sleep infinity`. On add-on stop, s6 sends SIGTERM to that placeholder; `sleep` does not trap it, so it dies as `256 (by signal 15)` and `nginx/finish` stamps the container exit code `128+15=143`. The Supervisor then reports that the add-on did not handle SIGTERM and shows Error instead of Stopped.

This traps SIGTERM in the placeholder and exits 0, so the container stops cleanly; the device builder process itself already drains and exits 0.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #16844

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
