### PR TITLE
[core] Skip MAC-suffix mDNS discovery for non-mDNS addresses

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -225,8 +225,9 @@ def _discover_mac_suffix_devices() -> list[str] | None:
 
     Returns:
         - ``None`` when discovery isn't applicable (``name_add_mac_suffix`` off,
-          mDNS disabled, or ``CORE.address`` is already an IP). Callers should
-          then fall back to whatever default OTA address they normally use.
+          mDNS disabled, or ``CORE.address`` isn't a ``.local`` mDNS address).
+          Callers should then fall back to whatever default OTA address they
+          normally use.
         - ``[]`` when discovery ran but found nothing. Callers should NOT fall
           back to the base name: with ``name_add_mac_suffix`` enabled, the base
           name by definition doesn't exist on the network.
@@ -236,7 +237,7 @@ def _discover_mac_suffix_devices() -> list[str] | None:
     ``aioesphomeapi`` via :func:`_resolve_network_devices`) reuses the IPs we
     already have without opening a second Zeroconf client.
     """
-    if not (has_name_add_mac_suffix() and has_mdns() and has_non_ip_address()):
+    if not (has_name_add_mac_suffix() and has_mdns() and has_mdns_address()):
         return None
     from esphome.zeroconf import discover_mdns_devices
 
@@ -503,17 +504,22 @@ def has_mdns() -> bool:
 
 
 def has_non_ip_address() -> bool:
-    """Check if CORE.address is set and is not an IP address."""
+    """Check if ``CORE.address`` is set and is not an IP address."""
     return CORE.address is not None and not is_ip_address(CORE.address)
 
 
+def has_mdns_address() -> bool:
+    """Check if ``CORE.address`` is a ``.local`` mDNS hostname."""
+    return CORE.address is not None and CORE.address.endswith(".local")
+
+
 def has_ip_address() -> bool:
-    """Check if CORE.address is a valid IP address."""
+    """Check if ``CORE.address`` is a valid IP address."""
     return CORE.address is not None and is_ip_address(CORE.address)
 
 
 def has_resolvable_address() -> bool:
-    """Check if CORE.address is resolvable (via mDNS, DNS, or is an IP address)."""
+    """Check if ``CORE.address`` is resolvable (via mDNS, DNS, or is an IP address)."""
     # Any address (IP, mDNS hostname, or regular DNS hostname) is resolvable
     # The resolve_ip_address() function in helpers.py handles all types via AsyncResolver
     if CORE.address is None:
@@ -532,7 +538,7 @@ def has_resolvable_address() -> bool:
         return True
 
     # .local mDNS hostnames are only resolvable if mDNS is enabled
-    return not CORE.address.endswith(".local")
+    return not has_mdns_address()
 
 
 def has_name_add_mac_suffix() -> bool:


### PR DESCRIPTION
# What does this implement/fix?

A regression was introduced in 2026.5 by the improvements in commit 9b45b046a8992e65ff19b7610f2cc72e238ac760 (#13135), whereby configurations with `name_add_mac_suffix: true` and either a custom `domain` (other than the default `.local`) or `use_address` set directly to a non-`.local` hostname (but also not an IP address) may have the resultant address of the device completely ignored in favor of exclusively utilizing mDNS discovery.

In practice, this breaks the upload and logs commands for such configurations, as using a non-`.local` hostname in an ESPHome device configuration (whether by setting `domain` or `use_address`) implies an intention not to utilize mDNS for address resolution at all, let alone exclusively with no fallback to the intended address.

This fix changes the implementation, which already bypasses exclusive mDNS discovery if `use_address` is set explicitly to an IP address, to expand that exemption to any address that is not specifically a `.local` address (which all supported networking components supply as the address by default, unless explicitly changed by the `domain` or `use_address` configuration options).

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes regression introduced by 9b45b046a8992e65ff19b7610f2cc72e238ac760 #13135