### PR TITLE
Mark configurable classes as final (1/21: a01nyub-aqi)

### DIFF
--- a/esphome/components/a01nyub/a01nyub.h
+++ b/esphome/components/a01nyub/a01nyub.h
@@ -8,7 +8,7 @@
 
 namespace esphome::a01nyub {
 
-class A01nyubComponent : public sensor::Sensor, public Component, public uart::UARTDevice {
+class A01nyubComponent final : public sensor::Sensor, public Component, public uart::UARTDevice {
  public:
   // Nothing really public.
 

--- a/esphome/components/a02yyuw/a02yyuw.h
+++ b/esphome/components/a02yyuw/a02yyuw.h
@@ -8,7 +8,7 @@
 
 namespace esphome::a02yyuw {
 
-class A02yyuwComponent : public sensor::Sensor, public Component, public uart::UARTDevice {
+class A02yyuwComponent final : public sensor::Sensor, public Component, public uart::UARTDevice {
  public:
   // Nothing really public.
 

--- a/esphome/components/a4988/a4988.h
+++ b/esphome/components/a4988/a4988.h
@@ -6,7 +6,7 @@
 
 namespace esphome::a4988 {
 
-class A4988 : public stepper::Stepper, public Component {
+class A4988 final : public stepper::Stepper, public Component {
  public:
   void set_step_pin(GPIOPin *step_pin) { step_pin_ = step_pin; }
   void set_dir_pin(GPIOPin *dir_pin) { dir_pin_ = dir_pin; }

--- a/esphome/components/absolute_humidity/absolute_humidity.h
+++ b/esphome/components/absolute_humidity/absolute_humidity.h
@@ -13,7 +13,7 @@ enum SaturationVaporPressureEquation {
 };
 
 /// This class implements calculation of absolute humidity from temperature and relative humidity.
-class AbsoluteHumidityComponent : public sensor::Sensor, public Component {
+class AbsoluteHumidityComponent final : public sensor::Sensor, public Component {
  public:
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { this->temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { this->humidity_sensor_ = humidity_sensor; }

--- a/esphome/components/ac_dimmer/ac_dimmer.h
+++ b/esphome/components/ac_dimmer/ac_dimmer.h
@@ -41,7 +41,7 @@ struct AcDimmerDataStore {
 #endif
 };
 
-class AcDimmer : public output::FloatOutput, public Component {
+class AcDimmer final : public output::FloatOutput, public Component {
  public:
   void setup() override;
 

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -54,7 +54,7 @@ template<typename T> class Aggregator {
   SamplingMode mode_{SamplingMode::AVG};
 };
 
-class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage_sampler::VoltageSampler {
+class ADCSensor final : public sensor::Sensor, public PollingComponent, public voltage_sampler::VoltageSampler {
  public:
   /// Update the sensor's state by reading the current ADC value.
   /// This method is called periodically based on the update interval.

--- a/esphome/components/adc128s102/adc128s102.h
+++ b/esphome/components/adc128s102/adc128s102.h
@@ -6,9 +6,9 @@
 
 namespace esphome::adc128s102 {
 
-class ADC128S102 : public Component,
-                   public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
-                                         spi::DATA_RATE_10MHZ> {
+class ADC128S102 final : public Component,
+                         public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                               spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_10MHZ> {
  public:
   ADC128S102() = default;
 

--- a/esphome/components/adc128s102/sensor/adc128s102_sensor.h
+++ b/esphome/components/adc128s102/sensor/adc128s102_sensor.h
@@ -9,10 +9,10 @@
 
 namespace esphome::adc128s102 {
 
-class ADC128S102Sensor : public PollingComponent,
-                         public Parented<ADC128S102>,
-                         public sensor::Sensor,
-                         public voltage_sampler::VoltageSampler {
+class ADC128S102Sensor final : public PollingComponent,
+                               public Parented<ADC128S102>,
+                               public sensor::Sensor,
+                               public voltage_sampler::VoltageSampler {
  public:
   ADC128S102Sensor(uint8_t channel);
 

--- a/esphome/components/addressable_light/addressable_light_display.h
+++ b/esphome/components/addressable_light/addressable_light_display.h
@@ -9,7 +9,7 @@
 
 namespace esphome::addressable_light {
 
-class AddressableLightDisplay : public display::DisplayBuffer {
+class AddressableLightDisplay final : public display::DisplayBuffer {
  public:
   light::AddressableLight *get_light() const { return this->light_; }
 

--- a/esphome/components/ade7880/ade7880.h
+++ b/esphome/components/ade7880/ade7880.h
@@ -65,7 +65,7 @@ struct ADE7880Store {
   static void gpio_intr(ADE7880Store *arg);
 };
 
-class ADE7880 : public i2c::I2CDevice, public PollingComponent {
+class ADE7880 final : public i2c::I2CDevice, public PollingComponent {
  public:
   void set_irq0_pin(InternalGPIOPin *pin) { this->irq0_pin_ = pin; }
   void set_irq1_pin(InternalGPIOPin *pin) { this->irq1_pin_ = pin; }

--- a/esphome/components/ade7953_i2c/ade7953_i2c.h
+++ b/esphome/components/ade7953_i2c/ade7953_i2c.h
@@ -10,7 +10,7 @@
 
 namespace esphome::ade7953_i2c {
 
-class AdE7953I2c : public ade7953_base::ADE7953, public i2c::I2CDevice {
+class AdE7953I2c final : public ade7953_base::ADE7953, public i2c::I2CDevice {
  public:
   void dump_config() override;
 

--- a/esphome/components/ads1115/ads1115.h
+++ b/esphome/components/ads1115/ads1115.h
@@ -43,7 +43,7 @@ enum ADS1115Samplerate {
   ADS1115_860SPS = 0b111
 };
 
-class ADS1115Component : public Component, public i2c::I2CDevice {
+class ADS1115Component final : public Component, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/ads1115/sensor/ads1115_sensor.h
+++ b/esphome/components/ads1115/sensor/ads1115_sensor.h
@@ -11,10 +11,10 @@
 namespace esphome::ads1115 {
 
 /// Internal holder class that is in instance of Sensor so that the hub can create individual sensors.
-class ADS1115Sensor : public sensor::Sensor,
-                      public PollingComponent,
-                      public voltage_sampler::VoltageSampler,
-                      public Parented<ADS1115Component> {
+class ADS1115Sensor final : public sensor::Sensor,
+                            public PollingComponent,
+                            public voltage_sampler::VoltageSampler,
+                            public Parented<ADS1115Component> {
  public:
   void update() override;
   void set_multiplexer(ADS1115Multiplexer multiplexer) { this->multiplexer_ = multiplexer; }

--- a/esphome/components/ads1118/ads1118.h
+++ b/esphome/components/ads1118/ads1118.h
@@ -26,9 +26,9 @@ enum ADS1118Gain {
   ADS1118_GAIN_0P256 = 0b101,
 };
 
-class ADS1118 : public Component,
-                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_TRAILING,
-                                      spi::DATA_RATE_1MHZ> {
+class ADS1118 final : public Component,
+                      public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                            spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_1MHZ> {
  public:
   ADS1118() = default;
   void setup() override;

--- a/esphome/components/ads1118/sensor/ads1118_sensor.h
+++ b/esphome/components/ads1118/sensor/ads1118_sensor.h
@@ -10,10 +10,10 @@
 
 namespace esphome::ads1118 {
 
-class ADS1118Sensor : public PollingComponent,
-                      public sensor::Sensor,
-                      public voltage_sampler::VoltageSampler,
-                      public Parented<ADS1118> {
+class ADS1118Sensor final : public PollingComponent,
+                            public sensor::Sensor,
+                            public voltage_sampler::VoltageSampler,
+                            public Parented<ADS1118> {
  public:
   void update() override;
 

--- a/esphome/components/ags10/ags10.h
+++ b/esphome/components/ags10/ags10.h
@@ -7,7 +7,7 @@
 
 namespace esphome::ags10 {
 
-class AGS10Component : public PollingComponent, public i2c::I2CDevice {
+class AGS10Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   /**
    * Sets TVOC sensor.
@@ -100,7 +100,7 @@ class AGS10Component : public PollingComponent, public i2c::I2CDevice {
   template<size_t N> optional<std::array<uint8_t, N>> read_and_check_(uint8_t a_register);
 };
 
-template<typename... Ts> class AGS10NewI2cAddressAction : public Action<Ts...>, public Parented<AGS10Component> {
+template<typename... Ts> class AGS10NewI2cAddressAction final : public Action<Ts...>, public Parented<AGS10Component> {
  public:
   TEMPLATABLE_VALUE(uint8_t, new_address)
 
@@ -116,7 +116,7 @@ enum AGS10SetZeroPointActionMode {
   CUSTOM_VALUE,
 };
 
-template<typename... Ts> class AGS10SetZeroPointAction : public Action<Ts...>, public Parented<AGS10Component> {
+template<typename... Ts> class AGS10SetZeroPointAction final : public Action<Ts...>, public Parented<AGS10Component> {
  public:
   TEMPLATABLE_VALUE(uint16_t, value)
   TEMPLATABLE_VALUE(AGS10SetZeroPointActionMode, mode)

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -10,7 +10,7 @@ namespace esphome::aht10 {
 
 enum AHT10Variant { AHT10, AHT20 };
 
-class AHT10Component : public PollingComponent, public i2c::I2CDevice {
+class AHT10Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void update() override;

--- a/esphome/components/aic3204/aic3204.h
+++ b/esphome/components/aic3204/aic3204.h
@@ -61,7 +61,7 @@ static const uint8_t AIC3204_ADC_PTM = 0x3D;       // Register 61 - ADC Power Tu
 static const uint8_t AIC3204_AN_IN_CHRG = 0x47;    // Register 71 - Analog Input Quick Charging Config
 static const uint8_t AIC3204_REF_STARTUP = 0x7B;   // Register 123 - Reference Power Up Config
 
-class AIC3204 : public audio_dac::AudioDac, public Component, public i2c::I2CDevice {
+class AIC3204 final : public audio_dac::AudioDac, public Component, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/aic3204/automation.h
+++ b/esphome/components/aic3204/automation.h
@@ -6,7 +6,7 @@
 
 namespace esphome::aic3204 {
 
-template<typename... Ts> class SetAutoMuteAction : public Action<Ts...> {
+template<typename... Ts> class SetAutoMuteAction final : public Action<Ts...> {
  public:
   explicit SetAutoMuteAction(AIC3204 *aic3204) : aic3204_(aic3204) {}
 

--- a/esphome/components/airthings_ble/airthings_listener.h
+++ b/esphome/components/airthings_ble/airthings_listener.h
@@ -7,7 +7,7 @@
 
 namespace esphome::airthings_ble {
 
-class AirthingsListener : public esp32_ble_tracker::ESPBTDeviceListener {
+class AirthingsListener final : public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 };

--- a/esphome/components/airthings_wave_mini/airthings_wave_mini.h
+++ b/esphome/components/airthings_wave_mini/airthings_wave_mini.h
@@ -12,7 +12,7 @@ static const char *const SERVICE_UUID = "b42e3882-ade7-11e4-89d3-123b93f75cba";
 static const char *const CHARACTERISTIC_UUID = "b42e3b98-ade7-11e4-89d3-123b93f75cba";
 static const char *const ACCESS_CONTROL_POINT_CHARACTERISTIC_UUID = "b42e3ef4-ade7-11e4-89d3-123b93f75cba";
 
-class AirthingsWaveMini : public airthings_wave_base::AirthingsWaveBase {
+class AirthingsWaveMini final : public airthings_wave_base::AirthingsWaveBase {
  public:
   AirthingsWaveMini();
 

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.h
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.h
@@ -19,7 +19,7 @@ static const char *const CHARACTERISTIC_UUID_WAVE_RADON_GEN2 = "b42e4dcc-ade7-11
 static const char *const ACCESS_CONTROL_POINT_CHARACTERISTIC_UUID_WAVE_RADON_GEN2 =
     "b42e50d8-ade7-11e4-89d3-123b93f75cba";
 
-class AirthingsWavePlus : public airthings_wave_base::AirthingsWaveBase {
+class AirthingsWavePlus final : public airthings_wave_base::AirthingsWaveBase {
  public:
   void setup() override;
 

--- a/esphome/components/alarm_control_panel/automation.h
+++ b/esphome/components/alarm_control_panel/automation.h
@@ -27,7 +27,7 @@ static_assert(std::is_trivially_copyable_v<StateAnyForwarder>);
 static_assert(sizeof(StateEnterForwarder<ACP_STATE_TRIGGERED>) <= sizeof(void *));
 static_assert(std::is_trivially_copyable_v<StateEnterForwarder<ACP_STATE_TRIGGERED>>);
 
-template<typename... Ts> class ArmAwayAction : public Action<Ts...> {
+template<typename... Ts> class ArmAwayAction final : public Action<Ts...> {
  public:
   explicit ArmAwayAction(AlarmControlPanel *alarm_control_panel) : alarm_control_panel_(alarm_control_panel) {}
 
@@ -39,7 +39,7 @@ template<typename... Ts> class ArmAwayAction : public Action<Ts...> {
   AlarmControlPanel *alarm_control_panel_;
 };
 
-template<typename... Ts> class ArmHomeAction : public Action<Ts...> {
+template<typename... Ts> class ArmHomeAction final : public Action<Ts...> {
  public:
   explicit ArmHomeAction(AlarmControlPanel *alarm_control_panel) : alarm_control_panel_(alarm_control_panel) {}
 
@@ -51,7 +51,7 @@ template<typename... Ts> class ArmHomeAction : public Action<Ts...> {
   AlarmControlPanel *alarm_control_panel_;
 };
 
-template<typename... Ts> class ArmNightAction : public Action<Ts...> {
+template<typename... Ts> class ArmNightAction final : public Action<Ts...> {
  public:
   explicit ArmNightAction(AlarmControlPanel *alarm_control_panel) : alarm_control_panel_(alarm_control_panel) {}
 
@@ -63,7 +63,7 @@ template<typename... Ts> class ArmNightAction : public Action<Ts...> {
   AlarmControlPanel *alarm_control_panel_;
 };
 
-template<typename... Ts> class DisarmAction : public Action<Ts...> {
+template<typename... Ts> class DisarmAction final : public Action<Ts...> {
  public:
   explicit DisarmAction(AlarmControlPanel *alarm_control_panel) : alarm_control_panel_(alarm_control_panel) {}
 
@@ -75,7 +75,7 @@ template<typename... Ts> class DisarmAction : public Action<Ts...> {
   AlarmControlPanel *alarm_control_panel_;
 };
 
-template<typename... Ts> class PendingAction : public Action<Ts...> {
+template<typename... Ts> class PendingAction final : public Action<Ts...> {
  public:
   explicit PendingAction(AlarmControlPanel *alarm_control_panel) : alarm_control_panel_(alarm_control_panel) {}
 
@@ -85,7 +85,7 @@ template<typename... Ts> class PendingAction : public Action<Ts...> {
   AlarmControlPanel *alarm_control_panel_;
 };
 
-template<typename... Ts> class TriggeredAction : public Action<Ts...> {
+template<typename... Ts> class TriggeredAction final : public Action<Ts...> {
  public:
   explicit TriggeredAction(AlarmControlPanel *alarm_control_panel) : alarm_control_panel_(alarm_control_panel) {}
 
@@ -95,7 +95,7 @@ template<typename... Ts> class TriggeredAction : public Action<Ts...> {
   AlarmControlPanel *alarm_control_panel_;
 };
 
-template<typename... Ts> class AlarmControlPanelCondition : public Condition<Ts...> {
+template<typename... Ts> class AlarmControlPanelCondition final : public Condition<Ts...> {
  public:
   AlarmControlPanelCondition(AlarmControlPanel *parent) : parent_(parent) {}
   bool check(const Ts &...x) override {

--- a/esphome/components/alpha3/alpha3.h
+++ b/esphome/components/alpha3/alpha3.h
@@ -31,7 +31,7 @@ static const int16_t GENI_RESPONSE_POWER_OFFSET = 12;
 static const int16_t GENI_RESPONSE_MOTOR_POWER_OFFSET = 16;  // not sure
 static const int16_t GENI_RESPONSE_MOTOR_SPEED_OFFSET = 20;
 
-class Alpha3 : public esphome::ble_client::BLEClientNode, public PollingComponent {
+class Alpha3 final : public esphome::ble_client::BLEClientNode, public PollingComponent {
  public:
   void setup() override;
   void update() override;

--- a/esphome/components/am2315c/am2315c.h
+++ b/esphome/components/am2315c/am2315c.h
@@ -27,7 +27,7 @@
 
 namespace esphome::am2315c {
 
-class AM2315C : public PollingComponent, public i2c::I2CDevice {
+class AM2315C final : public PollingComponent, public i2c::I2CDevice {
  public:
   void dump_config() override;
   void update() override;

--- a/esphome/components/am2320/am2320.h
+++ b/esphome/components/am2320/am2320.h
@@ -6,7 +6,7 @@
 
 namespace esphome::am2320 {
 
-class AM2320Component : public PollingComponent, public i2c::I2CDevice {
+class AM2320Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/am43/cover/am43_cover.h
+++ b/esphome/components/am43/cover/am43_cover.h
@@ -14,7 +14,7 @@ namespace esphome::am43 {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
-class Am43Component : public cover::Cover, public esphome::ble_client::BLEClientNode, public Component {
+class Am43Component final : public cover::Cover, public esphome::ble_client::BLEClientNode, public Component {
  public:
   void setup() override;
   void loop() override;

--- a/esphome/components/am43/sensor/am43_sensor.h
+++ b/esphome/components/am43/sensor/am43_sensor.h
@@ -14,7 +14,7 @@ namespace esphome::am43 {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
-class Am43 : public esphome::ble_client::BLEClientNode, public PollingComponent {
+class Am43 final : public esphome::ble_client::BLEClientNode, public PollingComponent {
  public:
   void setup() override;
   void update() override;

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
@@ -7,7 +7,7 @@
 
 namespace esphome::analog_threshold {
 
-class AnalogThresholdBinarySensor : public Component, public binary_sensor::BinarySensor {
+class AnalogThresholdBinarySensor final : public Component, public binary_sensor::BinarySensor {
  public:
   void dump_config() override;
   void setup() override;

--- a/esphome/components/animation/animation.h
+++ b/esphome/components/animation/animation.h
@@ -5,7 +5,7 @@
 
 namespace esphome::animation {
 
-class Animation : public image::Image {
+class Animation final : public image::Image {
  public:
   Animation(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count, image::ImageType type,
             image::Transparency transparent);
@@ -35,7 +35,7 @@ class Animation : public image::Image {
   int loop_current_iteration_;
 };
 
-template<typename... Ts> class AnimationNextFrameAction : public Action<Ts...> {
+template<typename... Ts> class AnimationNextFrameAction final : public Action<Ts...> {
  public:
   AnimationNextFrameAction(Animation *parent) : parent_(parent) {}
   void play(const Ts &...x) override { this->parent_->next_frame(); }
@@ -44,7 +44,7 @@ template<typename... Ts> class AnimationNextFrameAction : public Action<Ts...> {
   Animation *parent_;
 };
 
-template<typename... Ts> class AnimationPrevFrameAction : public Action<Ts...> {
+template<typename... Ts> class AnimationPrevFrameAction final : public Action<Ts...> {
  public:
   AnimationPrevFrameAction(Animation *parent) : parent_(parent) {}
   void play(const Ts &...x) override { this->parent_->prev_frame(); }
@@ -53,7 +53,7 @@ template<typename... Ts> class AnimationPrevFrameAction : public Action<Ts...> {
   Animation *parent_;
 };
 
-template<typename... Ts> class AnimationSetFrameAction : public Action<Ts...> {
+template<typename... Ts> class AnimationSetFrameAction final : public Action<Ts...> {
  public:
   AnimationSetFrameAction(Animation *parent) : parent_(parent) {}
   TEMPLATABLE_VALUE(uint16_t, frame)

--- a/esphome/components/anova/anova.h
+++ b/esphome/components/anova/anova.h
@@ -17,7 +17,7 @@ namespace espbt = esphome::esp32_ble_tracker;
 static const uint16_t ANOVA_SERVICE_UUID = 0xFFE0;
 static const uint16_t ANOVA_CHARACTERISTIC_UUID = 0xFFE1;
 
-class Anova : public climate::Climate, public esphome::ble_client::BLEClientNode, public PollingComponent {
+class Anova final : public climate::Climate, public esphome::ble_client::BLEClientNode, public PollingComponent {
  public:
   void setup() override;
   void loop() override;

--- a/esphome/components/apds9306/apds9306.h
+++ b/esphome/components/apds9306/apds9306.h
@@ -39,7 +39,7 @@ enum AmbientLightGain : uint8_t {
 };
 static const uint8_t AMBIENT_LIGHT_GAIN_VALUES[] = {1, 3, 6, 9, 18};
 
-class APDS9306 : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
+class APDS9306 final : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   float get_setup_priority() const override { return setup_priority::BUS; }

--- a/esphome/components/apds9960/apds9960.h
+++ b/esphome/components/apds9960/apds9960.h
@@ -12,7 +12,7 @@
 
 namespace esphome::apds9960 {
 
-class APDS9960 : public PollingComponent, public i2c::I2CDevice {
+class APDS9960 final : public PollingComponent, public i2c::I2CDevice {
 #ifdef USE_SENSOR
   SUB_SENSOR(red)
   SUB_SENSOR(green)

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -342,7 +342,7 @@ class APIServer final : public Component,
 
 extern APIServer *global_api_server;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-template<typename... Ts> class APIConnectedCondition : public Condition<Ts...> {
+template<typename... Ts> class APIConnectedCondition final : public Condition<Ts...> {
   TEMPLATABLE_VALUE(bool, state_subscription_only)
  public:
   bool check(const Ts &...x) override {

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -104,7 +104,7 @@ class ActionResponse {
 template<typename... Ts> using ActionResponseCallback = std::function<void(const ActionResponse &, Ts...)>;
 #endif
 
-template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts...> {
+template<typename... Ts> class HomeAssistantServiceCallAction final : public Action<Ts...> {
  public:
   explicit HomeAssistantServiceCallAction(APIServer *parent, bool is_event) : parent_(parent) {
     this->flags_.is_event = is_event;

--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -164,7 +164,8 @@ template<enums::SupportsResponseType Mode, typename... Ts> class UserServiceTrig
 
 // Specialization for NONE - no extra trigger arguments
 template<typename... Ts>
-class UserServiceTrigger<enums::SUPPORTS_RESPONSE_NONE, Ts...> : public UserServiceBase<Ts...>, public Trigger<Ts...> {
+class UserServiceTrigger<enums::SUPPORTS_RESPONSE_NONE, Ts...> final : public UserServiceBase<Ts...>,
+                                                                       public Trigger<Ts...> {
  public:
   UserServiceTrigger(const char *name, const std::array<const char *, sizeof...(Ts)> &arg_names)
       : UserServiceBase<Ts...>(name, arg_names, enums::SUPPORTS_RESPONSE_NONE) {}
@@ -175,8 +176,8 @@ class UserServiceTrigger<enums::SUPPORTS_RESPONSE_NONE, Ts...> : public UserServ
 
 // Specialization for OPTIONAL - call_id and return_response trigger arguments
 template<typename... Ts>
-class UserServiceTrigger<enums::SUPPORTS_RESPONSE_OPTIONAL, Ts...> : public UserServiceBase<Ts...>,
-                                                                     public Trigger<uint32_t, bool, Ts...> {
+class UserServiceTrigger<enums::SUPPORTS_RESPONSE_OPTIONAL, Ts...> final : public UserServiceBase<Ts...>,
+                                                                           public Trigger<uint32_t, bool, Ts...> {
  public:
   UserServiceTrigger(const char *name, const std::array<const char *, sizeof...(Ts)> &arg_names)
       : UserServiceBase<Ts...>(name, arg_names, enums::SUPPORTS_RESPONSE_OPTIONAL) {}
@@ -189,8 +190,8 @@ class UserServiceTrigger<enums::SUPPORTS_RESPONSE_OPTIONAL, Ts...> : public User
 
 // Specialization for ONLY - just call_id trigger argument
 template<typename... Ts>
-class UserServiceTrigger<enums::SUPPORTS_RESPONSE_ONLY, Ts...> : public UserServiceBase<Ts...>,
-                                                                 public Trigger<uint32_t, Ts...> {
+class UserServiceTrigger<enums::SUPPORTS_RESPONSE_ONLY, Ts...> final : public UserServiceBase<Ts...>,
+                                                                       public Trigger<uint32_t, Ts...> {
  public:
   UserServiceTrigger(const char *name, const std::array<const char *, sizeof...(Ts)> &arg_names)
       : UserServiceBase<Ts...>(name, arg_names, enums::SUPPORTS_RESPONSE_ONLY) {}
@@ -201,8 +202,8 @@ class UserServiceTrigger<enums::SUPPORTS_RESPONSE_ONLY, Ts...> : public UserServ
 
 // Specialization for STATUS - just call_id trigger argument (reports success/error without data)
 template<typename... Ts>
-class UserServiceTrigger<enums::SUPPORTS_RESPONSE_STATUS, Ts...> : public UserServiceBase<Ts...>,
-                                                                   public Trigger<uint32_t, Ts...> {
+class UserServiceTrigger<enums::SUPPORTS_RESPONSE_STATUS, Ts...> final : public UserServiceBase<Ts...>,
+                                                                         public Trigger<uint32_t, Ts...> {
  public:
   UserServiceTrigger(const char *name, const std::array<const char *, sizeof...(Ts)> &arg_names)
       : UserServiceBase<Ts...>(name, arg_names, enums::SUPPORTS_RESPONSE_STATUS) {}
@@ -221,7 +222,7 @@ class UserServiceTrigger<enums::SUPPORTS_RESPONSE_STATUS, Ts...> : public UserSe
 
 namespace esphome::api {
 
-template<typename... Ts> class APIRespondAction : public Action<Ts...> {
+template<typename... Ts> class APIRespondAction final : public Action<Ts...> {
  public:
   explicit APIRespondAction(APIServer *parent) : parent_(parent) {}
 
@@ -286,7 +287,7 @@ template<typename... Ts> class APIRespondAction : public Action<Ts...> {
 
 // Action to unregister a service call after execution completes
 // Automatically appended to the end of action lists for non-none response modes
-template<typename... Ts> class APIUnregisterServiceCallAction : public Action<Ts...> {
+template<typename... Ts> class APIUnregisterServiceCallAction final : public Action<Ts...> {
  public:
   explicit APIUnregisterServiceCallAction(APIServer *parent) : parent_(parent) {}
 

--- a/esphome/components/aqi/aqi_sensor.h
+++ b/esphome/components/aqi/aqi_sensor.h
@@ -6,7 +6,7 @@
 
 namespace esphome::aqi {
 
-class AQISensor : public sensor::Sensor, public Component {
+class AQISensor final : public sensor::Sensor, public Component {
  public:
   void setup() override;
   void dump_config() override;


### PR DESCRIPTION
# What does this implement/fix?

Adds the C++ `final` specifier to leaf, user-configurable component classes — and to automation action/trigger/condition primitives — so classes that are meant to be terminal can no longer be subclassed by external components. Only classes that are never used as a base anywhere in the ESPHome tree are marked, so no in-tree class is affected.

- **Series:** part 1 of 21
- **Components:** 30 (`a01nyub` – `aqi`, alphabetical)
- **Change:** mechanical — adds the `final` keyword only; no behavior, config, or API surface changes
- **Verification:** tree-wide static check that no class in any `.cpp`/`.h` derives from a `final`-marked class, plus representative compiles on esp8266-ard and esp32-idf

<details>
<summary><b>Components in this PR (30)</b></summary>

`a01nyub`, `a02yyuw`, `a4988`, `absolute_humidity`, `ac_dimmer`, `adc`, `adc128s102`, `addressable_light`, `ade7880`, `ade7953_i2c`, `ads1115`, `ads1118`, `ags10`, `aht10`, `aic3204`, `airthings_ble`, `airthings_wave_mini`, `airthings_wave_plus`, `alarm_control_panel`, `alpha3`, `am2315c`, `am2320`, `am43`, `analog_threshold`, `animation`, `anova`, `apds9306`, `apds9960`, `api`, `aqi`

</details>

<details>
<summary><b>All 21 PRs in this series</b></summary>

- #16952 — part 1 (`a01nyub` – `aqi`) ← **this PR**
- #16953 — part 2 (`as3935_i2c` – `ble_rssi`)
- #16954 — part 3 (`ble_scanner` – `ch423`)
- #16955 — part 4 (`chsc6x` – `dfplayer`)
- #16956 — part 5 (`dfrobot_sen0395` – `esp32_ble_beacon`)
- #16957 — part 6 (`esp32_ble_client` – `fujitsu_general`)
- #16958 — part 7 (`gcja5` – `hlw8032`)
- #16959 — part 8 (`hm3301` – `integration`)
- #16960 — part 9 (`internal_temperature` – `m5stack_8angle`)
- #16961 — part 10 (`matrix_keypad` – `micronova`)
- #16962 — part 11 (`microphone` – `ms8607`)
- #16963 — part 12 (`msa3xx` – `pm2005`)
- #16964 — part 13 (`pmsa003i` – `rc522`)
- #16965 — part 14 (`rc522_i2c` – `scd4x`)
- #16966 — part 15 (`script` – `slow_pwm`)
- #16967 — part 16 (`sm10bit_base` – `ssd1331_spi`)
- #16968 — part 17 (`ssd1351_spi` – `tem3200`)
- #16969 — part 18 (`template` – `tx20`)
- #16970 — part 19 (`uart` – `wl_134`)
- #16971 — part 20 (`wts01` – `zephyr_ble_server`)
- #16972 — part 21 (`zhlt01` – `zyaura`)

</details>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/developers.esphome.io#157

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
