### PR TITLE
Mark configurable classes as final (7/21: gcja5-hlw8032)

### DIFF
--- a/esphome/components/gcja5/gcja5.h
+++ b/esphome/components/gcja5/gcja5.h
@@ -7,7 +7,7 @@
 
 namespace esphome::gcja5 {
 
-class GCJA5Component : public Component, public uart::UARTDevice {
+class GCJA5Component final : public Component, public uart::UARTDevice {
  public:
   void dump_config() override;
   void loop() override;

--- a/esphome/components/gdk101/gdk101.h
+++ b/esphome/components/gdk101/gdk101.h
@@ -22,7 +22,7 @@ static const uint8_t GDK101_REG_READ_MEASURING_TIME = 0xB1;  // Mesuring time
 static const uint8_t GDK101_REG_READ_10MIN_AVG = 0xB2;       // Average radiation dose per 10 min
 static const uint8_t GDK101_REG_READ_1MIN_AVG = 0xB3;        // Average radiation dose per 1 min
 
-class GDK101Component : public PollingComponent, public i2c::I2CDevice {
+class GDK101Component final : public PollingComponent, public i2c::I2CDevice {
 #ifdef USE_SENSOR
   SUB_SENSOR(rad_1m)
   SUB_SENSOR(rad_10m)

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.h
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.h
@@ -6,7 +6,7 @@
 
 namespace esphome::gl_r01_i2c {
 
-class GLR01I2CComponent : public sensor::Sensor, public i2c::I2CDevice, public PollingComponent {
+class GLR01I2CComponent final : public sensor::Sensor, public i2c::I2CDevice, public PollingComponent {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -7,7 +7,7 @@
 
 namespace esphome::globals {
 
-template<typename T> class GlobalsComponent : public Component {
+template<typename T> class GlobalsComponent final : public Component {
  public:
   using value_type = T;
   explicit GlobalsComponent() = default;
@@ -127,7 +127,7 @@ template<typename T, uint8_t SZ> class RestoringGlobalStringComponent : public P
   ESPPreferenceObject rtc_;
 };
 
-template<class C, typename... Ts> class GlobalVarSetAction : public Action<Ts...> {
+template<class C, typename... Ts> class GlobalVarSetAction final : public Action<Ts...> {
  public:
   explicit GlobalVarSetAction(C *parent) : parent_(parent) {}
 

--- a/esphome/components/gp2y1010au0f/gp2y1010au0f.h
+++ b/esphome/components/gp2y1010au0f/gp2y1010au0f.h
@@ -7,7 +7,7 @@
 
 namespace esphome::gp2y1010au0f {
 
-class GP2Y1010AU0FSensor : public sensor::Sensor, public PollingComponent {
+class GP2Y1010AU0FSensor final : public sensor::Sensor, public PollingComponent {
  public:
   void update() override;
   void loop() override;

--- a/esphome/components/gp8403/gp8403.h
+++ b/esphome/components/gp8403/gp8403.h
@@ -15,7 +15,7 @@ enum GP8403Model : uint8_t {
   GP8413,
 };
 
-class GP8403Component : public Component, public i2c::I2CDevice {
+class GP8403Component final : public Component, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/gp8403/output/gp8403_output.h
+++ b/esphome/components/gp8403/output/gp8403_output.h
@@ -7,7 +7,7 @@
 
 namespace esphome::gp8403 {
 
-class GP8403Output : public Component, public output::FloatOutput, public Parented<GP8403Component> {
+class GP8403Output final : public Component, public output::FloatOutput, public Parented<GP8403Component> {
  public:
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA - 1; }

--- a/esphome/components/gpio/one_wire/gpio_one_wire.h
+++ b/esphome/components/gpio/one_wire/gpio_one_wire.h
@@ -6,7 +6,7 @@
 
 namespace esphome::gpio {
 
-class GPIOOneWireBus : public one_wire::OneWireBus, public Component {
+class GPIOOneWireBus final : public one_wire::OneWireBus, public Component {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/gpio/output/gpio_binary_output.h
+++ b/esphome/components/gpio/output/gpio_binary_output.h
@@ -6,7 +6,7 @@
 
 namespace esphome::gpio {
 
-class GPIOBinaryOutput : public output::BinaryOutput, public Component {
+class GPIOBinaryOutput final : public output::BinaryOutput, public Component {
  public:
   void set_pin(GPIOPin *pin) { pin_ = pin; }
 

--- a/esphome/components/gps/gps.h
+++ b/esphome/components/gps/gps.h
@@ -22,7 +22,7 @@ class GPSListener {
   GPS *parent_;
 };
 
-class GPS : public PollingComponent, public uart::UARTDevice {
+class GPS final : public PollingComponent, public uart::UARTDevice {
  public:
   void set_latitude_sensor(sensor::Sensor *latitude_sensor) { this->latitude_sensor_ = latitude_sensor; }
   void set_longitude_sensor(sensor::Sensor *longitude_sensor) { this->longitude_sensor_ = longitude_sensor; }

--- a/esphome/components/gps/time/gps_time.h
+++ b/esphome/components/gps/time/gps_time.h
@@ -6,7 +6,7 @@
 
 namespace esphome::gps {
 
-class GPSTime : public time::RealTimeClock, public GPSListener {
+class GPSTime final : public time::RealTimeClock, public GPSListener {
  public:
   void update() override { this->from_tiny_gps_(this->get_tiny_gps()); };
   void on_update(TinyGPSPlus &tiny_gps) override {

--- a/esphome/components/graph/graph.h
+++ b/esphome/components/graph/graph.h
@@ -42,7 +42,7 @@ enum ValuePositionType {
   VALUE_POSITION_TYPE_BELOW
 };
 
-class GraphLegend {
+class GraphLegend final {
  public:
   void init(Graph *g);
   void set_name_font(display::BaseFont *font) { this->font_label_ = font; }
@@ -105,7 +105,7 @@ class HistoryData {
   std::vector<float> samples_;
 };
 
-class GraphTrace {
+class GraphTrace final {
  public:
   void init(Graph *g);
   void set_name(std::string name) { name_ = std::move(name); }
@@ -134,7 +134,7 @@ class GraphTrace {
   friend GraphLegend;
 };
 
-class Graph : public Component {
+class Graph final : public Component {
  public:
   void draw(display::Display *buff, uint16_t x_offset, uint16_t y_offset, Color color);
   void draw_legend(display::Display *buff, uint16_t x_offset, uint16_t y_offset, Color color);

--- a/esphome/components/graphical_display_menu/graphical_display_menu.h
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.h
@@ -33,7 +33,7 @@ struct MenuItemValueArguments {
   bool is_menu_editing;
 };
 
-class GraphicalDisplayMenu final : public display_menu_base::DisplayMenuComponent {
+class GraphicalDisplayMenu : public display_menu_base::DisplayMenuComponent {
  public:
   void setup() override;
   void dump_config() override;
@@ -73,7 +73,7 @@ class GraphicalDisplayMenu final : public display_menu_base::DisplayMenuComponen
   CallbackManager<void()> on_redraw_callbacks_{};
 };
 
-class GraphicalDisplayMenuOnRedrawTrigger final : public Trigger<const GraphicalDisplayMenu *> {
+class GraphicalDisplayMenuOnRedrawTrigger : public Trigger<const GraphicalDisplayMenu *> {
  public:
   explicit GraphicalDisplayMenuOnRedrawTrigger(GraphicalDisplayMenu *parent) : parent_(parent) {
     parent->add_on_redraw_callback([this]() { this->trigger(this->parent_); });

--- a/esphome/components/graphical_display_menu/graphical_display_menu.h
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.h
@@ -33,7 +33,7 @@ struct MenuItemValueArguments {
   bool is_menu_editing;
 };
 
-class GraphicalDisplayMenu : public display_menu_base::DisplayMenuComponent {
+class GraphicalDisplayMenu final : public display_menu_base::DisplayMenuComponent {
  public:
   void setup() override;
   void dump_config() override;
@@ -73,7 +73,7 @@ class GraphicalDisplayMenu : public display_menu_base::DisplayMenuComponent {
   CallbackManager<void()> on_redraw_callbacks_{};
 };
 
-class GraphicalDisplayMenuOnRedrawTrigger : public Trigger<const GraphicalDisplayMenu *> {
+class GraphicalDisplayMenuOnRedrawTrigger final : public Trigger<const GraphicalDisplayMenu *> {
  public:
   explicit GraphicalDisplayMenuOnRedrawTrigger(GraphicalDisplayMenu *parent) : parent_(parent) {
     parent->add_on_redraw_callback([this]() { this->trigger(this->parent_); });

--- a/esphome/components/gree/gree.h
+++ b/esphome/components/gree/gree.h
@@ -79,7 +79,7 @@ static constexpr uint8_t GREE_PRESET_SLEEP_BIT = 0x80;
 // Model codes
 enum Model { GREE_GENERIC, GREE_YAN, GREE_YAA, GREE_YAC, GREE_YAC1FB9, GREE_YX1FF, GREE_YAG };
 
-class GreeClimate : public climate_ir::ClimateIR {
+class GreeClimate final : public climate_ir::ClimateIR {
  public:
   GreeClimate()
       : climate_ir::ClimateIR(GREE_TEMP_MIN, GREE_TEMP_MAX, 1.0f, true, true,

--- a/esphome/components/gree/switch/gree_switch.h
+++ b/esphome/components/gree/switch/gree_switch.h
@@ -6,7 +6,7 @@
 
 namespace esphome::gree {
 
-class GreeModeBitSwitch : public switch_::Switch, public Component, public Parented<GreeClimate> {
+class GreeModeBitSwitch final : public switch_::Switch, public Component, public Parented<GreeClimate> {
  public:
   GreeModeBitSwitch(const char *name, uint8_t bit_mask) : name_(name), bit_mask_(bit_mask) {}
 

--- a/esphome/components/grove_gas_mc_v2/grove_gas_mc_v2.h
+++ b/esphome/components/grove_gas_mc_v2/grove_gas_mc_v2.h
@@ -7,7 +7,7 @@
 
 namespace esphome::grove_gas_mc_v2 {
 
-class GroveGasMultichannelV2Component : public PollingComponent, public i2c::I2CDevice {
+class GroveGasMultichannelV2Component final : public PollingComponent, public i2c::I2CDevice {
   SUB_SENSOR(tvoc)
   SUB_SENSOR(carbon_monoxide)
   SUB_SENSOR(nitrogen_dioxide)

--- a/esphome/components/grove_tb6612fng/grove_tb6612fng.h
+++ b/esphome/components/grove_tb6612fng/grove_tb6612fng.h
@@ -47,7 +47,7 @@ enum StepperModeTypeT {
   MICRO_STEPPING = 3,
 };
 
-class GroveMotorDriveTB6612FNG : public Component, public i2c::I2CDevice {
+class GroveMotorDriveTB6612FNG final : public Component, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
@@ -162,7 +162,7 @@ class GroveMotorDriveTB6612FNG : public Component, public i2c::I2CDevice {
 };
 
 template<typename... Ts>
-class GROVETB6612FNGMotorRunAction : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
+class GROVETB6612FNGMotorRunAction final : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
  public:
   TEMPLATABLE_VALUE(uint8_t, channel)
   TEMPLATABLE_VALUE(uint16_t, speed)
@@ -183,7 +183,7 @@ class GROVETB6612FNGMotorRunAction : public Action<Ts...>, public Parented<Grove
 };
 
 template<typename... Ts>
-class GROVETB6612FNGMotorBrakeAction : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
+class GROVETB6612FNGMotorBrakeAction final : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
  public:
   TEMPLATABLE_VALUE(uint8_t, channel)
 
@@ -191,7 +191,7 @@ class GROVETB6612FNGMotorBrakeAction : public Action<Ts...>, public Parented<Gro
 };
 
 template<typename... Ts>
-class GROVETB6612FNGMotorStopAction : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
+class GROVETB6612FNGMotorStopAction final : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
  public:
   TEMPLATABLE_VALUE(uint8_t, channel)
 
@@ -199,19 +199,19 @@ class GROVETB6612FNGMotorStopAction : public Action<Ts...>, public Parented<Grov
 };
 
 template<typename... Ts>
-class GROVETB6612FNGMotorStandbyAction : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
+class GROVETB6612FNGMotorStandbyAction final : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
  public:
   void play(const Ts &...x) override { this->parent_->standby(); }
 };
 
 template<typename... Ts>
-class GROVETB6612FNGMotorNoStandbyAction : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
+class GROVETB6612FNGMotorNoStandbyAction final : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
  public:
   void play(const Ts &...x) override { this->parent_->not_standby(); }
 };
 
 template<typename... Ts>
-class GROVETB6612FNGMotorChangeAddressAction : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
+class GROVETB6612FNGMotorChangeAddressAction final : public Action<Ts...>, public Parented<GroveMotorDriveTB6612FNG> {
  public:
   TEMPLATABLE_VALUE(uint8_t, address)
 

--- a/esphome/components/growatt_solar/growatt_solar.h
+++ b/esphome/components/growatt_solar/growatt_solar.h
@@ -65,7 +65,7 @@ constexpr size_t RTU2_TODAY_PRODUCTION = 53;         // length = 2
 constexpr size_t RTU2_TOTAL_ENERGY_PRODUCTION = 55;  // length = 2
 constexpr size_t RTU2_INVERTER_MODULE_TEMP = 93;     // length = 1
 
-class GrowattSolar : public PollingComponent, public modbus::ModbusDevice {
+class GrowattSolar final : public PollingComponent, public modbus::ModbusDevice {
  public:
   void loop() override;
   void update() override;

--- a/esphome/components/gt911/binary_sensor/gt911_button.h
+++ b/esphome/components/gt911/binary_sensor/gt911_button.h
@@ -7,10 +7,10 @@
 
 namespace esphome::gt911 {
 
-class GT911Button : public binary_sensor::BinarySensor,
-                    public Component,
-                    public GT911ButtonListener,
-                    public Parented<GT911Touchscreen> {
+class GT911Button final : public binary_sensor::BinarySensor,
+                          public Component,
+                          public GT911ButtonListener,
+                          public Parented<GT911Touchscreen> {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.h
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.h
@@ -12,7 +12,7 @@ class GT911ButtonListener {
   virtual void update_button(uint8_t index, bool state) = 0;
 };
 
-class GT911Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice {
+class GT911Touchscreen final : public touchscreen::Touchscreen, public i2c::I2CDevice {
  public:
   /// @brief Initialize the GT911 touchscreen.
   ///

--- a/esphome/components/haier/automation.h
+++ b/esphome/components/haier/automation.h
@@ -6,7 +6,7 @@
 
 namespace esphome::haier {
 
-template<typename... Ts> class DisplayOnAction : public Action<Ts...> {
+template<typename... Ts> class DisplayOnAction final : public Action<Ts...> {
  public:
   DisplayOnAction(HaierClimateBase *parent) : parent_(parent) {}
   void play(const Ts &...x) { this->parent_->set_display_state(true); }
@@ -15,7 +15,7 @@ template<typename... Ts> class DisplayOnAction : public Action<Ts...> {
   HaierClimateBase *parent_;
 };
 
-template<typename... Ts> class DisplayOffAction : public Action<Ts...> {
+template<typename... Ts> class DisplayOffAction final : public Action<Ts...> {
  public:
   DisplayOffAction(HaierClimateBase *parent) : parent_(parent) {}
   void play(const Ts &...x) { this->parent_->set_display_state(false); }
@@ -24,7 +24,7 @@ template<typename... Ts> class DisplayOffAction : public Action<Ts...> {
   HaierClimateBase *parent_;
 };
 
-template<typename... Ts> class BeeperOnAction : public Action<Ts...> {
+template<typename... Ts> class BeeperOnAction final : public Action<Ts...> {
  public:
   BeeperOnAction(HonClimate *parent) : parent_(parent) {}
   void play(const Ts &...x) { this->parent_->set_beeper_state(true); }
@@ -33,7 +33,7 @@ template<typename... Ts> class BeeperOnAction : public Action<Ts...> {
   HonClimate *parent_;
 };
 
-template<typename... Ts> class BeeperOffAction : public Action<Ts...> {
+template<typename... Ts> class BeeperOffAction final : public Action<Ts...> {
  public:
   BeeperOffAction(HonClimate *parent) : parent_(parent) {}
   void play(const Ts &...x) { this->parent_->set_beeper_state(false); }
@@ -42,7 +42,7 @@ template<typename... Ts> class BeeperOffAction : public Action<Ts...> {
   HonClimate *parent_;
 };
 
-template<typename... Ts> class VerticalAirflowAction : public Action<Ts...> {
+template<typename... Ts> class VerticalAirflowAction final : public Action<Ts...> {
  public:
   VerticalAirflowAction(HonClimate *parent) : parent_(parent) {}
   TEMPLATABLE_VALUE(hon_protocol::VerticalSwingMode, direction)
@@ -52,7 +52,7 @@ template<typename... Ts> class VerticalAirflowAction : public Action<Ts...> {
   HonClimate *parent_;
 };
 
-template<typename... Ts> class HorizontalAirflowAction : public Action<Ts...> {
+template<typename... Ts> class HorizontalAirflowAction final : public Action<Ts...> {
  public:
   HorizontalAirflowAction(HonClimate *parent) : parent_(parent) {}
   TEMPLATABLE_VALUE(hon_protocol::HorizontalSwingMode, direction)
@@ -62,7 +62,7 @@ template<typename... Ts> class HorizontalAirflowAction : public Action<Ts...> {
   HonClimate *parent_;
 };
 
-template<typename... Ts> class HealthOnAction : public Action<Ts...> {
+template<typename... Ts> class HealthOnAction final : public Action<Ts...> {
  public:
   HealthOnAction(HaierClimateBase *parent) : parent_(parent) {}
   void play(const Ts &...x) { this->parent_->set_health_mode(true); }
@@ -71,7 +71,7 @@ template<typename... Ts> class HealthOnAction : public Action<Ts...> {
   HaierClimateBase *parent_;
 };
 
-template<typename... Ts> class HealthOffAction : public Action<Ts...> {
+template<typename... Ts> class HealthOffAction final : public Action<Ts...> {
  public:
   HealthOffAction(HaierClimateBase *parent) : parent_(parent) {}
   void play(const Ts &...x) { this->parent_->set_health_mode(false); }
@@ -80,7 +80,7 @@ template<typename... Ts> class HealthOffAction : public Action<Ts...> {
   HaierClimateBase *parent_;
 };
 
-template<typename... Ts> class StartSelfCleaningAction : public Action<Ts...> {
+template<typename... Ts> class StartSelfCleaningAction final : public Action<Ts...> {
  public:
   StartSelfCleaningAction(HonClimate *parent) : parent_(parent) {}
   void play(const Ts &...x) { this->parent_->start_self_cleaning(); }
@@ -89,7 +89,7 @@ template<typename... Ts> class StartSelfCleaningAction : public Action<Ts...> {
   HonClimate *parent_;
 };
 
-template<typename... Ts> class StartSteriCleaningAction : public Action<Ts...> {
+template<typename... Ts> class StartSteriCleaningAction final : public Action<Ts...> {
  public:
   StartSteriCleaningAction(HonClimate *parent) : parent_(parent) {}
   void play(const Ts &...x) { this->parent_->start_steri_cleaning(); }
@@ -98,7 +98,7 @@ template<typename... Ts> class StartSteriCleaningAction : public Action<Ts...> {
   HonClimate *parent_;
 };
 
-template<typename... Ts> class PowerOnAction : public Action<Ts...> {
+template<typename... Ts> class PowerOnAction final : public Action<Ts...> {
  public:
   PowerOnAction(HaierClimateBase *parent) : parent_(parent) {}
   void play(const Ts &...x) { this->parent_->send_power_on_command(); }
@@ -107,7 +107,7 @@ template<typename... Ts> class PowerOnAction : public Action<Ts...> {
   HaierClimateBase *parent_;
 };
 
-template<typename... Ts> class PowerOffAction : public Action<Ts...> {
+template<typename... Ts> class PowerOffAction final : public Action<Ts...> {
  public:
   PowerOffAction(HaierClimateBase *parent) : parent_(parent) {}
   void play(const Ts &...x) { this->parent_->send_power_off_command(); }
@@ -116,7 +116,7 @@ template<typename... Ts> class PowerOffAction : public Action<Ts...> {
   HaierClimateBase *parent_;
 };
 
-template<typename... Ts> class PowerToggleAction : public Action<Ts...> {
+template<typename... Ts> class PowerToggleAction final : public Action<Ts...> {
  public:
   PowerToggleAction(HaierClimateBase *parent) : parent_(parent) {}
   void play(const Ts &...x) { this->parent_->toggle_power(); }

--- a/esphome/components/haier/button/self_cleaning.h
+++ b/esphome/components/haier/button/self_cleaning.h
@@ -5,7 +5,7 @@
 
 namespace esphome::haier {
 
-class SelfCleaningButton : public button::Button, public Parented<HonClimate> {
+class SelfCleaningButton final : public button::Button, public Parented<HonClimate> {
  public:
   SelfCleaningButton() = default;
 

--- a/esphome/components/haier/button/steri_cleaning.h
+++ b/esphome/components/haier/button/steri_cleaning.h
@@ -5,7 +5,7 @@
 
 namespace esphome::haier {
 
-class SteriCleaningButton : public button::Button, public Parented<HonClimate> {
+class SteriCleaningButton final : public button::Button, public Parented<HonClimate> {
  public:
   SteriCleaningButton() = default;
 

--- a/esphome/components/haier/hon_climate.h
+++ b/esphome/components/haier/hon_climate.h
@@ -35,7 +35,7 @@ struct HonSettings {
   bool quiet_mode_state{false};
 };
 
-class HonClimate : public HaierClimateBase {
+class HonClimate final : public HaierClimateBase {
 #ifdef USE_SENSOR
  public:
   enum class SubSensorType {

--- a/esphome/components/haier/smartair2_climate.h
+++ b/esphome/components/haier/smartair2_climate.h
@@ -5,7 +5,7 @@
 
 namespace esphome::haier {
 
-class Smartair2Climate : public HaierClimateBase {
+class Smartair2Climate final : public HaierClimateBase {
  public:
   Smartair2Climate();
   Smartair2Climate(const Smartair2Climate &) = delete;

--- a/esphome/components/haier/switch/beeper.h
+++ b/esphome/components/haier/switch/beeper.h
@@ -5,7 +5,7 @@
 
 namespace esphome::haier {
 
-class BeeperSwitch : public switch_::Switch, public Parented<HonClimate> {
+class BeeperSwitch final : public switch_::Switch, public Parented<HonClimate> {
  public:
   BeeperSwitch() = default;
 

--- a/esphome/components/haier/switch/display.h
+++ b/esphome/components/haier/switch/display.h
@@ -5,7 +5,7 @@
 
 namespace esphome::haier {
 
-class DisplaySwitch : public switch_::Switch, public Parented<HaierClimateBase> {
+class DisplaySwitch final : public switch_::Switch, public Parented<HaierClimateBase> {
  public:
   DisplaySwitch() = default;
 

--- a/esphome/components/haier/switch/health_mode.h
+++ b/esphome/components/haier/switch/health_mode.h
@@ -5,7 +5,7 @@
 
 namespace esphome::haier {
 
-class HealthModeSwitch : public switch_::Switch, public Parented<HaierClimateBase> {
+class HealthModeSwitch final : public switch_::Switch, public Parented<HaierClimateBase> {
  public:
   HealthModeSwitch() = default;
 

--- a/esphome/components/haier/switch/quiet_mode.h
+++ b/esphome/components/haier/switch/quiet_mode.h
@@ -5,7 +5,7 @@
 
 namespace esphome::haier {
 
-class QuietModeSwitch : public switch_::Switch, public Parented<HonClimate> {
+class QuietModeSwitch final : public switch_::Switch, public Parented<HonClimate> {
  public:
   QuietModeSwitch() = default;
 

--- a/esphome/components/havells_solar/havells_solar.h
+++ b/esphome/components/havells_solar/havells_solar.h
@@ -8,7 +8,7 @@
 
 namespace esphome::havells_solar {
 
-class HavellsSolar : public PollingComponent, public modbus::ModbusDevice {
+class HavellsSolar final : public PollingComponent, public modbus::ModbusDevice {
  public:
   void set_voltage_sensor(uint8_t phase, sensor::Sensor *voltage_sensor) {
     this->phases_[phase].setup = true;

--- a/esphome/components/hbridge/fan/hbridge_fan.h
+++ b/esphome/components/hbridge/fan/hbridge_fan.h
@@ -12,7 +12,7 @@ enum DecayMode {
   DECAY_MODE_FAST = 1,
 };
 
-class HBridgeFan : public Component, public fan::Fan {
+class HBridgeFan final : public Component, public fan::Fan {
  public:
   HBridgeFan(int speed_count, DecayMode decay_mode) : speed_count_(speed_count), decay_mode_(decay_mode) {}
 
@@ -46,7 +46,7 @@ class HBridgeFan : public Component, public fan::Fan {
   void set_hbridge_levels_(float a_level, float b_level, float enable);
 };
 
-template<typename... Ts> class BrakeAction : public Action<Ts...> {
+template<typename... Ts> class BrakeAction final : public Action<Ts...> {
  public:
   explicit BrakeAction(HBridgeFan *parent) : parent_(parent) {}
 

--- a/esphome/components/hbridge/light/hbridge_light_output.h
+++ b/esphome/components/hbridge/light/hbridge_light_output.h
@@ -7,7 +7,7 @@
 
 namespace esphome::hbridge {
 
-class HBridgeLightOutput : public Component, public light::LightOutput {
+class HBridgeLightOutput final : public Component, public light::LightOutput {
  public:
   void set_pina_pin(output::FloatOutput *pina_pin) { this->pina_pin_ = pina_pin; }
   void set_pinb_pin(output::FloatOutput *pinb_pin) { this->pinb_pin_ = pinb_pin; }

--- a/esphome/components/hbridge/switch/hbridge_switch.h
+++ b/esphome/components/hbridge/switch/hbridge_switch.h
@@ -16,7 +16,7 @@ enum RelayState : uint8_t {
   RELAY_STATE_UNKNOWN = 4,
 };
 
-class HBridgeSwitch : public switch_::Switch, public Component {
+class HBridgeSwitch final : public switch_::Switch, public Component {
  public:
   void set_on_pin(GPIOPin *pin) { this->on_pin_ = pin; }
   void set_off_pin(GPIOPin *pin) { this->off_pin_ = pin; }

--- a/esphome/components/hc8/hc8.h
+++ b/esphome/components/hc8/hc8.h
@@ -9,7 +9,7 @@
 
 namespace esphome::hc8 {
 
-class HC8Component : public PollingComponent, public uart::UARTDevice {
+class HC8Component final : public PollingComponent, public uart::UARTDevice {
  public:
   void setup() override;
   void update() override;
@@ -26,7 +26,7 @@ class HC8Component : public PollingComponent, public uart::UARTDevice {
   bool warmup_complete_{false};
 };
 
-template<typename... Ts> class HC8CalibrateAction : public Action<Ts...>, public Parented<HC8Component> {
+template<typename... Ts> class HC8CalibrateAction final : public Action<Ts...>, public Parented<HC8Component> {
  public:
   TEMPLATABLE_VALUE(uint16_t, baseline)
 

--- a/esphome/components/hdc1080/hdc1080.h
+++ b/esphome/components/hdc1080/hdc1080.h
@@ -6,7 +6,7 @@
 
 namespace esphome::hdc1080 {
 
-class HDC1080Component : public PollingComponent, public i2c::I2CDevice {
+class HDC1080Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }

--- a/esphome/components/hdc2010/hdc2010.h
+++ b/esphome/components/hdc2010/hdc2010.h
@@ -6,7 +6,7 @@
 
 namespace esphome::hdc2010 {
 
-class HDC2010Component : public PollingComponent, public i2c::I2CDevice {
+class HDC2010Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void set_temperature_sensor(sensor::Sensor *temperature) { this->temperature_sensor_ = temperature; }
 

--- a/esphome/components/hdc2080/hdc2080.h
+++ b/esphome/components/hdc2080/hdc2080.h
@@ -6,7 +6,7 @@
 
 namespace esphome::hdc2080 {
 
-class HDC2080Component : public PollingComponent, public i2c::I2CDevice {
+class HDC2080Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void set_temperature(sensor::Sensor *temperature) { this->temperature_sensor_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { this->humidity_sensor_ = humidity; }

--- a/esphome/components/hdc302x/hdc302x.h
+++ b/esphome/components/hdc302x/hdc302x.h
@@ -20,7 +20,7 @@ enum HDC302XPowerMode : uint8_t {
  Datasheet:
  https://www.ti.com/lit/ds/symlink/hdc3020.pdf
  */
-class HDC302XComponent : public PollingComponent, public i2c::I2CDevice {
+class HDC302XComponent final : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
@@ -48,7 +48,7 @@ class HDC302XComponent : public PollingComponent, public i2c::I2CDevice {
   uint32_t conversion_delay_ms_();
 };
 
-template<typename... Ts> class HeaterOnAction : public Action<Ts...>, public Parented<HDC302XComponent> {
+template<typename... Ts> class HeaterOnAction final : public Action<Ts...>, public Parented<HDC302XComponent> {
  public:
   TEMPLATABLE_VALUE(uint16_t, power)
   TEMPLATABLE_VALUE(uint32_t, duration)
@@ -60,7 +60,7 @@ template<typename... Ts> class HeaterOnAction : public Action<Ts...>, public Par
   }
 };
 
-template<typename... Ts> class HeaterOffAction : public Action<Ts...>, public Parented<HDC302XComponent> {
+template<typename... Ts> class HeaterOffAction final : public Action<Ts...>, public Parented<HDC302XComponent> {
  public:
   void play(const Ts &...x) override { this->parent_->stop_heater(); }
 };

--- a/esphome/components/he60r/he60r.h
+++ b/esphome/components/he60r/he60r.h
@@ -7,7 +7,7 @@
 
 namespace esphome::he60r {
 
-class HE60rCover : public cover::Cover, public Component, public uart::UARTDevice {
+class HE60rCover final : public cover::Cover, public Component, public uart::UARTDevice {
  public:
   void setup() override;
   void loop() override;

--- a/esphome/components/heatpumpir/heatpumpir.h
+++ b/esphome/components/heatpumpir/heatpumpir.h
@@ -93,7 +93,7 @@ enum VerticalDirection {
 const float TEMP_MIN = 0;    // Celsius
 const float TEMP_MAX = 100;  // Celsius
 
-class HeatpumpIRClimate : public climate_ir::ClimateIR {
+class HeatpumpIRClimate final : public climate_ir::ClimateIR {
  public:
   HeatpumpIRClimate()
       : climate_ir::ClimateIR(TEMP_MIN, TEMP_MAX, 1.0f, true, true,

--- a/esphome/components/hitachi_ac344/hitachi_ac344.h
+++ b/esphome/components/hitachi_ac344/hitachi_ac344.h
@@ -75,7 +75,7 @@ const uint16_t HITACHI_AC344_BITS = HITACHI_AC344_STATE_LENGTH * 8;
 #define GETBIT8(a, b) ((a) & ((uint8_t) 1 << (b)))
 #define GETBITS8(data, offset, size) (((data) & (((uint8_t) UINT8_MAX >> (8 - (size))) << (offset))) >> (offset))
 
-class HitachiClimate : public climate_ir::ClimateIR {
+class HitachiClimate final : public climate_ir::ClimateIR {
  public:
   HitachiClimate()
       : climate_ir::ClimateIR(HITACHI_AC344_TEMP_MIN, HITACHI_AC344_TEMP_MAX, 1.0F, true, true,

--- a/esphome/components/hitachi_ac424/hitachi_ac424.h
+++ b/esphome/components/hitachi_ac424/hitachi_ac424.h
@@ -77,7 +77,7 @@ const uint16_t HITACHI_AC424_BITS = HITACHI_AC424_STATE_LENGTH * 8;
 #define HITACHI_AC424_GETBITS8(data, offset, size) \
   (((data) & (((uint8_t) UINT8_MAX >> (8 - (size))) << (offset))) >> (offset))
 
-class HitachiClimate : public climate_ir::ClimateIR {
+class HitachiClimate final : public climate_ir::ClimateIR {
  public:
   HitachiClimate()
       : climate_ir::ClimateIR(HITACHI_AC424_TEMP_MIN, HITACHI_AC424_TEMP_MAX, 1.0F, true, true,

--- a/esphome/components/hlk_fm22x/hlk_fm22x.h
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.h
@@ -71,7 +71,7 @@ enum HlkFm22xFaceDirection {
   FACE_DIRECTION_UP = 0x10,
 };
 
-class HlkFm22xComponent : public PollingComponent, public uart::UARTDevice {
+class HlkFm22xComponent final : public PollingComponent, public uart::UARTDevice {
  public:
   void setup() override;
   void update() override;
@@ -141,7 +141,7 @@ class HlkFm22xComponent : public PollingComponent, public uart::UARTDevice {
   CallbackManager<void(uint8_t)> enrollment_failed_callback_;
 };
 
-template<typename... Ts> class EnrollmentAction : public Action<Ts...>, public Parented<HlkFm22xComponent> {
+template<typename... Ts> class EnrollmentAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
   TEMPLATABLE_VALUE(std::string, name)
   TEMPLATABLE_VALUE(uint8_t, direction)
@@ -153,7 +153,7 @@ template<typename... Ts> class EnrollmentAction : public Action<Ts...>, public P
   }
 };
 
-template<typename... Ts> class DeleteAction : public Action<Ts...>, public Parented<HlkFm22xComponent> {
+template<typename... Ts> class DeleteAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
   TEMPLATABLE_VALUE(int16_t, face_id)
 
@@ -163,17 +163,17 @@ template<typename... Ts> class DeleteAction : public Action<Ts...>, public Paren
   }
 };
 
-template<typename... Ts> class DeleteAllAction : public Action<Ts...>, public Parented<HlkFm22xComponent> {
+template<typename... Ts> class DeleteAllAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
   void play(const Ts &...x) override { this->parent_->delete_all_faces(); }
 };
 
-template<typename... Ts> class ScanAction : public Action<Ts...>, public Parented<HlkFm22xComponent> {
+template<typename... Ts> class ScanAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
   void play(const Ts &...x) override { this->parent_->scan_face(); }
 };
 
-template<typename... Ts> class ResetAction : public Action<Ts...>, public Parented<HlkFm22xComponent> {
+template<typename... Ts> class ResetAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
   void play(const Ts &...x) override { this->parent_->reset(); }
 };

--- a/esphome/components/hlw8012/hlw8012.h
+++ b/esphome/components/hlw8012/hlw8012.h
@@ -23,7 +23,7 @@ enum HLW8012SensorModels {
 #define USE_PCNT false
 #endif
 
-class HLW8012Component : public PollingComponent {
+class HLW8012Component final : public PollingComponent {
  public:
   HLW8012Component()
       : cf_store_(*pulse_counter::get_storage(USE_PCNT)), cf1_store_(*pulse_counter::get_storage(USE_PCNT)) {}

--- a/esphome/components/hlw8032/hlw8032.h
+++ b/esphome/components/hlw8032/hlw8032.h
@@ -6,7 +6,7 @@
 
 namespace esphome::hlw8032 {
 
-class HLW8032Component : public Component, public uart::UARTDevice {
+class HLW8032Component final : public Component, public uart::UARTDevice {
  public:
   void loop() override;
   void dump_config() override;


### PR DESCRIPTION
# What does this implement/fix?

Adds the C++ `final` specifier to leaf, user-configurable component classes — and to automation action/trigger/condition primitives — so classes that are meant to be terminal can no longer be subclassed by external components. Only classes that are never used as a base anywhere in the ESPHome tree are marked, so no in-tree class is affected.

- **Series:** part 7 of 21
- **Components:** 29 (`gcja5` – `hlw8032`, alphabetical)
- **Change:** mechanical — adds the `final` keyword only; no behavior, config, or API surface changes
- **Verification:** tree-wide static check that no class in any `.cpp`/`.h` derives from a `final`-marked class, plus representative compiles on esp8266-ard and esp32-idf

<details>
<summary><b>Components in this PR (29)</b></summary>

`gcja5`, `gdk101`, `globals`, `gl_r01_i2c`, `gp2y1010au0f`, `gp8403`, `gpio`, `gps`, `graph`, `gree`, `grove_gas_mc_v2`, `grove_tb6612fng`, `growatt_solar`, `gt911`, `haier`, `havells_solar`, `hbridge`, `hc8`, `hdc1080`, `hdc2010`, `hdc2080`, `hdc302x`, `he60r`, `heatpumpir`, `hitachi_ac344`, `hitachi_ac424`, `hlk_fm22x`, `hlw8012`, `hlw8032`

</details>

<details>
<summary><b>All 21 PRs in this series</b></summary>

- #16952 — part 1 (`a01nyub` – `aqi`)
- #16953 — part 2 (`as3935_i2c` – `ble_rssi`)
- #16954 — part 3 (`ble_scanner` – `ch423`)
- #16955 — part 4 (`chsc6x` – `dfplayer`)
- #16956 — part 5 (`dfrobot_sen0395` – `esp32_ble_beacon`)
- #16957 — part 6 (`esp32_ble_client` – `fujitsu_general`)
- #16958 — part 7 (`gcja5` – `hlw8032`) ← **this PR**
- #16959 — part 8 (`hm3301` – `integration`)
- #16960 — part 9 (`internal_temperature` – `m5stack_8angle`)
- #16961 — part 10 (`matrix_keypad` – `micronova`)
- #16962 — part 11 (`microphone` – `ms8607`)
- #16963 — part 12 (`msa3xx` – `pm2005`)
- #16964 — part 13 (`pmsa003i` – `rc522`)
- #16965 — part 14 (`rc522_i2c` – `scd4x`)
- #16966 — part 15 (`script` – `slow_pwm`)
- #16967 — part 16 (`sm10bit_base` – `ssd1331_spi`)
- #16968 — part 17 (`ssd1351_spi` – `tem3200`)
- #16969 — part 18 (`template` – `tx20`)
- #16970 — part 19 (`uart` – `wl_134`)
- #16971 — part 20 (`wts01` – `zephyr_ble_server`)
- #16972 — part 21 (`zhlt01` – `zyaura`)

</details>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/developers.esphome.io#157

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

