### PR TITLE
Include model-driven display schemas in the language schema dump

### DIFF
--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -5,7 +5,11 @@ from esphome import core, pins
 import esphome.codegen as cg
 from esphome.components import display, spi
 from esphome.components.display import CONF_SHOW_TEST_CARD, validate_rotation
-from esphome.components.mipi import flatten_sequence, map_sequence
+from esphome.components.mipi import (
+    flatten_sequence,
+    map_sequence,
+    model_schema_extractor,
+)
 import esphome.config_validation as cv
 from esphome.config_validation import update_interval
 from esphome.const import (
@@ -111,6 +115,7 @@ def model_schema(config):
     )
 
 
+@model_schema_extractor(MODELS, model_schema)
 def customise_schema(config):
     """
     Create a customised config schema for a specific model and validate the configuration.

--- a/esphome/components/mipi/__init__.py
+++ b/esphome/components/mipi/__init__.py
@@ -2,7 +2,11 @@
 # Various configuration constants for MIPI displays
 # Various utility functions for MIPI DBI configuration
 
+from collections.abc import Callable
+import functools
 from typing import Any, Self
+
+import voluptuous as vol
 
 from esphome.components.const import CONF_COLOR_DEPTH
 from esphome.components.display import CONF_SHOW_TEST_CARD, display_ns
@@ -18,6 +22,7 @@ from esphome.const import (
     CONF_LAMBDA,
     CONF_MIRROR_X,
     CONF_MIRROR_Y,
+    CONF_MODEL,
     CONF_OFFSET_HEIGHT,
     CONF_OFFSET_WIDTH,
     CONF_PAGES,
@@ -27,6 +32,7 @@ from esphome.const import (
     CONF_WIDTH,
 )
 from esphome.core import TimePeriod
+from esphome.schema_extractors import SCHEMA_EXTRACT, schema_extractor
 
 LOGGER = cv.logging.getLogger(__name__)
 
@@ -237,6 +243,54 @@ def flatten_sequence(sequence: tuple | list):
 
 def delay(ms):
     return DELAY_FLAG, ms
+
+
+# Generic placeholder model present in every DriverChip registry; skipped when
+# choosing a representative model for schema extraction.
+_CUSTOM_MODEL = "CUSTOM"
+
+
+def model_schema_extractor(
+    models: dict[str, Any],
+    model_schema: Callable[[dict[str, Any]], Any],
+    extra: dict[str, Any] | None = None,
+) -> Callable[[Callable[[Any], Any]], Callable[[Any], Any]]:
+    """
+    Decorate a model-driven display CONFIG_SCHEMA so the language-schema dumper
+    can extract it.
+
+    The schema is generated per ``model`` at validation time, so the static
+    dumper has nothing to walk. When the dumper passes SCHEMA_EXTRACT, resolve a
+    representative schema for a real model (the generic "CUSTOM" placeholder
+    over-constrains fields like init_sequence) plus any *extra* keys the model
+    needs, e.g. a bus mode, and hand that back; runtime validation is untouched.
+    """
+
+    def decorate(config_schema: Callable[[Any], Any]) -> Callable[[Any], Any]:
+        @schema_extractor("schema")
+        @functools.wraps(config_schema)
+        def wrapper(config: Any) -> Any:
+            if config is not SCHEMA_EXTRACT:
+                return config_schema(config)
+            names = sorted(models)
+            representative = next((n for n in names if n != _CUSTOM_MODEL), names[0])
+            schema = model_schema({CONF_MODEL: representative, **(extra or {})})
+            if isinstance(schema, vol.All):
+                schema = next(
+                    (v for v in schema.validators if isinstance(v, vol.Schema)),
+                    schema,
+                )
+            if isinstance(schema, vol.Schema):
+                # The resolved schema pins ``model`` to the representative; expose
+                # the full model list so the dumped enum offers every model.
+                schema = schema.extend(
+                    {cv.Required(CONF_MODEL): cv.one_of(*names, upper=True)}
+                )
+            return schema
+
+        return wrapper
+
+    return decorate
 
 
 class DriverChip:

--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -32,6 +32,7 @@ from esphome.components.mipi import (
     dimension_schema,
     get_color_depth,
     map_sequence,
+    model_schema_extractor,
     power_of_two,
     requires_buffer,
 )
@@ -161,6 +162,7 @@ def model_schema(config):
     )
 
 
+@model_schema_extractor(MODELS, model_schema)
 def _config_schema(config):
     config = cv.Schema(
         {

--- a/esphome/components/mipi_rgb/display.py
+++ b/esphome/components/mipi_rgb/display.py
@@ -30,6 +30,7 @@ from esphome.components.mipi import (
     DriverChip,
     dimension_schema,
     map_sequence,
+    model_schema_extractor,
     power_of_two,
     requires_buffer,
 )
@@ -219,6 +220,7 @@ def model_schema(config):
     return schema
 
 
+@model_schema_extractor(MODELS, model_schema)
 def _config_schema(config):
     config = cv.Schema(
         {

--- a/esphome/components/mipi_spi/display.py
+++ b/esphome/components/mipi_spi/display.py
@@ -22,6 +22,7 @@ from esphome.components.mipi import (
     dimension_schema,
     get_color_depth,
     map_sequence,
+    model_schema_extractor,
     power_of_two,
     requires_buffer,
 )
@@ -227,6 +228,7 @@ def model_schema(config):
     return schema
 
 
+@model_schema_extractor(MODELS, model_schema, extra={CONF_BUS_MODE: TYPE_SINGLE})
 def customise_schema(config):
     """
     Create a customised config schema for a specific model and validate the configuration.

