### PR TITLE
[Dashboard][CLI] Ota firmware with ota password and md5 generation

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1570,6 +1570,7 @@ def command_logs(args: ArgsProtocol, config: ConfigType) -> int | None:
     )
     return show_logs(config, args, devices)
 
+
 def command_run(args: ArgsProtocol, config: ConfigType) -> int | None:
     exit_code = write_cpp(config)
     if exit_code != 0:
@@ -2200,9 +2201,7 @@ def parse_args(argv):
         action="store_true",
     )
 
-    parser_compile_all = subparsers.add_parser(
-        "compile-all", help="Compile ."
-    )
+    parser_compile_all = subparsers.add_parser("compile-all", help="Compile .")
     parser_compile_all.add_argument(
         "configuration", help="Your YAML file or configuration directory.", nargs="*"
     )

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1523,6 +1523,19 @@ def command_compile(args: ArgsProtocol, config: ConfigType) -> int | None:
     return 0
 
 
+def command_compile_all(args: ArgsProtocol) -> int | None:
+    files = list_yaml_files(args.configuration)
+
+    def build_command(f):
+        dashboard = ["--dashboard"] if CORE.dashboard else []
+        command = [*ESPHOME_COMMAND, *dashboard, "compile", f]
+        if args.only_generate:
+            command.append("--only-generate")
+        return command
+
+    return run_multiple_configs(files, build_command)
+
+
 def command_upload(args: ArgsProtocol, config: ConfigType) -> int | None:
     # Get devices, resolving special identifiers like OTA
     devices = choose_upload_log_host(
@@ -1556,7 +1569,6 @@ def command_logs(args: ArgsProtocol, config: ConfigType) -> int | None:
         purpose=Purpose.LOGGING,
     )
     return show_logs(config, args, devices)
-
 
 def command_run(args: ArgsProtocol, config: ConfigType) -> int | None:
     exit_code = write_cpp(config)
@@ -2019,6 +2031,7 @@ PRE_CONFIG_ACTIONS = {
     "version": command_version,
     "dashboard": command_dashboard,
     "vscode": command_vscode,
+    "compile-all": command_compile_all,
     "update-all": command_update_all,
     "clean-all": command_clean_all,
 }
