### PR TITLE
Mark configurable classes as final (2/21: as3935_i2c-ble_rssi)

### DIFF
--- a/esphome/components/as3935_i2c/as3935_i2c.h
+++ b/esphome/components/as3935_i2c/as3935_i2c.h
@@ -5,7 +5,7 @@
 
 namespace esphome::as3935_i2c {
 
-class I2CAS3935Component : public as3935::AS3935Component, public i2c::I2CDevice {
+class I2CAS3935Component final : public as3935::AS3935Component, public i2c::I2CDevice {
  public:
   void dump_config() override;
 

--- a/esphome/components/as3935_spi/as3935_spi.h
+++ b/esphome/components/as3935_spi/as3935_spi.h
@@ -8,9 +8,9 @@ namespace esphome::as3935_spi {
 
 enum AS3935RegisterMasks { SPI_READ_M = 0x40 };
 
-class SPIAS3935Component : public as3935::AS3935Component,
-                           public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
-                                                 spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_2MHZ> {
+class SPIAS3935Component final : public as3935::AS3935Component,
+                                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                                       spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_2MHZ> {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/as5600/as5600.h
+++ b/esphome/components/as5600/as5600.h
@@ -43,7 +43,7 @@ enum AS5600MagnetStatus : uint8_t {
   MAGNET_WEAK = 6,    // 0b110 / magnet too weak
 };
 
-class AS5600Component : public Component, public i2c::I2CDevice {
+class AS5600Component final : public Component, public i2c::I2CDevice {
  public:
   /// Set up the internal sensor array.
   void setup() override;

--- a/esphome/components/as5600/sensor/as5600_sensor.h
+++ b/esphome/components/as5600/sensor/as5600_sensor.h
@@ -9,7 +9,7 @@
 
 namespace esphome::as5600 {
 
-class AS5600Sensor : public PollingComponent, public Parented<AS5600Component>, public sensor::Sensor {
+class AS5600Sensor final : public PollingComponent, public Parented<AS5600Component>, public sensor::Sensor {
  public:
   void update() override;
   void dump_config() override;

--- a/esphome/components/as7341/as7341.h
+++ b/esphome/components/as7341/as7341.h
@@ -73,7 +73,7 @@ enum AS7341Gain {
   AS7341_GAIN_512X,
 };
 
-class AS7341Component : public PollingComponent, public i2c::I2CDevice {
+class AS7341Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/at581x/at581x.h
+++ b/esphome/components/at581x/at581x.h
@@ -12,7 +12,7 @@
 
 namespace esphome::at581x {
 
-class AT581XComponent : public Component, public i2c::I2CDevice {
+class AT581XComponent final : public Component, public i2c::I2CDevice {
  public:
 #ifdef USE_SWITCH
   void set_rf_power_switch(switch_::Switch *s) {

--- a/esphome/components/at581x/automation.h
+++ b/esphome/components/at581x/automation.h
@@ -7,12 +7,12 @@
 
 namespace esphome::at581x {
 
-template<typename... Ts> class AT581XResetAction : public Action<Ts...>, public Parented<AT581XComponent> {
+template<typename... Ts> class AT581XResetAction final : public Action<Ts...>, public Parented<AT581XComponent> {
  public:
   void play(const Ts &...x) { this->parent_->reset_hardware_frontend(); }
 };
 
-template<typename... Ts> class AT581XSettingsAction : public Action<Ts...>, public Parented<AT581XComponent> {
+template<typename... Ts> class AT581XSettingsAction final : public Action<Ts...>, public Parented<AT581XComponent> {
  public:
   TEMPLATABLE_VALUE(int8_t, hw_frontend_reset)
   TEMPLATABLE_VALUE(int, frequency)

--- a/esphome/components/at581x/switch/rf_switch.h
+++ b/esphome/components/at581x/switch/rf_switch.h
@@ -5,7 +5,7 @@
 
 namespace esphome::at581x {
 
-class RFSwitch : public switch_::Switch, public Parented<AT581XComponent> {
+class RFSwitch final : public switch_::Switch, public Parented<AT581XComponent> {
  protected:
   void write_state(bool state) override;
 };

--- a/esphome/components/atc_mithermometer/atc_mithermometer.h
+++ b/esphome/components/atc_mithermometer/atc_mithermometer.h
@@ -18,7 +18,7 @@ struct ParseResult {
   int raw_offset;
 };
 
-class ATCMiThermometer : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
+class ATCMiThermometer final : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
 

--- a/esphome/components/atm90e26/atm90e26.h
+++ b/esphome/components/atm90e26/atm90e26.h
@@ -6,9 +6,9 @@
 
 namespace esphome::atm90e26 {
 
-class ATM90E26Component : public PollingComponent,
-                          public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH,
-                                                spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_200KHZ> {
+class ATM90E26Component final : public PollingComponent,
+                                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH,
+                                                      spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_200KHZ> {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -13,9 +13,9 @@
 
 namespace esphome::atm90e32 {
 
-class ATM90E32Component : public PollingComponent,
-                          public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH,
-                                                spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_1MHZ> {
+class ATM90E32Component final : public PollingComponent,
+                                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH,
+                                                      spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_1MHZ> {
  public:
   static const uint8_t PHASEA = 0;
   static const uint8_t PHASEB = 1;

--- a/esphome/components/atm90e32/button/atm90e32_button.h
+++ b/esphome/components/atm90e32/button/atm90e32_button.h
@@ -6,7 +6,7 @@
 
 namespace esphome::atm90e32 {
 
-class ATM90E32GainCalibrationButton : public button::Button, public Parented<ATM90E32Component> {
+class ATM90E32GainCalibrationButton final : public button::Button, public Parented<ATM90E32Component> {
  public:
   ATM90E32GainCalibrationButton() = default;
 
@@ -14,7 +14,7 @@ class ATM90E32GainCalibrationButton : public button::Button, public Parented<ATM
   void press_action() override;
 };
 
-class ATM90E32ClearGainCalibrationButton : public button::Button, public Parented<ATM90E32Component> {
+class ATM90E32ClearGainCalibrationButton final : public button::Button, public Parented<ATM90E32Component> {
  public:
   ATM90E32ClearGainCalibrationButton() = default;
 
@@ -22,7 +22,7 @@ class ATM90E32ClearGainCalibrationButton : public button::Button, public Parente
   void press_action() override;
 };
 
-class ATM90E32OffsetCalibrationButton : public button::Button, public Parented<ATM90E32Component> {
+class ATM90E32OffsetCalibrationButton final : public button::Button, public Parented<ATM90E32Component> {
  public:
   ATM90E32OffsetCalibrationButton() = default;
 
@@ -30,7 +30,7 @@ class ATM90E32OffsetCalibrationButton : public button::Button, public Parented<A
   void press_action() override;
 };
 
-class ATM90E32ClearOffsetCalibrationButton : public button::Button, public Parented<ATM90E32Component> {
+class ATM90E32ClearOffsetCalibrationButton final : public button::Button, public Parented<ATM90E32Component> {
  public:
   ATM90E32ClearOffsetCalibrationButton() = default;
 
@@ -38,7 +38,7 @@ class ATM90E32ClearOffsetCalibrationButton : public button::Button, public Paren
   void press_action() override;
 };
 
-class ATM90E32PowerOffsetCalibrationButton : public button::Button, public Parented<ATM90E32Component> {
+class ATM90E32PowerOffsetCalibrationButton final : public button::Button, public Parented<ATM90E32Component> {
  public:
   ATM90E32PowerOffsetCalibrationButton() = default;
 
@@ -46,7 +46,7 @@ class ATM90E32PowerOffsetCalibrationButton : public button::Button, public Paren
   void press_action() override;
 };
 
-class ATM90E32ClearPowerOffsetCalibrationButton : public button::Button, public Parented<ATM90E32Component> {
+class ATM90E32ClearPowerOffsetCalibrationButton final : public button::Button, public Parented<ATM90E32Component> {
  public:
   ATM90E32ClearPowerOffsetCalibrationButton() = default;
 

--- a/esphome/components/audio_adc/automation.h
+++ b/esphome/components/audio_adc/automation.h
@@ -6,7 +6,7 @@
 
 namespace esphome::audio_adc {
 
-template<typename... Ts> class SetMicGainAction : public Action<Ts...> {
+template<typename... Ts> class SetMicGainAction final : public Action<Ts...> {
  public:
   explicit SetMicGainAction(AudioAdc *audio_adc) : audio_adc_(audio_adc) {}
 

--- a/esphome/components/audio_dac/automation.h
+++ b/esphome/components/audio_dac/automation.h
@@ -6,7 +6,7 @@
 
 namespace esphome::audio_dac {
 
-template<typename... Ts> class MuteOffAction : public Action<Ts...> {
+template<typename... Ts> class MuteOffAction final : public Action<Ts...> {
  public:
   explicit MuteOffAction(AudioDac *audio_dac) : audio_dac_(audio_dac) {}
 
@@ -16,7 +16,7 @@ template<typename... Ts> class MuteOffAction : public Action<Ts...> {
   AudioDac *audio_dac_;
 };
 
-template<typename... Ts> class MuteOnAction : public Action<Ts...> {
+template<typename... Ts> class MuteOnAction final : public Action<Ts...> {
  public:
   explicit MuteOnAction(AudioDac *audio_dac) : audio_dac_(audio_dac) {}
 
@@ -26,7 +26,7 @@ template<typename... Ts> class MuteOnAction : public Action<Ts...> {
   AudioDac *audio_dac_;
 };
 
-template<typename... Ts> class SetVolumeAction : public Action<Ts...> {
+template<typename... Ts> class SetVolumeAction final : public Action<Ts...> {
  public:
   explicit SetVolumeAction(AudioDac *audio_dac) : audio_dac_(audio_dac) {}
 

--- a/esphome/components/audio_file/media_source/audio_file_media_source.h
+++ b/esphome/components/audio_file/media_source/audio_file_media_source.h
@@ -23,7 +23,9 @@ namespace esphome::audio_file {
 //     (the orchestrator calls set_listener() on us with a MediaSourceListener*).
 //   - micro_decoder::DecoderListener: the underlying decoder calls back *into* us with decoded
 //     audio and state changes (we call decoder_->set_listener(this) in setup()).
-class AudioFileMediaSource : public Component, public media_source::MediaSource, public micro_decoder::DecoderListener {
+class AudioFileMediaSource final : public Component,
+                                   public media_source::MediaSource,
+                                   public micro_decoder::DecoderListener {
  public:
   void setup() override;
   void loop() override;

--- a/esphome/components/audio_http/audio_http_media_source.h
+++ b/esphome/components/audio_http/audio_http_media_source.h
@@ -23,7 +23,9 @@ namespace esphome::audio_http {
 //   - micro_decoder::DecoderListener: the underlying decoder calls back *into* us with decoded
 //     audio and state changes (we call decoder_->set_listener(this) in setup()).
 // The two set_listener() methods live on different base classes and serve opposite directions.
-class AudioHTTPMediaSource : public Component, public media_source::MediaSource, public micro_decoder::DecoderListener {
+class AudioHTTPMediaSource final : public Component,
+                                   public media_source::MediaSource,
+                                   public micro_decoder::DecoderListener {
  public:
   void setup() override;
   void loop() override;

--- a/esphome/components/axs15231/touchscreen/axs15231_touchscreen.h
+++ b/esphome/components/axs15231/touchscreen/axs15231_touchscreen.h
@@ -7,7 +7,7 @@
 
 namespace esphome::axs15231 {
 
-class AXS15231Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice {
+class AXS15231Touchscreen final : public touchscreen::Touchscreen, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/ballu/ballu.h
+++ b/esphome/components/ballu/ballu.h
@@ -10,7 +10,7 @@ namespace esphome::ballu {
 const float YKR_K_002E_TEMP_MIN = 16.0;
 const float YKR_K_002E_TEMP_MAX = 32.0;
 
-class BalluClimate : public climate_ir::ClimateIR {
+class BalluClimate final : public climate_ir::ClimateIR {
  public:
   BalluClimate()
       : climate_ir::ClimateIR(YKR_K_002E_TEMP_MIN, YKR_K_002E_TEMP_MAX, 1.0f, true, true,

--- a/esphome/components/bang_bang/bang_bang_climate.h
+++ b/esphome/components/bang_bang/bang_bang_climate.h
@@ -16,7 +16,7 @@ struct BangBangClimateTargetTempConfig {
   float default_temperature_high{NAN};
 };
 
-class BangBangClimate : public climate::Climate, public Component {
+class BangBangClimate final : public climate::Climate, public Component {
  public:
   BangBangClimate();
   void setup() override;

--- a/esphome/components/bedjet/bedjet_hub.h
+++ b/esphome/components/bedjet/bedjet_hub.h
@@ -33,7 +33,7 @@ static const espbt::ESPBTUUID BEDJET_NAME_UUID = espbt::ESPBTUUID::from_raw("000
 /**
  * Hub component connecting to the BedJet device over Bluetooth.
  */
-class BedJetHub : public esphome::ble_client::BLEClientNode, public PollingComponent {
+class BedJetHub final : public esphome::ble_client::BLEClientNode, public PollingComponent {
  public:
   /* BedJet functionality exposed to `BedJetClient` children and/or accessible from action lambdas. */
 

--- a/esphome/components/bedjet/climate/bedjet_climate.h
+++ b/esphome/components/bedjet/climate/bedjet_climate.h
@@ -12,7 +12,7 @@
 
 namespace esphome::bedjet {
 
-class BedJetClimate : public climate::Climate, public BedJetClient, public PollingComponent {
+class BedJetClimate final : public climate::Climate, public BedJetClient, public PollingComponent {
  public:
   void setup() override;
   void loop() override;

--- a/esphome/components/bedjet/fan/bedjet_fan.h
+++ b/esphome/components/bedjet/fan/bedjet_fan.h
@@ -12,7 +12,7 @@
 
 namespace esphome::bedjet {
 
-class BedJetFan : public fan::Fan, public BedJetClient, public PollingComponent {
+class BedJetFan final : public fan::Fan, public BedJetClient, public PollingComponent {
  public:
   void update() override;
   void dump_config() override;

--- a/esphome/components/bedjet/sensor/bedjet_sensor.h
+++ b/esphome/components/bedjet/sensor/bedjet_sensor.h
@@ -7,7 +7,7 @@
 
 namespace esphome::bedjet {
 
-class BedjetSensor : public BedJetClient, public Component {
+class BedjetSensor final : public BedJetClient, public Component {
  public:
   void dump_config() override;
 

--- a/esphome/components/beken_spi_led_strip/led_strip.h
+++ b/esphome/components/beken_spi_led_strip/led_strip.h
@@ -19,7 +19,7 @@ enum RGBOrder : uint8_t {
   ORDER_BRG,
 };
 
-class BekenSPILEDStripLightOutput : public light::AddressableLight {
+class BekenSPILEDStripLightOutput final : public light::AddressableLight {
  public:
   void setup() override;
   void write_state(light::LightState *state) override;

--- a/esphome/components/bh1750/bh1750.h
+++ b/esphome/components/bh1750/bh1750.h
@@ -13,7 +13,7 @@ enum BH1750Mode : uint8_t {
 };
 
 /// This class implements support for the i2c-based BH1750 ambient light sensor.
-class BH1750Sensor : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
+class BH1750Sensor final : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
  public:
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)

--- a/esphome/components/bh1900nux/bh1900nux.h
+++ b/esphome/components/bh1900nux/bh1900nux.h
@@ -6,7 +6,7 @@
 
 namespace esphome::bh1900nux {
 
-class BH1900NUXSensor : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
+class BH1900NUXSensor final : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void update() override;

--- a/esphome/components/binary/fan/binary_fan.h
+++ b/esphome/components/binary/fan/binary_fan.h
@@ -6,7 +6,7 @@
 
 namespace esphome::binary {
 
-class BinaryFan : public Component, public fan::Fan {
+class BinaryFan final : public Component, public fan::Fan {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/binary/light/binary_light_output.h
+++ b/esphome/components/binary/light/binary_light_output.h
@@ -6,7 +6,7 @@
 
 namespace esphome::binary {
 
-class BinaryLightOutput : public light::LightOutput {
+class BinaryLightOutput final : public light::LightOutput {
  public:
   void set_output(output::BinaryOutput *output) { output_ = output; }
   light::LightTraits get_traits() override {

--- a/esphome/components/binary_sensor/automation.h
+++ b/esphome/components/binary_sensor/automation.h
@@ -18,7 +18,7 @@ struct MultiClickTriggerEvent {
   uint32_t max_length;
 };
 
-class PressTrigger : public Trigger<> {
+class PressTrigger final : public Trigger<> {
  public:
   explicit PressTrigger(BinarySensor *parent) {
     parent->add_on_state_callback([this](bool state) {
@@ -28,7 +28,7 @@ class PressTrigger : public Trigger<> {
   }
 };
 
-class ReleaseTrigger : public Trigger<> {
+class ReleaseTrigger final : public Trigger<> {
  public:
   explicit ReleaseTrigger(BinarySensor *parent) {
     parent->add_on_state_callback([this](bool state) {
@@ -40,7 +40,7 @@ class ReleaseTrigger : public Trigger<> {
 
 bool match_interval(uint32_t min_length, uint32_t max_length, uint32_t length);
 
-class ClickTrigger : public Trigger<> {
+class ClickTrigger final : public Trigger<> {
  public:
   explicit ClickTrigger(BinarySensor *parent, uint32_t min_length, uint32_t max_length)
       : min_length_(min_length), max_length_(max_length) {
@@ -61,7 +61,7 @@ class ClickTrigger : public Trigger<> {
   uint32_t max_length_;     /// Maximum length of click. 0 means no maximum.
 };
 
-class DoubleClickTrigger : public Trigger<> {
+class DoubleClickTrigger final : public Trigger<> {
  public:
   explicit DoubleClickTrigger(BinarySensor *parent, uint32_t min_length, uint32_t max_length)
       : min_length_(min_length), max_length_(max_length) {
@@ -127,7 +127,7 @@ class MultiClickTriggerBase : public Trigger<>, public Component {
 
 /// Template wrapper that provides inline std::array storage for timing events.
 /// N is set by code generation to match the exact number of timing events configured in YAML.
-template<size_t N> class MultiClickTrigger : public MultiClickTriggerBase {
+template<size_t N> class MultiClickTrigger final : public MultiClickTriggerBase {
  public:
   MultiClickTrigger(BinarySensor *parent, std::initializer_list<MultiClickTriggerEvent> timing)
       : MultiClickTriggerBase(parent) {
@@ -140,14 +140,14 @@ template<size_t N> class MultiClickTrigger : public MultiClickTriggerBase {
   std::array<MultiClickTriggerEvent, N> timing_storage_{};
 };
 
-class StateTrigger : public Trigger<bool> {
+class StateTrigger final : public Trigger<bool> {
  public:
   explicit StateTrigger(BinarySensor *parent) {
     parent->add_on_state_callback([this](bool state) { this->trigger(state); });
   }
 };
 
-class StateChangeTrigger : public Trigger<optional<bool>, optional<bool> > {
+class StateChangeTrigger final : public Trigger<optional<bool>, optional<bool> > {
  public:
   explicit StateChangeTrigger(BinarySensor *parent) {
     parent->add_full_state_callback(
@@ -155,7 +155,7 @@ class StateChangeTrigger : public Trigger<optional<bool>, optional<bool> > {
   }
 };
 
-template<typename... Ts> class BinarySensorCondition : public Condition<Ts...> {
+template<typename... Ts> class BinarySensorCondition final : public Condition<Ts...> {
  public:
   BinarySensorCondition(BinarySensor *parent, bool state) : parent_(parent), state_(state) {}
   bool check(const Ts &...x) override { return this->parent_->state == this->state_; }
@@ -165,7 +165,7 @@ template<typename... Ts> class BinarySensorCondition : public Condition<Ts...> {
   bool state_;
 };
 
-template<typename... Ts> class BinarySensorPublishAction : public Action<Ts...> {
+template<typename... Ts> class BinarySensorPublishAction final : public Action<Ts...> {
  public:
   explicit BinarySensorPublishAction(BinarySensor *sensor) : sensor_(sensor) {}
   TEMPLATABLE_VALUE(bool, state)
@@ -179,7 +179,7 @@ template<typename... Ts> class BinarySensorPublishAction : public Action<Ts...> 
   BinarySensor *sensor_;
 };
 
-template<typename... Ts> class BinarySensorInvalidateAction : public Action<Ts...> {
+template<typename... Ts> class BinarySensorInvalidateAction final : public Action<Ts...> {
  public:
   explicit BinarySensorInvalidateAction(BinarySensor *sensor) : sensor_(sensor) {}
 

--- a/esphome/components/binary_sensor_map/binary_sensor_map.h
+++ b/esphome/components/binary_sensor_map/binary_sensor_map.h
@@ -29,7 +29,7 @@ struct BinarySensorMapChannel {
  *
  * Each binary sensor has configured parameters that each mapping type uses to compute the single numerical result
  */
-class BinarySensorMap : public sensor::Sensor, public Component {
+class BinarySensorMap final : public sensor::Sensor, public Component {
  public:
   void dump_config() override;
 

--- a/esphome/components/bl0906/bl0906.h
+++ b/esphome/components/bl0906/bl0906.h
@@ -53,7 +53,7 @@ class BL0906;
 
 using ActionCallbackFuncPtr = void (BL0906::*)();
 
-class BL0906 : public PollingComponent, public uart::UARTDevice {
+class BL0906 final : public PollingComponent, public uart::UARTDevice {
   SUB_SENSOR(voltage)
   SUB_SENSOR(current_1)
   SUB_SENSOR(current_2)
@@ -103,7 +103,7 @@ class BL0906 : public PollingComponent, public uart::UARTDevice {
   std::vector<ActionCallbackFuncPtr> action_queue_{};
 };
 
-template<typename... Ts> class ResetEnergyAction : public Action<Ts...>, public Parented<BL0906> {
+template<typename... Ts> class ResetEnergyAction final : public Action<Ts...>, public Parented<BL0906> {
  public:
   void play(const Ts &...x) override { this->parent_->enqueue_action_(&BL0906::reset_energy_); }
 };

--- a/esphome/components/bl0939/bl0939.h
+++ b/esphome/components/bl0939/bl0939.h
@@ -56,7 +56,7 @@ union DataPacket {  // NOLINT(altera-struct-pack-align)
   };
 } __attribute__((packed));
 
-class BL0939 : public PollingComponent, public uart::UARTDevice {
+class BL0939 final : public PollingComponent, public uart::UARTDevice {
  public:
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
   void set_current_sensor_1(sensor::Sensor *current_sensor_1) { current_sensor_1_ = current_sensor_1; }

--- a/esphome/components/bl0940/bl0940.h
+++ b/esphome/components/bl0940/bl0940.h
@@ -33,7 +33,7 @@ struct DataPacket {
   uint8_t checksum;        // Packet checksum
 } __attribute__((packed));
 
-class BL0940 : public PollingComponent, public uart::UARTDevice {
+class BL0940 final : public PollingComponent, public uart::UARTDevice {
  public:
   // Sensor setters
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }

--- a/esphome/components/bl0940/button/calibration_reset_button.h
+++ b/esphome/components/bl0940/button/calibration_reset_button.h
@@ -7,7 +7,7 @@ namespace esphome::bl0940 {
 
 class BL0940;  // Forward declaration of BL0940 class
 
-class CalibrationResetButton : public button::Button, public Component, public Parented<BL0940> {
+class CalibrationResetButton final : public button::Button, public Component, public Parented<BL0940> {
  public:
   void dump_config() override;
 

--- a/esphome/components/bl0940/number/calibration_number.h
+++ b/esphome/components/bl0940/number/calibration_number.h
@@ -6,7 +6,7 @@
 
 namespace esphome::bl0940 {
 
-class CalibrationNumber : public number::Number, public Component {
+class CalibrationNumber final : public number::Number, public Component {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/bl0942/bl0942.h
+++ b/esphome/components/bl0942/bl0942.h
@@ -83,7 +83,7 @@ enum LineFrequency : uint8_t {
   LINE_FREQUENCY_60HZ = 60,
 };
 
-class BL0942 : public PollingComponent, public uart::UARTDevice {
+class BL0942 final : public PollingComponent, public uart::UARTDevice {
  public:
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { this->voltage_sensor_ = voltage_sensor; }
   void set_current_sensor(sensor::Sensor *current_sensor) { this->current_sensor_ = current_sensor; }

--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -23,7 +23,7 @@ class Automation {
 };
 
 // implement on_connect automation.
-class BLEClientConnectTrigger : public Trigger<>, public BLEClientNode {
+class BLEClientConnectTrigger final : public Trigger<>, public BLEClientNode {
  public:
   explicit BLEClientConnectTrigger(BLEClient *parent) { parent->register_ble_node(this); }
   void loop() override {}
@@ -37,7 +37,7 @@ class BLEClientConnectTrigger : public Trigger<>, public BLEClientNode {
 };
 
 // on_disconnect automation
-class BLEClientDisconnectTrigger : public Trigger<>, public BLEClientNode {
+class BLEClientDisconnectTrigger final : public Trigger<>, public BLEClientNode {
  public:
   explicit BLEClientDisconnectTrigger(BLEClient *parent) { parent->register_ble_node(this); }
   void loop() override {}
@@ -61,7 +61,7 @@ class BLEClientDisconnectTrigger : public Trigger<>, public BLEClientNode {
   }
 };
 
-class BLEClientPasskeyRequestTrigger : public Trigger<>, public BLEClientNode {
+class BLEClientPasskeyRequestTrigger final : public Trigger<>, public BLEClientNode {
  public:
   explicit BLEClientPasskeyRequestTrigger(BLEClient *parent) { parent->register_ble_node(this); }
   void loop() override {}
@@ -71,7 +71,7 @@ class BLEClientPasskeyRequestTrigger : public Trigger<>, public BLEClientNode {
   }
 };
 
-class BLEClientPasskeyNotificationTrigger : public Trigger<uint32_t>, public BLEClientNode {
+class BLEClientPasskeyNotificationTrigger final : public Trigger<uint32_t>, public BLEClientNode {
  public:
   explicit BLEClientPasskeyNotificationTrigger(BLEClient *parent) { parent->register_ble_node(this); }
   void loop() override {}
@@ -82,7 +82,7 @@ class BLEClientPasskeyNotificationTrigger : public Trigger<uint32_t>, public BLE
   }
 };
 
-class BLEClientNumericComparisonRequestTrigger : public Trigger<uint32_t>, public BLEClientNode {
+class BLEClientNumericComparisonRequestTrigger final : public Trigger<uint32_t>, public BLEClientNode {
  public:
   explicit BLEClientNumericComparisonRequestTrigger(BLEClient *parent) { parent->register_ble_node(this); }
   void loop() override {}
@@ -94,7 +94,7 @@ class BLEClientNumericComparisonRequestTrigger : public Trigger<uint32_t>, publi
 };
 
 // implement the ble_client.ble_write action.
-template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, public BLEClientNode {
+template<typename... Ts> class BLEClientWriteAction final : public Action<Ts...>, public BLEClientNode {
  public:
   BLEClientWriteAction(BLEClient *ble_client) {
     ble_client->register_ble_node(this);
@@ -231,7 +231,7 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
   esp_gatt_write_type_t write_type_{};
 };
 
-template<typename... Ts> class BLEClientPasskeyReplyAction : public Action<Ts...> {
+template<typename... Ts> class BLEClientPasskeyReplyAction final : public Action<Ts...> {
  public:
   BLEClientPasskeyReplyAction(BLEClient *ble_client) { parent_ = ble_client; }
 
@@ -268,7 +268,7 @@ template<typename... Ts> class BLEClientPasskeyReplyAction : public Action<Ts...
   } value_{.simple = 0};
 };
 
-template<typename... Ts> class BLEClientNumericComparisonReplyAction : public Action<Ts...> {
+template<typename... Ts> class BLEClientNumericComparisonReplyAction final : public Action<Ts...> {
  public:
   BLEClientNumericComparisonReplyAction(BLEClient *ble_client) { parent_ = ble_client; }
 
@@ -301,7 +301,7 @@ template<typename... Ts> class BLEClientNumericComparisonReplyAction : public Ac
   } value_{.simple = false};
 };
 
-template<typename... Ts> class BLEClientRemoveBondAction : public Action<Ts...> {
+template<typename... Ts> class BLEClientRemoveBondAction final : public Action<Ts...> {
  public:
   BLEClientRemoveBondAction(BLEClient *ble_client) { parent_ = ble_client; }
 
@@ -315,7 +315,7 @@ template<typename... Ts> class BLEClientRemoveBondAction : public Action<Ts...> 
   BLEClient *parent_{nullptr};
 };
 
-template<typename... Ts> class BLEClientConnectAction : public Action<Ts...>, public BLEClientNode {
+template<typename... Ts> class BLEClientConnectAction final : public Action<Ts...>, public BLEClientNode {
  public:
   BLEClientConnectAction(BLEClient *ble_client) {
     ble_client->register_ble_node(this);
@@ -364,7 +364,7 @@ template<typename... Ts> class BLEClientConnectAction : public Action<Ts...>, pu
   std::tuple<Ts...> var_{};
 };
 
-template<typename... Ts> class BLEClientDisconnectAction : public Action<Ts...>, public BLEClientNode {
+template<typename... Ts> class BLEClientDisconnectAction final : public Action<Ts...>, public BLEClientNode {
  public:
   BLEClientDisconnectAction(BLEClient *ble_client) {
     ble_client->register_ble_node(this);

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -44,7 +44,7 @@ class BLEClientNode {
   uint64_t address_;
 };
 
-class BLEClient : public BLEClientBase {
+class BLEClient final : public BLEClientBase {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/ble_client/output/ble_binary_output.h
+++ b/esphome/components/ble_client/output/ble_binary_output.h
@@ -11,7 +11,7 @@ namespace esphome::ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
-class BLEBinaryOutput : public output::BinaryOutput, public BLEClientNode, public Component {
+class BLEBinaryOutput final : public output::BinaryOutput, public BLEClientNode, public Component {
  public:
   void dump_config() override;
   void loop() override {}

--- a/esphome/components/ble_client/sensor/automation.h
+++ b/esphome/components/ble_client/sensor/automation.h
@@ -7,7 +7,7 @@
 
 namespace esphome::ble_client {
 
-class BLESensorNotifyTrigger : public Trigger<float>, public BLESensor {
+class BLESensorNotifyTrigger final : public Trigger<float>, public BLESensor {
  public:
   explicit BLESensorNotifyTrigger(BLESensor *sensor) { sensor_ = sensor; }
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,

--- a/esphome/components/ble_client/sensor/ble_rssi_sensor.h
+++ b/esphome/components/ble_client/sensor/ble_rssi_sensor.h
@@ -12,7 +12,7 @@ namespace esphome::ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
-class BLEClientRSSISensor : public sensor::Sensor, public PollingComponent, public BLEClientNode {
+class BLEClientRSSISensor final : public sensor::Sensor, public PollingComponent, public BLEClientNode {
  public:
   void loop() override;
   void update() override;

--- a/esphome/components/ble_client/switch/ble_switch.h
+++ b/esphome/components/ble_client/switch/ble_switch.h
@@ -12,7 +12,7 @@ namespace esphome::ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
-class BLEClientSwitch : public switch_::Switch, public Component, public BLEClientNode {
+class BLEClientSwitch final : public switch_::Switch, public Component, public BLEClientNode {
  public:
   void dump_config() override;
   void loop() override {}

--- a/esphome/components/ble_client/text_sensor/automation.h
+++ b/esphome/components/ble_client/text_sensor/automation.h
@@ -7,7 +7,7 @@
 
 namespace esphome::ble_client {
 
-class BLETextSensorNotifyTrigger : public Trigger<std::string>, public BLETextSensor {
+class BLETextSensorNotifyTrigger final : public Trigger<std::string>, public BLETextSensor {
  public:
   explicit BLETextSensorNotifyTrigger(BLETextSensor *sensor) { sensor_ = sensor; }
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,

--- a/esphome/components/ble_nus/ble_nus.h
+++ b/esphome/components/ble_nus/ble_nus.h
@@ -11,7 +11,7 @@
 
 namespace esphome::ble_nus {
 
-class BLENUS : public uart::UARTComponent, public Component {
+class BLENUS final : public uart::UARTComponent, public Component {
   enum TxStatus {
     TX_DISABLED,
     TX_ENABLED,

--- a/esphome/components/ble_presence/ble_presence_device.h
+++ b/esphome/components/ble_presence/ble_presence_device.h
@@ -8,9 +8,9 @@
 
 namespace esphome::ble_presence {
 
-class BLEPresenceDevice : public binary_sensor::BinarySensorInitiallyOff,
-                          public esp32_ble_tracker::ESPBTDeviceListener,
-                          public Component {
+class BLEPresenceDevice final : public binary_sensor::BinarySensorInitiallyOff,
+                                public esp32_ble_tracker::ESPBTDeviceListener,
+                                public Component {
  public:
   void set_address(uint64_t address) {
     this->match_by_ = MATCH_BY_MAC_ADDRESS;

--- a/esphome/components/ble_rssi/ble_rssi_sensor.h
+++ b/esphome/components/ble_rssi/ble_rssi_sensor.h
@@ -8,7 +8,7 @@
 
 namespace esphome::ble_rssi {
 
-class BLERSSISensor : public sensor::Sensor, public esp32_ble_tracker::ESPBTDeviceListener, public Component {
+class BLERSSISensor final : public sensor::Sensor, public esp32_ble_tracker::ESPBTDeviceListener, public Component {
  public:
   void set_address(uint64_t address) {
     this->match_by_ = MATCH_BY_MAC_ADDRESS;


### PR DESCRIPTION
# What does this implement/fix?

Adds the C++ `final` specifier to leaf, user-configurable component classes — and to automation action/trigger/condition primitives — so classes that are meant to be terminal can no longer be subclassed by external components. Only classes that are never used as a base anywhere in the ESPHome tree are marked, so no in-tree class is affected.

- **Series:** part 2 of 21
- **Components:** 30 (`as3935_i2c` – `ble_rssi`, alphabetical)
- **Change:** mechanical — adds the `final` keyword only; no behavior, config, or API surface changes
- **Verification:** tree-wide static check that no class in any `.cpp`/`.h` derives from a `final`-marked class, plus representative compiles on esp8266-ard and esp32-idf

<details>
<summary><b>Components in this PR (30)</b></summary>

`as3935_i2c`, `as3935_spi`, `as5600`, `as7341`, `at581x`, `atc_mithermometer`, `atm90e26`, `atm90e32`, `audio_adc`, `audio_dac`, `audio_file`, `audio_http`, `axs15231`, `ballu`, `bang_bang`, `bedjet`, `beken_spi_led_strip`, `bh1750`, `bh1900nux`, `binary`, `binary_sensor`, `binary_sensor_map`, `bl0906`, `bl0939`, `bl0940`, `bl0942`, `ble_client`, `ble_nus`, `ble_presence`, `ble_rssi`

</details>

<details>
<summary><b>All 21 PRs in this series</b></summary>

- #16952 — part 1 (`a01nyub` – `aqi`)
- #16953 — part 2 (`as3935_i2c` – `ble_rssi`) ← **this PR**
- #16954 — part 3 (`ble_scanner` – `ch423`)
- #16955 — part 4 (`chsc6x` – `dfplayer`)
- #16956 — part 5 (`dfrobot_sen0395` – `esp32_ble_beacon`)
- #16957 — part 6 (`esp32_ble_client` – `fujitsu_general`)
- #16958 — part 7 (`gcja5` – `hlw8032`)
- #16959 — part 8 (`hm3301` – `integration`)
- #16960 — part 9 (`internal_temperature` – `m5stack_8angle`)
- #16961 — part 10 (`matrix_keypad` – `micronova`)
- #16962 — part 11 (`microphone` – `ms8607`)
- #16963 — part 12 (`msa3xx` – `pm2005`)
- #16964 — part 13 (`pmsa003i` – `rc522`)
- #16965 — part 14 (`rc522_i2c` – `scd4x`)
- #16966 — part 15 (`script` – `slow_pwm`)
- #16967 — part 16 (`sm10bit_base` – `ssd1331_spi`)
- #16968 — part 17 (`ssd1351_spi` – `tem3200`)
- #16969 — part 18 (`template` – `tx20`)
- #16970 — part 19 (`uart` – `wl_134`)
- #16971 — part 20 (`wts01` – `zephyr_ble_server`)
- #16972 — part 21 (`zhlt01` – `zyaura`)

</details>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/developers.esphome.io#157

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