--- a/script/build_language_schema.py
+++ b/script/build_language_schema.py
@@ -1002,6 +1002,10 @@ def convert(schema, config_var, path):
             else:
                 config_var["use_id_type"] = str(data.base)
                 config_var[S_TYPE] = "use_id"
+        elif schema_type == "schema":
+            # A callable CONFIG_SCHEMA that returned a representative schema
+            # for extraction (model-driven components); walk it as usual.
+            convert(data, config_var, path)
         else:
             raise TypeError("Unknown extracted schema type")
     elif config_var.get("key") == "GeneratedID":

--- a/tests/script/test_build_language_schema.py
+++ b/tests/script/test_build_language_schema.py
@@ -117,6 +117,23 @@ def test_convert_emits_explicit_sensitive_marker() -> None:
     assert config_var["type"] == "string"
 
 
+def test_convert_walks_callable_schema_extractor() -> None:
+    """A callable schema tagged for "schema" extraction is resolved and walked."""
+    from esphome.schema_extractors import SCHEMA_EXTRACT, schema_extractor
+
+    @schema_extractor("schema")
+    def dynamic_schema(value):
+        if value is SCHEMA_EXTRACT:
+            return cv.Schema({cv.Required("foo"): cv.string})
+        return value
+
+    config_var: dict = {}
+    _bls.convert(dynamic_schema, config_var, "/test")
+
+    assert config_var["type"] == "schema"
+    assert "foo" in config_var["schema"]["config_vars"]
+
+
 def test_convert_keys_emits_heuristic_sensitive_marker() -> None:
     converted: dict = {}
     _bls.convert_keys(converted, {cv.Optional("password"): cv.string}, "/root")


### PR DESCRIPTION
# What does this implement/fix?

The `mipi_spi`, `mipi_dsi`, `mipi_rgb` and `epaper_spi` display platforms build their config schema dynamically per model, so the static schema dumper could not serialize them; they were missing entirely from the generated language schema that powers schema.esphome.io, the VS Code extension and other tooling.

This lets a callable `CONFIG_SCHEMA` opt in to extraction. `build_language_schema` gains a `schema` extractor case that walks the returned schema through the existing schema walker; a shared `mipi.model_schema_extractor` decorator resolves a representative schema for the first model (and re-adds the full model list to the model enum) when the dumper passes the extract sentinel. Runtime validation is untouched, the extraction branch only runs for the dumper.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16870

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
display:
  - platform: mipi_spi
    model: st7789v
    cs_pin: GPIO5
    dc_pin: GPIO16
    reset_pin: GPIO17
    dimensions:
      width: 240
      height: 240
    invert_colors: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
