### PR TITLE
[image] Use LVGL 9 color formats

### DIFF
--- a/esphome/components/image/image.cpp
+++ b/esphome/components/image/image.cpp
@@ -123,26 +123,18 @@ lv_image_dsc_t *Image::get_lv_image_dsc() {
         break;
 
       case IMAGE_TYPE_RGB:
-#if LV_COLOR_DEPTH == 32
         switch (this->transparency_) {
           case TRANSPARENCY_ALPHA_CHANNEL:
-            this->dsc_.header.cf = LV_IMG_CF_TRUE_COLOR_ALPHA;
+            this->dsc_.header.cf = LV_COLOR_FORMAT_ARGB8888;
             break;
           case TRANSPARENCY_CHROMA_KEY:
-            this->dsc_.header.cf = LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED;
-            break;
           default:
-            this->dsc_.header.cf = LV_IMG_CF_TRUE_COLOR;
+            this->dsc_.header.cf = LV_COLOR_FORMAT_RGB888;
             break;
         }
-#else
-        this->dsc_.header.cf =
-            this->transparency_ == TRANSPARENCY_ALPHA_CHANNEL ? LV_COLOR_FORMAT_ARGB8888 : LV_COLOR_FORMAT_RGB888;
-#endif
         break;
 
       case IMAGE_TYPE_RGB565:
-#if LV_COLOR_DEPTH == 16
         switch (this->transparency_) {
           case TRANSPARENCY_ALPHA_CHANNEL:
             this->dsc_.header.cf = LV_COLOR_FORMAT_RGB565A8;
@@ -150,10 +142,6 @@ lv_image_dsc_t *Image::get_lv_image_dsc() {
           default:
             this->dsc_.header.cf = LV_COLOR_FORMAT_RGB565;
         }
-#else
-        this->dsc_.header.cf =
-            this->transparency_ == TRANSPARENCY_ALPHA_CHANNEL ? LV_IMG_CF_RGB565A8 : LV_IMG_CF_RGB565;
-#endif
         break;
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Updates `Image::get_lv_image_dsc()` to use LVGL 9 `LV_COLOR_FORMAT_*` values instead of the removed `LV_IMG_CF_*` aliases.

This fixes compilation when the `image` component is used together with LVGL 9.5, where descriptors should be populated with `lv_color_format_t` values directly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes compilation with LVGL 9.5 image descriptors

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- Not applicable; this is an internal compatibility fix and does not add or change user-facing configuration.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
image:
  - file: mdi:home
    id: home_icon
    type: RGB565

lvgl:
  widgets:
    - image:
        src: home_icon
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

Local validation:
- `python -m py_compile esphome/components/image/__init__.py`
- Confirmed in a combined ESP32-P4 IDF firmware build using LVGL 9.5 and uploaded to hardware.