@@ -2182,6 +2195,18 @@ def parse_args(argv):
         "configuration", help="Your YAML configuration file(s).", nargs="+"
     )
     parser_compile.add_argument(
+        "--only-generate",
+        help="Only generate source code, do not compile.",
+        action="store_true",
+    )
+
+    parser_compile_all = subparsers.add_parser(
+        "compile-all", help="Compile ."
+    )
+    parser_compile_all.add_argument(
+        "configuration", help="Your YAML file or configuration directory.", nargs="*"
+    )
+    parser_compile_all.add_argument(
         "--only-generate",
         help="Only generate source code, do not compile.",
         action="store_true",

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -1046,7 +1046,50 @@ class DownloadBinaryRequestHandler(BaseHandler):
                 return gzip.compress(data, 9)
             return data
 
-    @authenticated
+    def _generate_md5sum(self, path: Path, filename: str, compressed: bool) -> bytes:
+        """Generate a .md5sum payload for the requested file."""
+        hash_md5 = hashlib.md5()
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                hash_md5.update(chunk)
+        data = f"{hash_md5.hexdigest()}  {filename}\n".encode("ascii")
+        if compressed:
+            return gzip.compress(data, 9)
+        return data
+
+    def _require_auth(self) -> None:
+        self.set_status(401)
+        self.set_header("WWW-Authenticate", 'Basic realm="ESPHome"')
+        self.finish("Unauthorized")
+
+    def _check_config_basic_auth(
+        self, configuration: str | None, storage_json: StorageJSON | None
+    ) -> bool:
+        auth_header = self.request.headers.get("Authorization")
+        if not isinstance(auth_header, str) or not auth_header.startswith("Basic "):
+            return False
+        try:
+            auth_decoded = base64.b64decode(auth_header[6:]).decode()
+            username, password = auth_decoded.split(":", 1)
+        except (binascii.Error, ValueError, UnicodeDecodeError):
+            return False
+
+        if configuration is None or storage_json is None:
+            return False
+
+        if username != Path(configuration).stem:
+            return False
+
+        try:
+            config = yaml_util.load_yaml(settings.rel_path(configuration))
+        except (vol.Invalid, OSError, yaml.YAMLError):
+            return False
+
+        ota_config = config.get("ota", [])
+        if not isinstance(ota_config, list):
+            return False
+        return any(ota_config.get("password") == password for ota_config in ota_config if isinstance(ota_config, dict))
+
     @bind_config
     async def get(self, configuration: str | None = None) -> None:
         """Download a binary file."""
@@ -1059,12 +1102,25 @@ class DownloadBinaryRequestHandler(BaseHandler):
             self.send_error(404)
             return
 
+        if not is_authenticated(self) and not self._check_config_basic_auth(
+            configuration, storage_json
+        ):
+            self._require_auth()
+            return
+
         # fallback to type=, but prioritize file=
         file_name = self.get_argument("type", None)
         file_name = self.get_argument("file", file_name)
         if file_name is None or not file_name.strip():
             self.send_error(400)
             return
+
+        is_md5sum = file_name.endswith(".md5sum")
+        request_file_name = file_name[:-7] if is_md5sum else file_name
+        if is_md5sum and not request_file_name:
+            self.send_error(400)
+            return
+
         # get requested download name, or build it based on filename
         download_name = self.get_argument(
             "download",
@@ -1076,7 +1132,7 @@ class DownloadBinaryRequestHandler(BaseHandler):
             return
 
         base_dir = storage_json.firmware_bin_path.parent.resolve()
-        path = base_dir.joinpath(file_name).resolve()
+        path = base_dir.joinpath(request_file_name).resolve()
         try:
             path.relative_to(base_dir)
         except ValueError:
@@ -1095,9 +1151,9 @@ class DownloadBinaryRequestHandler(BaseHandler):
 
             found = False
             for image in idedata.extra_flash_images:
-                if image.path.as_posix().endswith(file_name):
+                if image.path.as_posix().endswith(request_file_name):
                     path = image.path
-                    download_name = file_name
+                    download_name = file_name if is_md5sum else file_name
                     found = True
                     break
 
@@ -1106,6 +1162,19 @@ class DownloadBinaryRequestHandler(BaseHandler):
                 return
 
         download_name = download_name + ".gz" if compressed else download_name
+
+        if is_md5sum:
+            self.set_header("Content-Type", "text/plain")
+            self.set_header(
+                "Content-Disposition", f'attachment; filename="{download_name}"'
+            )
+            self.set_header("Cache-Control", "no-cache")
+            data = await loop.run_in_executor(
+                None, self._generate_md5sum, path, request_file_name, compressed
+            )
+            self.write(data)
+            self.finish()
+            return
 
         self.set_header("Content-Type", "application/octet-stream")
         self.set_header(

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -491,6 +491,13 @@ class EsphomeCompileHandler(EsphomeCommandWebSocket):
         command.append(config_file)
         return command
 
+class EsphomeCompileAllHandler(EsphomeCommandWebSocket):
+    async def build_command(self, json_message: dict[str, Any]) -> list[str]:
+        command = [*DASHBOARD_COMMAND, "compile-all", settings.config_dir]
+        if json_message.get("only_generate", False):
+            command.append("--only-generate")
+        return command
+
 
 class EsphomeValidateHandler(EsphomeCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
@@ -1109,22 +1116,22 @@ class DownloadBinaryRequestHandler(BaseHandler):
             return
 
         # fallback to type=, but prioritize file=
-        file_name = self.get_argument("type", None)
-        file_name = self.get_argument("file", file_name)
-        if file_name is None or not file_name.strip():
+        request_file_name = self.get_argument("type", None)
+        request_file_name = self.get_argument("file", request_file_name)
+        if request_file_name is None or not request_file_name.strip():
             self.send_error(400)
             return
 
-        is_md5sum = file_name.endswith(".md5sum")
-        request_file_name = file_name[:-7] if is_md5sum else file_name
-        if is_md5sum and not request_file_name:
+        is_md5sum = request_file_name.endswith(".md5sum")
+        source_file_name = request_file_name[:-7] if is_md5sum else request_file_name
+        if is_md5sum and not source_file_name:
             self.send_error(400)
             return
 
         # get requested download name, or build it based on filename
         download_name = self.get_argument(
             "download",
-            f"{storage_json.name}-{file_name}",
+            f"{storage_json.name}-{request_file_name}",
         )
 
         if storage_json.firmware_bin_path is None:
@@ -1132,7 +1139,7 @@ class DownloadBinaryRequestHandler(BaseHandler):
             return
 
         base_dir = storage_json.firmware_bin_path.parent.resolve()
-        path = base_dir.joinpath(request_file_name).resolve()
+        path = base_dir.joinpath(source_file_name).resolve()
         try:
             path.relative_to(base_dir)
         except ValueError:
@@ -1151,9 +1158,9 @@ class DownloadBinaryRequestHandler(BaseHandler):
 
             found = False
             for image in idedata.extra_flash_images:
-                if image.path.as_posix().endswith(request_file_name):
+                if image.path.as_posix().endswith(source_file_name):
                     path = image.path
-                    download_name = file_name if is_md5sum else file_name
+                    download_name = request_file_name if is_md5sum else request_file_name
                     found = True
                     break
 
@@ -1170,7 +1177,7 @@ class DownloadBinaryRequestHandler(BaseHandler):
             )
             self.set_header("Cache-Control", "no-cache")
             data = await loop.run_in_executor(
-                None, self._generate_md5sum, path, request_file_name, compressed
+                None, self._generate_md5sum, path, source_file_name, compressed
             )
             self.write(data)
             self.finish()
@@ -1645,6 +1652,7 @@ def make_app(debug: bool | None = None) -> tornado.web.Application:
             (f"{rel}upload", EsphomeUploadHandler),
             (f"{rel}run", EsphomeRunHandler),
             (f"{rel}compile", EsphomeCompileHandler),
+            (f"{rel}compile-all", EsphomeCompileAllHandler),
             (f"{rel}validate", EsphomeValidateHandler),
             (f"{rel}clean-mqtt", EsphomeCleanMqttHandler),
             (f"{rel}clean-all", EsphomeCleanAllHandler),

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -491,6 +491,7 @@ class EsphomeCompileHandler(EsphomeCommandWebSocket):
         command.append(config_file)
         return command
 
+
 class EsphomeCompileAllHandler(EsphomeCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
         command = [*DASHBOARD_COMMAND, "compile-all", settings.config_dir]
@@ -1095,7 +1096,11 @@ class DownloadBinaryRequestHandler(BaseHandler):
         ota_config = config.get("ota", [])
         if not isinstance(ota_config, list):
             return False
-        return any(ota_config.get("password") == password for ota_config in ota_config if isinstance(ota_config, dict))
+        return any(
+            ota_config.get("password") == password
+            for ota_config in ota_config
+            if isinstance(ota_config, dict)
+        )
 
     @bind_config
     async def get(self, configuration: str | None = None) -> None:
@@ -1160,7 +1165,9 @@ class DownloadBinaryRequestHandler(BaseHandler):
             for image in idedata.extra_flash_images:
                 if image.path.as_posix().endswith(source_file_name):
                     path = image.path
-                    download_name = request_file_name if is_md5sum else request_file_name
+                    download_name = (
+                        request_file_name if is_md5sum else request_file_name
+                    )
                     found = True
                     break
 

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -1923,7 +1923,9 @@ def test_download_binary_handler_config_basic_auth(
 
     mock_storage = Mock()
     mock_storage.name = "test"
-    mock_storage.firmware_bin_path = tmp_path / ".esphome" / "build" / "test" / "firmware.bin"
+    mock_storage.firmware_bin_path = (
+        tmp_path / ".esphome" / "build" / "test" / "firmware.bin"
+    )
     mock_storage_json.load.return_value = mock_storage
 
     auth_header = base64.b64encode(b"test:my_ota_password").decode("ascii")
@@ -1931,9 +1933,12 @@ def test_download_binary_handler_config_basic_auth(
     handler.request = Mock()
     handler.request.headers = {"Authorization": f"Basic {auth_header}"}
 
-    assert web_server.DownloadBinaryRequestHandler._check_config_basic_auth(
-        handler, "test.yaml", mock_storage
-    ) is True
+    assert (
+        web_server.DownloadBinaryRequestHandler._check_config_basic_auth(
+            handler, "test.yaml", mock_storage
+        )
+        is True
+    )
 
 
 def test_is_authenticated_no_auth_configured(

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -6,6 +6,7 @@ import base64
 from collections.abc import Generator
 from contextlib import asynccontextmanager
 import gzip
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -365,6 +366,37 @@ async def test_download_binary_handler_compressed(
     assert decompressed == original_content
     assert response.headers["Content-Type"] == "application/octet-stream"
     assert "firmware.bin.gz" in response.headers["Content-Disposition"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_ext_storage_path")
+async def test_download_binary_handler_md5sum_file(
+    dashboard: DashboardTestHelper,
+    tmp_path: Path,
+    mock_storage_json: MagicMock,
+) -> None:
+    """Test auto-generation of .md5sum files for a firmware download."""
+    build_dir = tmp_path / ".esphome" / "build" / "test"
+    build_dir.mkdir(parents=True)
+    firmware_file = build_dir / "firmware.bin"
+    content = b"fake firmware content"
+    firmware_file.write_bytes(content)
+
+    mock_storage = Mock()
+    mock_storage.name = "test_device"
+    mock_storage.firmware_bin_path = firmware_file
+    mock_storage_json.load.return_value = mock_storage
+
+    response = await dashboard.fetch(
+        "/download.bin?configuration=test.yaml&file=firmware.bin.md5sum",
+        method="GET",
+    )
+    assert response.code == 200
+    assert response.headers["Content-Type"] == "text/plain"
+    expected_md5 = hashlib.md5(content).hexdigest().encode("ascii")
+    assert response.body == expected_md5 + b"  firmware.bin\n"
+    assert "attachment" in response.headers["Content-Disposition"]
+    assert "test_device-firmware.bin.md5sum" in response.headers["Content-Disposition"]
 
 
 @pytest.mark.asyncio
@@ -1877,6 +1909,31 @@ def test_is_authenticated_wrong_credentials(
     mock_auth_settings.check_password.return_value = False
     handler = _make_auth_handler(f"Basic {creds}")
     assert web_server.is_authenticated(handler) is False
+
+
+def test_download_binary_handler_config_basic_auth(
+    tmp_path: Path,
+    mock_dashboard_settings: MagicMock,
+    mock_storage_json: MagicMock,
+) -> None:
+    """Basic auth should be accepted for the matching configuration and OTA password."""
+    config_path = tmp_path / "test.yaml"
+    config_path.write_text("ota:\n  password: my_ota_password\n")
+    mock_dashboard_settings.rel_path.side_effect = lambda filename: tmp_path / filename
+
+    mock_storage = Mock()
+    mock_storage.name = "test"
+    mock_storage.firmware_bin_path = tmp_path / ".esphome" / "build" / "test" / "firmware.bin"
+    mock_storage_json.load.return_value = mock_storage
+
+    auth_header = base64.b64encode(b"test:my_ota_password").decode("ascii")
+    handler = Mock(spec=web_server.DownloadBinaryRequestHandler)
+    handler.request = Mock()
+    handler.request.headers = {"Authorization": f"Basic {auth_header}"}
+
+    assert web_server.DownloadBinaryRequestHandler._check_config_basic_auth(
+        handler, "test.yaml", mock_storage
+    ) is True
 
 
 def test_is_authenticated_no_auth_configured(


### PR DESCRIPTION
# What does this implement/fix?

One problem one faces when trying to use OTA over HTTP Request is serving the firmware file. The Documentation and a Forum post i found recommend compiling the firmware and move it to a external service to publish the firmware. Using the DownloadBinaryRequestHandler to serve the OTA firmware would make ota over http request possible using esphome only. This PR  extends the DownloadBinaryRequestHandler to allow devices flashed with a configuration containing the ota component to authenticate using the ota password and download their respective firmware builds. On top of that it is also possible to request md5sum files, which are dynamically created.

Additionally a added the compile-all command as a QOL feature so one can build all configurations at once.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: gardenctl
  friendly_name: gardenctl

esp8266:
  board: esp01_1m

# Enable Home Assistant API

ota:
 - platform: http_request
    user: "gardenctl" # should be eval to configration name
    password: "123123"

wifi:
  ssid: "test"
  password: "test123456"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
