### PR TITLE
[heatpumpir] Add IR receiver support for Mitsubishi Heavy ZJ

### DIFF
--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -126,6 +126,6 @@ async def to_code(config):
     cg.add(var.set_max_temperature(config[CONF_MAX_TEMPERATURE]))
     cg.add(var.set_min_temperature(config[CONF_MIN_TEMPERATURE]))
 
-    cg.add_library("tonia/HeatpumpIR", "1.0.41")
+    cg.add_library("tonia/HeatpumpIR", "1.0.42")
     if CORE.is_libretiny or CORE.is_esp32:
         CORE.add_platformio_option("lib_ignore", ["IRremoteESP8266"])

--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -11,7 +11,7 @@ from esphome.core import CORE
 
 CODEOWNERS = ["@rob-deutsch"]
 
-AUTO_LOAD = ["climate_ir"]
+AUTO_LOAD = ["climate_ir", "remote_receiver"]
 
 heatpumpir_ns = cg.esphome_ns.namespace("heatpumpir")
 HeatpumpIRClimate = heatpumpir_ns.class_("HeatpumpIRClimate", climate_ir.ClimateIR)

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -243,6 +243,136 @@ void HeatpumpIRClimate::transmit_state() {
                      swing_h_cmd);
 }
 
+static const uint16_t MITSUBISHI_HEAVY_ZJ_HDR_MARK = 3200;
+static const uint16_t MITSUBISHI_HEAVY_ZJ_HDR_SPACE = 1600;
+static const uint16_t MITSUBISHI_HEAVY_ZJ_BIT_MARK = 400;
+static const uint16_t MITSUBISHI_HEAVY_ZJ_ONE_SPACE = 1200;
+static const uint16_t MITSUBISHI_HEAVY_ZJ_ZERO_SPACE = 400;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_STATE_LENGTH = 11;
+
+static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE0 = 0x52;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE1 = 0xAE;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE2 = 0xC3;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE3 = 0x26;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE4 = 0xD9;
+
+static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_AUTO = 0x07;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_HEAT = 0x03;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_COOL = 0x06;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_DRY = 0x05;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_FAN = 0x04;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_POWER_OFF = 0x08;
+
+static const uint8_t MITSUBISHI_HEAVY_ZJ_FAN_AUTO = 0xE0;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_FAN1 = 0xA0;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_FAN2 = 0x80;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_FAN3 = 0x60;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_HIPOWER = 0x40;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_ECONO = 0x00;
+
+static const uint8_t MITSUBISHI_HEAVY_ZJ_HS_SWING = 0x4C;
+static const uint8_t MITSUBISHI_HEAVY_ZJ_VS_SWING = 0x0A;
+
+bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
+  if (this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZJ)
+    return false;
+
+  uint8_t frame[11] = {};
+
+  if (!data.expect_item(MITSUBISHI_HEAVY_ZJ_HDR_MARK, MITSUBISHI_HEAVY_ZJ_HDR_SPACE)) {
+    return false;
+  }
+
+  for (uint8_t pos = 0; pos < MITSUBISHI_HEAVY_ZJ_STATE_LENGTH; pos++) {
+    uint8_t byte = 0;
+    for (int8_t bit = 0; bit < 8; bit++) {
+      if (data.expect_item(MITSUBISHI_HEAVY_ZJ_BIT_MARK, MITSUBISHI_HEAVY_ZJ_ONE_SPACE)) {
+        byte |= 1 << bit;
+      } else if (!data.expect_item(MITSUBISHI_HEAVY_ZJ_BIT_MARK, MITSUBISHI_HEAVY_ZJ_ZERO_SPACE)) {
+        return false;
+      }
+    }
+    frame[pos] = byte;
+
+    if ((pos == 0 && byte != MITSUBISHI_HEAVY_ZJ_BYTE0) || (pos == 1 && byte != MITSUBISHI_HEAVY_ZJ_BYTE1) ||
+        (pos == 2 && byte != MITSUBISHI_HEAVY_ZJ_BYTE2) || (pos == 3 && byte != MITSUBISHI_HEAVY_ZJ_BYTE3) ||
+        (pos == 4 && byte != MITSUBISHI_HEAVY_ZJ_BYTE4)) {
+      return false;
+    }
+  }
+
+  if ((uint8_t) (frame[5] ^ frame[6]) != 0xFF || (uint8_t) (frame[7] ^ frame[8]) != 0xFF ||
+      (uint8_t) (frame[9] ^ frame[10]) != 0xFF) {
+    return false;
+  }
+
+  if (frame[9] & MITSUBISHI_HEAVY_ZJ_POWER_OFF) {
+    this->mode = climate::CLIMATE_MODE_OFF;
+  } else {
+    uint8_t opmode = frame[9] & 0x07;
+    switch (opmode) {
+      case MITSUBISHI_HEAVY_ZJ_MODE_AUTO:
+        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+        break;
+      case MITSUBISHI_HEAVY_ZJ_MODE_HEAT:
+        this->mode = climate::CLIMATE_MODE_HEAT;
+        break;
+      case MITSUBISHI_HEAVY_ZJ_MODE_COOL:
+        this->mode = climate::CLIMATE_MODE_COOL;
+        break;
+      case MITSUBISHI_HEAVY_ZJ_MODE_DRY:
+        this->mode = climate::CLIMATE_MODE_DRY;
+        break;
+      case MITSUBISHI_HEAVY_ZJ_MODE_FAN:
+        this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+        break;
+      default:
+        return false;
+    }
+  }
+
+  uint8_t temp_nibble = (frame[9] >> 4) & 0x0F;
+  this->target_temperature = 17 + ((~temp_nibble) & 0x0F);
+
+  uint8_t fan = frame[7] & 0xE0;
+  if (fan == MITSUBISHI_HEAVY_ZJ_FAN_AUTO) {
+    this->fan_mode = climate::CLIMATE_FAN_AUTO;
+    this->preset = climate::CLIMATE_PRESET_NONE;
+  } else if (fan == MITSUBISHI_HEAVY_ZJ_FAN1) {
+    this->fan_mode = climate::CLIMATE_FAN_LOW;
+    this->preset = climate::CLIMATE_PRESET_NONE;
+  } else if (fan == MITSUBISHI_HEAVY_ZJ_FAN2) {
+    this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+    this->preset = climate::CLIMATE_PRESET_NONE;
+  } else if (fan == MITSUBISHI_HEAVY_ZJ_FAN3) {
+    this->fan_mode = climate::CLIMATE_FAN_HIGH;
+    this->preset = climate::CLIMATE_PRESET_NONE;
+  } else if (fan == MITSUBISHI_HEAVY_ZJ_HIPOWER) {
+    this->preset = climate::CLIMATE_PRESET_BOOST;
+  } else if (fan == MITSUBISHI_HEAVY_ZJ_ECONO) {
+    this->preset = climate::CLIMATE_PRESET_ECO;
+  }
+
+  uint8_t swing_h = frame[5] & 0xDC;
+  uint8_t swing_v = (frame[5] & 0x02) | (frame[7] & 0x18);
+
+  bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZJ_HS_SWING);
+  bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZJ_VS_SWING);
+
+  if (h_swing && v_swing) {
+    this->swing_mode = climate::CLIMATE_SWING_BOTH;
+  } else if (h_swing) {
+    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+  } else if (v_swing) {
+    this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+  } else {
+    this->swing_mode = climate::CLIMATE_SWING_OFF;
+  }
+
+  this->publish_state();
+  return true;
+}
+
 }  // namespace esphome::heatpumpir
 
 #endif

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -243,13 +243,13 @@ void HeatpumpIRClimate::transmit_state() {
                      swing_h_cmd);
 }
 
-static const uint8_t MITSUBISHI_HEAVY_ZJ_STATE_LENGTH = 11;
+static const uint8_t MITSUBISHI_HEAVY_ZMP_STATE_LENGTH = 11;
 
-static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE0 = 0x52;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE1 = 0xAE;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE2 = 0xC3;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE3 = 0x26;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE4 = 0xD9;
+static const uint8_t MITSUBISHI_HEAVY_ZMP_BYTE0 = 0x52;
+static const uint8_t MITSUBISHI_HEAVY_ZMP_BYTE1 = 0xAE;
+static const uint8_t MITSUBISHI_HEAVY_ZMP_BYTE2 = 0xC3;
+static const uint8_t MITSUBISHI_HEAVY_ZMP_BYTE3 = 0x26;
+static const uint8_t MITSUBISHI_HEAVY_ZMP_BYTE4 = 0xD9;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZMP)
@@ -260,7 +260,7 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE))
     return false;
 
