### PR TITLE
[mipi_spi] add WAVESHARE-ESP32-S3-TOUCH-AMOLED-2.16

### DIFF
--- a/esphome/components/mipi_spi/models/waveshare.py
+++ b/esphome/components/mipi_spi/models/waveshare.py
@@ -177,6 +177,20 @@ CO5300.extend(
     reset_pin=39,
 )
 
+# Waveshare ESP32-S3 Touch AMOLED 2.16" (CO5300 controller)
+# Pin assignments are the same as the 1.75" devkit: CS=12, RESET=39. Width/height set to 480x480.
+CO5300.extend(
+    "WAVESHARE-ESP32-S3-TOUCH-AMOLED-2.16",
+    width=480,
+    height=480,
+    pixel_mode="16bit",
+    offset_height=0,
+    offset_width=0,
+    cs_pin=12,
+    reset_pin=39,
+    data_rate="40MHz",
+)
+
 AXS15231.extend(
     "WAVESHARE-ESP32-S3-TOUCH-LCD-3.49",
     width=172,


### PR DESCRIPTION
# What does this implement/fix?

Add a new display to `mipi_spi`.


<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6759

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
