### PR TITLE
[spi] Skip logging on begin_transaction() of an auto-releasing write-only SPI device

### DIFF
--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -197,8 +197,10 @@ class SPIDelegateHw : public SPIDelegate {
       config.flags |= SPI_DEVICE_BIT_LSBFIRST;
     if (this->write_only_) {
       config.flags |= SPI_DEVICE_HALFDUPLEX | SPI_DEVICE_NO_DUMMY;
-      ESP_LOGD(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
-               Utility::get_pin_no(this->cs_pin_));
+      if (!this->release_device_) {
+        ESP_LOGD(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
+                 Utility::get_pin_no(this->cs_pin_));
+      }
     }
     esp_err_t const err = spi_bus_add_device(this->channel_, &config, &this->handle_);
     if (err != ESP_OK) {

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -17,7 +17,7 @@ class SPIDelegateHw : public SPIDelegate {
         write_only_(write_only) {
     if (!this->release_device_)
       add_device_();
-    
+
     if (this->write_only_) {
       ESP_LOGD(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
                Utility::get_pin_no(this->cs_pin_));

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -15,8 +15,12 @@ class SPIDelegateHw : public SPIDelegate {
         channel_(channel),
         release_device_(release_device),
         write_only_(write_only) {
-    if (!this->release_device_)
+    if (!this->release_device_) {
       add_device_();
+    } else {
+      ESP_LOGD(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
+               Utility::get_pin_no(this->cs_pin_));
+    }
   }
 
   bool is_ready() override { return this->handle_ != nullptr; }

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -19,7 +19,7 @@ class SPIDelegateHw : public SPIDelegate {
       add_device_();
 
     if (this->write_only_) {
-      ESP_LOGD(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
+      ESP_LOGV(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
                Utility::get_pin_no(this->cs_pin_));
     }
   }

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -15,9 +15,10 @@ class SPIDelegateHw : public SPIDelegate {
         channel_(channel),
         release_device_(release_device),
         write_only_(write_only) {
-    if (!this->release_device_) {
+    if (!this->release_device_)
       add_device_();
-    } else {
+    
+    if (this->write_only_) {
       ESP_LOGD(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
                Utility::get_pin_no(this->cs_pin_));
     }
@@ -199,13 +200,8 @@ class SPIDelegateHw : public SPIDelegate {
     config.post_cb = nullptr;
     if (this->bit_order_ == BIT_ORDER_LSB_FIRST)
       config.flags |= SPI_DEVICE_BIT_LSBFIRST;
-    if (this->write_only_) {
+    if (this->write_only_)
       config.flags |= SPI_DEVICE_HALFDUPLEX | SPI_DEVICE_NO_DUMMY;
-      if (!this->release_device_) {
-        ESP_LOGD(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
-                 Utility::get_pin_no(this->cs_pin_));
-      }
-    }
     esp_err_t const err = spi_bus_add_device(this->channel_, &config, &this->handle_);
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Add device failed - err %X", err);


### PR DESCRIPTION
# What does this implement/fix?

Normally a debug line is logged when an SPI device is setup in a write-only (half duplex) mode. This is done once from a SPI delegate constructor, when registering the device.  
But with the addition of a `release_device:` flag from https://github.com/esphome/esphome/pull/9128, this is done repeatedly on every write transaction, spamming the same diagnostic with every write. Log is flooded very easily especially with `mipi_spi` displays with `release_device: true` when updating often (e.g. animating), since they always have the write-only flag set to true. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(this only applies to ESP-IDF since it's a requirement for the `release_device:` flag.)

## Example entry for `config.yaml`:

```yaml
display:
  - id: display_main
    platform: mipi_spi
    model: ili9341
    cs_pin: ...
    reset_pin: ...
    dc_pin: ...
    release_device: true
    
lvgl:
    widgets:
      - spinner:
          height: 50
          width: 50
          spin_time: 1s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] (N/A) Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] (N/A) Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