-  for (uint8_t pos = 0; pos < MITSUBISHI_HEAVY_ZJ_STATE_LENGTH; pos++) {
+  for (uint8_t pos = 0; pos < MITSUBISHI_HEAVY_ZMP_STATE_LENGTH; pos++) {
     uint8_t byte = 0;
     for (int8_t bit = 0; bit < 8; bit++) {
       if (data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ONE_SPACE)) {
@@ -271,9 +271,9 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
     }
     frame[pos] = byte;
 
-    if ((pos == 0 && byte != MITSUBISHI_HEAVY_ZJ_BYTE0) || (pos == 1 && byte != MITSUBISHI_HEAVY_ZJ_BYTE1) ||
-        (pos == 2 && byte != MITSUBISHI_HEAVY_ZJ_BYTE2) || (pos == 3 && byte != MITSUBISHI_HEAVY_ZJ_BYTE3) ||
-        (pos == 4 && byte != MITSUBISHI_HEAVY_ZJ_BYTE4)) {
+    if ((pos == 0 && byte != MITSUBISHI_HEAVY_ZMP_BYTE0) || (pos == 1 && byte != MITSUBISHI_HEAVY_ZMP_BYTE1) ||
+        (pos == 2 && byte != MITSUBISHI_HEAVY_ZMP_BYTE2) || (pos == 3 && byte != MITSUBISHI_HEAVY_ZMP_BYTE3) ||
+        (pos == 4 && byte != MITSUBISHI_HEAVY_ZMP_BYTE4)) {
       return false;
     }
   }

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -337,7 +337,6 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
       bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZMP_MITSUBISHI_HEAVY_ZMP_HS_SWING);
       bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
-      ESP_LOGD(TAG, "ZMP: swing_h=0x%02X swing_v=0x%02X", swing_h, swing_v);
 
       if (h_swing && v_swing)
         this->swing_mode = climate::CLIMATE_SWING_BOTH;

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -337,6 +337,7 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
       bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZMP_MITSUBISHI_HEAVY_ZMP_HS_SWING);
       bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
+      ESP_LOGD(TAG, "ZMP: swing_h=0x%02X swing_v=0x%02X", swing_h, swing_v);
 
       if (h_swing && v_swing)
         this->swing_mode = climate::CLIMATE_SWING_BOTH;

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -330,12 +330,12 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
       // ZMP horizontal swing constants (not defined in library)
-      static const uint8_t HS_MASK = 0xDC;
-      static const uint8_t HS_SWING = 0x5C;
+      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_MASK = 0xDC;
+      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_SWING = 0x5C;
 
-      uint8_t swing_h = frame[5] & HS_MASK;
+      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_ZMP_HS_MASK;
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
-      bool h_swing = (swing_h == HS_SWING);
+      bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZMP_HS_SWING);
       bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
 
       if (h_swing && v_swing)

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -253,14 +253,6 @@ static const uint8_t MITSUBISHI_HEAVY_FAN_MASK = 0xE0;
 static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK5 = 0x02;
 static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK7 = 0x18;
 static const uint8_t MITSUBISHI_HEAVY_CHECKSUM_BYTE = 0xFF;
-// ZMP horizontal swing not in library. Standard=0x4C, some remotes use MITSUBISHI_HEAVY_HS_SWING_ALT.
-static const uint8_t MITSUBISHI_HEAVY_HS_SWING = 0x4C;
-static const uint8_t MITSUBISHI_HEAVY_HS_SWING_ALT = MITSUBISHI_HEAVY_HS_SWING_ALT;
-static const uint8_t MITSUBISHI_HEAVY_HS_MASK = 0xDC;
-// ZMP horizontal swing not in library. Standard=0x4C, some remotes use MITSUBISHI_HEAVY_HS_SWING_ALT.
-static const uint8_t MITSUBISHI_HEAVY_HS_SWING = 0x4C;
-static const uint8_t MITSUBISHI_HEAVY_HS_SWING_ALT = MITSUBISHI_HEAVY_HS_SWING_ALT;
-static const uint8_t MITSUBISHI_HEAVY_HS_MASK = 0xDC;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   uint8_t frame[11] = {};
@@ -337,10 +329,14 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
-      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_HS_MASK;
-      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_HS_MASK;
+      // ZMP horizontal swing constants (not defined in library)
+      static const uint8_t HS_MASK = 0xDC;
+      static const uint8_t HS_SWING = 0x4C;
+      static const uint8_t HS_SWING_ALT = 0x5C;
+
+      uint8_t swing_h = frame[5] & HS_MASK;
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
-      bool h_swing = (swing_h == MITSUBISHI_HEAVY_HS_SWING) || (swing_h == MITSUBISHI_HEAVY_HS_SWING_ALT);
+      bool h_swing = (swing_h == HS_SWING) || (swing_h == HS_SWING_ALT);
       bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
 
       if (h_swing && v_swing)

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -246,6 +246,13 @@ void HeatpumpIRClimate::transmit_state() {
 // ZJ/ZMP frame prefix bytes (not defined by library)
 static const uint8_t MITSUBISHI_HEAVY_FRAME_PREFIX[5] = {0x52, 0xAE, 0xC3, 0x26, 0xD9};
 
+static const uint8_t MITSUBISHI_HEAVY_MODE_MASK = 0x07;
+static const uint8_t MITSUBISHI_HEAVY_TEMP_MASK = 0x0F;
+static const uint8_t MITSUBISHI_HEAVY_FAN_MASK = 0xE0;
+static const uint8_t MITSUBISHI_HEAVY_SWING_V_LO = 0x02;
+static const uint8_t MITSUBISHI_HEAVY_SWING_V_HI = 0x18;
+static const uint8_t MITSUBISHI_HEAVY_CHECKSUM_BYTE = 0xFF;
+
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   uint8_t frame[11] = {};
 
@@ -267,8 +274,9 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       return false;
   }
 
