### PR TITLE
[device-builder] Add opt-in toggle for the new ESPHome Device Builder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,8 +75,6 @@ WORKDIR /config
 # Set entrypoint to esphome (via a script) so that the user doesn't have to type 'esphome'
 # in every docker command twice
 ENTRYPOINT ["/entrypoint.sh"]
-# When no arguments given, start the dashboard in the workdir
-CMD ["dashboard", "/config"]
 
 
 # ======================= ha-addon-type image =======================

--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -27,4 +27,28 @@ if [[ -d /build ]]; then
     export ESPHOME_BUILD_PATH=/build
 fi
 
+# The image does not hard-code a CMD; the proper default is supplied here based
+# on which version is selected. Any command passed to the container is forwarded
+# verbatim and must be consistent with the selected version.
+case "${USE_NEW_DEVICE_BUILDER,,}" in
+    1 | true | yes | on)
+        # Install the latest prerelease of esphome-device-builder on boot.
+        # This is a temporary install-on-boot step until esphome-device-builder
+        # becomes a direct dependency of esphome.
+        echo "Installing latest prerelease of esphome-device-builder..."
+        uv pip install --system --no-cache-dir --prerelease=allow --upgrade \
+            esphome-device-builder
+
+        # Default to serving the config directory when no command is given.
+        if [[ $# -eq 0 ]]; then
+            set -- /config
+        fi
+        exec esphome-device-builder "$@"
+        ;;
+esac
+
+# Default to the dashboard when no command is given.
+if [[ $# -eq 0 ]]; then
+    set -- dashboard /config
+fi
 exec esphome "$@"


### PR DESCRIPTION
# What does this implement/fix?

Ports the Home Assistant add-on's `use_new_device_builder` toggle (#16247) to
the regular ESPHome docker image.

Setting the `USE_NEW_DEVICE_BUILDER` environment variable (`1`/`true`/`yes`/`on`)
makes the container install the latest `esphome-device-builder` prerelease on
boot and run it in place of the dashboard. When the variable is unset, the image
behaves exactly as before and starts `esphome dashboard /config`.

To make this possible the default command was moved out of the Dockerfile `CMD`
and into the entrypoint, which now selects the proper default per version:
- unset → `esphome dashboard /config`
- enabled → `esphome-device-builder /config`

As with the add-on, this is a temporary install-on-boot step until
`esphome-device-builder` becomes a direct dependency of esphome. The two CLIs do
not accept exactly the same options (e.g. dashboard's `--address` is `--host` in
device-builder, and `--socket`/`--open-ui` do not exist), so arguments are not
translated: any explicit command passed to the container is forwarded verbatim
and must be consistent with the selected version.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Mirrors #16247 (HA add-on toggle)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (docker env var; can add docs if desired)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

N/A — this changes the docker image entrypoint, not device firmware. Verified by
building the docker-type image and running it four ways (toggle on/off ×
command/no-command); each resolved to the expected binary and started correctly.

## Example entry for `config.yaml`:

N/A — enabled via a docker environment variable, not YAML:

```bash
docker run -e USE_NEW_DEVICE_BUILDER=1 -p 6052:6052 -v "$PWD":/config esphome/esphome
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). N/A — no test harness exists for the docker entrypoint script.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in https://github.com/esphome/device-builder/pull/1447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
