### PR TITLE
[esp32] Install GPIO ISR service at default (lowest) priority

### DIFF
--- a/esphome/components/esp32/gpio.cpp
+++ b/esphome/components/esp32/gpio.cpp
@@ -87,7 +87,13 @@ void ESP32InternalGPIOPin::attach_interrupt(void (*func)(void *), void *arg, gpi
   gpio_set_intr_type(this->get_pin_num(), idf_type);
   gpio_intr_enable(this->get_pin_num());
   if (!isr_service_installed) {
-    auto res = gpio_install_isr_service(ESP_INTR_FLAG_LEVEL3);
+    // Install the shared GPIO ISR at the default (lowest) priority, matching the ESP-IDF driver
+    // default. The dispatched per-pin handlers may wake the main loop via vTaskNotifyGiveFromISR(),
+    // which takes the FreeRTOS kernel spinlock. A higher-priority (e.g. level 3) GPIO ISR can
+    // preempt a lower-priority driver ISR/critical section that already holds that lock and then
+    // spin on it forever -> Interrupt WDT reboot (see issue #16886, RMT + pcf8574 interrupt).
+    // At the lowest level the GPIO ISR cannot preempt another lock holder on the core.
+    auto res = gpio_install_isr_service(0);
     if (res != ESP_OK) {
       ESP_LOGE(TAG, "attach_interrupt(): call to gpio_install_isr_service() failed, error code: %d", res);
       return;


### PR DESCRIPTION
# What does this implement/fix?

The shared GPIO ISR service is installed with `ESP_INTR_FLAG_LEVEL3`. Since the per-pin handlers can now wake the main loop from ISR context via `vTaskNotifyGiveFromISR()` (which acquires the FreeRTOS kernel spinlock), running them at level 3 creates a priority-inversion deadlock:

- The main task / a peripheral driver (e.g. RMT in `esp32_rmt_led_strip`, `remote_transmitter`, `remote_receiver`) is holding the kernel spinlock at low priority.
- A level-3 GPIO edge ISR (e.g. a `pcf8574` interrupt) preempts it and tries to take the same lock.
- The high-priority ISR spins forever (`portMUX_NO_TIMEOUT`); the preempted holder can never run to release it → Interrupt WDT timeout → boot loop.

Installing the service at the default (lowest) priority — matching the ESP-IDF driver default, and what `ethernet` already does — makes the GPIO ISR the lowest level on the core, so it can no longer preempt another lock holder. This closes the whole class of deadlock rather than patching one peripheral.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16886

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Reproducer from the issue: pcf8574 input interrupt + RMT LED strip
i2c:
  - id: i2c_pcf
    sda: 4
    scl: 2
    scan: false

pcf8574:
  - id: pcf8574_1
    i2c_id: i2c_pcf
    address: 0x21
    interrupt_pin:
      number: 39
      mode:
        input: true

light:
  - name: RMT test
    platform: esp32_rmt_led_strip
    rgb_order: RGB
    chipset: WS2811
    pin: 14
    num_leds: 166
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).