-  if ((uint8_t) (frame[5] ^ frame[6]) != 0xFF || (uint8_t) (frame[7] ^ frame[8]) != 0xFF ||
-      (uint8_t) (frame[9] ^ frame[10]) != 0xFF) {
+  if ((uint8_t) (frame[5] ^ frame[6]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
+      (uint8_t) (frame[7] ^ frame[8]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
+      (uint8_t) (frame[9] ^ frame[10]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE) {
     return false;
   }
 
@@ -276,7 +284,7 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (frame[9] & MITSUBISHI_HEAVY_MODE_OFF) {
     this->mode = climate::CLIMATE_MODE_OFF;
   } else {
-    switch (frame[9] & 0x07) {
+    switch (frame[9] & MITSUBISHI_HEAVY_MODE_MASK) {
       case MITSUBISHI_HEAVY_MODE_AUTO:
         this->mode = climate::CLIMATE_MODE_HEAT_COOL;
         break;
@@ -297,12 +305,12 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
     }
   }
 
-  this->target_temperature = 17 + ((~(frame[9] >> 4)) & 0x0F);
+  this->target_temperature = 17 + ((~(frame[9] >> 4)) & MITSUBISHI_HEAVY_TEMP_MASK);
 
   // Protocol-specific: fan, presets, and swing
   switch (this->protocol_) {
     case PROTOCOL_MITSUBISHI_HEAVY_ZMP: {
-      uint8_t fan = frame[7] & 0xE0;
+      uint8_t fan = frame[7] & MITSUBISHI_HEAVY_FAN_MASK;
       if (fan == MITSUBISHI_HEAVY_ZMP_FAN_AUTO) {
         this->fan_mode = climate::CLIMATE_FAN_AUTO;
       } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN1) {
@@ -316,7 +324,7 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
-      uint8_t swing_v = (frame[5] & 0x02) | (frame[7] & 0x18);
+      uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_LO) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_HI);
       this->swing_mode = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING) ? climate::CLIMATE_SWING_VERTICAL
                                                                      : climate::CLIMATE_SWING_OFF;
       break;

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -280,63 +280,60 @@ static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK7 = 0x18;
 static const uint8_t MITSUBISHI_HEAVY_CHECKSUM_BYTE = 0xFF;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
-
-  uint8_t frame[11] = {};
-
-  if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE))
-    return false;
-
-  for (uint8_t pos = 0; pos < 11; pos++) {
-    uint8_t byte = 0;
-    for (int8_t bit = 0; bit < 8; bit++) {
-      if (data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ONE_SPACE)) {
-        byte |= 1 << bit;
-      } else if (!data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ZERO_SPACE)) {
-        return false;
-      }
-    }
-    frame[pos] = byte;
-
-    if (pos < 5 && byte != MITSUBISHI_HEAVY_FRAME_PREFIX[pos])
-      return false;
-  }
-
-  if ((uint8_t) (frame[5] ^ frame[6]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
-      (uint8_t) (frame[7] ^ frame[8]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
-      (uint8_t) (frame[9] ^ frame[10]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE) {
-    return false;
-  }
-
-  // Shared: operating mode
-  if (frame[9] & MITSUBISHI_HEAVY_MODE_OFF) {
-    this->mode = climate::CLIMATE_MODE_OFF;
-  } else {
-    switch (frame[9] & MITSUBISHI_HEAVY_MODE_MASK) {
-      case MITSUBISHI_HEAVY_MODE_AUTO:
-        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-        break;
-      case MITSUBISHI_HEAVY_MODE_HEAT:
-        this->mode = climate::CLIMATE_MODE_HEAT;
-        break;
-      case MITSUBISHI_HEAVY_MODE_COOL:
-        this->mode = climate::CLIMATE_MODE_COOL;
-        break;
-      case MITSUBISHI_HEAVY_MODE_DRY:
-        this->mode = climate::CLIMATE_MODE_DRY;
-        break;
-      case MITSUBISHI_HEAVY_MODE_FAN:
-        this->mode = climate::CLIMATE_MODE_FAN_ONLY;
-        break;
-      default:
-        return false;
-    }
-  }
-
-  this->target_temperature = 17 + ((~(frame[9] >> 4)) & MITSUBISHI_HEAVY_TEMP_MASK);
-
-  // Protocol-specific: fan, presets, and swing
   switch (this->protocol_) {
     case PROTOCOL_MITSUBISHI_HEAVY_ZMP: {
+      uint8_t frame[11] = {};
+
+      if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE))
+        return false;
+
+      for (uint8_t pos = 0; pos < 11; pos++) {
+        uint8_t byte = 0;
+        for (int8_t bit = 0; bit < 8; bit++) {
+          if (data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ONE_SPACE)) {
+            byte |= 1 << bit;
+          } else if (!data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ZERO_SPACE)) {
+            return false;
+          }
+        }
+        frame[pos] = byte;
+
+        if (pos < 5 && byte != MITSUBISHI_HEAVY_FRAME_PREFIX[pos])
+          return false;
+      }
+
+      if ((uint8_t) (frame[5] ^ frame[6]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
+          (uint8_t) (frame[7] ^ frame[8]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
+          (uint8_t) (frame[9] ^ frame[10]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE) {
+        return false;
+      }
+
+      if (frame[9] & MITSUBISHI_HEAVY_MODE_OFF) {
+        this->mode = climate::CLIMATE_MODE_OFF;
+      } else {
+        switch (frame[9] & MITSUBISHI_HEAVY_MODE_MASK) {
+          case MITSUBISHI_HEAVY_MODE_AUTO:
+            this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+            break;
+          case MITSUBISHI_HEAVY_MODE_HEAT:
+            this->mode = climate::CLIMATE_MODE_HEAT;
+            break;
+          case MITSUBISHI_HEAVY_MODE_COOL:
+            this->mode = climate::CLIMATE_MODE_COOL;
+            break;
+          case MITSUBISHI_HEAVY_MODE_DRY:
+            this->mode = climate::CLIMATE_MODE_DRY;
+            break;
+          case MITSUBISHI_HEAVY_MODE_FAN:
+            this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+            break;
+          default:
+            return false;
+        }
+      }
+
+      this->target_temperature = 17 + ((~(frame[9] >> 4)) & MITSUBISHI_HEAVY_TEMP_MASK);
+
       uint8_t fan = frame[7] & MITSUBISHI_HEAVY_FAN_MASK;
       if (fan == MITSUBISHI_HEAVY_ZMP_FAN_AUTO) {
         this->fan_mode = climate::CLIMATE_FAN_AUTO;
@@ -355,12 +352,13 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
-      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_MASK = 0xDC;
-      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_SWING = 0x5C;
 
-      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_ZMP_HS_MASK;
+      static const uint8_t ZMP_HS_MASK = 0xDC;
+      static const uint8_t ZMP_HS_SWING = 0x5C;
+
+      uint8_t swing_h = frame[5] & ZMP_HS_MASK;
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
-      bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZMP_HS_SWING);
+      bool h_swing = (swing_h == ZMP_HS_SWING);
       bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
 
       if (h_swing && v_swing)

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -243,11 +243,6 @@ void HeatpumpIRClimate::transmit_state() {
                      swing_h_cmd);
 }
 
-static const uint16_t MITSUBISHI_HEAVY_ZJ_HDR_MARK = 3200;
-static const uint16_t MITSUBISHI_HEAVY_ZJ_HDR_SPACE = 1600;
-static const uint16_t MITSUBISHI_HEAVY_ZJ_BIT_MARK = 400;
-static const uint16_t MITSUBISHI_HEAVY_ZJ_ONE_SPACE = 1200;
-static const uint16_t MITSUBISHI_HEAVY_ZJ_ZERO_SPACE = 400;
 static const uint8_t MITSUBISHI_HEAVY_ZJ_STATE_LENGTH = 11;
 
 static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE0 = 0x52;
@@ -256,29 +251,22 @@ static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE2 = 0xC3;
 static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE3 = 0x26;
 static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE4 = 0xD9;
 
-static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_AUTO = 0x07;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_HEAT = 0x03;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_COOL = 0x06;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_DRY = 0x05;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_FAN = 0x04;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_POWER_OFF = 0x08;
-
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZJ)
     return false;
 
   uint8_t frame[11] = {};
 
-  if (!data.expect_item(MITSUBISHI_HEAVY_ZJ_HDR_MARK, MITSUBISHI_HEAVY_ZJ_HDR_SPACE)) {
+  if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE)) {
     return false;
   }
 
   for (uint8_t pos = 0; pos < MITSUBISHI_HEAVY_ZJ_STATE_LENGTH; pos++) {
     uint8_t byte = 0;
     for (int8_t bit = 0; bit < 8; bit++) {
-      if (data.expect_item(MITSUBISHI_HEAVY_ZJ_BIT_MARK, MITSUBISHI_HEAVY_ZJ_ONE_SPACE)) {
+      if (data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ONE_SPACE)) {
         byte |= 1 << bit;
-      } else if (!data.expect_item(MITSUBISHI_HEAVY_ZJ_BIT_MARK, MITSUBISHI_HEAVY_ZJ_ZERO_SPACE)) {
+      } else if (!data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ZERO_SPACE)) {
         return false;
       }
     }
@@ -296,24 +284,24 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
     return false;
   }
 
-  if (frame[9] & MITSUBISHI_HEAVY_ZJ_POWER_OFF) {
+  if (frame[9] & MITSUBISHI_HEAVY_MODE_OFF) {
     this->mode = climate::CLIMATE_MODE_OFF;
   } else {
     uint8_t opmode = frame[9] & 0x07;
     switch (opmode) {
-      case MITSUBISHI_HEAVY_ZJ_MODE_AUTO:
+      case MITSUBISHI_HEAVY_MODE_AUTO:
         this->mode = climate::CLIMATE_MODE_HEAT_COOL;
         break;
-      case MITSUBISHI_HEAVY_ZJ_MODE_HEAT:
+      case MITSUBISHI_HEAVY_MODE_HEAT:
         this->mode = climate::CLIMATE_MODE_HEAT;
         break;
-      case MITSUBISHI_HEAVY_ZJ_MODE_COOL:
+      case MITSUBISHI_HEAVY_MODE_COOL:
         this->mode = climate::CLIMATE_MODE_COOL;
         break;
-      case MITSUBISHI_HEAVY_ZJ_MODE_DRY:
+      case MITSUBISHI_HEAVY_MODE_DRY:
         this->mode = climate::CLIMATE_MODE_DRY;
         break;
-      case MITSUBISHI_HEAVY_ZJ_MODE_FAN:
+      case MITSUBISHI_HEAVY_MODE_FAN:
         this->mode = climate::CLIMATE_MODE_FAN_ONLY;
         break;
       default:

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -252,7 +252,7 @@ static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE3 = 0x26;
 static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE4 = 0xD9;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
-  if (this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZJ)
+  if (this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZJ && this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZMP)
     return false;
 
   uint8_t frame[11] = {};
@@ -313,6 +313,8 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   this->target_temperature = 17 + ((~temp_nibble) & 0x0F);
 
   uint8_t fan = frame[7] & 0xE0;
+  bool is_zmp = (this->protocol_ == PROTOCOL_MITSUBISHI_HEAVY_ZMP);
+
   if (fan == MITSUBISHI_HEAVY_ZJ_FAN_AUTO) {
     this->fan_mode = climate::CLIMATE_FAN_AUTO;
     this->preset = climate::CLIMATE_PRESET_NONE;
@@ -325,7 +327,7 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   } else if (fan == MITSUBISHI_HEAVY_ZJ_FAN3) {
     this->fan_mode = climate::CLIMATE_FAN_HIGH;
     this->preset = climate::CLIMATE_PRESET_NONE;
-  } else if (fan == MITSUBISHI_HEAVY_ZJ_HIPOWER) {
+  } else if (fan == (is_zmp ? 0x20 : 0x40)) {
     this->preset = climate::CLIMATE_PRESET_BOOST;
   } else if (fan == MITSUBISHI_HEAVY_ZJ_ECONO) {
     this->preset = climate::CLIMATE_PRESET_ECO;
@@ -334,7 +336,7 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   uint8_t swing_h = frame[5] & 0xDC;
   uint8_t swing_v = (frame[5] & 0x02) | (frame[7] & 0x18);
 
-  bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZJ_HS_SWING);
+  bool h_swing = (swing_h == 0x4C) || (swing_h == 0x5C);
   bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZJ_VS_SWING);
 
   if (h_swing && v_swing) {

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -252,14 +252,13 @@ static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE3 = 0x26;
 static const uint8_t MITSUBISHI_HEAVY_ZJ_BYTE4 = 0xD9;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
-  if (this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZJ && this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZMP)
+  if (this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZMP)
     return false;
 
   uint8_t frame[11] = {};
 
-  if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE)) {
+  if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE))
     return false;
