### PR TITLE
[packet_transport] Store Provider name as std::string

### DIFF
--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -404,13 +404,14 @@ static bool process_rolling_code(Provider &provider, PacketDecoder &decoder) {
     return false;
   }
   if (code1 < provider.last_code[1] || (code1 == provider.last_code[1] && code0 <= provider.last_code[0])) {
-    ESP_LOGW(TAG, "Rolling code for %s %08lX:%08lX is old", provider.name, (unsigned long) code1,
+    ESP_LOGW(TAG, "Rolling code for %s %08lX:%08lX is old", provider.name.c_str(), (unsigned long) code1,
              (unsigned long) code0);
     return false;
   }
   provider.last_code[0] = code0;
   provider.last_code[1] = code1;
-  ESP_LOGV(TAG, "Saw new rolling code for %s %08lX:%08lX", provider.name, (unsigned long) code1, (unsigned long) code0);
+  ESP_LOGV(TAG, "Saw new rolling code for %s %08lX:%08lX", provider.name.c_str(), (unsigned long) code1,
+           (unsigned long) code0);
   return true;
 }
 

--- a/esphome/components/packet_transport/packet_transport.h
+++ b/esphome/components/packet_transport/packet_transport.h
@@ -12,6 +12,7 @@
 
 #include <map>
 #include <span>
+#include <string>
 #include <vector>
 
 /**
@@ -29,7 +30,7 @@ template<typename T> using string_map_t = std::map<std::string, T, std::less<>>;
 
 struct Provider {
   std::vector<uint8_t> encryption_key;
-  const char *name;
+  std::string name;
   uint32_t last_code[2];
   uint32_t last_key_response_time;
 #ifdef USE_STATUS_SENSOR


### PR DESCRIPTION
# What does this implement/fix?

`Provider::name` in `packet_transport` is stored as a `const char *` that aliases the string passed to `add_provider()`:

```cpp
struct Provider {
  std::vector<uint8_t> encryption_key;
  const char *name;            // aliases the caller's string
  ...
};

void add_provider(const char *hostname) {
  if (!this->providers_.contains(hostname)) {
    Provider provider{};
    provider.name = hostname;  // stores the pointer, not a copy
    this->providers_[hostname] = provider;
    ...
  }
}
```

This is only safe today because the **single** caller is the code generator, which always passes string literals (static storage). Any non-codegen caller of `add_provider()` — e.g. a future automation/action that builds a peer name dynamically — would leave `Provider::name` dangling once the source string went out of scope, leading to garbage reads or a crash in the rolling-code log path that dereferences it.

This PR makes `Provider` **own** its name by storing it as `std::string`, so registration copies the value and the lifetime hazard is removed. This also unblocks runtime provider management (adding/removing peers after boot) without each caller having to guarantee static string lifetime.

Notes:
- The providers map is already keyed by `std::string` (`string_map_t<Provider>`), so lookups and `std::less<>` heterogeneous comparison are unaffected.
- `add_provider()` keeps its `const char *` signature, so existing codegen (`var.add_provider("name")`) is unchanged — this is purely an internal storage change, not a public API change.
- The only read sites of `Provider::name` are two `ESP_LOG` statements, updated to use `.c_str()`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (standalone hardening; prerequisite for runtime provider management)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (no user-facing config or API change)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change — existing packet_transport configs compile and behave identically.
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).