### PR TITLE
[espidf] Warn when the install path is too long for Windows MAX_PATH

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -85,14 +85,20 @@ def _get_idf_tools_path() -> Path:
     return CORE.data_dir / "idf"
 
 
-# Windows' default MAX_PATH is 260 characters. ESP-IDF toolchains contain very
-# deeply nested files -- the longest (picolibc C++ headers) runs ~209 characters
-# below the IDF tools directory. If that directory's own path is long, those
-# files exceed the limit and the toolchain extracts only partially (e.g. the
-# assembler goes missing), which later surfaces as a cryptic "cannot execute
-# 'as'" build failure. Warn up front so the user can pick a shorter path.
+# Windows' default MAX_PATH is 260 characters. ESP-IDF toolchains nest deeply
+# below the IDF tools directory: the longest file on disk (picolibc C++
+# headers) sits ~209 characters down, but the operative number is worse -- gcc
+# probes its multilib include dirs via un-normalized self-relative paths
+# ("bin/../lib/gcc/<target>/<ver>/../../../../<target>/include/..."), and
+# Windows checks the path string as given, before collapsing "..". Measured
+# worst case (riscv32, esp-15.2.0, longest multilib + no-rtti, probing
+# bits/c++config.h): ~243 characters below the tools directory. Exceeding the
+# limit surfaces as cryptic build failures -- missing headers ("fatal error:
+# bits/c++config.h: No such file or directory") or partial extraction
+# ("cannot execute 'as'"). Warn up front so the user can shorten the path or
+# enable long path support.
 _WINDOWS_MAX_PATH = 260
-_TOOLCHAIN_NESTED_PATH_LEN = 210
+_TOOLCHAIN_NESTED_PATH_LEN = 245
 
 
 def _windows_long_paths_enabled() -> bool:
@@ -125,11 +131,15 @@ def _check_windows_path_length() -> None:
         return
     _LOGGER.warning(
         "ESPHome install path is %d characters long (%s). ESP-IDF toolchain "
-        "files nest up to ~%d characters deeper, exceeding the Windows %d-"
-        "character path limit (projected ~%d). The toolchain may extract "
-        "incompletely and cause build errors such as \"cannot execute 'as'\". "
-        "Move your ESPHome project to a shorter path (e.g. C:\\esphome) or "
-        "enable Windows long path support.",
+        "paths reach up to ~%d characters deeper (including the compiler's "
+        "internal 'bin/../lib/...' relative paths), exceeding the Windows "
+        "%d-character path limit (projected ~%d). This causes cryptic build "
+        'failures such as "fatal error: bits/c++config.h: No such file or '
+        'directory" or "cannot execute \'as\'". Enable Windows long path '
+        "support (set HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem\\"
+        "LongPathsEnabled to 1 and reboot), or move your ESPHome project to "
+        "a shorter path. After fixing, delete the .esphome\\idf directory so "
+        "the toolchain reinstalls cleanly.",
         len(tools_path),
         tools_path,
         _TOOLCHAIN_NESTED_PATH_LEN,

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -98,6 +98,7 @@ def _get_idf_tools_path() -> Path:
 # ("cannot execute 'as'"). Warn up front so the user can shorten the path or
 # enable long path support.
 _WINDOWS_MAX_PATH = 260
+# Measured 243 plus a small safety margin for future toolchain growth.
 _TOOLCHAIN_NESTED_PATH_LEN = 245
 
 
@@ -130,7 +131,7 @@ def _check_windows_path_length() -> None:
     if projected <= _WINDOWS_MAX_PATH:
         return
     _LOGGER.warning(
-        "ESPHome install path is too long for the default Windows path limit:\n"
+        "ESP-IDF tools path is too long for the default Windows path limit:\n"
         "  %s (%d characters)\n"
         "ESP-IDF toolchain paths reach up to ~%d characters deeper (including the\n"
         "compiler's internal 'bin/../lib/...' relative paths), projecting to ~%d\n"
@@ -143,8 +144,8 @@ def _check_windows_path_length() -> None:
         "    HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem\\LongPathsEnabled\n"
         "    to 1 and reboot, or\n"
         "  - Move your ESPHome project to a shorter path\n"
-        "Then delete the .esphome\\idf directory so the toolchain reinstalls "
-        "cleanly.",
+        "Then delete the ESP-IDF tools directory above so the toolchain "
+        "reinstalls cleanly.",
         tools_path,
         len(tools_path),
         _TOOLCHAIN_NESTED_PATH_LEN,

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -85,6 +85,59 @@ def _get_idf_tools_path() -> Path:
     return CORE.data_dir / "idf"
 
 
+# Windows' default MAX_PATH is 260 characters. ESP-IDF toolchains contain very
+# deeply nested files -- the longest (picolibc C++ headers) runs ~209 characters
+# below the IDF tools directory. If that directory's own path is long, those
+# files exceed the limit and the toolchain extracts only partially (e.g. the
+# assembler goes missing), which later surfaces as a cryptic "cannot execute
+# 'as'" build failure. Warn up front so the user can pick a shorter path.
+_WINDOWS_MAX_PATH = 260
+_TOOLCHAIN_NESTED_PATH_LEN = 210
+
+
+def _windows_long_paths_enabled() -> bool:
+    """Return True if Windows long path support is enabled in the registry."""
+    try:
+        import winreg  # pylint: disable=import-error  # Windows-only module
+
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SYSTEM\CurrentControlSet\Control\FileSystem",
+        ) as key:
+            value, _ = winreg.QueryValueEx(key, "LongPathsEnabled")
+            return value == 1
+    except OSError:
+        return False
+
+
+def _check_windows_path_length() -> None:
+    """Warn when the install path is too long for Windows' MAX_PATH limit.
+
+    No-op off Windows or when long path support is enabled. Otherwise warns if
+    the deepest toolchain file would exceed the 260-character limit, which makes
+    ESP-IDF toolchains extract incompletely and fail to build.
+    """
+    if platform.system() != "Windows" or _windows_long_paths_enabled():
+        return
+    tools_path = str(_get_idf_tools_path())
+    projected = len(tools_path) + _TOOLCHAIN_NESTED_PATH_LEN
+    if projected <= _WINDOWS_MAX_PATH:
+        return
+    _LOGGER.warning(
+        "ESPHome install path is %d characters long (%s). ESP-IDF toolchain "
+        "files nest up to ~%d characters deeper, exceeding the Windows %d-"
+        "character path limit (projected ~%d). The toolchain may extract "
+        "incompletely and cause build errors such as \"cannot execute 'as'\". "
+        "Move your ESPHome project to a shorter path (e.g. C:\\esphome) or "
+        "enable Windows long path support.",
+        len(tools_path),
+        tools_path,
+        _TOOLCHAIN_NESTED_PATH_LEN,
+        _WINDOWS_MAX_PATH,
+        projected,
+    )
+
+
 def _get_framework_path(version: str) -> Path:
     """
     Get the path to the ESPHome ESP-IDF framework directory for a specific version.
@@ -705,6 +758,8 @@ def check_esp_idf_install(
     Returns:
         tuple of (framework_path, python_env_path)
     """
+    _check_windows_path_length()
+
     env = {}
     env["IDF_TOOLS_PATH"] = str(_get_idf_tools_path())
     env["IDF_PATH"] = ""

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -130,21 +130,26 @@ def _check_windows_path_length() -> None:
     if projected <= _WINDOWS_MAX_PATH:
         return
     _LOGGER.warning(
-        "ESPHome install path is %d characters long (%s). ESP-IDF toolchain "
-        "paths reach up to ~%d characters deeper (including the compiler's "
-        "internal 'bin/../lib/...' relative paths), exceeding the Windows "
-        "%d-character path limit (projected ~%d). This causes cryptic build "
-        'failures such as "fatal error: bits/c++config.h: No such file or '
-        'directory" or "cannot execute \'as\'". Enable Windows long path '
-        "support (set HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem\\"
-        "LongPathsEnabled to 1 and reboot), or move your ESPHome project to "
-        "a shorter path. After fixing, delete the .esphome\\idf directory so "
-        "the toolchain reinstalls cleanly.",
-        len(tools_path),
+        "ESPHome install path is too long for the default Windows path limit:\n"
+        "  %s (%d characters)\n"
+        "ESP-IDF toolchain paths reach up to ~%d characters deeper (including the\n"
+        "compiler's internal 'bin/../lib/...' relative paths), projecting to ~%d\n"
+        "characters -- over the %d-character limit. This causes cryptic build\n"
+        "failures such as:\n"
+        "  fatal error: bits/c++config.h: No such file or directory\n"
+        "  cannot execute 'as': CreateProcess: No such file or directory\n"
+        "To fix, either:\n"
+        "  - Enable Windows long path support: set\n"
+        "    HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem\\LongPathsEnabled\n"
+        "    to 1 and reboot, or\n"
+        "  - Move your ESPHome project to a shorter path\n"
+        "Then delete the .esphome\\idf directory so the toolchain reinstalls "
+        "cleanly.",
         tools_path,
+        len(tools_path),
         _TOOLCHAIN_NESTED_PATH_LEN,
-        _WINDOWS_MAX_PATH,
         projected,
+        _WINDOWS_MAX_PATH,
     )
 
 

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -140,71 +140,6 @@ def _get_idf_tool(name: str) -> str:
     return executable
 
 
-# Child programs the gcc driver spawns (assembler, compiler proper). These live
-# in nested toolchain directories (<target>/bin/as, libexec/gcc/.../cc1) that
-# ESP-IDF's own ``idf_tools.py check`` does NOT verify -- it only confirms the
-# top-level tool directory exists. Antivirus on Windows routinely quarantines
-# these inner binaries after install, which then surfaces as a cryptic
-# "cannot execute 'as'" failure deep inside cmake's compiler check.
-_TOOLCHAIN_CHILD_PROGRAMS: tuple[str, ...] = ("as", "cc1", "cc1plus")
-
-
-def _verify_toolchain_integrity() -> None:
-    """Verify each cross-compiler's child programs (as, cc1, cc1plus) exist.
-
-    gcc resolves these relative to its own location; ``-print-prog-name`` echoes
-    a full path when the program is found and the bare name when it is not. A
-    bare name therefore means the binary is missing -- almost always antivirus
-    quarantine on Windows. Raise with actionable guidance rather than letting it
-    fail cryptically inside cmake.
-    """
-    env = _get_idf_env()
-
-    # One bare gcc driver per toolchain bin dir is enough: arch variants
-    # (xtensa-esp32s3-elf-gcc, ...) share the same lib/libexec tree.
-    drivers: dict[Path, Path] = {}
-    for entry in env.get("PATH", "").split(os.pathsep):
-        bin_dir = Path(entry)
-        if not bin_dir.is_dir():
-            continue
-        for gcc in sorted(bin_dir.glob("*-elf-gcc*")):
-            if gcc.stem.endswith("-elf-gcc"):  # skip gcc-ar/-nm/-ranlib/-<ver>
-                drivers.setdefault(bin_dir, gcc)
-                break
-
-    missing: list[str] = []
-    for gcc in drivers.values():
-        for prog in _TOOLCHAIN_CHILD_PROGRAMS:
-            result = subprocess.run(
-                [str(gcc), f"-print-prog-name={prog}"],
-                env=env,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            resolved = result.stdout.strip()
-            if os.sep not in resolved:  # bare name -> gcc could not find it
-                missing.append(f"{prog} (for {gcc.name})")
-
-    if not missing:
-        return
-
-    listing = "\n  ".join(missing)
-    hint = ""
-    if os.name == "nt":
-        hint = (
-            "\n\nOn Windows this is almost always antivirus quarantining "
-            "toolchain files after installation. Add an exclusion for your "
-            "ESPHome project folder (the one containing the .esphome directory) "
-            "under Windows Security > Virus & threat protection > Exclusions, "
-            "delete the .esphome\\idf folder, then recompile."
-        )
-    raise EsphomeError(
-        "The ESP-IDF toolchain is incomplete -- gcc cannot find these required "
-        f"programs:\n  {listing}{hint}"
-    )
-
-
 def run_idf_py(
     *args, cwd: Path | None = None, capture_output: bool = False
 ) -> int | str:
@@ -390,10 +325,6 @@ def run_compile(config, verbose: bool) -> int:
 
     # Check if we need to do discovery phase
     if need_reconfigure():
-        # Fail fast with a clear message if the toolchain is incomplete (e.g.
-        # antivirus quarantined the assembler) rather than letting cmake's
-        # compiler check fail cryptically with "cannot execute 'as'".
-        _verify_toolchain_integrity()
         _LOGGER.info("Discovering available ESP-IDF components...")
         write_project(minimal=True)
         rc = run_reconfigure()

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -140,6 +140,71 @@ def _get_idf_tool(name: str) -> str:
     return executable
 
 
+# Child programs the gcc driver spawns (assembler, compiler proper). These live
+# in nested toolchain directories (<target>/bin/as, libexec/gcc/.../cc1) that
+# ESP-IDF's own ``idf_tools.py check`` does NOT verify -- it only confirms the
+# top-level tool directory exists. Antivirus on Windows routinely quarantines
+# these inner binaries after install, which then surfaces as a cryptic
+# "cannot execute 'as'" failure deep inside cmake's compiler check.
+_TOOLCHAIN_CHILD_PROGRAMS: tuple[str, ...] = ("as", "cc1", "cc1plus")
+
+
+def _verify_toolchain_integrity() -> None:
+    """Verify each cross-compiler's child programs (as, cc1, cc1plus) exist.
+
+    gcc resolves these relative to its own location; ``-print-prog-name`` echoes
+    a full path when the program is found and the bare name when it is not. A
+    bare name therefore means the binary is missing -- almost always antivirus
+    quarantine on Windows. Raise with actionable guidance rather than letting it
+    fail cryptically inside cmake.
+    """
+    env = _get_idf_env()
+
+    # One bare gcc driver per toolchain bin dir is enough: arch variants
+    # (xtensa-esp32s3-elf-gcc, ...) share the same lib/libexec tree.
+    drivers: dict[Path, Path] = {}
+    for entry in env.get("PATH", "").split(os.pathsep):
+        bin_dir = Path(entry)
+        if not bin_dir.is_dir():
+            continue
+        for gcc in sorted(bin_dir.glob("*-elf-gcc*")):
+            if gcc.stem.endswith("-elf-gcc"):  # skip gcc-ar/-nm/-ranlib/-<ver>
+                drivers.setdefault(bin_dir, gcc)
+                break
+
+    missing: list[str] = []
+    for gcc in drivers.values():
+        for prog in _TOOLCHAIN_CHILD_PROGRAMS:
+            result = subprocess.run(
+                [str(gcc), f"-print-prog-name={prog}"],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            resolved = result.stdout.strip()
+            if os.sep not in resolved:  # bare name -> gcc could not find it
+                missing.append(f"{prog} (for {gcc.name})")
+
+    if not missing:
+        return
+
+    listing = "\n  ".join(missing)
+    hint = ""
+    if os.name == "nt":
+        hint = (
+            "\n\nOn Windows this is almost always antivirus quarantining "
+            "toolchain files after installation. Add an exclusion for your "
+            "ESPHome project folder (the one containing the .esphome directory) "
+            "under Windows Security > Virus & threat protection > Exclusions, "
+            "delete the .esphome\\idf folder, then recompile."
+        )
+    raise EsphomeError(
+        "The ESP-IDF toolchain is incomplete -- gcc cannot find these required "
+        f"programs:\n  {listing}{hint}"
+    )
+
+
 def run_idf_py(
     *args, cwd: Path | None = None, capture_output: bool = False
 ) -> int | str:
@@ -325,6 +390,10 @@ def run_compile(config, verbose: bool) -> int:
 
     # Check if we need to do discovery phase
     if need_reconfigure():
+        # Fail fast with a clear message if the toolchain is incomplete (e.g.
+        # antivirus quarantined the assembler) rather than letting cmake's
+        # compiler check fail cryptically with "cannot execute 'as'".
+        _verify_toolchain_integrity()
         _LOGGER.info("Discovering available ESP-IDF components...")
         write_project(minimal=True)
         rc = run_reconfigure()

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -2,9 +2,12 @@
 
 # pylint: disable=protected-access
 
+from contextlib import contextmanager
 import io
 import json
+import logging
 from pathlib import Path
+import sys
 import tarfile
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -13,6 +16,7 @@ import pytest
 
 from esphome.espidf.framework import (
     _check_stamp,
+    _check_windows_path_length,
     _clone_idf_with_submodules,
     _get_framework_path,
     _get_idf_tool_paths,
@@ -22,6 +26,7 @@ from esphome.espidf.framework import (
     _get_python_version,
     _parse_git_source,
     _patch_tools_json_for_linux_arm64,
+    _windows_long_paths_enabled,
     _write_idf_version_txt,
     _write_stamp,
     check_esp_idf_install,
@@ -682,3 +687,116 @@ def test_write_idf_version_txt_warns_on_write_error(tmp_path: Path) -> None:
     with patch("pathlib.Path.write_text", side_effect=OSError("denied")):
         # write failure is caught and warned, not raised
         _write_idf_version_txt(tmp_path, "5.1.2")
+
+
+def _fake_winreg(
+    query_result: int | None = None, query_error: OSError | None = None
+) -> SimpleNamespace:
+    """Build a minimal winreg stand-in (the real module is Windows-only)."""
+
+    @contextmanager
+    def open_key(root, path):
+        yield "hkey"
+
+    def query_value_ex(key, name):
+        if query_error is not None:
+            raise query_error
+        return query_result, 4  # (value, REG_DWORD)
+
+    return SimpleNamespace(
+        HKEY_LOCAL_MACHINE=object(),
+        OpenKey=open_key,
+        QueryValueEx=query_value_ex,
+    )
+
+
+@pytest.mark.parametrize(("reg_value", "expected"), [(1, True), (0, False)])
+def test_windows_long_paths_enabled_reads_registry(
+    reg_value: int, expected: bool
+) -> None:
+    with patch.dict(sys.modules, {"winreg": _fake_winreg(query_result=reg_value)}):
+        assert _windows_long_paths_enabled() is expected
+
+
+def test_windows_long_paths_enabled_missing_value() -> None:
+    """A missing registry value (FileNotFoundError is an OSError) reads as disabled."""
+    fake = _fake_winreg(query_error=FileNotFoundError("no such value"))
+    with patch.dict(sys.modules, {"winreg": fake}):
+        assert _windows_long_paths_enabled() is False
+
+
+# 8 chars -> projected well under the 260 limit even with the ~245-char reserve
+_SHORT_IDF_PATH = "C:\\e\\idf"
+# 25 chars -> projected over the limit
+_LONG_IDF_PATH = "C:\\Users\\bob\\.esphome\\idf"
+
+
+def test_check_windows_path_length_noop_off_windows(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Off Windows the check returns before touching the registry or the path."""
+    with (
+        patch("esphome.espidf.framework.platform.system", return_value="Linux"),
+        patch(
+            "esphome.espidf.framework._windows_long_paths_enabled"
+        ) as long_paths_mock,
+        caplog.at_level(logging.WARNING),
+    ):
+        _check_windows_path_length()
+    long_paths_mock.assert_not_called()
+    assert not caplog.records
+
+
+def test_check_windows_path_length_noop_when_long_paths_enabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with (
+        patch("esphome.espidf.framework.platform.system", return_value="Windows"),
+        patch(
+            "esphome.espidf.framework._windows_long_paths_enabled", return_value=True
+        ),
+        patch("esphome.espidf.framework._get_idf_tools_path") as get_path_mock,
+        caplog.at_level(logging.WARNING),
+    ):
+        _check_windows_path_length()
+    get_path_mock.assert_not_called()
+    assert not caplog.records
+
+
+def test_check_windows_path_length_short_path_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with (
+        patch("esphome.espidf.framework.platform.system", return_value="Windows"),
+        patch(
+            "esphome.espidf.framework._windows_long_paths_enabled", return_value=False
+        ),
+        patch(
+            "esphome.espidf.framework._get_idf_tools_path",
+            return_value=_SHORT_IDF_PATH,
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        _check_windows_path_length()
+    assert not caplog.records
+
+
+def test_check_windows_path_length_long_path_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with (
+        patch("esphome.espidf.framework.platform.system", return_value="Windows"),
+        patch(
+            "esphome.espidf.framework._windows_long_paths_enabled", return_value=False
+        ),
+        patch(
+            "esphome.espidf.framework._get_idf_tools_path",
+            return_value=_LONG_IDF_PATH,
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        _check_windows_path_length()
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert _LONG_IDF_PATH in message
+    assert "long path support" in message


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF builds on Windows fail with cryptic errors when the ESPHome install path is too long, e.g. `fatal error: bits/c++config.h: No such file or directory` or `cannot execute 'as': CreateProcess: No such file or directory`.

The toolchain nests files deeply below the IDF tools directory, and gcc probes its multilib include dirs with un-normalized self-relative paths (`bin/../lib/gcc/<target>/<ver>/../../../../...`). Windows checks the path string as given, before collapsing the `..` segments, against the 260-character MAX_PATH limit. The measured worst case (riscv32, esp-15.2.0) is ~243 characters below the tools directory, so even fairly short install paths can exceed the limit — install paths of 37 and 53 characters both failed in the wild.

This adds a warning at install time when the projected path length would exceed the limit, recommending enabling Windows long path support or moving the project to a shorter path, and deleting `.esphome/idf` afterwards so the toolchain reinstalls cleanly. No-op on other platforms and when long path support is already enabled.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Other

**Related issue or feature (if applicable):**

- N/A (reported on Discord)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: esp32-c6-devkitc-1
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