-  }
 
   for (uint8_t pos = 0; pos < MITSUBISHI_HEAVY_ZJ_STATE_LENGTH; pos++) {
     uint8_t byte = 0;
@@ -314,46 +313,33 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
 
   uint8_t fan = frame[7] & 0xE0;
 
-  if (fan == MITSUBISHI_HEAVY_ZJ_FAN_AUTO) {
+  if (fan == MITSUBISHI_HEAVY_ZMP_FAN_AUTO) {
     this->fan_mode = climate::CLIMATE_FAN_AUTO;
-    this->preset = climate::CLIMATE_PRESET_NONE;
-  } else if (fan == MITSUBISHI_HEAVY_ZJ_FAN1) {
+  } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN1) {
     this->fan_mode = climate::CLIMATE_FAN_LOW;
-    this->preset = climate::CLIMATE_PRESET_NONE;
-  } else if (fan == MITSUBISHI_HEAVY_ZJ_FAN2) {
+  } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN2) {
     this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
-    this->preset = climate::CLIMATE_PRESET_NONE;
-  } else if (fan == MITSUBISHI_HEAVY_ZJ_FAN3) {
+  } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN3) {
     this->fan_mode = climate::CLIMATE_FAN_HIGH;
-    this->preset = climate::CLIMATE_PRESET_NONE;
-  } else if (this->protocol_ == PROTOCOL_MITSUBISHI_HEAVY_ZMP) {
-    if (fan == MITSUBISHI_HEAVY_ZMP_HIPOWER) {
-      this->preset = climate::CLIMATE_PRESET_BOOST;
-    } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
-      this->preset = climate::CLIMATE_PRESET_ECO;
-    }
-  } else {
-    if (fan == MITSUBISHI_HEAVY_ZJ_HIPOWER) {
-      this->preset = climate::CLIMATE_PRESET_BOOST;
-    } else if (fan == MITSUBISHI_HEAVY_ZJ_ECONO) {
-      this->preset = climate::CLIMATE_PRESET_ECO;
-    }
+  } else if (fan == MITSUBISHI_HEAVY_ZMP_HIPOWER) {
+    this->preset = climate::CLIMATE_PRESET_BOOST;
+  } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
+    this->preset = climate::CLIMATE_PRESET_ECO;
   }
 
-  if (h_swing && v_swing) {
-    this->swing_mode = climate::CLIMATE_SWING_BOTH;
-  } else if (h_swing) {
-    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
-  } else if (v_swing) {
+  uint8_t swing_v = (frame[5] & 0x02) | (frame[7] & 0x18);
+
+  if (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING)
     this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
-  } else {
+  else
     this->swing_mode = climate::CLIMATE_SWING_OFF;
-  }
 
   this->publish_state();
   return true;
 }
 
 }  // namespace esphome::heatpumpir
+
+#endif
 
 #endif

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -245,9 +245,6 @@ void HeatpumpIRClimate::transmit_state() {
 
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
-  if (this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZMP)
-    return false;
-
   uint8_t frame[11] = {};
 
   if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE))
@@ -264,9 +261,8 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
     }
     frame[pos] = byte;
 
-    if ((pos == 0 && byte != 0x52) || (pos == 1 && byte != 0xAE) ||
-        (pos == 2 && byte != 0xC3) || (pos == 3 && byte != 0x26) ||
-        (pos == 4 && byte != 0xD9)) {
+    if ((pos == 0 && byte != 0x52) || (pos == 1 && byte != 0xAE) || (pos == 2 && byte != 0xC3) ||
+        (pos == 3 && byte != 0x26) || (pos == 4 && byte != 0xD9)) {
       return false;
     }
   }
@@ -276,11 +272,11 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
     return false;
   }
 
+  // Shared: operating mode
   if (frame[9] & MITSUBISHI_HEAVY_MODE_OFF) {
     this->mode = climate::CLIMATE_MODE_OFF;
   } else {
-    uint8_t opmode = frame[9] & 0x07;
-    switch (opmode) {
+    switch (frame[9] & 0x07) {
       case MITSUBISHI_HEAVY_MODE_AUTO:
         this->mode = climate::CLIMATE_MODE_HEAT_COOL;
         break;
@@ -301,30 +297,32 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
     }
   }
 
-  uint8_t temp_nibble = (frame[9] >> 4) & 0x0F;
-  this->target_temperature = 17 + ((~temp_nibble) & 0x0F);
+  this->target_temperature = 17 + ((~(frame[9] >> 4)) & 0x0F);
 
-  // ZMP: fan speed, presets, and vertical swing
-  {
-    uint8_t fan = frame[7] & 0xE0;
-
-    if (fan == MITSUBISHI_HEAVY_ZMP_FAN_AUTO) {
-      this->fan_mode = climate::CLIMATE_FAN_AUTO;
-    } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN1) {
-      this->fan_mode = climate::CLIMATE_FAN_LOW;
-    } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN2) {
-      this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
-    } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN3) {
-      this->fan_mode = climate::CLIMATE_FAN_HIGH;
-    } else if (fan == MITSUBISHI_HEAVY_ZMP_HIPOWER) {
-      this->preset = climate::CLIMATE_PRESET_BOOST;
-    } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
-      this->preset = climate::CLIMATE_PRESET_ECO;
+  // Protocol-specific: fan, presets, and swing
+  switch (this->protocol_) {
+    case PROTOCOL_MITSUBISHI_HEAVY_ZMP: {
+      uint8_t fan = frame[7] & 0xE0;
+      if (fan == MITSUBISHI_HEAVY_ZMP_FAN_AUTO) {
+        this->fan_mode = climate::CLIMATE_FAN_AUTO;
+      } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN1) {
+        this->fan_mode = climate::CLIMATE_FAN_LOW;
+      } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN2) {
+        this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+      } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN3) {
+        this->fan_mode = climate::CLIMATE_FAN_HIGH;
+      } else if (fan == MITSUBISHI_HEAVY_ZMP_HIPOWER) {
+        this->preset = climate::CLIMATE_PRESET_BOOST;
+      } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
+        this->preset = climate::CLIMATE_PRESET_ECO;
+      }
+      uint8_t swing_v = (frame[5] & 0x02) | (frame[7] & 0x18);
+      this->swing_mode = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING) ? climate::CLIMATE_SWING_VERTICAL
+                                                                     : climate::CLIMATE_SWING_OFF;
+      break;
     }
-
-    uint8_t swing_v = (frame[5] & 0x02) | (frame[7] & 0x18);
-    this->swing_mode = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING) ? climate::CLIMATE_SWING_VERTICAL
-                                                                   : climate::CLIMATE_SWING_OFF;
+    default:
+      return false;
   }
 
   this->publish_state();

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -330,12 +330,12 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
       // ZMP horizontal swing constants (not defined in library)
-      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_MASK = 0xDC;
-      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_SWING = 0x5C;
+      static const uint8_t MITSUBISHI_HEAVY_ZMP_MITSUBISHI_HEAVY_ZMP_HS_MASK = 0xDC;
+      static const uint8_t MITSUBISHI_HEAVY_ZMP_MITSUBISHI_HEAVY_ZMP_HS_SWING = 0x5C;
 
