### PR TITLE
[improv_serial] Report stopped state when Wi-Fi is disabled

### DIFF
--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -338,6 +338,14 @@ void ESP32ImprovComponent::process_incoming_data_() {
           this->incoming_data_.clear();
           return;
         }
+        if (wifi::global_wifi_component->is_disabled()) {
+          // Wi-Fi is disabled, so we can't provision. Respond immediately
+          // instead of letting the client wait out its provisioning timeout.
+          ESP_LOGW(TAG, "Wi-Fi is disabled; cannot provision");
+          this->set_error_(improv::ERROR_UNABLE_TO_CONNECT);
+          this->incoming_data_.clear();
+          return;
+        }
         wifi::WiFiAP sta{};
         sta.set_ssid(command.ssid.c_str());
         sta.set_password(command.password.c_str());

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -22,7 +22,9 @@ void ImprovSerialComponent::setup() {
 
   if (wifi::global_wifi_component->has_sta()) {
     this->state_ = improv::STATE_PROVISIONED;
-  } else {
+  } else if (!wifi::global_wifi_component->is_disabled()) {
+    // Respect Wi-Fi's disabled state; forcing a scan while disabled throws
+    // the wifi component into an invalid state from which it cannot recover.
     wifi::global_wifi_component->start_scanning();
   }
 }
@@ -230,6 +232,13 @@ bool ImprovSerialComponent::parse_improv_serial_byte_(uint8_t byte) {
 bool ImprovSerialComponent::parse_improv_payload_(improv::ImprovCommand &command) {
   switch (command.command) {
     case improv::WIFI_SETTINGS: {
+      if (wifi::global_wifi_component->is_disabled()) {
+        // Wi-Fi is disabled, so we can't provision. Respond immediately
+        // instead of letting the client wait out its provisioning timeout.
+        ESP_LOGW(TAG, "Wi-Fi is disabled; cannot provision");
+        this->set_error_(improv::ERROR_UNABLE_TO_CONNECT);
+        return true;
+      }
       wifi::WiFiAP sta{};
       sta.set_ssid(command.ssid.c_str());
       sta.set_password(command.password.c_str());
@@ -245,6 +254,14 @@ bool ImprovSerialComponent::parse_improv_payload_(improv::ImprovCommand &command
       return true;
     }
     case improv::GET_CURRENT_STATE:
+      if (wifi::global_wifi_component->is_disabled()) {
+        // Wi-Fi is disabled; report the Improv "stopped" state so a client can tell
+        // the user that provisioning is unavailable. Reported transiently without
+        // disturbing our internal provisioning state machine, so a later `wifi.enable`
+        // still reports the correct state.
+        this->send_current_state_(improv::STATE_STOPPED);
+        return true;
+      }
       this->set_state_(this->state_);
       if (this->state_ == improv::STATE_PROVISIONED) {
         std::vector<uint8_t> url = this->build_rpc_settings_response_(improv::GET_CURRENT_STATE);
@@ -299,6 +316,10 @@ bool ImprovSerialComponent::parse_improv_payload_(improv::ImprovCommand &command
 
 void ImprovSerialComponent::set_state_(improv::State state) {
   this->state_ = state;
+  this->send_current_state_(state);
+}
+
+void ImprovSerialComponent::send_current_state_(improv::State state) {
   this->tx_header_[TX_TYPE_IDX] = TYPE_CURRENT_STATE;
   this->tx_header_[TX_DATA_IDX] = state;
   this->write_data_();

--- a/esphome/components/improv_serial/improv_serial_component.h
+++ b/esphome/components/improv_serial/improv_serial_component.h
@@ -57,6 +57,7 @@ class ImprovSerialComponent : public Component, public improv_base::ImprovBase {
   bool parse_improv_payload_(improv::ImprovCommand &command);
 
   void set_state_(improv::State state);
+  void send_current_state_(improv::State state);
   void set_error_(improv::Error error);
   void send_response_(std::vector<uint8_t> &response);
   void on_wifi_connect_timeout_();


### PR DESCRIPTION
# What does this implement/fix?

When Wi-Fi is disabled at runtime — for example, a device that runs on Ethernet and disables Wi-Fi — Improv provisioning cannot succeed. Until now the only practical way to avoid leading the user through a doomed provisioning attempt was to disable the component's `loop()` entirely (e.g. from an `ethernet.on_connect` automation). That stops the component from responding to anything, so the Improv client just waits out a timeout with no explanation.

This keeps the Improv components responsive while Wi-Fi is disabled and gives the client an immediate, meaningful response instead of a timeout:

**`improv_serial`**
- Reports the Improv **stopped** state (`0x00`) in response to the client's current-state request when Wi-Fi is disabled. This is sent transiently (via a new `send_current_state_()` helper split out of `set_state_()`) so it does not disturb the internal provisioning state machine — a later `wifi.enable` still reports the correct state.
- Rejects a `WIFI_SETTINGS` request immediately with `ERROR_UNABLE_TO_CONNECT` when Wi-Fi is disabled, instead of starting a connection attempt that can only time out after 30 s.
- Skips the startup scan while Wi-Fi is disabled — calling `start_scanning()` forces the Wi-Fi component out of its disabled state.

**`esp32_improv`**
- Rejects a `WIFI_SETTINGS` request immediately with `ERROR_UNABLE_TO_CONNECT` when Wi-Fi is disabled. (The BLE service is normally never advertised while Wi-Fi is disabled, so this primarily covers the race where Wi-Fi becomes disabled while a BLE client is already connected.)

Currently-shipped Improv clients (e.g. `improv-wifi-serial-sdk@2.5.0`, used by ESP Web Tools) do not yet recognize the stopped state and will still show the Wi-Fi form, so the immediate `UNABLE_TO_CONNECT` keeps their behavior graceful (instant feedback rather than a timeout). A future client update can recognize the stopped state and tell the user that Wi-Fi provisioning is unavailable. This change is forward-compatible and requires no client change to be useful today.

No configuration or public API changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Improv over serial; no new configuration. With Wi-Fi disabled at runtime
# (e.g. running on Ethernet), the client now receives an immediate response
# instead of waiting out a timeout.
improv_serial:

wifi:
  enable_on_boot: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
