### PR TITLE
Mark configurable classes as final (4/21: chsc6x-dfplayer)

### DIFF
--- a/esphome/components/chsc6x/chsc6x_touchscreen.h
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.h
@@ -17,7 +17,7 @@ static const uint8_t CHSC6X_REG_STATUS_Y_COR = 0x04;
 static const uint8_t CHSC6X_REG_STATUS_LEN = 0x05;
 static const uint8_t CHSC6X_CHIP_ID = 0x2e;
 
-class CHSC6XTouchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice {
+class CHSC6XTouchscreen final : public touchscreen::Touchscreen, public i2c::I2CDevice {
  public:
   void setup() override;
   void update_touches() override;

--- a/esphome/components/climate/automation.h
+++ b/esphome/components/climate/automation.h
@@ -17,7 +17,7 @@ namespace esphome::climate {
 // (e.g. `const T & &` if Ts already carries a reference, or `const const
 // T &` if Ts already carries a const). This keeps trigger args no-copy
 // regardless of whether the trigger supplies `T`, `T &`, or `const T &`.
-template<typename... Ts> class ControlAction : public Action<Ts...> {
+template<typename... Ts> class ControlAction final : public Action<Ts...> {
  public:
   using ApplyFn = void (*)(ClimateCall &, const std::remove_cvref_t<Ts> &...);
   ControlAction(Climate *climate, ApplyFn apply) : climate_(climate), apply_(apply) {}
@@ -33,14 +33,14 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
   ApplyFn apply_;
 };
 
-class ControlTrigger : public Trigger<ClimateCall &> {
+class ControlTrigger final : public Trigger<ClimateCall &> {
  public:
   ControlTrigger(Climate *climate) {
     climate->add_on_control_callback([this](ClimateCall &x) { this->trigger(x); });
   }
 };
 
-class StateTrigger : public Trigger<Climate &> {
+class StateTrigger final : public Trigger<Climate &> {
  public:
   StateTrigger(Climate *climate) {
     climate->add_on_state_callback([this](Climate &x) { this->trigger(x); });

--- a/esphome/components/climate_ir_lg/climate_ir_lg.h
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.h
@@ -10,7 +10,7 @@ namespace esphome::climate_ir_lg {
 const uint8_t TEMP_MIN = 18;  // Celsius
 const uint8_t TEMP_MAX = 30;  // Celsius
 
-class LgIrClimate : public climate_ir::ClimateIR {
+class LgIrClimate final : public climate_ir::ClimateIR {
  public:
   LgIrClimate()
       : climate_ir::ClimateIR(TEMP_MIN, TEMP_MAX, 1.0f, true, true,

--- a/esphome/components/cm1106/cm1106.h
+++ b/esphome/components/cm1106/cm1106.h
@@ -7,7 +7,7 @@
 
 namespace esphome::cm1106 {
 
-class CM1106Component : public PollingComponent, public uart::UARTDevice {
+class CM1106Component final : public PollingComponent, public uart::UARTDevice {
  public:
   void setup() override;
   void update() override;
@@ -23,7 +23,7 @@ class CM1106Component : public PollingComponent, public uart::UARTDevice {
   bool cm1106_write_command_(const uint8_t *command, size_t command_len, uint8_t *response, size_t response_len);
 };
 
-template<typename... Ts> class CM1106CalibrateZeroAction : public Action<Ts...> {
+template<typename... Ts> class CM1106CalibrateZeroAction final : public Action<Ts...> {
  public:
   CM1106CalibrateZeroAction(CM1106Component *cm1106) : cm1106_(cm1106) {}
 

--- a/esphome/components/color_temperature/ct_light_output.h
+++ b/esphome/components/color_temperature/ct_light_output.h
@@ -6,7 +6,7 @@
 
 namespace esphome::color_temperature {
 
-class CTLightOutput : public light::LightOutput {
+class CTLightOutput final : public light::LightOutput {
  public:
   void set_color_temperature(output::FloatOutput *color_temperature) { color_temperature_ = color_temperature; }
   void set_brightness(output::FloatOutput *brightness) { brightness_ = brightness; }

--- a/esphome/components/combination/combination.h
+++ b/esphome/components/combination/combination.h
@@ -58,7 +58,7 @@ class CombinationOneParameterComponent : public CombinationComponent {
   FixedVector<SensorSource> sensor_sources_;
 };
 
-class KalmanCombinationComponent : public CombinationOneParameterComponent {
+class KalmanCombinationComponent final : public CombinationOneParameterComponent {
  public:
   void dump_config() override;
   void setup() override;
@@ -85,7 +85,7 @@ class KalmanCombinationComponent : public CombinationOneParameterComponent {
   float variance_{INFINITY};
 };
 
-class LinearCombinationComponent : public CombinationOneParameterComponent {
+class LinearCombinationComponent final : public CombinationOneParameterComponent {
  public:
   void dump_config() override { this->log_config_(LOG_STR("linear")); }
   void setup() override;
@@ -93,49 +93,49 @@ class LinearCombinationComponent : public CombinationOneParameterComponent {
   void handle_new_value(float value);
 };
 
-class MaximumCombinationComponent : public CombinationNoParameterComponent {
+class MaximumCombinationComponent final : public CombinationNoParameterComponent {
  public:
   void dump_config() override { this->log_config_(LOG_STR("max")); }
 
   void handle_new_value(float value) override;
 };
 
-class MeanCombinationComponent : public CombinationNoParameterComponent {
+class MeanCombinationComponent final : public CombinationNoParameterComponent {
  public:
   void dump_config() override { this->log_config_(LOG_STR("mean")); }
 
   void handle_new_value(float value) override;
 };
 
-class MedianCombinationComponent : public CombinationNoParameterComponent {
+class MedianCombinationComponent final : public CombinationNoParameterComponent {
  public:
   void dump_config() override { this->log_config_(LOG_STR("median")); }
 
   void handle_new_value(float value) override;
 };
 
-class MinimumCombinationComponent : public CombinationNoParameterComponent {
+class MinimumCombinationComponent final : public CombinationNoParameterComponent {
  public:
   void dump_config() override { this->log_config_(LOG_STR("min")); }
 
   void handle_new_value(float value) override;
 };
 
-class MostRecentCombinationComponent : public CombinationNoParameterComponent {
+class MostRecentCombinationComponent final : public CombinationNoParameterComponent {
  public:
   void dump_config() override { this->log_config_(LOG_STR("most_recently_updated")); }
 
   void handle_new_value(float value) override;
 };
 
-class RangeCombinationComponent : public CombinationNoParameterComponent {
+class RangeCombinationComponent final : public CombinationNoParameterComponent {
  public:
   void dump_config() override { this->log_config_(LOG_STR("range")); }
 
   void handle_new_value(float value) override;
 };
 
-class SumCombinationComponent : public CombinationNoParameterComponent {
+class SumCombinationComponent final : public CombinationNoParameterComponent {
  public:
   void dump_config() override { this->log_config_(LOG_STR("sum")); }
 

--- a/esphome/components/coolix/coolix.h
+++ b/esphome/components/coolix/coolix.h
@@ -10,7 +10,7 @@ namespace esphome::coolix {
 const uint8_t COOLIX_TEMP_MIN = 17;  // Celsius
 const uint8_t COOLIX_TEMP_MAX = 30;  // Celsius
 
-class CoolixClimate : public climate_ir::ClimateIR {
+class CoolixClimate final : public climate_ir::ClimateIR {
  public:
   CoolixClimate()
       : climate_ir::ClimateIR(COOLIX_TEMP_MIN, COOLIX_TEMP_MAX, 1.0f, true, true,

--- a/esphome/components/copy/binary_sensor/copy_binary_sensor.h
+++ b/esphome/components/copy/binary_sensor/copy_binary_sensor.h
@@ -5,7 +5,7 @@
 
 namespace esphome::copy {
 
-class CopyBinarySensor : public binary_sensor::BinarySensor, public Component {
+class CopyBinarySensor final : public binary_sensor::BinarySensor, public Component {
  public:
   void set_source(binary_sensor::BinarySensor *source) { source_ = source; }
   void setup() override;

--- a/esphome/components/copy/button/copy_button.h
+++ b/esphome/components/copy/button/copy_button.h
@@ -5,7 +5,7 @@
 
 namespace esphome::copy {
 
-class CopyButton : public button::Button, public Component {
+class CopyButton final : public button::Button, public Component {
  public:
   void set_source(button::Button *source) { source_ = source; }
   void dump_config() override;

--- a/esphome/components/copy/cover/copy_cover.h
+++ b/esphome/components/copy/cover/copy_cover.h
@@ -5,7 +5,7 @@
 
 namespace esphome::copy {
 
-class CopyCover : public cover::Cover, public Component {
+class CopyCover final : public cover::Cover, public Component {
  public:
   void set_source(cover::Cover *source) { source_ = source; }
   void setup() override;

--- a/esphome/components/copy/fan/copy_fan.h
+++ b/esphome/components/copy/fan/copy_fan.h
@@ -5,7 +5,7 @@
 
 namespace esphome::copy {
 
-class CopyFan : public fan::Fan, public Component {
+class CopyFan final : public fan::Fan, public Component {
  public:
   void set_source(fan::Fan *source) { source_ = source; }
   void setup() override;

--- a/esphome/components/copy/lock/copy_lock.h
+++ b/esphome/components/copy/lock/copy_lock.h
@@ -5,7 +5,7 @@
 
 namespace esphome::copy {
 
-class CopyLock : public lock::Lock, public Component {
+class CopyLock final : public lock::Lock, public Component {
  public:
   void set_source(lock::Lock *source) { source_ = source; }
   void setup() override;

--- a/esphome/components/copy/number/copy_number.h
+++ b/esphome/components/copy/number/copy_number.h
@@ -5,7 +5,7 @@
 
 namespace esphome::copy {
 
-class CopyNumber : public number::Number, public Component {
+class CopyNumber final : public number::Number, public Component {
  public:
   void set_source(number::Number *source) { source_ = source; }
   void setup() override;

--- a/esphome/components/copy/select/copy_select.h
+++ b/esphome/components/copy/select/copy_select.h
@@ -5,7 +5,7 @@
 
 namespace esphome::copy {
 
-class CopySelect : public select::Select, public Component {
+class CopySelect final : public select::Select, public Component {
  public:
   void set_source(select::Select *source) { source_ = source; }
   void setup() override;

--- a/esphome/components/copy/sensor/copy_sensor.h
+++ b/esphome/components/copy/sensor/copy_sensor.h
@@ -5,7 +5,7 @@
 
 namespace esphome::copy {
 
-class CopySensor : public sensor::Sensor, public Component {
+class CopySensor final : public sensor::Sensor, public Component {
  public:
   void set_source(sensor::Sensor *source) { source_ = source; }
   void setup() override;

--- a/esphome/components/copy/switch/copy_switch.h
+++ b/esphome/components/copy/switch/copy_switch.h
@@ -5,7 +5,7 @@
 
 namespace esphome::copy {
 
-class CopySwitch : public switch_::Switch, public Component {
+class CopySwitch final : public switch_::Switch, public Component {
  public:
   void set_source(switch_::Switch *source) { source_ = source; }
   void setup() override;

--- a/esphome/components/copy/text/copy_text.h
+++ b/esphome/components/copy/text/copy_text.h
@@ -5,7 +5,7 @@
 
 namespace esphome::copy {
 
-class CopyText : public text::Text, public Component {
+class CopyText final : public text::Text, public Component {
  public:
   void set_source(text::Text *source) { source_ = source; }
   void setup() override;

--- a/esphome/components/copy/text_sensor/copy_text_sensor.h
+++ b/esphome/components/copy/text_sensor/copy_text_sensor.h
@@ -5,7 +5,7 @@
 
 namespace esphome::copy {
 
-class CopyTextSensor : public text_sensor::TextSensor, public Component {
+class CopyTextSensor final : public text_sensor::TextSensor, public Component {
  public:
   void set_source(text_sensor::TextSensor *source) { source_ = source; }
   void setup() override;

--- a/esphome/components/cover/automation.h
+++ b/esphome/components/cover/automation.h
@@ -6,7 +6,7 @@
 
 namespace esphome::cover {
 
-template<typename... Ts> class OpenAction : public Action<Ts...> {
+template<typename... Ts> class OpenAction final : public Action<Ts...> {
  public:
   explicit OpenAction(Cover *cover) : cover_(cover) {}
 
@@ -16,7 +16,7 @@ template<typename... Ts> class OpenAction : public Action<Ts...> {
   Cover *cover_;
 };
 
-template<typename... Ts> class CloseAction : public Action<Ts...> {
+template<typename... Ts> class CloseAction final : public Action<Ts...> {
  public:
   explicit CloseAction(Cover *cover) : cover_(cover) {}
 
@@ -26,7 +26,7 @@ template<typename... Ts> class CloseAction : public Action<Ts...> {
   Cover *cover_;
 };
 
-template<typename... Ts> class StopAction : public Action<Ts...> {
+template<typename... Ts> class StopAction final : public Action<Ts...> {
  public:
   explicit StopAction(Cover *cover) : cover_(cover) {}
 
@@ -36,7 +36,7 @@ template<typename... Ts> class StopAction : public Action<Ts...> {
   Cover *cover_;
 };
 
-template<typename... Ts> class ToggleAction : public Action<Ts...> {
+template<typename... Ts> class ToggleAction final : public Action<Ts...> {
  public:
   explicit ToggleAction(Cover *cover) : cover_(cover) {}
 
@@ -59,7 +59,7 @@ template<typename... Ts> class ToggleAction : public Action<Ts...> {
 // T &` if Ts already carries a const). This keeps trigger args no-copy
 // regardless of whether the trigger supplies `T`, `T &`, or `const T &`.
 
-template<typename... Ts> class ControlAction : public Action<Ts...> {
+template<typename... Ts> class ControlAction final : public Action<Ts...> {
  public:
   using ApplyFn = void (*)(CoverCall &, const std::remove_cvref_t<Ts> &...);
   ControlAction(Cover *cover, ApplyFn apply) : cover_(cover), apply_(apply) {}
@@ -75,7 +75,7 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
   ApplyFn apply_;
 };
 
-template<typename... Ts> class CoverPublishAction : public Action<Ts...> {
+template<typename... Ts> class CoverPublishAction final : public Action<Ts...> {
  public:
   using ApplyFn = void (*)(Cover *, const std::remove_cvref_t<Ts> &...);
   CoverPublishAction(Cover *cover, ApplyFn apply) : cover_(cover), apply_(apply) {}
@@ -90,7 +90,7 @@ template<typename... Ts> class CoverPublishAction : public Action<Ts...> {
   ApplyFn apply_;
 };
 
-template<bool OPEN, typename... Ts> class CoverPositionCondition : public Condition<Ts...> {
+template<bool OPEN, typename... Ts> class CoverPositionCondition final : public Condition<Ts...> {
  public:
   CoverPositionCondition(Cover *cover) : cover_(cover) {}
 
@@ -103,7 +103,7 @@ template<bool OPEN, typename... Ts> class CoverPositionCondition : public Condit
 template<typename... Ts> using CoverIsOpenCondition = CoverPositionCondition<true, Ts...>;
 template<typename... Ts> using CoverIsClosedCondition = CoverPositionCondition<false, Ts...>;
 
-template<bool OPEN> class CoverPositionTrigger : public Trigger<> {
+template<bool OPEN> class CoverPositionTrigger final : public Trigger<> {
  public:
   CoverPositionTrigger(Cover *a_cover) : cover_(a_cover) {
     a_cover->add_on_state_callback([this]() {
@@ -123,7 +123,7 @@ template<bool OPEN> class CoverPositionTrigger : public Trigger<> {
 using CoverOpenedTrigger = CoverPositionTrigger<true>;
 using CoverClosedTrigger = CoverPositionTrigger<false>;
 
-template<CoverOperation OP> class CoverTrigger : public Trigger<> {
+template<CoverOperation OP> class CoverTrigger final : public Trigger<> {
  public:
   CoverTrigger(Cover *a_cover) : cover_(a_cover) {
     a_cover->add_on_state_callback([this]() {

--- a/esphome/components/cs5460a/cs5460a.h
+++ b/esphome/components/cs5460a/cs5460a.h
@@ -52,9 +52,9 @@ enum CS5460APGAGain {
   CS5460A_PGA_GAIN_50X = 0b1,
 };
 
-class CS5460AComponent : public Component,
-                         public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
-                                               spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_1MHZ> {
+class CS5460AComponent final : public Component,
+                               public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                                     spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_1MHZ> {
  public:
   void set_samples(uint32_t samples) { samples_ = samples; }
   void set_phase_offset(int8_t phase_offset) { phase_offset_ = phase_offset; }
@@ -108,7 +108,7 @@ class CS5460AComponent : public Component,
   uint32_t prev_raw_energy_{0};
 };
 
-template<typename... Ts> class CS5460ARestartAction : public Action<Ts...> {
+template<typename... Ts> class CS5460ARestartAction final : public Action<Ts...> {
  public:
   CS5460ARestartAction(CS5460AComponent *cs5460a) : cs5460a_(cs5460a) {}
 

--- a/esphome/components/cse7761/cse7761.h
+++ b/esphome/components/cse7761/cse7761.h
@@ -16,7 +16,7 @@ struct CSE7761DataStruct {
 };
 
 /// This class implements support for the CSE7761 UART power sensor.
-class CSE7761Component : public PollingComponent, public uart::UARTDevice {
+class CSE7761Component final : public PollingComponent, public uart::UARTDevice {
  public:
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
   void set_active_power_1_sensor(sensor::Sensor *power_sensor_1) { power_sensor_1_ = power_sensor_1; }

--- a/esphome/components/cse7766/cse7766.h
+++ b/esphome/components/cse7766/cse7766.h
@@ -9,7 +9,7 @@ namespace esphome::cse7766 {
 
 static constexpr size_t CSE7766_RAW_DATA_SIZE = 24;
 
-class CSE7766Component : public Component, public uart::UARTDevice {
+class CSE7766Component final : public Component, public uart::UARTDevice {
  public:
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
   void set_current_sensor(sensor::Sensor *current_sensor) { current_sensor_ = current_sensor; }

--- a/esphome/components/cst226/binary_sensor/cs226_button.h
+++ b/esphome/components/cst226/binary_sensor/cs226_button.h
@@ -6,10 +6,10 @@
 
 namespace esphome::cst226 {
 
-class CST226Button : public binary_sensor::BinarySensor,
-                     public Component,
-                     public CST226ButtonListener,
-                     public Parented<CST226Touchscreen> {
+class CST226Button final : public binary_sensor::BinarySensor,
+                           public Component,
+                           public CST226ButtonListener,
+                           public Parented<CST226Touchscreen> {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/cst226/touchscreen/cst226_touchscreen.h
+++ b/esphome/components/cst226/touchscreen/cst226_touchscreen.h
@@ -15,7 +15,7 @@ class CST226ButtonListener {
   virtual void update_button(bool state) = 0;
 };
 
-class CST226Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice {
+class CST226Touchscreen final : public touchscreen::Touchscreen, public i2c::I2CDevice {
  public:
   void setup() override;
   void update_touches() override;

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.h
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.h
@@ -37,7 +37,7 @@ class CST816ButtonListener {
   virtual void update_button(bool state) = 0;
 };
 
-class CST816Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice {
+class CST816Touchscreen final : public touchscreen::Touchscreen, public i2c::I2CDevice {
  public:
   void setup() override;
   void update_touches() override;

--- a/esphome/components/ct_clamp/ct_clamp_sensor.h
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.h
@@ -7,7 +7,7 @@
 
 namespace esphome::ct_clamp {
 
-class CTClampSensor : public sensor::Sensor, public PollingComponent {
+class CTClampSensor final : public sensor::Sensor, public PollingComponent {
  public:
   void update() override;
   void loop() override;

--- a/esphome/components/current_based/current_based_cover.h
+++ b/esphome/components/current_based/current_based_cover.h
@@ -8,7 +8,7 @@
 
 namespace esphome::current_based {
 
-class CurrentBasedCover : public cover::Cover, public Component {
+class CurrentBasedCover final : public cover::Cover, public Component {
  public:
   void setup() override;
   void loop() override;

--- a/esphome/components/cwww/cwww_light_output.h
+++ b/esphome/components/cwww/cwww_light_output.h
@@ -6,7 +6,7 @@
 
 namespace esphome::cwww {
 
-class CWWWLightOutput : public light::LightOutput {
+class CWWWLightOutput final : public light::LightOutput {
  public:
   void set_cold_white(output::FloatOutput *cold_white) { cold_white_ = cold_white; }
   void set_warm_white(output::FloatOutput *warm_white) { warm_white_ = warm_white; }

--- a/esphome/components/dac7678/dac7678_output.h
+++ b/esphome/components/dac7678/dac7678_output.h
@@ -9,7 +9,7 @@ namespace esphome::dac7678 {
 
 class DAC7678Output;
 
-class DAC7678Channel : public output::FloatOutput, public Parented<DAC7678Output> {
+class DAC7678Channel final : public output::FloatOutput, public Parented<DAC7678Output> {
  public:
   void set_channel(uint8_t channel) { channel_ = channel; }
 
@@ -24,7 +24,7 @@ class DAC7678Channel : public output::FloatOutput, public Parented<DAC7678Output
 };
 
 /// DAC7678 float output component.
-class DAC7678Output : public Component, public i2c::I2CDevice {
+class DAC7678Output final : public Component, public i2c::I2CDevice {
  public:
   DAC7678Output() {}
 

--- a/esphome/components/daikin/daikin.h
+++ b/esphome/components/daikin/daikin.h
@@ -39,7 +39,7 @@ const uint32_t DAIKIN_MESSAGE_SPACE = 32300;
 // State Frame size
 const uint8_t DAIKIN_STATE_FRAME_SIZE = 19;
 
-class DaikinClimate : public climate_ir::ClimateIR {
+class DaikinClimate final : public climate_ir::ClimateIR {
  public:
   DaikinClimate()
       : climate_ir::ClimateIR(DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX, 1.0f, true, true,

--- a/esphome/components/daikin_arc/daikin_arc.h
+++ b/esphome/components/daikin_arc/daikin_arc.h
@@ -45,7 +45,7 @@ const uint8_t DAIKIN_DBG_TOLERANCE = 25;
 // State Frame size
 const uint8_t DAIKIN_STATE_FRAME_SIZE = 19;
 
-class DaikinArcClimate : public climate_ir::ClimateIR {
+class DaikinArcClimate final : public climate_ir::ClimateIR {
  public:
   DaikinArcClimate()
       : climate_ir::ClimateIR(DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX, 0.5f, true, true,

--- a/esphome/components/daikin_brc/daikin_brc.h
+++ b/esphome/components/daikin_brc/daikin_brc.h
@@ -48,7 +48,7 @@ const uint8_t DAIKIN_BRC_PREAMBLE_SIZE = 7;
 // Transmit Frame size - includes a preamble
 const uint8_t DAIKIN_BRC_TRANSMIT_FRAME_SIZE = DAIKIN_BRC_PREAMBLE_SIZE + DAIKIN_BRC_STATE_FRAME_SIZE;
 
-class DaikinBrcClimate : public climate_ir::ClimateIR {
+class DaikinBrcClimate final : public climate_ir::ClimateIR {
  public:
   DaikinBrcClimate()
       : climate_ir::ClimateIR(DAIKIN_BRC_TEMP_MIN_C, DAIKIN_BRC_TEMP_MAX_C, 0.5f, true, true,

--- a/esphome/components/dallas_temp/dallas_temp.h
+++ b/esphome/components/dallas_temp/dallas_temp.h
@@ -6,7 +6,7 @@
 
 namespace esphome::dallas_temp {
 
-class DallasTemperatureSensor : public PollingComponent, public sensor::Sensor, public one_wire::OneWireDevice {
+class DallasTemperatureSensor final : public PollingComponent, public sensor::Sensor, public one_wire::OneWireDevice {
  public:
   void setup() override;
   void update() override;

--- a/esphome/components/daly_bms/daly_bms.h
+++ b/esphome/components/daly_bms/daly_bms.h
@@ -17,7 +17,7 @@
 
 namespace esphome::daly_bms {
 
-class DalyBmsComponent : public PollingComponent, public uart::UARTDevice {
+class DalyBmsComponent final : public PollingComponent, public uart::UARTDevice {
  public:
   DalyBmsComponent() = default;
 

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -96,7 +96,7 @@ class DateCall {
   optional<uint8_t> day_;
 };
 
-template<typename... Ts> class DateSetAction : public Action<Ts...>, public Parented<DateEntity> {
+template<typename... Ts> class DateSetAction final : public Action<Ts...>, public Parented<DateEntity> {
  public:
   TEMPLATABLE_VALUE(ESPTime, date)
 

--- a/esphome/components/datetime/datetime_base.h
+++ b/esphome/components/datetime/datetime_base.h
@@ -31,7 +31,7 @@ class DateTimeBase : public EntityBase {
 #endif
 };
 
-class DateTimeStateTrigger : public Trigger<ESPTime> {
+class DateTimeStateTrigger final : public Trigger<ESPTime> {
  public:
   explicit DateTimeStateTrigger(DateTimeBase *parent) : parent_(parent) {
     parent->add_on_state_callback([this]() { this->trigger(this->parent_->state_as_esptime()); });

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -121,7 +121,7 @@ class DateTimeCall {
   optional<uint8_t> second_;
 };
 
-template<typename... Ts> class DateTimeSetAction : public Action<Ts...>, public Parented<DateTimeEntity> {
+template<typename... Ts> class DateTimeSetAction final : public Action<Ts...>, public Parented<DateTimeEntity> {
  public:
   TEMPLATABLE_VALUE(ESPTime, datetime)
 
@@ -136,7 +136,7 @@ template<typename... Ts> class DateTimeSetAction : public Action<Ts...>, public 
 };
 
 #ifdef USE_TIME
-class OnDateTimeTrigger : public Trigger<>, public Component, public Parented<DateTimeEntity> {
+class OnDateTimeTrigger final : public Trigger<>, public Component, public Parented<DateTimeEntity> {
  public:
   void loop() override;
 

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -98,7 +98,7 @@ class TimeCall {
   optional<uint8_t> second_;
 };
 
-template<typename... Ts> class TimeSetAction : public Action<Ts...>, public Parented<TimeEntity> {
+template<typename... Ts> class TimeSetAction final : public Action<Ts...>, public Parented<TimeEntity> {
  public:
   TEMPLATABLE_VALUE(ESPTime, time)
 
@@ -113,7 +113,7 @@ template<typename... Ts> class TimeSetAction : public Action<Ts...>, public Pare
 };
 
 #ifdef USE_TIME
-class OnTimeTrigger : public Trigger<>, public Component, public Parented<TimeEntity> {
+class OnTimeTrigger final : public Trigger<>, public Component, public Parented<TimeEntity> {
  public:
   void loop() override;
 

--- a/esphome/components/debug/debug_component.h
+++ b/esphome/components/debug/debug_component.h
@@ -21,7 +21,7 @@ static constexpr size_t WAKEUP_CAUSE_BUFFER_SIZE = 128;
 
 // buf_append_printf is now provided by esphome/core/helpers.h
 
-class DebugComponent : public PollingComponent {
+class DebugComponent final : public PollingComponent {
  public:
   void loop() override;
   void update() override;

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -70,7 +70,7 @@ template<typename... Ts> class PreventDeepSleepAction;
  * and set_run_duration, then set how long the deep sleep should last using set_sleep_duration and optionally
  * on the ESP32 set_wakeup_pin.
  */
-class DeepSleepComponent : public Component {
+class DeepSleepComponent final : public Component {
  public:
   /// Set the duration in ms the component should sleep once it's in deep sleep mode.
   void set_sleep_duration(uint32_t time_ms);
@@ -161,7 +161,7 @@ class DeepSleepComponent : public Component {
 
 extern bool global_has_deep_sleep;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-template<typename... Ts> class EnterDeepSleepAction : public Action<Ts...> {
+template<typename... Ts> class EnterDeepSleepAction final : public Action<Ts...> {
  public:
   EnterDeepSleepAction(DeepSleepComponent *deep_sleep) : deep_sleep_(deep_sleep) {}
   TEMPLATABLE_VALUE(uint32_t, sleep_duration);
@@ -233,12 +233,13 @@ template<typename... Ts> class EnterDeepSleepAction : public Action<Ts...> {
 #endif
 };
 
-template<typename... Ts> class PreventDeepSleepAction : public Action<Ts...>, public Parented<DeepSleepComponent> {
+template<typename... Ts>
+class PreventDeepSleepAction final : public Action<Ts...>, public Parented<DeepSleepComponent> {
  public:
   void play(const Ts &...x) override { this->parent_->prevent_deep_sleep(); }
 };
 
-template<typename... Ts> class AllowDeepSleepAction : public Action<Ts...>, public Parented<DeepSleepComponent> {
+template<typename... Ts> class AllowDeepSleepAction final : public Action<Ts...>, public Parented<DeepSleepComponent> {
  public:
   void play(const Ts &...x) override { this->parent_->allow_deep_sleep(); }
 };

--- a/esphome/components/delonghi/delonghi.h
+++ b/esphome/components/delonghi/delonghi.h
@@ -39,7 +39,7 @@ const uint32_t DELONGHI_ZERO_SPACE = 670;
 // State Frame size
 const uint8_t DELONGHI_STATE_FRAME_SIZE = 8;
 
-class DelonghiClimate : public climate_ir::ClimateIR {
+class DelonghiClimate final : public climate_ir::ClimateIR {
  public:
   DelonghiClimate()
       : climate_ir::ClimateIR(DELONGHI_TEMP_MIN, DELONGHI_TEMP_MAX, 1.0f, true, true,

--- a/esphome/components/demo/demo_alarm_control_panel.h
+++ b/esphome/components/demo/demo_alarm_control_panel.h
@@ -13,7 +13,7 @@ enum class DemoAlarmControlPanelType {
   TYPE_3,
 };
 
-class DemoAlarmControlPanel : public AlarmControlPanel, public Component {
+class DemoAlarmControlPanel final : public AlarmControlPanel, public Component {
  public:
   void setup() override {}
 

--- a/esphome/components/demo/demo_binary_sensor.h
+++ b/esphome/components/demo/demo_binary_sensor.h
@@ -5,7 +5,7 @@
 
 namespace esphome::demo {
 
-class DemoBinarySensor : public binary_sensor::BinarySensor, public PollingComponent {
+class DemoBinarySensor final : public binary_sensor::BinarySensor, public PollingComponent {
  public:
   void setup() override { this->publish_initial_state(false); }
   void update() override {

--- a/esphome/components/demo/demo_button.h
+++ b/esphome/components/demo/demo_button.h
@@ -5,7 +5,7 @@
 
 namespace esphome::demo {
 
-class DemoButton : public button::Button {
+class DemoButton final : public button::Button {
  protected:
   void press_action() override {}
 };

--- a/esphome/components/demo/demo_climate.h
+++ b/esphome/components/demo/demo_climate.h
@@ -11,7 +11,7 @@ enum class DemoClimateType {
   TYPE_3,
 };
 
-class DemoClimate : public climate::Climate, public Component {
+class DemoClimate final : public climate::Climate, public Component {
  public:
   void set_type(DemoClimateType type) { type_ = type; }
   void setup() override {

--- a/esphome/components/demo/demo_cover.h
+++ b/esphome/components/demo/demo_cover.h
@@ -12,7 +12,7 @@ enum class DemoCoverType {
   TYPE_4,
 };
 
-class DemoCover : public cover::Cover, public Component {
+class DemoCover final : public cover::Cover, public Component {
  public:
   void set_type(DemoCoverType type) { type_ = type; }
   void setup() override {

--- a/esphome/components/demo/demo_date.h
+++ b/esphome/components/demo/demo_date.h
@@ -9,7 +9,7 @@
 
 namespace esphome::demo {
 
-class DemoDate : public datetime::DateEntity, public Component {
+class DemoDate final : public datetime::DateEntity, public Component {
  public:
   void setup() override {
     this->year_ = 2038;

--- a/esphome/components/demo/demo_datetime.h
+++ b/esphome/components/demo/demo_datetime.h
@@ -9,7 +9,7 @@
 
 namespace esphome::demo {
 
-class DemoDateTime : public datetime::DateTimeEntity, public Component {
+class DemoDateTime final : public datetime::DateTimeEntity, public Component {
  public:
   void setup() override {
     this->year_ = 2038;

--- a/esphome/components/demo/demo_fan.h
+++ b/esphome/components/demo/demo_fan.h
@@ -12,7 +12,7 @@ enum class DemoFanType {
   TYPE_4,
 };
 
-class DemoFan : public fan::Fan, public Component {
+class DemoFan final : public fan::Fan, public Component {
  public:
   void set_type(DemoFanType type) { type_ = type; }
   fan::FanTraits get_traits() override {

--- a/esphome/components/demo/demo_light.h
+++ b/esphome/components/demo/demo_light.h
@@ -22,7 +22,7 @@ enum class DemoLightType {
   TYPE_7,
 };
 
-class DemoLight : public light::LightOutput, public Component {
+class DemoLight final : public light::LightOutput, public Component {
  public:
   void set_type(DemoLightType type) { type_ = type; }
   light::LightTraits get_traits() override {

--- a/esphome/components/demo/demo_lock.h
+++ b/esphome/components/demo/demo_lock.h
@@ -4,7 +4,7 @@
 
 namespace esphome::demo {
 
-class DemoLock : public lock::Lock {
+class DemoLock final : public lock::Lock {
  protected:
   void control(const lock::LockCall &call) override {
     auto state = call.get_state();

--- a/esphome/components/demo/demo_number.h
+++ b/esphome/components/demo/demo_number.h
@@ -11,7 +11,7 @@ enum class DemoNumberType {
   TYPE_3,
 };
 
-class DemoNumber : public number::Number, public Component {
+class DemoNumber final : public number::Number, public Component {
  public:
   void set_type(DemoNumberType type) { type_ = type; }
   void setup() override {

--- a/esphome/components/demo/demo_select.h
+++ b/esphome/components/demo/demo_select.h
@@ -5,7 +5,7 @@
 
 namespace esphome::demo {
 
-class DemoSelect : public select::Select, public Component {
+class DemoSelect final : public select::Select, public Component {
  protected:
   void control(size_t index) override { this->publish_state(index); }
 };

--- a/esphome/components/demo/demo_sensor.h
+++ b/esphome/components/demo/demo_sensor.h
@@ -6,7 +6,7 @@
 
 namespace esphome::demo {
 
-class DemoSensor : public sensor::Sensor, public PollingComponent {
+class DemoSensor final : public sensor::Sensor, public PollingComponent {
  public:
   void update() override {
     float val = random_float();

--- a/esphome/components/demo/demo_switch.h
+++ b/esphome/components/demo/demo_switch.h
@@ -6,7 +6,7 @@
 
 namespace esphome::demo {
 
-class DemoSwitch : public switch_::Switch, public Component {
+class DemoSwitch final : public switch_::Switch, public Component {
  public:
   void setup() override {
     bool initial = random_float() < 0.5;

--- a/esphome/components/demo/demo_text.h
+++ b/esphome/components/demo/demo_text.h
@@ -5,7 +5,7 @@
 
 namespace esphome::demo {
 
-class DemoText : public text::Text, public Component {
+class DemoText final : public text::Text, public Component {
  public:
   void setup() override { this->publish_state("I am a text entity"); }
 

--- a/esphome/components/demo/demo_text_sensor.h
+++ b/esphome/components/demo/demo_text_sensor.h
@@ -6,7 +6,7 @@
 
 namespace esphome::demo {
 
-class DemoTextSensor : public text_sensor::TextSensor, public PollingComponent {
+class DemoTextSensor final : public text_sensor::TextSensor, public PollingComponent {
  public:
   void update() override {
     float val = random_float();

--- a/esphome/components/demo/demo_time.h
+++ b/esphome/components/demo/demo_time.h
@@ -9,7 +9,7 @@
 
 namespace esphome::demo {
 
-class DemoTime : public datetime::TimeEntity, public Component {
+class DemoTime final : public datetime::TimeEntity, public Component {
  public:
   void setup() override {
     this->hour_ = 3;

--- a/esphome/components/demo/demo_valve.h
+++ b/esphome/components/demo/demo_valve.h
@@ -9,7 +9,7 @@ enum class DemoValveType {
   TYPE_2,
 };
 
-class DemoValve : public valve::Valve {
+class DemoValve final : public valve::Valve {
  public:
   valve::ValveTraits get_traits() override {
     valve::ValveTraits traits;

--- a/esphome/components/dew_point/dew_point.h
+++ b/esphome/components/dew_point/dew_point.h
@@ -5,7 +5,7 @@
 
 namespace esphome::dew_point {
 
-class DewPointComponent : public Component, public sensor::Sensor {
+class DewPointComponent final : public Component, public sensor::Sensor {
  public:
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { this->temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { this->humidity_sensor_ = humidity_sensor; }

--- a/esphome/components/dfplayer/dfplayer.h
+++ b/esphome/components/dfplayer/dfplayer.h
@@ -24,7 +24,7 @@ enum Device {
 
 // See the datasheet here:
 // https://github.com/DFRobot/DFRobotDFPlayerMini/blob/master/doc/FN-M16P%2BEmbedded%2BMP3%2BAudio%2BModule%2BDatasheet.pdf
-class DFPlayer : public uart::UARTDevice, public Component {
+class DFPlayer final : public uart::UARTDevice, public Component {
  public:
   void loop() override;
 
@@ -82,7 +82,7 @@ class DFPlayer : public uart::UARTDevice, public Component {
 DFPLAYER_SIMPLE_ACTION(NextAction, next)
 DFPLAYER_SIMPLE_ACTION(PreviousAction, previous)
 
-template<typename... Ts> class PlayMp3Action : public Action<Ts...>, public Parented<DFPlayer> {
+template<typename... Ts> class PlayMp3Action final : public Action<Ts...>, public Parented<DFPlayer> {
  public:
   TEMPLATABLE_VALUE(uint16_t, file)
 
@@ -92,7 +92,7 @@ template<typename... Ts> class PlayMp3Action : public Action<Ts...>, public Pare
   }
 };
 
-template<typename... Ts> class PlayFileAction : public Action<Ts...>, public Parented<DFPlayer> {
+template<typename... Ts> class PlayFileAction final : public Action<Ts...>, public Parented<DFPlayer> {
  public:
   TEMPLATABLE_VALUE(uint16_t, file)
   TEMPLATABLE_VALUE(bool, loop)
@@ -108,7 +108,7 @@ template<typename... Ts> class PlayFileAction : public Action<Ts...>, public Par
   }
 };
 
-template<typename... Ts> class PlayFolderAction : public Action<Ts...>, public Parented<DFPlayer> {
+template<typename... Ts> class PlayFolderAction final : public Action<Ts...>, public Parented<DFPlayer> {
  public:
   TEMPLATABLE_VALUE(uint16_t, folder)
   TEMPLATABLE_VALUE(uint16_t, file)
@@ -126,7 +126,7 @@ template<typename... Ts> class PlayFolderAction : public Action<Ts...>, public P
   }
 };
 
-template<typename... Ts> class SetDeviceAction : public Action<Ts...>, public Parented<DFPlayer> {
+template<typename... Ts> class SetDeviceAction final : public Action<Ts...>, public Parented<DFPlayer> {
  public:
   TEMPLATABLE_VALUE(Device, device)
 
@@ -136,7 +136,7 @@ template<typename... Ts> class SetDeviceAction : public Action<Ts...>, public Pa
   }
 };
 
-template<typename... Ts> class SetVolumeAction : public Action<Ts...>, public Parented<DFPlayer> {
+template<typename... Ts> class SetVolumeAction final : public Action<Ts...>, public Parented<DFPlayer> {
  public:
   TEMPLATABLE_VALUE(uint8_t, volume)
 
@@ -146,7 +146,7 @@ template<typename... Ts> class SetVolumeAction : public Action<Ts...>, public Pa
   }
 };
 
-template<typename... Ts> class SetEqAction : public Action<Ts...>, public Parented<DFPlayer> {
+template<typename... Ts> class SetEqAction final : public Action<Ts...>, public Parented<DFPlayer> {
  public:
   TEMPLATABLE_VALUE(EqPreset, eq)
 
@@ -165,7 +165,7 @@ DFPLAYER_SIMPLE_ACTION(RandomAction, random)
 DFPLAYER_SIMPLE_ACTION(VolumeUpAction, volume_up)
 DFPLAYER_SIMPLE_ACTION(VolumeDownAction, volume_down)
 
-template<typename... Ts> class DFPlayerIsPlayingCondition : public Condition<Ts...>, public Parented<DFPlayer> {
+template<typename... Ts> class DFPlayerIsPlayingCondition final : public Condition<Ts...>, public Parented<DFPlayer> {
  public:
   bool check(const Ts &...x) override { return this->parent_->is_playing(); }
 };


### PR DESCRIPTION
# What does this implement/fix?

Adds the C++ `final` specifier to leaf, user-configurable component classes — and to automation action/trigger/condition primitives — so classes that are meant to be terminal can no longer be subclassed by external components. Only classes that are never used as a base anywhere in the ESPHome tree are marked, so no in-tree class is affected.

- **Series:** part 4 of 21
- **Components:** 30 (`chsc6x` – `dfplayer`, alphabetical)
- **Change:** mechanical — adds the `final` keyword only; no behavior, config, or API surface changes
- **Verification:** tree-wide static check that no class in any `.cpp`/`.h` derives from a `final`-marked class, plus representative compiles on esp8266-ard and esp32-idf

<details>
<summary><b>Components in this PR (30)</b></summary>

`chsc6x`, `climate`, `climate_ir_lg`, `cm1106`, `color_temperature`, `combination`, `coolix`, `copy`, `cover`, `cs5460a`, `cse7761`, `cse7766`, `cst226`, `cst816`, `ct_clamp`, `current_based`, `cwww`, `dac7678`, `daikin`, `daikin_arc`, `daikin_brc`, `dallas_temp`, `daly_bms`, `datetime`, `debug`, `deep_sleep`, `delonghi`, `demo`, `dew_point`, `dfplayer`

</details>

<details>
<summary><b>All 21 PRs in this series</b></summary>

- #16952 — part 1 (`a01nyub` – `aqi`)
- #16953 — part 2 (`as3935_i2c` – `ble_rssi`)
- #16954 — part 3 (`ble_scanner` – `ch423`)
- #16955 — part 4 (`chsc6x` – `dfplayer`) ← **this PR**
- #16956 — part 5 (`dfrobot_sen0395` – `esp32_ble_beacon`)
- #16957 — part 6 (`esp32_ble_client` – `fujitsu_general`)
- #16958 — part 7 (`gcja5` – `hlw8032`)
- #16959 — part 8 (`hm3301` – `integration`)
- #16960 — part 9 (`internal_temperature` – `m5stack_8angle`)
- #16961 — part 10 (`matrix_keypad` – `micronova`)
- #16962 — part 11 (`microphone` – `ms8607`)
- #16963 — part 12 (`msa3xx` – `pm2005`)
- #16964 — part 13 (`pmsa003i` – `rc522`)
- #16965 — part 14 (`rc522_i2c` – `scd4x`)
- #16966 — part 15 (`script` – `slow_pwm`)
- #16967 — part 16 (`sm10bit_base` – `ssd1331_spi`)
- #16968 — part 17 (`ssd1351_spi` – `tem3200`)
- #16969 — part 18 (`template` – `tx20`)
- #16970 — part 19 (`uart` – `wl_134`)
- #16971 — part 20 (`wts01` – `zephyr_ble_server`)
- #16972 — part 21 (`zhlt01` – `zyaura`)

</details>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/developers.esphome.io#157

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