-      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_ZMP_HS_MASK;
+      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_ZMP_MITSUBISHI_HEAVY_ZMP_HS_MASK;
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
-      bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZMP_HS_SWING);
+      bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZMP_MITSUBISHI_HEAVY_ZMP_HS_SWING);
       bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
 
       if (h_swing && v_swing)

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -2,7 +2,6 @@
 
 #if defined(USE_ARDUINO) || defined(USE_ESP32)
 
-#include <cmath>
 #include <map>
 #include <IRSender.h>
 #include <HeatpumpIRFactory.h>
@@ -114,7 +113,7 @@ void HeatpumpIRClimate::setup() {
       this->current_temperature = state;
 
       IRSenderESPHome esp_sender(this->transmitter_);
-      this->heatpump_ir_->send(esp_sender, uint8_t(std::lround(this->current_temperature)));
+      this->heatpump_ir_->send(esp_sender, uint8_t(lround(this->current_temperature)));
 
       // current temperature changed, publish state
       this->publish_state();
@@ -123,6 +122,15 @@ void HeatpumpIRClimate::setup() {
   } else {
     this->current_temperature = NAN;
   }
+}
+
+climate::ClimateTraits HeatpumpIRClimate::traits() {
+  auto traits = climate_ir::ClimateIR::traits();
+  if (this->protocol_ == PROTOCOL_MITSUBISHI_HEAVY_ZJ || this->protocol_ == PROTOCOL_MITSUBISHI_HEAVY_ZMP) {
+    traits.set_supported_presets(
+        {climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO, climate::CLIMATE_PRESET_BOOST});
+  }
+  return traits;
 }
 
 void HeatpumpIRClimate::transmit_state() {
@@ -203,6 +211,23 @@ void HeatpumpIRClimate::transmit_state() {
       break;
   }
 
+  if (this->protocol_ == PROTOCOL_MITSUBISHI_HEAVY_ZJ || this->protocol_ == PROTOCOL_MITSUBISHI_HEAVY_ZMP) {
+    switch (this->preset.value_or(climate::CLIMATE_PRESET_NONE)) {
+      case climate::CLIMATE_PRESET_ECO:
+        fan_speed_cmd = FAN_5;
+        break;
+      case climate::CLIMATE_PRESET_BOOST:
+        fan_speed_cmd = FAN_4;
+        break;
+      default:
+        // FAN_4/FAN_5 are HiPower/Econo modes, not fan speeds.
+        // Shift down so normal fan control uses FAN_1-FAN_3.
+        if (fan_speed_cmd >= FAN_2)
+          fan_speed_cmd--;
+        break;
+    }
+  }
+
   switch (this->mode) {
     case climate::CLIMATE_MODE_COOL:
       power_mode_cmd = POWER_ON;
@@ -255,6 +280,7 @@ static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK7 = 0x18;
 static const uint8_t MITSUBISHI_HEAVY_CHECKSUM_BYTE = 0xFF;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
+
   uint8_t frame[11] = {};
 
   if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE))
@@ -329,13 +355,12 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
-      // ZMP horizontal swing constants (not defined in library)
-      static const uint8_t MITSUBISHI_HEAVY_ZMP_MITSUBISHI_HEAVY_ZMP_HS_MASK = 0xDC;
-      static const uint8_t MITSUBISHI_HEAVY_ZMP_MITSUBISHI_HEAVY_ZMP_HS_SWING = 0x5C;
+      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_MASK = 0xDC;
+      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_SWING = 0x5C;
 
-      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_ZMP_MITSUBISHI_HEAVY_ZMP_HS_MASK;
+      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_ZMP_HS_MASK;
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
-      bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZMP_MITSUBISHI_HEAVY_ZMP_HS_SWING);
+      bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZMP_HS_SWING);
       bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
 
       if (h_swing && v_swing)

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -330,6 +330,7 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
       uint8_t swing_h = frame[5] & 0xDC;
+      uint8_t swing_h = frame[5] & 0xDC;
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
       bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZJ_HS_SWING) || (swing_h == 0x5C);
       bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -360,5 +360,3 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
 }  // namespace esphome::heatpumpir
 
 #endif
-
-#endif

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -329,9 +329,19 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
+      uint8_t swing_h = frame[5] & 0xDC;
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
-      this->swing_mode = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING) ? climate::CLIMATE_SWING_VERTICAL
-                                                                     : climate::CLIMATE_SWING_OFF;
+      bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZJ_HS_SWING) || (swing_h == 0x5C);
+      bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
+
+      if (h_swing && v_swing)
+        this->swing_mode = climate::CLIMATE_SWING_BOTH;
+      else if (h_swing)
+        this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+      else if (v_swing)
+        this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+      else
+        this->swing_mode = climate::CLIMATE_SWING_OFF;
       break;
     }
     default:

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -304,28 +304,28 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   uint8_t temp_nibble = (frame[9] >> 4) & 0x0F;
   this->target_temperature = 17 + ((~temp_nibble) & 0x0F);
 
-  uint8_t fan = frame[7] & 0xE0;
+  // ZMP: fan speed, presets, and vertical swing
+  {
+    uint8_t fan = frame[7] & 0xE0;
 
-  if (fan == MITSUBISHI_HEAVY_ZMP_FAN_AUTO) {
-    this->fan_mode = climate::CLIMATE_FAN_AUTO;
-  } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN1) {
-    this->fan_mode = climate::CLIMATE_FAN_LOW;
-  } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN2) {
-    this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
-  } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN3) {
-    this->fan_mode = climate::CLIMATE_FAN_HIGH;
-  } else if (fan == MITSUBISHI_HEAVY_ZMP_HIPOWER) {
-    this->preset = climate::CLIMATE_PRESET_BOOST;
-  } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
-    this->preset = climate::CLIMATE_PRESET_ECO;
+    if (fan == MITSUBISHI_HEAVY_ZMP_FAN_AUTO) {
+      this->fan_mode = climate::CLIMATE_FAN_AUTO;
+    } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN1) {
+      this->fan_mode = climate::CLIMATE_FAN_LOW;
+    } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN2) {
+      this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+    } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN3) {
+      this->fan_mode = climate::CLIMATE_FAN_HIGH;
+    } else if (fan == MITSUBISHI_HEAVY_ZMP_HIPOWER) {
+      this->preset = climate::CLIMATE_PRESET_BOOST;
+    } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
+      this->preset = climate::CLIMATE_PRESET_ECO;
+    }
+
+    uint8_t swing_v = (frame[5] & 0x02) | (frame[7] & 0x18);
+    this->swing_mode = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING) ? climate::CLIMATE_SWING_VERTICAL
+                                                                   : climate::CLIMATE_SWING_OFF;
   }
-
-  uint8_t swing_v = (frame[5] & 0x02) | (frame[7] & 0x18);
-
-  if (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING)
-    this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
-  else
-    this->swing_mode = climate::CLIMATE_SWING_OFF;
 
   this->publish_state();
   return true;

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -313,7 +313,6 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   this->target_temperature = 17 + ((~temp_nibble) & 0x0F);
 
   uint8_t fan = frame[7] & 0xE0;
-  bool is_zmp = (this->protocol_ == PROTOCOL_MITSUBISHI_HEAVY_ZMP);
 
   if (fan == MITSUBISHI_HEAVY_ZJ_FAN_AUTO) {
     this->fan_mode = climate::CLIMATE_FAN_AUTO;
@@ -327,17 +326,19 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   } else if (fan == MITSUBISHI_HEAVY_ZJ_FAN3) {
     this->fan_mode = climate::CLIMATE_FAN_HIGH;
     this->preset = climate::CLIMATE_PRESET_NONE;
-  } else if (fan == (is_zmp ? 0x20 : 0x40)) {
-    this->preset = climate::CLIMATE_PRESET_BOOST;
-  } else if (fan == MITSUBISHI_HEAVY_ZJ_ECONO) {
-    this->preset = climate::CLIMATE_PRESET_ECO;
+  } else if (this->protocol_ == PROTOCOL_MITSUBISHI_HEAVY_ZMP) {
+    if (fan == MITSUBISHI_HEAVY_ZMP_HIPOWER) {
+      this->preset = climate::CLIMATE_PRESET_BOOST;
+    } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
+      this->preset = climate::CLIMATE_PRESET_ECO;
+    }
+  } else {
+    if (fan == MITSUBISHI_HEAVY_ZJ_HIPOWER) {
+      this->preset = climate::CLIMATE_PRESET_BOOST;
+    } else if (fan == MITSUBISHI_HEAVY_ZJ_ECONO) {
+      this->preset = climate::CLIMATE_PRESET_ECO;
+    }
   }
