### PR TITLE
Add PEP 572 walrus operator preference to coding conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,19 @@ This document provides essential context for AI models interacting with this pro
         - Protected/private fields: `lower_snake_case_with_trailing_underscore_`
         - Favor descriptive names over abbreviations
 
+*   **Python Idioms:**
+    *   **Assignment expressions (PEP 572):** Prefer the walrus operator (`:=`) wherever it removes a redundant lookup or a throwaway temporary. The most common case in component code is presence-checking a config key and then indexing it separately — fetch once with `.get()` and bind in the condition instead:
+        ```python
+        # Bad - looks up CONF_BLAH twice
+        if CONF_BLAH in config:
+            cg.add(var.set_blah(config[CONF_BLAH]))
+
+        # Good - single lookup, value bound inline
+        if (blah := config.get(CONF_BLAH)) is not None:
+            cg.add(var.set_blah(blah))
+        ```
+        The same applies to `while` loops and comprehensions where it avoids recomputing a value. Don't contort code to use it — reach for `:=` only when it genuinely cuts repetition or an extra assignment line.
+
 *   **C++ Field Visibility:**
     *   **Prefer `protected`:** Use `protected` for most class fields to enable extensibility and testing. Fields should be `lower_snake_case_with_trailing_underscore_`.
     *   **Use `private` for safety-critical cases:** Use `private` visibility when direct field access could introduce bugs or violate invariants:


### PR DESCRIPTION
# What does this implement/fix?

Adds a "Python Idioms" subsection to the coding conventions in `AGENTS.md` (surfaced to agents via the `CLAUDE.md` and `.github/copilot-instructions.md` symlinks) documenting a preference for PEP 572 assignment expressions (the walrus operator) where they remove a redundant lookup or throwaway temporary. The worked example is the common ESPHome pattern of presence-checking a config key and then indexing it separately, rewritten to a single `.get()` bound in the condition.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).