### PR TITLE
[esp32] Add flash_mode and flash_frequency config options

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1616,9 +1616,15 @@ FLASH_SIZES = [
 
 CONF_FLASH_SIZE = "flash_size"
 CONF_FLASH_MODE = "flash_mode"
+CONF_FLASH_FREQUENCY = "flash_frequency"
 CONF_CPU_FREQUENCY = "cpu_frequency"
 CONF_PARTITIONS = "partitions"
 FLASH_MODES = ["qio", "qout", "dio", "dout", "opi"]
+# The full ESP-IDF ESPTOOLPY_FLASHFREQ choice set; which entries are valid
+# depends on the variant and is enforced by the IDF Kconfig at build time.
+FLASH_FREQUENCIES = [
+    f"{freq}MHZ" for freq in (120, 80, 64, 60, 48, 40, 32, 30, 26, 24, 20, 16)
+]
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -1635,6 +1641,9 @@ CONFIG_SCHEMA = cv.All(
             # No default: when unset, the board definition (PlatformIO) or the
             # sdkconfig default (ESP-IDF) decides, preserving existing builds.
             cv.Optional(CONF_FLASH_MODE): cv.one_of(*FLASH_MODES, lower=True),
+            cv.Optional(CONF_FLASH_FREQUENCY): cv.one_of(
+                *FLASH_FREQUENCIES, upper=True
+            ),
             cv.Optional(CONF_PARTITIONS): cv.Any(
                 cv.file_,
                 cv.ensure_list(
@@ -1873,6 +1882,10 @@ async def to_code(config):
         )
         if CONF_FLASH_MODE in config:
             cg.add_platformio_option("board_build.flash_mode", config[CONF_FLASH_MODE])
+        if CONF_FLASH_FREQUENCY in config:
+            cg.add_platformio_option(
+                "board_build.f_flash", f"{config[CONF_FLASH_FREQUENCY][:-3]}000000L"
+            )
 
         if CONF_SOURCE in conf:
             cg.add_platformio_option("platform_packages", [conf[CONF_SOURCE]])
@@ -2026,6 +2039,10 @@ async def to_code(config):
     if CONF_FLASH_MODE in config:
         add_idf_sdkconfig_option(
             f"CONFIG_ESPTOOLPY_FLASHMODE_{config[CONF_FLASH_MODE].upper()}", True
+        )
+    if CONF_FLASH_FREQUENCY in config:
+        add_idf_sdkconfig_option(
+            f"CONFIG_ESPTOOLPY_FLASHFREQ_{config[CONF_FLASH_FREQUENCY][:-3]}M", True
         )
 
     # ESP32-P4: ESP-IDF 5.5.3 changed the default of ESP32P4_SELECTS_REV_LESS_V3

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1615,8 +1615,10 @@ FLASH_SIZES = [
 ]
 
 CONF_FLASH_SIZE = "flash_size"
+CONF_FLASH_MODE = "flash_mode"
 CONF_CPU_FREQUENCY = "cpu_frequency"
 CONF_PARTITIONS = "partitions"
+FLASH_MODES = ["qio", "qout", "dio", "dout", "opi"]
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -1630,6 +1632,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_FLASH_SIZE, default="4MB"): cv.one_of(
                 *FLASH_SIZES, upper=True
             ),
+            # No default: when unset, the board definition (PlatformIO) or the
+            # sdkconfig default (ESP-IDF) decides, preserving existing builds.
+            cv.Optional(CONF_FLASH_MODE): cv.one_of(*FLASH_MODES, lower=True),
             cv.Optional(CONF_PARTITIONS): cv.Any(
                 cv.file_,
                 cv.ensure_list(
@@ -1866,6 +1871,8 @@ async def to_code(config):
             "board_upload.maximum_size",
             int(config[CONF_FLASH_SIZE].removesuffix("MB")) * 1024 * 1024,
         )
+        if CONF_FLASH_MODE in config:
+            cg.add_platformio_option("board_build.flash_mode", config[CONF_FLASH_MODE])
 
         if CONF_SOURCE in conf:
             cg.add_platformio_option("platform_packages", [conf[CONF_SOURCE]])
@@ -2016,6 +2023,10 @@ async def to_code(config):
     add_idf_sdkconfig_option(
         f"CONFIG_ESPTOOLPY_FLASHSIZE_{config[CONF_FLASH_SIZE]}", True
     )
+    if CONF_FLASH_MODE in config:
+        add_idf_sdkconfig_option(
+            f"CONFIG_ESPTOOLPY_FLASHMODE_{config[CONF_FLASH_MODE].upper()}", True
+        )
 
     # ESP32-P4: ESP-IDF 5.5.3 changed the default of ESP32P4_SELECTS_REV_LESS_V3
     # from y to n. PlatformIO uses sections.ld.in (for rev <3) or

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1620,8 +1620,6 @@ CONF_FLASH_FREQUENCY = "flash_frequency"
 CONF_CPU_FREQUENCY = "cpu_frequency"
 CONF_PARTITIONS = "partitions"
 FLASH_MODES = ["qio", "qout", "dio", "dout", "opi"]
-# The full ESP-IDF ESPTOOLPY_FLASHFREQ choice set; which entries are valid
-# depends on the variant and is enforced by the IDF Kconfig at build time.
 FLASH_FREQUENCIES = [
     f"{freq}MHZ" for freq in (120, 80, 64, 60, 48, 40, 32, 30, 26, 24, 20, 16)
 ]
@@ -1638,8 +1636,6 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_FLASH_SIZE, default="4MB"): cv.one_of(
                 *FLASH_SIZES, upper=True
             ),
-            # No default: when unset, the board definition (PlatformIO) or the
-            # sdkconfig default (ESP-IDF) decides, preserving existing builds.
             cv.Optional(CONF_FLASH_MODE): cv.one_of(*FLASH_MODES, lower=True),
             cv.Optional(CONF_FLASH_FREQUENCY): cv.one_of(
                 *FLASH_FREQUENCIES, upper=True

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1876,11 +1876,11 @@ async def to_code(config):
             "board_upload.maximum_size",
             int(config[CONF_FLASH_SIZE].removesuffix("MB")) * 1024 * 1024,
         )
-        if CONF_FLASH_MODE in config:
-            cg.add_platformio_option("board_build.flash_mode", config[CONF_FLASH_MODE])
-        if CONF_FLASH_FREQUENCY in config:
+        if flash_mode := config.get(CONF_FLASH_MODE):
+            cg.add_platformio_option("board_build.flash_mode", flash_mode)
+        if flash_frequency := config.get(CONF_FLASH_FREQUENCY):
             cg.add_platformio_option(
-                "board_build.f_flash", f"{config[CONF_FLASH_FREQUENCY][:-3]}000000L"
+                "board_build.f_flash", f"{flash_frequency[:-3]}000000L"
             )
 
         if CONF_SOURCE in conf:

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2036,9 +2036,9 @@ async def to_code(config):
         add_idf_sdkconfig_option(
             f"CONFIG_ESPTOOLPY_FLASHMODE_{flash_mode.upper()}", True
         )
-    if CONF_FLASH_FREQUENCY in config:
+    if flash_frequency := config.get(CONF_FLASH_FREQUENCY):
         add_idf_sdkconfig_option(
-            f"CONFIG_ESPTOOLPY_FLASHFREQ_{config[CONF_FLASH_FREQUENCY][:-3]}M", True
+            f"CONFIG_ESPTOOLPY_FLASHFREQ_{flash_frequency[:-3]}M", True
         )
 
     # ESP32-P4: ESP-IDF 5.5.3 changed the default of ESP32P4_SELECTS_REV_LESS_V3

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2032,9 +2032,9 @@ async def to_code(config):
     add_idf_sdkconfig_option(
         f"CONFIG_ESPTOOLPY_FLASHSIZE_{config[CONF_FLASH_SIZE]}", True
     )
-    if CONF_FLASH_MODE in config:
+    if flash_mode := config.get(CONF_FLASH_MODE):
         add_idf_sdkconfig_option(
-            f"CONFIG_ESPTOOLPY_FLASHMODE_{config[CONF_FLASH_MODE].upper()}", True
+            f"CONFIG_ESPTOOLPY_FLASHMODE_{flash_mode.upper()}", True
         )
     if CONF_FLASH_FREQUENCY in config:
         add_idf_sdkconfig_option(

--- a/tests/component_tests/esp32/config/flash_mode_default.yaml
+++ b/tests/component_tests/esp32/config/flash_mode_default.yaml
@@ -1,0 +1,7 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf

--- a/tests/component_tests/esp32/config/flash_mode_idf.yaml
+++ b/tests/component_tests/esp32/config/flash_mode_idf.yaml
@@ -4,5 +4,6 @@ esphome:
 esp32:
   board: esp32dev
   flash_mode: qio
+  flash_frequency: 80MHz
   framework:
     type: esp-idf

--- a/tests/component_tests/esp32/config/flash_mode_idf.yaml
+++ b/tests/component_tests/esp32/config/flash_mode_idf.yaml
@@ -1,0 +1,8 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  flash_mode: qio
+  framework:
+    type: esp-idf

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -285,3 +285,25 @@ def test_native_idf_enables_reproducible_build(
 
     sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
     assert sdkconfig.get("CONFIG_APP_REPRODUCIBLE_BUILD") is True
+
+
+def test_flash_mode_sets_sdkconfig_and_pio_option(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """flash_mode selects the esptool flash mode on both backends."""
+    generate_main(component_config_path("flash_mode_idf.yaml"))
+    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    assert sdkconfig.get("CONFIG_ESPTOOLPY_FLASHMODE_QIO") is True
+    assert CORE.platformio_options.get("board_build.flash_mode") == "qio"
+
+
+def test_flash_mode_unset_leaves_defaults(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Without flash_mode the board/sdkconfig defaults stay untouched."""
+    generate_main(component_config_path("flash_mode_default.yaml"))
+    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    assert not any(key.startswith("CONFIG_ESPTOOLPY_FLASHMODE_") for key in sdkconfig)
+    assert "board_build.flash_mode" not in CORE.platformio_options

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -291,11 +291,13 @@ def test_flash_mode_sets_sdkconfig_and_pio_option(
     generate_main: Callable[[str | Path], str],
     component_config_path: Callable[[str], Path],
 ) -> None:
-    """flash_mode selects the esptool flash mode on both backends."""
+    """flash_mode/flash_frequency select the esptool flash parameters on both backends."""
     generate_main(component_config_path("flash_mode_idf.yaml"))
     sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
     assert sdkconfig.get("CONFIG_ESPTOOLPY_FLASHMODE_QIO") is True
+    assert sdkconfig.get("CONFIG_ESPTOOLPY_FLASHFREQ_80M") is True
     assert CORE.platformio_options.get("board_build.flash_mode") == "qio"
+    assert CORE.platformio_options.get("board_build.f_flash") == "80000000L"
 
 
 def test_flash_mode_unset_leaves_defaults(
@@ -306,4 +308,6 @@ def test_flash_mode_unset_leaves_defaults(
     generate_main(component_config_path("flash_mode_default.yaml"))
     sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
     assert not any(key.startswith("CONFIG_ESPTOOLPY_FLASHMODE_") for key in sdkconfig)
+    assert not any(key.startswith("CONFIG_ESPTOOLPY_FLASHFREQ_") for key in sdkconfig)
     assert "board_build.flash_mode" not in CORE.platformio_options
+    assert "board_build.f_flash" not in CORE.platformio_options


### PR DESCRIPTION
# What does this implement/fix?

Adds top-level `flash_mode` and `flash_frequency` options to the `esp32` platform config, complementing the existing `flash_size`:

```yaml
esp32:
  board: esp32dev
  flash_mode: qio        # qio / qout / dio / dout / opi
  flash_frequency: 80MHz
```

Today this is commonly done via `platformio_options: board_build.flash_mode: dio` / `board_build.f_flash: 80000000L`, which only works on the PlatformIO backend — it has no effect on the native ESP-IDF toolchain. The new options work on both:

- **PlatformIO**: emits `board_build.flash_mode` / `board_build.f_flash` into `platformio.ini` (effective for both Arduino and ESP-IDF framework builds, governing PIO's esptool flash command and bootloader/image header)
- **ESP-IDF framework** (PlatformIO and native toolchain): emits `CONFIG_ESPTOOLPY_FLASHMODE_<MODE>=y` / `CONFIG_ESPTOOLPY_FLASHFREQ_<N>M=y` into sdkconfig, alongside the existing `CONFIG_ESPTOOLPY_FLASHSIZE_*` handling

Setting both mechanisms from a single option keeps the flashed bootloader and the built image headers consistent — a mismatch between them is a classic source of boot loops when users change flash parameters by hand.

Both options have **no default** on purpose: when unset, the PlatformIO board definition or the ESP-IDF sdkconfig default decides, exactly as today — existing builds are unaffected.

- `flash_mode: opi` is accepted for octal-flash chips (e.g. ESP32-S3); ESP-IDF validates applicability at build time.
- `flash_frequency` accepts the full ESP-IDF `ESPTOOLPY_FLASHFREQ` choice set (`16MHz`–`120MHz`); which values are valid depends on the variant and is enforced by the IDF Kconfig at build time.

Existing `platformio_options` configs keep working unchanged on PlatformIO; user-supplied `platformio_options` are applied after platform options, so they still take precedence if both are set.

esp8266 already has the flash mode equivalent as `board_flash_mode`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6782

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test

esp32:
  board: esp32dev
  flash_mode: qio
  flash_frequency: 80MHz
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).