-
-  uint8_t swing_h = frame[5] & 0xDC;
-  uint8_t swing_v = (frame[5] & 0x02) | (frame[7] & 0x18);
-
-  bool h_swing = (swing_h == 0x4C) || (swing_h == 0x5C);
-  bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZJ_VS_SWING);
 
   if (h_swing && v_swing) {
     this->swing_mode = climate::CLIMATE_SWING_BOTH;

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -280,97 +280,100 @@ static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK7 = 0x18;
 static const uint8_t MITSUBISHI_HEAVY_CHECKSUM_BYTE = 0xFF;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
-
-  uint8_t frame[11] = {};
-
-  if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE))
-    return false;
-
-  for (uint8_t pos = 0; pos < 11; pos++) {
-    uint8_t byte = 0;
-    for (int8_t bit = 0; bit < 8; bit++) {
-      if (data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ONE_SPACE)) {
-        byte |= 1 << bit;
-      } else if (!data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ZERO_SPACE)) {
-        return false;
-      }
-    }
-    frame[pos] = byte;
-
-    if (pos < 5 && byte != MITSUBISHI_HEAVY_FRAME_PREFIX[pos])
-      return false;
-  }
-
-  if ((uint8_t) (frame[5] ^ frame[6]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
-      (uint8_t) (frame[7] ^ frame[8]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
-      (uint8_t) (frame[9] ^ frame[10]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE) {
-    return false;
-  }
-
-  // Shared: operating mode
-  if (frame[9] & MITSUBISHI_HEAVY_MODE_OFF) {
-    this->mode = climate::CLIMATE_MODE_OFF;
-  } else {
-    switch (frame[9] & MITSUBISHI_HEAVY_MODE_MASK) {
-      case MITSUBISHI_HEAVY_MODE_AUTO:
-        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-        break;
-      case MITSUBISHI_HEAVY_MODE_HEAT:
-        this->mode = climate::CLIMATE_MODE_HEAT;
-        break;
-      case MITSUBISHI_HEAVY_MODE_COOL:
-        this->mode = climate::CLIMATE_MODE_COOL;
-        break;
-      case MITSUBISHI_HEAVY_MODE_DRY:
-        this->mode = climate::CLIMATE_MODE_DRY;
-        break;
-      case MITSUBISHI_HEAVY_MODE_FAN:
-        this->mode = climate::CLIMATE_MODE_FAN_ONLY;
-        break;
-      default:
-        return false;
-    }
-  }
-
-  this->target_temperature = 17 + ((~(frame[9] >> 4)) & MITSUBISHI_HEAVY_TEMP_MASK);
-
-  // Protocol-specific: fan, presets, and swing
   switch (this->protocol_) {
-    case PROTOCOL_MITSUBISHI_HEAVY_ZMP: {
-      uint8_t fan = frame[7] & MITSUBISHI_HEAVY_FAN_MASK;
-      if (fan == MITSUBISHI_HEAVY_ZMP_FAN_AUTO) {
-        this->fan_mode = climate::CLIMATE_FAN_AUTO;
-        this->preset = climate::CLIMATE_PRESET_NONE;
-      } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN1) {
-        this->fan_mode = climate::CLIMATE_FAN_LOW;
-        this->preset = climate::CLIMATE_PRESET_NONE;
-      } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN2) {
-        this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
-        this->preset = climate::CLIMATE_PRESET_NONE;
-      } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN3) {
-        this->fan_mode = climate::CLIMATE_FAN_HIGH;
-        this->preset = climate::CLIMATE_PRESET_NONE;
-      } else if (fan == MITSUBISHI_HEAVY_ZMP_HIPOWER) {
-        this->preset = climate::CLIMATE_PRESET_BOOST;
-      } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
-        this->preset = climate::CLIMATE_PRESET_ECO;
+    case PROTOCOL_MITSUBISHI_HEAVY_ZJ:
+    case PROTOCOL_MITSUBISHI_HEAVY_ZMP:
+    case PROTOCOL_MITSUBISHI_HEAVY_ZM: {
+      uint8_t frame[11] = {};
+
+      if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE))
+        return false;
+
+      for (uint8_t pos = 0; pos < 11; pos++) {
+        uint8_t byte = 0;
+        for (int8_t bit = 0; bit < 8; bit++) {
+          if (data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ONE_SPACE)) {
+            byte |= 1 << bit;
+          } else if (!data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ZERO_SPACE)) {
+            return false;
+          }
+        }
+        frame[pos] = byte;
+
+        if (pos < 5 && byte != MITSUBISHI_HEAVY_FRAME_PREFIX[pos])
+          return false;
       }
-      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_MASK = 0xDC;
-      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_SWING = 0x5C;
 
-      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_ZMP_HS_MASK;
-      uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
-      bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZMP_HS_SWING);
-      bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
+      if ((uint8_t) (frame[5] ^ frame[6]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
+          (uint8_t) (frame[7] ^ frame[8]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
+          (uint8_t) (frame[9] ^ frame[10]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE) {
+        return false;
+      }
 
-      if (h_swing && v_swing)
-        this->swing_mode = climate::CLIMATE_SWING_BOTH;
-      else if (h_swing)
-        this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
-      else if (v_swing)
-        this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
-      else
-        this->swing_mode = climate::CLIMATE_SWING_OFF;
+      if (frame[9] & MITSUBISHI_HEAVY_MODE_OFF) {
+        this->mode = climate::CLIMATE_MODE_OFF;
+      } else {
+        switch (frame[9] & MITSUBISHI_HEAVY_MODE_MASK) {
+          case MITSUBISHI_HEAVY_MODE_AUTO:
+            this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+            break;
+          case MITSUBISHI_HEAVY_MODE_HEAT:
+            this->mode = climate::CLIMATE_MODE_HEAT;
+            break;
+          case MITSUBISHI_HEAVY_MODE_COOL:
+            this->mode = climate::CLIMATE_MODE_COOL;
+            break;
+          case MITSUBISHI_HEAVY_MODE_DRY:
+            this->mode = climate::CLIMATE_MODE_DRY;
+            break;
+          case MITSUBISHI_HEAVY_MODE_FAN:
+            this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+            break;
+          default:
+            return false;
+        }
+      }
+
+      this->target_temperature = 17 + ((~(frame[9] >> 4)) & MITSUBISHI_HEAVY_TEMP_MASK);
+
+      // Protocol-specific fan, presets, and swing
+      if (this->protocol_ == PROTOCOL_MITSUBISHI_HEAVY_ZMP) {
+        uint8_t fan = frame[7] & MITSUBISHI_HEAVY_FAN_MASK;
+        if (fan == MITSUBISHI_HEAVY_ZMP_FAN_AUTO) {
+          this->fan_mode = climate::CLIMATE_FAN_AUTO;
+          this->preset = climate::CLIMATE_PRESET_NONE;
+        } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN1) {
+          this->fan_mode = climate::CLIMATE_FAN_LOW;
+          this->preset = climate::CLIMATE_PRESET_NONE;
+        } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN2) {
+          this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+          this->preset = climate::CLIMATE_PRESET_NONE;
+        } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN3) {
+          this->fan_mode = climate::CLIMATE_FAN_HIGH;
+          this->preset = climate::CLIMATE_PRESET_NONE;
+        } else if (fan == MITSUBISHI_HEAVY_ZMP_HIPOWER) {
+          this->preset = climate::CLIMATE_PRESET_BOOST;
+        } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
+          this->preset = climate::CLIMATE_PRESET_ECO;
+        }
+
+        static const uint8_t ZMP_HS_MASK = 0xDC;
+        static const uint8_t ZMP_HS_SWING = 0x5C;
+
+        uint8_t swing_h = frame[5] & ZMP_HS_MASK;
+        uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
+        bool h_swing = (swing_h == ZMP_HS_SWING);
+        bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
+
+        if (h_swing && v_swing)
+          this->swing_mode = climate::CLIMATE_SWING_BOTH;
+        else if (h_swing)
+          this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+        else if (v_swing)
+          this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+        else
+          this->swing_mode = climate::CLIMATE_SWING_OFF;
+      }
       break;
     }
     default:

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -280,60 +280,63 @@ static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK7 = 0x18;
 static const uint8_t MITSUBISHI_HEAVY_CHECKSUM_BYTE = 0xFF;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
