### PR TITLE
[esp8266] Decode crash handler PC and backtrace in logs

### DIFF
--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -492,6 +492,15 @@ def _parse_register(config, regex, line):
 STACKTRACE_ESP8266_EXCEPTION_TYPE_RE = re.compile(r"[eE]xception \((\d+)\):")
 STACKTRACE_ESP8266_PC_RE = re.compile(r"epc1=0x(4[0-9a-fA-F]{7})")
 STACKTRACE_ESP8266_EXCVADDR_RE = re.compile(r"excvaddr=0x(4[0-9a-fA-F]{7})")
+# Structured crash handler output (crash_handler.cpp) from a previous boot:
+#   PC: 0x40220060
+#   EXCVADDR: 0x0000008A
+#   BT0: 0x40212345
+STACKTRACE_ESP8266_CRASH_PC_RE = re.compile(r".*PC\s*:\s*(?:0x)?(4[0-9a-fA-F]{7})")
+STACKTRACE_ESP8266_CRASH_EXCVADDR_RE = re.compile(
+    r".*EXCVADDR\s*:\s*(?:0x)?(4[0-9a-fA-F]{7})"
+)
+STACKTRACE_ESP8266_CRASH_BT_RE = re.compile(r"BT\d+:\s*0x([0-9a-fA-F]{8})")
 STACKTRACE_BAD_ALLOC_RE = re.compile(
     r"^last failed alloc call: (4[0-9a-fA-F]{7})\((\d+)\)$"
 )
@@ -508,9 +517,16 @@ def process_stacktrace(config, line, backtrace_state):
             "Exception type: %s", ESP8266_EXCEPTION_CODES.get(code, "unknown")
         )
 
-    # ESP8266 PC/EXCVADDR
+    # ESP8266 PC/EXCVADDR (legacy Arduino postmortem)
     _parse_register(config, STACKTRACE_ESP8266_PC_RE, line)
     _parse_register(config, STACKTRACE_ESP8266_EXCVADDR_RE, line)
+
+    # ESP8266 structured crash handler (crash_handler.cpp) from previous boot
+    _parse_register(config, STACKTRACE_ESP8266_CRASH_PC_RE, line)
+    _parse_register(config, STACKTRACE_ESP8266_CRASH_EXCVADDR_RE, line)
+    match = re.search(STACKTRACE_ESP8266_CRASH_BT_RE, line)
+    if match is not None:
+        _decode_pc(config, match.group(1))
 
     # bad alloc
     match = re.match(STACKTRACE_BAD_ALLOC_RE, line)

--- a/tests/unit_tests/components/test_esp_stacktrace.py
+++ b/tests/unit_tests/components/test_esp_stacktrace.py
@@ -45,6 +45,36 @@ def test_process_stacktrace_esp8266_backtrace(
     assert state is False
 
 
+def test_process_stacktrace_esp8266_crash_handler(
+    setup_core: Path, mock_esp8266_decode_pc: Mock
+) -> None:
+    """Test process_stacktrace handles ESP8266 crash handler backtrace lines."""
+    from esphome.components.esp8266 import process_stacktrace
+
+    config = {"name": "test"}
+
+    # Simulate crash handler log lines as they appear from the API/serial
+    line_pc = "[E][esp8266:191]:   PC: 0x40220060"
+    state = process_stacktrace(config, line_pc, False)
+    mock_esp8266_decode_pc.assert_called_once_with(config, "40220060")
+    assert state is False
+
+    mock_esp8266_decode_pc.reset_mock()
+
+    # Near-null data address (wild pointer) is not a code address, must be ignored
+    line_excvaddr = "[E][esp8266:193]:   EXCVADDR: 0x0000008A"
+    state = process_stacktrace(config, line_excvaddr, False)
+    mock_esp8266_decode_pc.assert_not_called()
+    assert state is False
+
+    mock_esp8266_decode_pc.reset_mock()
+
+    line_bt0 = "[E][esp8266:196]:   BT0: 0x40212345"
+    state = process_stacktrace(config, line_bt0, False)
+    mock_esp8266_decode_pc.assert_called_once_with(config, "40212345")
+    assert state is False
+
+
 def test_process_stacktrace_esp32_backtrace(
     setup_core: Path, mock_esp32_decode_pc: Mock
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The ESP8266 structured crash handler in `crash_handler.cpp` prints crash info from the previous boot as `PC: 0x...`, `EXCVADDR: 0x...` and `BTn: 0x...`, but the host side log decoder only recognized the legacy Arduino postmortem format (`epc1=`, `excvaddr=`, `>>>stack>>>`). As a result none of those addresses were passed to addr2line, so users saw raw addresses with no decoded traceback.

This adds regexes for the new crash handler lines and feeds the PC and backtrace addresses through `_decode_pc`, mirroring what the ESP32 decoder already does. EXCVADDR values that are data addresses (a near null wild pointer, the common case) are correctly ignored since they are not code addresses. The legacy format handling is left intact for older firmware.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp8266:
  board: esp01_1m
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
