### PR TITLE
[core] Support platformio_options on the native ESP-IDF toolchain

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2687,13 +2687,7 @@ def _write_idf_component_yml():
             # Don't process arduino libraries
             if name not in ARDUINO_DISABLED_LIBRARIES
         ]
-        # lib_ignore from esphome->platformio_options filters both top-level
-        # libraries and dependencies discovered during conversion.
-        lib_ignore = {
-            name.split("/")[-1].lower()
-            for name in CORE.platformio_options.get("lib_ignore", [])
-        }
-        for component in generate_idf_components(libraries, lib_ignore=lib_ignore):
+        for component in generate_idf_components(libraries):
             dependencies[component.get_sanitized_name()] = {
                 "override_path": str(component.path)
             }

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2687,7 +2687,13 @@ def _write_idf_component_yml():
             # Don't process arduino libraries
             if name not in ARDUINO_DISABLED_LIBRARIES
         ]
-        for component in generate_idf_components(libraries):
+        # lib_ignore from esphome->platformio_options filters both top-level
+        # libraries and dependencies discovered during conversion.
+        lib_ignore = {
+            name.split("/")[-1].lower()
+            for name in CORE.platformio_options.get("lib_ignore", [])
+        }
+        for component in generate_idf_components(libraries, lib_ignore=lib_ignore):
             dependencies[component.get_sanitized_name()] = {
                 "override_path": str(component.path)
             }

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -958,6 +958,13 @@ class EsphomeCore:
         return build_flag
 
     def add_build_unflag(self, build_unflag: str) -> None:
+        if self.using_toolchain_esp_idf:
+            # The native ESP-IDF build generator does not consume build_unflags
+            _LOGGER.warning(
+                "Build unflag %s is ignored when building with the native "
+                "ESP-IDF toolchain",
+                build_unflag,
+            )
         self.build_unflags.add(build_unflag)
         _LOGGER.debug("Adding build unflag: %s", build_unflag)
 

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -503,6 +503,21 @@ async def add_includes(includes: list[str], is_c_header: bool = False) -> None:
             include_file(path, basename, is_c_header)
 
 
+def _add_library_str(lib: str) -> None:
+    if "@" in lib:
+        name, vers = lib.split("@", 1)
+        cg.add_library(name, vers)
+    elif "://" in lib:
+        # Repository...
+        if "=" in lib:
+            name, repo = lib.split("=", 1)
+            cg.add_library(name, None, repo)
+        else:
+            cg.add_library(None, None, lib)
+    else:
+        cg.add_library(lib, None)
+
+
 @coroutine_with_priority(CoroPriority.FINAL)
 async def _add_platformio_options(pio_options: dict[str, str | list[str]]) -> None:
     if CORE.using_toolchain_esp_idf:
@@ -679,19 +694,7 @@ async def to_code(config: ConfigType) -> None:
 
     # Libraries
     for lib in config[CONF_LIBRARIES]:
-        if "@" in lib:
-            name, vers = lib.split("@", 1)
-            cg.add_library(name, vers)
-        elif "://" in lib:
-            # Repository...
-            if "=" in lib:
-                name, repo = lib.split("=", 1)
-                cg.add_library(name, None, repo)
-            else:
-                cg.add_library(None, None, lib)
-
-        else:
-            cg.add_library(lib, None)
+        _add_library_str(lib)
 
     cg.add_build_flag("-Wno-unused-variable")
     cg.add_build_flag("-Wno-unused-but-set-variable")
@@ -734,8 +737,19 @@ async def to_code(config: ConfigType) -> None:
                 trigger, [(cg.std_string, "version")], conf
             )
 
-    if config[CONF_PLATFORMIO_OPTIONS]:
-        CORE.add_job(_add_platformio_options, config[CONF_PLATFORMIO_OPTIONS])
+    if pio_options := dict(config[CONF_PLATFORMIO_OPTIONS]):
+        if CORE.using_toolchain_esp_idf and (
+            lib_deps := pio_options.pop("lib_deps", None)
+        ):
+            # Route lib_deps through the regular library mechanism so the
+            # libraries are converted to IDF components like any other PIO
+            # library. Processed here (like libraries above) rather than in
+            # the FINAL job so FINAL-priority consumers of the library list
+            # (e.g. Arduino selective compilation) see them.
+            for lib in [lib_deps] if isinstance(lib_deps, str) else lib_deps:
+                _add_library_str(lib)
+        if pio_options:
+            CORE.add_job(_add_platformio_options, pio_options)
 
     if config[CONF_BUILD_FLAGS]:
         CORE.add_job(_add_build_flags, config[CONF_BUILD_FLAGS])

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -521,29 +521,28 @@ def _add_library_str(lib: str) -> None:
 @coroutine_with_priority(CoroPriority.FINAL)
 async def _add_platformio_options(pio_options: dict[str, str | list[str]]) -> None:
     if CORE.using_toolchain_esp_idf:
-        # The native ESP-IDF build doesn't read platformio.ini; honor build_flags
-        # by routing them through the regular build flag mechanism and warn about
-        # any other option, which would otherwise be silently ignored.
+        # The native ESP-IDF build doesn't read platformio.ini; honor the
+        # options with a native equivalent and warn about the rest, which
+        # would otherwise be silently ignored.
         for key, val in pio_options.items():
+            vals = [val] if isinstance(val, str) else val
             if key == CONF_BUILD_FLAGS:
-                for flag in [val] if isinstance(val, str) else val:
+                # Routed through the regular build flag mechanism
+                for flag in vals:
                     cg.add_build_flag(flag)
-            elif key == "upload_speed":
-                # Read from the raw config at upload time (upload_using_esptool),
-                # so it works on the native toolchain too.
-                pass
             elif key == "lib_deps":
                 # Routed through the regular library mechanism so the libraries
-                # are converted to IDF components like any other PIO library.
-                for lib in [val] if isinstance(val, str) else val:
+                # are converted to IDF components like any other PIO library
+                for lib in vals:
                     _add_library_str(lib)
             elif key == "lib_ignore":
-                # Stored so the PIO-library-to-IDF-component conversion
-                # (generate_idf_components) can read it; it filters both
-                # top-level libraries and dependencies discovered during
-                # conversion.
-                cg.add_platformio_option(key, [val] if isinstance(val, str) else val)
-            else:
+                # Read by the PIO-library-to-IDF-component conversion
+                # (generate_idf_components); filters both top-level libraries
+                # and dependencies discovered during conversion
+                cg.add_platformio_option(key, vals)
+            elif key != "upload_speed":
+                # upload_speed needs no handling: it is read from the raw
+                # config at upload time (upload_using_esptool)
                 _LOGGER.warning(
                     "esphome->platformio_options->%s is ignored when building with "
                     "the native ESP-IDF toolchain",

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -517,6 +517,11 @@ async def _add_platformio_options(pio_options: dict[str, str | list[str]]) -> No
                 # Read from the raw config at upload time (upload_using_esptool),
                 # so it works on the native toolchain too.
                 pass
+            elif key == "lib_ignore":
+                # Stored so the PIO-library-to-IDF-component conversion
+                # (generate_idf_components) can filter both top-level libraries
+                # and dependencies discovered during conversion.
+                cg.add_platformio_option(key, [val] if isinstance(val, str) else val)
             else:
                 _LOGGER.warning(
                     "esphome->platformio_options->%s is ignored when building with "

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -504,7 +504,26 @@ async def add_includes(includes: list[str], is_c_header: bool = False) -> None:
 
 
 @coroutine_with_priority(CoroPriority.FINAL)
-async def _add_platformio_options(pio_options):
+async def _add_platformio_options(pio_options: dict[str, str | list[str]]) -> None:
+    if CORE.using_toolchain_esp_idf:
+        # The native ESP-IDF build doesn't read platformio.ini; honor build_flags
+        # by routing them through the regular build flag mechanism and warn about
+        # any other option, which would otherwise be silently ignored.
+        for key, val in pio_options.items():
+            if key == CONF_BUILD_FLAGS:
+                for flag in [val] if isinstance(val, str) else val:
+                    cg.add_build_flag(flag)
+            elif key == "upload_speed":
+                # Read from the raw config at upload time (upload_using_esptool),
+                # so it works on the native toolchain too.
+                pass
+            else:
+                _LOGGER.warning(
+                    "esphome->platformio_options->%s is ignored when building with "
+                    "the native ESP-IDF toolchain",
+                    key,
+                )
+        return
     # Add includes at the very end, so that they override everything
     for key, val in pio_options.items():
         if key in ["build_flags", "lib_ignore"] and not isinstance(val, list):

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -532,10 +532,16 @@ async def _add_platformio_options(pio_options: dict[str, str | list[str]]) -> No
                 # Read from the raw config at upload time (upload_using_esptool),
                 # so it works on the native toolchain too.
                 pass
+            elif key == "lib_deps":
+                # Routed through the regular library mechanism so the libraries
+                # are converted to IDF components like any other PIO library.
+                for lib in [val] if isinstance(val, str) else val:
+                    _add_library_str(lib)
             elif key == "lib_ignore":
                 # Stored so the PIO-library-to-IDF-component conversion
-                # (generate_idf_components) can filter both top-level libraries
-                # and dependencies discovered during conversion.
+                # (generate_idf_components) can read it; it filters both
+                # top-level libraries and dependencies discovered during
+                # conversion.
                 cg.add_platformio_option(key, [val] if isinstance(val, str) else val)
             else:
                 _LOGGER.warning(
@@ -737,19 +743,8 @@ async def to_code(config: ConfigType) -> None:
                 trigger, [(cg.std_string, "version")], conf
             )
 
-    if pio_options := dict(config[CONF_PLATFORMIO_OPTIONS]):
-        if CORE.using_toolchain_esp_idf and (
-            lib_deps := pio_options.pop("lib_deps", None)
-        ):
-            # Route lib_deps through the regular library mechanism so the
-            # libraries are converted to IDF components like any other PIO
-            # library. Processed here (like libraries above) rather than in
-            # the FINAL job so FINAL-priority consumers of the library list
-            # (e.g. Arduino selective compilation) see them.
-            for lib in [lib_deps] if isinstance(lib_deps, str) else lib_deps:
-                _add_library_str(lib)
-        if pio_options:
-            CORE.add_job(_add_platformio_options, pio_options)
+    if config[CONF_PLATFORMIO_OPTIONS]:
+        CORE.add_job(_add_platformio_options, config[CONF_PLATFORMIO_OPTIONS])
 
     if config[CONF_BUILD_FLAGS]:
         CORE.add_job(_add_build_flags, config[CONF_BUILD_FLAGS])

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -527,7 +527,13 @@ async def _add_platformio_options(pio_options: dict[str, str | list[str]]) -> No
         for key, val in pio_options.items():
             vals = [val] if isinstance(val, str) else val
             if key == CONF_BUILD_FLAGS:
-                # Routed through the regular build flag mechanism
+                # Deprecated: esphome->build_flags is the native equivalent.
+                # Remove before 2026.12.0
+                _LOGGER.warning(
+                    "esphome->platformio_options->build_flags is deprecated; use "
+                    "esphome->build_flags instead. Support for it will be removed "
+                    "in 2026.12.0."
+                )
                 for flag in vals:
                     cg.add_build_flag(flag)
             elif key == "lib_deps":

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -688,9 +688,7 @@ def _node_key(
     return name, False, (owner, pkgname)
 
 
-def generate_idf_components(
-    libraries: list[Library], lib_ignore: set[str] | None = None
-) -> list[IDFComponent]:
+def generate_idf_components(libraries: list[Library]) -> list[IDFComponent]:
     """Resolve and convert a batch of PlatformIO libraries to IDF components.
 
     Resolves the whole set together rather than each library independently: it
@@ -706,11 +704,16 @@ def generate_idf_components(
     transitive dependencies are converted too and wired into each component's
     generated manifest.
 
-    ``lib_ignore`` is a set of lowercase library short names (part after the
-    ``/``) to exclude, matched against both the top-level libraries and every
-    dependency discovered during the graph walk.
+    ``lib_ignore`` from ``esphome->platformio_options`` excludes libraries by
+    short name (part after the ``/``), matched against both the top-level
+    libraries and every dependency discovered during the graph walk.
     """
     nodes: dict[str, _LibNode] = {}
+
+    lib_ignore = {
+        name.split("/")[-1].lower()
+        for name in CORE.platformio_options.get("lib_ignore", [])
+    }
 
     # The generated CMakeLists.txt/idf_component.yml inside the shared cache
     # bake in the dependency wiring, which lib_ignore changes; salt the cache

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -56,7 +56,7 @@ ESPHOME_DATA_EXTRA_CMAKE_KEY = "EXTRA_CMAKE"
 
 
 class Source:
-    def download(self, dir_suffix: str, force: bool = False) -> Path:
+    def download(self, dir_suffix: str, force: bool = False, salt: str = "") -> Path:
         raise NotImplementedError
 
 
@@ -64,10 +64,12 @@ class URLSource(Source):
     def __init__(self, url: str):
         self.url = url
 
-    def download(self, dir_suffix: str, force: bool = False) -> Path:
+    def download(self, dir_suffix: str, force: bool = False, salt: str = "") -> Path:
         base_dir = Path(CORE.data_dir) / DOMAIN
         h = hashlib.new("sha256")
         h.update(self.url.encode())
+        if salt:
+            h.update(salt.encode())
         path = base_dir / h.hexdigest()[:8] / dir_suffix
         # Marker file written last to signal a complete extraction. Using a
         # marker (instead of just `path.is_dir()`) means an interrupted
@@ -99,12 +101,12 @@ class GitSource(Source):
         self.url = url
         self.ref = ref
 
-    def download(self, dir_suffix: str, force: bool = False) -> Path:
+    def download(self, dir_suffix: str, force: bool = False, salt: str = "") -> Path:
         path, _ = git.clone_or_update(
             url=self.url,
             ref=self.ref,
             refresh=git.NEVER_REFRESH if not force else None,
-            domain=DOMAIN,
+            domain=f"{DOMAIN}/{salt}" if salt else DOMAIN,
             submodules=[],
             subpath=Path(dir_suffix),
         )
@@ -146,14 +148,16 @@ class IDFComponent:
     def get_require_name(self):
         return self.get_sanitized_name().replace("/", "__")
 
-    def download(self, force: bool = False):
+    def download(self, force: bool = False, salt: str = ""):
         """
         The dependency name should match the directory name at the end of the override path.
         The ESP-IDF build system uses the directory name as the component name, so the directory of the override_path should match the component name.
         If you want to specify the full name of the component with the namespace, replace / in the component name with __.
         @see https://docs.espressif.com/projects/idf-component-manager/en/latest/reference/manifest_file.html
         """
-        self.path = self.source.download(self.get_sanitized_name(), force=force)
+        self.path = self.source.download(
+            self.get_sanitized_name(), force=force, salt=salt
+        )
 
 
 def _apply_extra_script(component: IDFComponent) -> None:
@@ -684,7 +688,9 @@ def _node_key(
     return name, False, (owner, pkgname)
 
 
-def generate_idf_components(libraries: list[Library]) -> list[IDFComponent]:
+def generate_idf_components(
+    libraries: list[Library], lib_ignore: set[str] | None = None
+) -> list[IDFComponent]:
     """Resolve and convert a batch of PlatformIO libraries to IDF components.
 
     Resolves the whole set together rather than each library independently: it
@@ -699,8 +705,27 @@ def generate_idf_components(libraries: list[Library]) -> list[IDFComponent]:
     The returned list holds the top-level components (those directly requested);
     transitive dependencies are converted too and wired into each component's
     generated manifest.
+
+    ``lib_ignore`` is a set of lowercase library short names (part after the
+    ``/``) to exclude, matched against both the top-level libraries and every
+    dependency discovered during the graph walk.
     """
     nodes: dict[str, _LibNode] = {}
+
+    # The generated CMakeLists.txt/idf_component.yml inside the shared cache
+    # bake in the dependency wiring, which lib_ignore changes; salt the cache
+    # path so configs with different lib_ignore values don't fight over (and
+    # constantly rewrite) the same converted component files.
+    salt = (
+        hashlib.sha256(",".join(sorted(lib_ignore)).encode()).hexdigest()[:8]
+        if lib_ignore
+        else ""
+    )
+
+    def is_ignored(name: str | None) -> bool:
+        if not lib_ignore or name is None:
+            return False
+        return name.split("/")[-1].lower() in lib_ignore
 
     def add_spec(name: str | None, version: str | None, repository: str | None) -> str:
         key, is_git, locator = _node_key(name, version, repository)
@@ -718,6 +743,7 @@ def generate_idf_components(libraries: list[Library]) -> list[IDFComponent]:
     top_level = [
         add_spec(library.name, library.version, library.repository)
         for library in libraries
+        if not is_ignored(library.name)
     ]
 
     # Collect + resolve to a fixpoint: a node is (re)resolved whenever its
@@ -749,7 +775,7 @@ def generate_idf_components(libraries: list[Library]) -> list[IDFComponent]:
             component = IDFComponent(
                 _owner_pkgname_to_name(owner, name), version, URLSource(url)
             )
-        component.download()
+        component.download(salt=salt)
 
         library_json_path = component.path / "library.json"
         library_properties_path = component.path / "library.properties"
@@ -787,6 +813,12 @@ def generate_idf_components(libraries: list[Library]) -> list[IDFComponent]:
             except InvalidIDFComponent as e:
                 _LOGGER.debug("Skip dependency %s: %s", dependency.get("name"), str(e))
                 continue
+            dep_name = _owner_pkgname_to_name(
+                dependency.get("owner"), dependency.get("name")
+            )
+            if is_ignored(dep_name):
+                _LOGGER.debug("Skip ignored dependency %s", dep_name)
+                continue
             # The version field may actually be a URL (git/archive dependency).
             dep_version = dependency["version"]
             dep_url = None
@@ -796,11 +828,7 @@ def generate_idf_components(libraries: list[Library]) -> list[IDFComponent]:
                     dep_url, dep_version = dep_version, None
             except (TypeError, ValueError):
                 pass
-            dep_key = add_spec(
-                _owner_pkgname_to_name(dependency.get("owner"), dependency.get("name")),
-                dep_version,
-                dep_url,
-            )
+            dep_key = add_spec(dep_name, dep_version, dep_url)
             node.edges.add(dep_key)
             worklist.append(dep_key)
 

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -1246,3 +1246,28 @@ async def test_add_platformio_options_platformio() -> None:
         "lib_ignore": ["libsodium"],
         "upload_speed": "115200",
     }
+
+
+def test_add_library_str_bare_url_requires_name() -> None:
+    """A bare repository URL has no library name; CORE.add_library rejects it."""
+    with pytest.raises(ValueError, match="must have a name"):
+        config._add_library_str("https://github.com/esphome/noise-c.git")
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+async def test_to_code_adds_libraries(yaml_file: Callable[[str], Path]) -> None:
+    """esphome->libraries entries are parsed and registered via cg.add_library."""
+    result = load_config_from_fixture(yaml_file, "libraries.yaml", FIXTURES_DIR)
+    assert result is not None
+
+    with patch("esphome.core.config.cg") as mock_cg:
+        mock_cg.RawStatement.side_effect = lambda *args, **kwargs: MagicMock()
+        mock_cg.RawExpression.side_effect = lambda *args, **kwargs: MagicMock()
+        await config.to_code(result[CONF_ESPHOME])
+
+    mock_cg.add_library.assert_any_call("SomeLib", None)
+    mock_cg.add_library.assert_any_call("bblanchon/ArduinoJson", "7.4.2")
+    mock_cg.add_library.assert_any_call(
+        "noise-c", None, "https://github.com/esphome/noise-c.git"
+    )

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -20,6 +20,9 @@ from esphome.const import (
     CONF_NAME,
     CONF_NAME_ADD_MAC_SUFFIX,
     KEY_CORE,
+    KEY_TARGET_FRAMEWORK,
+    KEY_TARGET_PLATFORM,
+    Toolchain,
 )
 from esphome.core import CORE, config
 from esphome.core.config import (
@@ -1161,3 +1164,85 @@ def test_make_app_name_cpp_special_chars_escaped() -> None:
     cpp_expr, _, _ = make_app_name_cpp('my "device"', "buf", "-", add_mac_suffix=False)
     # cpp_string_escape uses octal escapes for quotes
     assert '"' not in cpp_expr[1:-1]  # no unescaped quotes inside the outer quotes
+
+
+@pytest.mark.parametrize(
+    ("lib", "name", "version", "repository"),
+    [
+        ("ArduinoJson", "ArduinoJson", None, None),
+        ("bblanchon/ArduinoJson@7.4.2", "bblanchon/ArduinoJson", "7.4.2", None),
+        (
+            "noise-c=https://github.com/esphome/noise-c.git",
+            "noise-c",
+            None,
+            "https://github.com/esphome/noise-c.git",
+        ),
+    ],
+)
+def test_add_library_str(
+    lib: str, name: str, version: str | None, repository: str | None
+) -> None:
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp32",
+        KEY_TARGET_FRAMEWORK: "esp-idf",
+    }
+
+    config._add_library_str(lib)
+
+    libraries = list(CORE.platformio_libraries.values())
+    assert len(libraries) == 1
+    assert libraries[0].name == name
+    assert libraries[0].version == version
+    assert libraries[0].repository == repository
+
+
+@pytest.mark.asyncio
+async def test_add_platformio_options_native_idf(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """On the native IDF toolchain, build_flags/lib_deps/lib_ignore are
+    honored, upload_speed is silent and everything else warns."""
+    CORE.toolchain = Toolchain.ESP_IDF
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp32",
+        KEY_TARGET_FRAMEWORK: "esp-idf",
+    }
+
+    await config._add_platformio_options(
+        {
+            "build_flags": "-DSINGLE_FLAG",  # string and list forms both valid
+            "lib_deps": ["bblanchon/ArduinoJson@7.4.2"],
+            "lib_ignore": "libsodium",
+            "upload_speed": "115200",
+            "board_build.f_flash": "80000000L",
+        }
+    )
+
+    assert "-DSINGLE_FLAG" in CORE.build_flags
+    assert "ArduinoJson" in CORE.platformio_libraries
+    # lib_ignore is stored (listified) for generate_idf_components to read;
+    # nothing else lands in platformio_options on the native toolchain.
+    assert CORE.platformio_options == {"lib_ignore": ["libsodium"]}
+    assert "esphome->platformio_options->board_build.f_flash is ignored" in caplog.text
+    assert "upload_speed" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_add_platformio_options_platformio() -> None:
+    """On the PlatformIO toolchain all options pass through to the ini,
+    with build_flags/lib_ignore listified."""
+    CORE.toolchain = Toolchain.PLATFORMIO
+
+    await config._add_platformio_options(
+        {
+            "build_flags": "-DSINGLE_FLAG",
+            "lib_ignore": "libsodium",
+            "upload_speed": "115200",
+        }
+    )
+
+    assert CORE.platformio_options == {
+        "build_flags": ["-DSINGLE_FLAG"],
+        "lib_ignore": ["libsodium"],
+        "upload_speed": "115200",
+    }

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -1225,10 +1225,20 @@ async def test_add_platformio_options_native_idf(
     assert CORE.platformio_options == {"lib_ignore": ["libsodium"]}
     assert "esphome->platformio_options->board_build.f_flash is ignored" in caplog.text
     assert "upload_speed" not in caplog.text
+    # build_flags has a first-class esphome equivalent, so it is deprecated.
+    # lib_deps/lib_ignore are kept as valid platformio_options (no warning).
+    assert (
+        "esphome->platformio_options->build_flags is deprecated; use "
+        "esphome->build_flags instead" in caplog.text
+    )
+    assert "lib_deps is deprecated" not in caplog.text
+    assert "lib_ignore is deprecated" not in caplog.text
 
 
 @pytest.mark.asyncio
-async def test_add_platformio_options_platformio() -> None:
+async def test_add_platformio_options_platformio(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """On the PlatformIO toolchain all options pass through to the ini,
     with build_flags/lib_ignore listified."""
     CORE.toolchain = Toolchain.PLATFORMIO
@@ -1246,6 +1256,9 @@ async def test_add_platformio_options_platformio() -> None:
         "lib_ignore": ["libsodium"],
         "upload_speed": "115200",
     }
+    # platformio_options is the correct mechanism on the PlatformIO toolchain,
+    # so the native-equivalent deprecation must not fire here.
+    assert "deprecated" not in caplog.text
 
 
 def test_add_library_str_bare_url_requires_name() -> None:

--- a/tests/unit_tests/fixtures/core/config/libraries.yaml
+++ b/tests/unit_tests/fixtures/core/config/libraries.yaml
@@ -1,0 +1,8 @@
+esphome:
+  name: test-libraries
+  libraries:
+    - SomeLib
+    - bblanchon/ArduinoJson@7.4.2
+    - noise-c=https://github.com/esphome/noise-c.git
+
+host:

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -915,3 +915,21 @@ class TestEsphomeCore:
             mock_enable.assert_called_once_with("Wire")
 
         assert "Wire" in target.platformio_libraries
+
+    def test_add_build_unflag__warns_on_native_idf_toolchain(
+        self, target, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Build unflags are not consumed by the native IDF build generator,
+        so adding one on that toolchain warns; PlatformIO stays silent."""
+        target.toolchain = const.Toolchain.PLATFORMIO
+        target.add_build_unflag("-fno-rtti")
+        assert "ignored" not in caplog.text
+
+        target.toolchain = const.Toolchain.ESP_IDF
+        target.add_build_unflag("-fno-exceptions")
+        assert (
+            "Build unflag -fno-exceptions is ignored when building with the "
+            "native ESP-IDF toolchain" in caplog.text
+        )
+        # The unflag is still recorded either way.
+        assert target.build_unflags == {"-fno-rtti", "-fno-exceptions"}

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -861,3 +861,41 @@ def test_generate_idf_components_incompatible_dependency_skipped(
     assert [c.name for c in top] == ["esphome/A"]
     # The incompatible dependency was dropped, not wired in.
     assert top[0].dependencies == []
+
+
+def test_url_source_salt_changes_cache_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The salt is mixed into the URL hash so salted conversions get their own
+    cache tree. Pre-created extraction markers keep this network-free."""
+    monkeypatch.setattr(CORE, "config_path", tmp_path / "test.yaml")
+    url = "http://example.com/lib.tar.gz"
+    base = tmp_path / ".esphome" / "pio_components"
+    expected = {}
+    for salt in ("", "abcd1234"):
+        digest = hashlib.sha256((url + salt).encode()).hexdigest()[:8]
+        expected[salt] = base / digest / "lib"
+        expected[salt].mkdir(parents=True)
+        (expected[salt] / ".esphome_extracted").touch()
+
+    source = URLSource(url)
+    assert source.download("lib") == expected[""]
+    assert source.download("lib", salt="abcd1234") == expected["abcd1234"]
+
+
+def test_git_source_salt_scopes_domain(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The salt becomes a subdirectory of the git clone domain."""
+    domains: list[str] = []
+
+    def fake_clone_or_update(**kwargs):
+        domains.append(kwargs["domain"])
+        return Path("/cloned"), None
+
+    monkeypatch.setattr(
+        esphome.espidf.component.git, "clone_or_update", fake_clone_or_update
+    )
+
+    source = GitSource("https://github.com/esphome/noise-c.git", "v1.0")
+    source.download("noise-c")
+    source.download("noise-c", salt="abcd1234")
+    assert domains == ["pio_components", "pio_components/abcd1234"]

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -515,7 +516,7 @@ def test_generate_idf_components_dedupes_shared_dependency(
         "esphome/C": {"name": "C"},
     }
 
-    def fake_download(self, force=False):
+    def fake_download(self, force=False, salt=""):
         self.path = tmp_path / self.get_sanitized_name().replace("/", "__")
         (self.path / "src").mkdir(parents=True, exist_ok=True)
         (self.path / "src" / "x.c").write_text("int x;")
@@ -557,6 +558,60 @@ def test_generate_idf_components_dedupes_shared_dependency(
     assert "idf_component_register" in generated
 
 
+def test_generate_idf_components_lib_ignore_filters_top_level_and_dependencies(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    esp32_idf_core: None,
+) -> None:
+    # lib_ignore must drop B at the top level and C when it is discovered as a
+    # dependency of A during the graph walk -- neither may be resolved,
+    # downloaded, or wired into a manifest. Matching is by lowercase short name.
+    manifests = {
+        "esphome/A": {
+            "name": "A",
+            "dependencies": [
+                {"owner": "esphome", "name": "C", "version": "==1.10021.0"}
+            ],
+        },
+        "esphome/B": {"name": "B"},
+    }
+
+    download_salts: list[str] = []
+
+    def fake_download(self, force=False, salt=""):
+        download_salts.append(salt)
+        self.path = tmp_path / self.get_sanitized_name().replace("/", "__")
+        (self.path / "src").mkdir(parents=True, exist_ok=True)
+        (self.path / "src" / "x.c").write_text("int x;")
+        (self.path / "library.json").write_text(json.dumps(manifests[self.name]))
+
+    monkeypatch.setattr(IDFComponent, "download", fake_download)
+
+    resolve_calls: list[str] = []
+
+    def fake_resolve(owner, pkgname, requirements):
+        resolve_calls.append(pkgname)
+        return owner, pkgname, "1.0.0", f"http://x/{pkgname}.tar.gz"
+
+    monkeypatch.setattr(
+        esphome.espidf.component, "_resolve_registry_version", fake_resolve
+    )
+
+    top = generate_idf_components(
+        [Library("esphome/A", "1.0.0", None), Library("esphome/B", "1.0.0", None)],
+        lib_ignore={"b", "c"},
+    )
+
+    assert [c.name for c in top] == ["esphome/A"]
+    # Ignored libraries were never resolved (and therefore never downloaded).
+    assert resolve_calls == ["A"]
+    # The ignored dependency is not wired into A's manifest.
+    assert top[0].dependencies == []
+    # lib_ignore changes the generated wiring, so the cache path is salted to
+    # keep this conversion separate from ones with a different lib_ignore.
+    assert download_salts == [hashlib.sha256(b"b,c").hexdigest()[:8]]
+
+
 def test_generate_idf_components_handles_dependency_cycle(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -575,7 +630,7 @@ def test_generate_idf_components_handles_dependency_cycle(
         },
     }
 
-    def fake_download(self, force=False):
+    def fake_download(self, force=False, salt=""):
         self.path = tmp_path / self.get_sanitized_name().replace("/", "__")
         (self.path / "src").mkdir(parents=True, exist_ok=True)
         (self.path / "src" / "x.c").write_text("int x;")
@@ -632,7 +687,7 @@ def test_generate_idf_components_git_overrides_registry_warns(
         "esphome/shared": {"name": "shared"},
     }
 
-    def fake_download(self, force=False):
+    def fake_download(self, force=False, salt=""):
         self.path = tmp_path / self.get_sanitized_name().replace("/", "__")
         (self.path / "src").mkdir(parents=True, exist_ok=True)
         (self.path / "src" / "x.c").write_text("int x;")
@@ -669,7 +724,7 @@ def test_generate_idf_components_missing_manifest_raises(
 ) -> None:
     # A library with neither library.json nor library.properties is invalid;
     # fail loudly rather than silently generating build files for it.
-    def fake_download(self, force=False):
+    def fake_download(self, force=False, salt=""):
         self.path = tmp_path / self.get_sanitized_name().replace("/", "__")
         (self.path / "src").mkdir(parents=True, exist_ok=True)
         # no library.json / library.properties written
@@ -711,7 +766,7 @@ def test_generate_idf_components_warns_on_noncanonical_duplicate(
         "owner/shared": {"name": "shared"},
     }
 
-    def fake_download(self, force=False):
+    def fake_download(self, force=False, salt=""):
         self.path = tmp_path / self.get_sanitized_name().replace("/", "__")
         (self.path / "src").mkdir(parents=True, exist_ok=True)
         (self.path / "src" / "x.c").write_text("int x;")
@@ -744,7 +799,7 @@ def test_generate_idf_components_incompatible_top_level_raises(
 ) -> None:
     # A top-level library that isn't ESP-IDF/esp32 compatible must fail fast,
     # not be silently dropped.
-    def fake_download(self, force=False):
+    def fake_download(self, force=False, salt=""):
         self.path = tmp_path / self.get_sanitized_name().replace("/", "__")
         (self.path / "src").mkdir(parents=True, exist_ok=True)
         (self.path / "library.json").write_text(
@@ -782,7 +837,7 @@ def test_generate_idf_components_incompatible_dependency_skipped(
         "esphome/B": {"name": "B", "platforms": ["espressif8266"]},
     }
 
-    def fake_download(self, force=False):
+    def fake_download(self, force=False, salt=""):
         self.path = tmp_path / self.get_sanitized_name().replace("/", "__")
         (self.path / "src").mkdir(parents=True, exist_ok=True)
         (self.path / "library.json").write_text(json.dumps(manifests[self.name]))

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -596,10 +596,12 @@ def test_generate_idf_components_lib_ignore_filters_top_level_and_dependencies(
     monkeypatch.setattr(
         esphome.espidf.component, "_resolve_registry_version", fake_resolve
     )
+    # lib_ignore is read from CORE.platformio_options (stored there by
+    # _add_platformio_options); matched by lowercase short name.
+    monkeypatch.setattr(CORE, "platformio_options", {"lib_ignore": ["B", "esphome/C"]})
 
     top = generate_idf_components(
-        [Library("esphome/A", "1.0.0", None), Library("esphome/B", "1.0.0", None)],
-        lib_ignore={"b", "c"},
+        [Library("esphome/A", "1.0.0", None), Library("esphome/B", "1.0.0", None)]
     )
 
     assert [c.name for c in top] == ["esphome/A"]

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -899,3 +899,16 @@ def test_git_source_salt_scopes_domain(monkeypatch: pytest.MonkeyPatch) -> None:
     source.download("noise-c")
     source.download("noise-c", salt="abcd1234")
     assert domains == ["pio_components", "pio_components/abcd1234"]
+
+
+def test_idf_component_download_passes_salt() -> None:
+    """IDFComponent.download forwards the sanitized name and salt to the
+    source and records the returned path."""
+    source = MagicMock()
+    source.download.return_value = Path("/converted/owner/name")
+
+    c = IDFComponent("owner/name", "1.0", source=source)
+    c.download(force=True, salt="abcd1234")
+
+    source.download.assert_called_once_with("owner/name", force=True, salt="abcd1234")
+    assert c.path == Path("/converted/owner/name")


### PR DESCRIPTION
# What does this implement/fix?

On the native ESP-IDF toolchain, the entire `esphome.platformio_options` block was silently ignored: the native build generator never reads `CORE.platformio_options`, so options that users rely on (e.g. `build_flags`, `lib_deps`, `lib_ignore`) were dropped without any indication.

This PR makes the options with a native equivalent work, and warns about the rest:

| Option | Native handling |
|---|---|
| `build_flags` | Routed through `cg.add_build_flag()`, so the flags reach the build the same way `esphome.build_flags` does |
| `lib_deps` | Parsed with the same logic as `esphome.libraries` and routed through `cg.add_library()`, so the libraries are converted to IDF components like any other PIO library (participating in batch version resolution) |
| `lib_ignore` | Filters the PIO-library-to-IDF-component conversion — both top-level libraries and dependencies discovered during the conversion graph walk. Matched by lowercase short name (part after `/`), like PlatformIO |
| `upload_speed` | Already honored (read from the raw config at upload time); exempted from the warning |
| anything else | `WARNING esphome->platformio_options-><key> is ignored when building with the native ESP-IDF toolchain` |

Additionally, `cg.add_build_unflag()` now warns on the native toolchain, where build unflags are not consumed by the build generator. After #16907 nothing in-tree calls it on the native path, so any such call is a genuinely ignored flag (e.g. from an external component).

**Implementation notes:**

- `lib_ignore` is read by `generate_idf_components()` directly from `CORE.platformio_options`; an ignored dependency is never registry-resolved, downloaded, or wired into a generated manifest. The `espidf.clang_tidy` conversion path picks up the filtering automatically.
- The converted-component cache (`pio_components/<hash>`) bakes the dependency wiring into the generated `CMakeLists.txt`/`idf_component.yml`, which `lib_ignore` changes — so the cache path is salted with a hash of the `lib_ignore` set. Configs with the same `lib_ignore` share the cache; configs with different values get separate trees instead of rewriting each other's files on alternating builds. No `lib_ignore` → unchanged paths, existing caches stay valid.
- The library string parser shared by `esphome.libraries` is factored into `_add_library_str()` and reused for `lib_deps`.
- PlatformIO backend behavior is unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (existing `platformio_options` documentation applies; can add a note about native toolchain support if desired)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test
  platformio_options:
    build_flags:
      - "-DMY_CUSTOM_DEFINE"
    lib_deps:
      - "bblanchon/ArduinoJson@7.4.2"
    lib_ignore:
      - libsodium

esp32:
  board: esp32dev
  toolchain: esp-idf
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).