+
+  uint8_t frame[11] = {};
+
+  if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE))
+    return false;
+
+  for (uint8_t pos = 0; pos < 11; pos++) {
+    uint8_t byte = 0;
+    for (int8_t bit = 0; bit < 8; bit++) {
+      if (data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ONE_SPACE)) {
+        byte |= 1 << bit;
+      } else if (!data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ZERO_SPACE)) {
+        return false;
+      }
+    }
+    frame[pos] = byte;
+
+    if (pos < 5 && byte != MITSUBISHI_HEAVY_FRAME_PREFIX[pos])
+      return false;
+  }
+
+  if ((uint8_t) (frame[5] ^ frame[6]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
+      (uint8_t) (frame[7] ^ frame[8]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
+      (uint8_t) (frame[9] ^ frame[10]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE) {
+    return false;
+  }
+
+  // Shared: operating mode
+  if (frame[9] & MITSUBISHI_HEAVY_MODE_OFF) {
+    this->mode = climate::CLIMATE_MODE_OFF;
+  } else {
+    switch (frame[9] & MITSUBISHI_HEAVY_MODE_MASK) {
+      case MITSUBISHI_HEAVY_MODE_AUTO:
+        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+        break;
+      case MITSUBISHI_HEAVY_MODE_HEAT:
+        this->mode = climate::CLIMATE_MODE_HEAT;
+        break;
+      case MITSUBISHI_HEAVY_MODE_COOL:
+        this->mode = climate::CLIMATE_MODE_COOL;
+        break;
+      case MITSUBISHI_HEAVY_MODE_DRY:
+        this->mode = climate::CLIMATE_MODE_DRY;
+        break;
+      case MITSUBISHI_HEAVY_MODE_FAN:
+        this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+        break;
+      default:
+        return false;
+    }
+  }
+
+  this->target_temperature = 17 + ((~(frame[9] >> 4)) & MITSUBISHI_HEAVY_TEMP_MASK);
+
+  // Protocol-specific: fan, presets, and swing
   switch (this->protocol_) {
     case PROTOCOL_MITSUBISHI_HEAVY_ZMP: {
-      uint8_t frame[11] = {};
-
-      if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE))
-        return false;
-
-      for (uint8_t pos = 0; pos < 11; pos++) {
-        uint8_t byte = 0;
-        for (int8_t bit = 0; bit < 8; bit++) {
-          if (data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ONE_SPACE)) {
-            byte |= 1 << bit;
-          } else if (!data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ZERO_SPACE)) {
-            return false;
-          }
-        }
-        frame[pos] = byte;
-
-        if (pos < 5 && byte != MITSUBISHI_HEAVY_FRAME_PREFIX[pos])
-          return false;
-      }
-
-      if ((uint8_t) (frame[5] ^ frame[6]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
-          (uint8_t) (frame[7] ^ frame[8]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE ||
-          (uint8_t) (frame[9] ^ frame[10]) != MITSUBISHI_HEAVY_CHECKSUM_BYTE) {
-        return false;
-      }
-
-      if (frame[9] & MITSUBISHI_HEAVY_MODE_OFF) {
-        this->mode = climate::CLIMATE_MODE_OFF;
-      } else {
-        switch (frame[9] & MITSUBISHI_HEAVY_MODE_MASK) {
-          case MITSUBISHI_HEAVY_MODE_AUTO:
-            this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-            break;
-          case MITSUBISHI_HEAVY_MODE_HEAT:
-            this->mode = climate::CLIMATE_MODE_HEAT;
-            break;
-          case MITSUBISHI_HEAVY_MODE_COOL:
-            this->mode = climate::CLIMATE_MODE_COOL;
-            break;
-          case MITSUBISHI_HEAVY_MODE_DRY:
-            this->mode = climate::CLIMATE_MODE_DRY;
-            break;
-          case MITSUBISHI_HEAVY_MODE_FAN:
-            this->mode = climate::CLIMATE_MODE_FAN_ONLY;
-            break;
-          default:
-            return false;
-        }
-      }
-
-      this->target_temperature = 17 + ((~(frame[9] >> 4)) & MITSUBISHI_HEAVY_TEMP_MASK);
-
       uint8_t fan = frame[7] & MITSUBISHI_HEAVY_FAN_MASK;
       if (fan == MITSUBISHI_HEAVY_ZMP_FAN_AUTO) {
         this->fan_mode = climate::CLIMATE_FAN_AUTO;
@@ -352,13 +355,12 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
+      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_MASK = 0xDC;
+      static const uint8_t MITSUBISHI_HEAVY_ZMP_HS_SWING = 0x5C;
 
-      static const uint8_t ZMP_HS_MASK = 0xDC;
-      static const uint8_t ZMP_HS_SWING = 0x5C;
-
-      uint8_t swing_h = frame[5] & ZMP_HS_MASK;
+      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_ZMP_HS_MASK;
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
-      bool h_swing = (swing_h == ZMP_HS_SWING);
+      bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZMP_HS_SWING);
       bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
 
       if (h_swing && v_swing)

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -263,15 +263,6 @@ static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_DRY = 0x05;
 static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_FAN = 0x04;
 static const uint8_t MITSUBISHI_HEAVY_ZJ_POWER_OFF = 0x08;
 
-static const uint8_t MITSUBISHI_HEAVY_ZJ_FAN_AUTO = 0xE0;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_FAN1 = 0xA0;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_FAN2 = 0x80;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_FAN3 = 0x60;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_HIPOWER = 0x40;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_ECONO = 0x00;
-
-static const uint8_t MITSUBISHI_HEAVY_ZJ_HS_SWING = 0x4C;
-static const uint8_t MITSUBISHI_HEAVY_ZJ_VS_SWING = 0x0A;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZJ)

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -243,6 +243,8 @@ void HeatpumpIRClimate::transmit_state() {
                      swing_h_cmd);
 }
 
+// ZJ/ZMP frame prefix bytes (not defined by library)
+static const uint8_t MITSUBISHI_HEAVY_FRAME_PREFIX[5] = {0x52, 0xAE, 0xC3, 0x26, 0xD9};
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   uint8_t frame[11] = {};
@@ -261,10 +263,8 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
     }
     frame[pos] = byte;
 
-    if ((pos == 0 && byte != 0x52) || (pos == 1 && byte != 0xAE) || (pos == 2 && byte != 0xC3) ||
-        (pos == 3 && byte != 0x26) || (pos == 4 && byte != 0xD9)) {
+    if (pos < 5 && byte != MITSUBISHI_HEAVY_FRAME_PREFIX[pos])
       return false;
-    }
   }
 
   if ((uint8_t) (frame[5] ^ frame[6]) != 0xFF || (uint8_t) (frame[7] ^ frame[8]) != 0xFF ||

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -253,9 +253,13 @@ static const uint8_t MITSUBISHI_HEAVY_FAN_MASK = 0xE0;
 static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK5 = 0x02;
 static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK7 = 0x18;
 static const uint8_t MITSUBISHI_HEAVY_CHECKSUM_BYTE = 0xFF;
-// ZMP horizontal swing not in library. Standard=0x4C, some remotes use 0x5C.
+// ZMP horizontal swing not in library. Standard=0x4C, some remotes use MITSUBISHI_HEAVY_HS_SWING_ALT.
 static const uint8_t MITSUBISHI_HEAVY_HS_SWING = 0x4C;
-static const uint8_t MITSUBISHI_HEAVY_HS_SWING_ALT = 0x5C;
+static const uint8_t MITSUBISHI_HEAVY_HS_SWING_ALT = MITSUBISHI_HEAVY_HS_SWING_ALT;
+static const uint8_t MITSUBISHI_HEAVY_HS_MASK = 0xDC;
+// ZMP horizontal swing not in library. Standard=0x4C, some remotes use MITSUBISHI_HEAVY_HS_SWING_ALT.
+static const uint8_t MITSUBISHI_HEAVY_HS_SWING = 0x4C;
+static const uint8_t MITSUBISHI_HEAVY_HS_SWING_ALT = MITSUBISHI_HEAVY_HS_SWING_ALT;
 static const uint8_t MITSUBISHI_HEAVY_HS_MASK = 0xDC;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
@@ -333,7 +337,7 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
-      uint8_t swing_h = frame[5] & 0xDC;
+      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_HS_MASK;
       uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_HS_MASK;
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
       bool h_swing = (swing_h == MITSUBISHI_HEAVY_HS_SWING) || (swing_h == MITSUBISHI_HEAVY_HS_SWING_ALT);

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -314,12 +314,16 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       uint8_t fan = frame[7] & MITSUBISHI_HEAVY_FAN_MASK;
       if (fan == MITSUBISHI_HEAVY_ZMP_FAN_AUTO) {
         this->fan_mode = climate::CLIMATE_FAN_AUTO;
+        this->preset = climate::CLIMATE_PRESET_NONE;
       } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN1) {
         this->fan_mode = climate::CLIMATE_FAN_LOW;
+        this->preset = climate::CLIMATE_PRESET_NONE;
       } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN2) {
         this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+        this->preset = climate::CLIMATE_PRESET_NONE;
       } else if (fan == MITSUBISHI_HEAVY_ZMP_FAN3) {
         this->fan_mode = climate::CLIMATE_FAN_HIGH;
+        this->preset = climate::CLIMATE_PRESET_NONE;
       } else if (fan == MITSUBISHI_HEAVY_ZMP_HIPOWER) {
         this->preset = climate::CLIMATE_PRESET_BOOST;
       } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -243,13 +243,6 @@ void HeatpumpIRClimate::transmit_state() {
                      swing_h_cmd);
 }
 
