### PR TITLE
[tests] Mock target branch in memory-impact exclusion test

### DIFF
--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -1470,6 +1470,7 @@ def test_detect_memory_impact_config_no_common_platform(tmp_path: Path) -> None:
     assert result["use_merged_config"] == "true"
 
 
+@pytest.mark.usefixtures("mock_target_branch_dev")
 def test_detect_memory_impact_config_variant_only_platform_excluded(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

`test_detect_memory_impact_config_variant_only_platform_excluded` asserts `should_run == "true"` but, unlike its sibling memory-impact tests, never applied the `mock_target_branch_dev` fixture. `detect_memory_impact_config()` short-circuits to `should_run == "false"` whenever the target branch starts with `beta`/`release`, and `get_target_branch()` reads `GITHUB_BASE_REF`. On any PR targeting `beta` or `release` (e.g. the `2026.6.0b1` release PR #16912) that env var leaks into the test, the guard fires, and the assertion fails with `assert 'false' == 'true'` across the whole pytest matrix. Adding the `@pytest.mark.usefixtures("mock_target_branch_dev")` decorator pins the target branch to `dev` so the test is deterministic regardless of which branch CI is running against.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes the failing pytest jobs on release/beta PRs such as #16912

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).