-static const uint8_t MITSUBISHI_HEAVY_ZMP_STATE_LENGTH = 11;
-
-static const uint8_t MITSUBISHI_HEAVY_ZMP_BYTE0 = 0x52;
-static const uint8_t MITSUBISHI_HEAVY_ZMP_BYTE1 = 0xAE;
-static const uint8_t MITSUBISHI_HEAVY_ZMP_BYTE2 = 0xC3;
-static const uint8_t MITSUBISHI_HEAVY_ZMP_BYTE3 = 0x26;
-static const uint8_t MITSUBISHI_HEAVY_ZMP_BYTE4 = 0xD9;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZMP)
@@ -260,7 +253,7 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (!data.expect_item(MITSUBISHI_HEAVY_HDR_MARK, MITSUBISHI_HEAVY_HDR_SPACE))
     return false;
 
-  for (uint8_t pos = 0; pos < MITSUBISHI_HEAVY_ZMP_STATE_LENGTH; pos++) {
+  for (uint8_t pos = 0; pos < 11; pos++) {
     uint8_t byte = 0;
     for (int8_t bit = 0; bit < 8; bit++) {
       if (data.expect_item(MITSUBISHI_HEAVY_BIT_MARK, MITSUBISHI_HEAVY_ONE_SPACE)) {
@@ -271,9 +264,9 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
     }
     frame[pos] = byte;
 
-    if ((pos == 0 && byte != MITSUBISHI_HEAVY_ZMP_BYTE0) || (pos == 1 && byte != MITSUBISHI_HEAVY_ZMP_BYTE1) ||
-        (pos == 2 && byte != MITSUBISHI_HEAVY_ZMP_BYTE2) || (pos == 3 && byte != MITSUBISHI_HEAVY_ZMP_BYTE3) ||
-        (pos == 4 && byte != MITSUBISHI_HEAVY_ZMP_BYTE4)) {
+    if ((pos == 0 && byte != 0x52) || (pos == 1 && byte != 0xAE) ||
+        (pos == 2 && byte != 0xC3) || (pos == 3 && byte != 0x26) ||
+        (pos == 4 && byte != 0xD9)) {
       return false;
     }
   }

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -249,8 +249,9 @@ static const uint8_t MITSUBISHI_HEAVY_FRAME_PREFIX[5] = {0x52, 0xAE, 0xC3, 0x26,
 static const uint8_t MITSUBISHI_HEAVY_MODE_MASK = 0x07;
 static const uint8_t MITSUBISHI_HEAVY_TEMP_MASK = 0x0F;
 static const uint8_t MITSUBISHI_HEAVY_FAN_MASK = 0xE0;
-static const uint8_t MITSUBISHI_HEAVY_SWING_V_LO = 0x02;
-static const uint8_t MITSUBISHI_HEAVY_SWING_V_HI = 0x18;
+// Vertical swing is split: bit 1 in frame[5], bits 4+3 in frame[7]
+static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK5 = 0x02;
+static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK7 = 0x18;
 static const uint8_t MITSUBISHI_HEAVY_CHECKSUM_BYTE = 0xFF;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
@@ -324,7 +325,7 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       } else if (fan == MITSUBISHI_HEAVY_ZMP_ECONO) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
-      uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_LO) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_HI);
+      uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
       this->swing_mode = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING) ? climate::CLIMATE_SWING_VERTICAL
                                                                      : climate::CLIMATE_SWING_OFF;
       break;

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -331,12 +331,11 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
       }
       // ZMP horizontal swing constants (not defined in library)
       static const uint8_t HS_MASK = 0xDC;
-      static const uint8_t HS_SWING = 0x4C;
-      static const uint8_t HS_SWING_ALT = 0x5C;
+      static const uint8_t HS_SWING = 0x5C;
 
       uint8_t swing_h = frame[5] & HS_MASK;
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
-      bool h_swing = (swing_h == HS_SWING) || (swing_h == HS_SWING_ALT);
+      bool h_swing = (swing_h == HS_SWING);
       bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
 
       if (h_swing && v_swing)

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -263,7 +263,6 @@ static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_DRY = 0x05;
 static const uint8_t MITSUBISHI_HEAVY_ZJ_MODE_FAN = 0x04;
 static const uint8_t MITSUBISHI_HEAVY_ZJ_POWER_OFF = 0x08;
 
-
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (this->protocol_ != PROTOCOL_MITSUBISHI_HEAVY_ZJ)
     return false;

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -253,6 +253,10 @@ static const uint8_t MITSUBISHI_HEAVY_FAN_MASK = 0xE0;
 static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK5 = 0x02;
 static const uint8_t MITSUBISHI_HEAVY_SWING_V_MASK7 = 0x18;
 static const uint8_t MITSUBISHI_HEAVY_CHECKSUM_BYTE = 0xFF;
+// ZMP horizontal swing not in library. Standard=0x4C, some remotes use 0x5C.
+static const uint8_t MITSUBISHI_HEAVY_HS_SWING = 0x4C;
+static const uint8_t MITSUBISHI_HEAVY_HS_SWING_ALT = 0x5C;
+static const uint8_t MITSUBISHI_HEAVY_HS_MASK = 0xDC;
 
 bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
   uint8_t frame[11] = {};
@@ -330,9 +334,9 @@ bool HeatpumpIRClimate::on_receive(remote_base::RemoteReceiveData data) {
         this->preset = climate::CLIMATE_PRESET_ECO;
       }
       uint8_t swing_h = frame[5] & 0xDC;
-      uint8_t swing_h = frame[5] & 0xDC;
+      uint8_t swing_h = frame[5] & MITSUBISHI_HEAVY_HS_MASK;
       uint8_t swing_v = (frame[5] & MITSUBISHI_HEAVY_SWING_V_MASK5) | (frame[7] & MITSUBISHI_HEAVY_SWING_V_MASK7);
-      bool h_swing = (swing_h == MITSUBISHI_HEAVY_ZJ_HS_SWING) || (swing_h == 0x5C);
+      bool h_swing = (swing_h == MITSUBISHI_HEAVY_HS_SWING) || (swing_h == MITSUBISHI_HEAVY_HS_SWING_ALT);
       bool v_swing = (swing_v == MITSUBISHI_HEAVY_ZMP_VS_SWING);
 
       if (h_swing && v_swing)

--- a/esphome/components/heatpumpir/heatpumpir.h
+++ b/esphome/components/heatpumpir/heatpumpir.h
@@ -117,6 +117,8 @@ class HeatpumpIRClimate : public climate_ir::ClimateIR {
   HeatpumpIR *heatpump_ir_;
   /// Transmit via IR the state of this climate controller.
   void transmit_state() override;
+  /// Handle received IR data from the remote control.
+  bool on_receive(remote_base::RemoteReceiveData data) override;
   Protocol protocol_;
   HorizontalDirection default_horizontal_direction_;
   VerticalDirection default_vertical_direction_;


### PR DESCRIPTION
# What does this implement/fix?

Adds IR receiver support for Mitsubishi Heavy ZJ protocol to the heatpumpir component, allowing the climate state to sync when the physical remote control is used.

## Changes
- Decodes 88-bit ZJ IR frames in `on_receive()`
- Validates header bytes (0x52,0xAE,0xC3,0x26,0xD9) and inverted byte pairs
- Syncs: power, mode (auto/heat/cool/dry/fan), temperature, fan speed, presets (eco/boost), swing modes
- Other protocols return false (not attempted)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

**Related issue or feature (if applicable):**

- none

**Pull request in esphome.io with documentation (if applicable):**

- esphome/esphome.io#6753

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for config.yaml:

```yaml
remote_receiver:
  id: rcvr
  pin:
    number: GPIOXX
    inverted: true
    mode:
      input: true
      pullup: true
  tolerance: 55%

climate:
  - platform: heatpumpir
    protocol: mitsubishi_heavy_zj
    name: Heat Pump
    receiver_id: rcvr
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under tests/ folder).

