### PR TITLE
Mark configurable classes as final (11/21: microphone-ms8607)

### DIFF
--- a/esphome/components/micro_wake_word/automation.h
+++ b/esphome/components/micro_wake_word/automation.h
@@ -7,22 +7,22 @@
 
 namespace esphome::micro_wake_word {
 
-template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<MicroWakeWord> {
+template<typename... Ts> class StartAction final : public Action<Ts...>, public Parented<MicroWakeWord> {
  public:
   void play(const Ts &...x) override { this->parent_->start(); }
 };
 
-template<typename... Ts> class StopAction : public Action<Ts...>, public Parented<MicroWakeWord> {
+template<typename... Ts> class StopAction final : public Action<Ts...>, public Parented<MicroWakeWord> {
  public:
   void play(const Ts &...x) override { this->parent_->stop(); }
 };
 
-template<typename... Ts> class IsRunningCondition : public Condition<Ts...>, public Parented<MicroWakeWord> {
+template<typename... Ts> class IsRunningCondition final : public Condition<Ts...>, public Parented<MicroWakeWord> {
  public:
   bool check(const Ts &...x) override { return this->parent_->is_running(); }
 };
 
-template<typename... Ts> class EnableModelAction : public Action<Ts...> {
+template<typename... Ts> class EnableModelAction final : public Action<Ts...> {
  public:
   explicit EnableModelAction(WakeWordModel *wake_word_model) : wake_word_model_(wake_word_model) {}
   void play(const Ts &...x) override { this->wake_word_model_->enable(); }
@@ -31,7 +31,7 @@ template<typename... Ts> class EnableModelAction : public Action<Ts...> {
   WakeWordModel *wake_word_model_;
 };
 
-template<typename... Ts> class DisableModelAction : public Action<Ts...> {
+template<typename... Ts> class DisableModelAction final : public Action<Ts...> {
  public:
   explicit DisableModelAction(WakeWordModel *wake_word_model) : wake_word_model_(wake_word_model) {}
   void play(const Ts &...x) override { this->wake_word_model_->disable(); }
@@ -40,7 +40,7 @@ template<typename... Ts> class DisableModelAction : public Action<Ts...> {
   WakeWordModel *wake_word_model_;
 };
 
-template<typename... Ts> class ModelIsEnabledCondition : public Condition<Ts...> {
+template<typename... Ts> class ModelIsEnabledCondition final : public Condition<Ts...> {
  public:
   explicit ModelIsEnabledCondition(WakeWordModel *wake_word_model) : wake_word_model_(wake_word_model) {}
   bool check(const Ts &...x) override { return this->wake_word_model_->is_enabled(); }

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -31,10 +31,10 @@ enum State {
   STOPPED,
 };
 
-class MicroWakeWord : public Component
+class MicroWakeWord final : public Component
 #ifdef USE_OTA_STATE_LISTENER
     ,
-                      public ota::OTAGlobalStateListener
+                            public ota::OTAGlobalStateListener
 #endif
 {
  public:

--- a/esphome/components/microphone/automation.h
+++ b/esphome/components/microphone/automation.h
@@ -7,34 +7,34 @@
 
 namespace esphome::microphone {
 
-template<typename... Ts> class CaptureAction : public Action<Ts...>, public Parented<Microphone> {
+template<typename... Ts> class CaptureAction final : public Action<Ts...>, public Parented<Microphone> {
   void play(const Ts &...x) override { this->parent_->start(); }
 };
 
-template<typename... Ts> class StopCaptureAction : public Action<Ts...>, public Parented<Microphone> {
+template<typename... Ts> class StopCaptureAction final : public Action<Ts...>, public Parented<Microphone> {
   void play(const Ts &...x) override { this->parent_->stop(); }
 };
 
-template<typename... Ts> class MuteAction : public Action<Ts...>, public Parented<Microphone> {
+template<typename... Ts> class MuteAction final : public Action<Ts...>, public Parented<Microphone> {
   void play(const Ts &...x) override { this->parent_->set_mute_state(true); }
 };
-template<typename... Ts> class UnmuteAction : public Action<Ts...>, public Parented<Microphone> {
+template<typename... Ts> class UnmuteAction final : public Action<Ts...>, public Parented<Microphone> {
   void play(const Ts &...x) override { this->parent_->set_mute_state(false); }
 };
 
-class DataTrigger : public Trigger<const std::vector<uint8_t> &> {
+class DataTrigger final : public Trigger<const std::vector<uint8_t> &> {
  public:
   explicit DataTrigger(Microphone *mic) {
     mic->add_data_callback([this](const std::vector<uint8_t> &data) { this->trigger(data); });
   }
 };
 
-template<typename... Ts> class IsCapturingCondition : public Condition<Ts...>, public Parented<Microphone> {
+template<typename... Ts> class IsCapturingCondition final : public Condition<Ts...>, public Parented<Microphone> {
  public:
   bool check(const Ts &...x) override { return this->parent_->is_running(); }
 };
 
-template<typename... Ts> class IsMutedCondition : public Condition<Ts...>, public Parented<Microphone> {
+template<typename... Ts> class IsMutedCondition final : public Condition<Ts...>, public Parented<Microphone> {
  public:
   bool check(const Ts &...x) override { return this->parent_->get_mute_state(); }
 };

--- a/esphome/components/microphone/microphone_source.h
+++ b/esphome/components/microphone/microphone_source.h
@@ -13,7 +13,7 @@ namespace esphome::microphone {
 
 static const int32_t MAX_GAIN_FACTOR = 64;
 
-class MicrophoneSource {
+class MicrophoneSource final {
   /*
    * @brief Helper class that handles converting raw microphone data to a requested format.
    * Components requesting microphone audio should register a callback through this class instead of registering a

--- a/esphome/components/mics_4514/mics_4514.h
+++ b/esphome/components/mics_4514/mics_4514.h
@@ -7,7 +7,7 @@
 
 namespace esphome::mics_4514 {
 
-class MICS4514Component : public PollingComponent, public i2c::I2CDevice {
+class MICS4514Component final : public PollingComponent, public i2c::I2CDevice {
   SUB_SENSOR(carbon_monoxide)
   SUB_SENSOR(nitrogen_dioxide)
   SUB_SENSOR(methane)

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -21,7 +21,7 @@ using climate::ClimateModeMask;
 using climate::ClimateSwingModeMask;
 using climate::ClimatePresetMask;
 
-class AirConditioner : public ApplianceBase<dudanov::midea::ac::AirConditioner>, public climate::Climate {
+class AirConditioner final : public ApplianceBase<dudanov::midea::ac::AirConditioner>, public climate::Climate {
  public:
   void dump_config() override;
   void set_outdoor_temperature_sensor(Sensor *sensor) { this->outdoor_sensor_ = sensor; }

--- a/esphome/components/midea_ir/midea_ir.h
+++ b/esphome/components/midea_ir/midea_ir.h
@@ -11,7 +11,7 @@ const uint8_t MIDEA_TEMPC_MAX = 30;  // Celsius
 const uint8_t MIDEA_TEMPF_MIN = 62;  // Fahrenheit
 const uint8_t MIDEA_TEMPF_MAX = 86;  // Fahrenheit
 
-class MideaIR : public climate_ir::ClimateIR {
+class MideaIR final : public climate_ir::ClimateIR {
  public:
   MideaIR()
       : climate_ir::ClimateIR(

--- a/esphome/components/mipi_dsi/mipi_dsi.h
+++ b/esphome/components/mipi_dsi/mipi_dsi.h
@@ -35,7 +35,7 @@ const uint8_t MADCTL_MV = 0x20;     // row/column swap
 const uint8_t MADCTL_XFLIP = 0x02;  // Mirror the display horizontally
 const uint8_t MADCTL_YFLIP = 0x01;  // Mirror the display vertically
 
-class MipiDsi : public display::Display {
+class MipiDsi final : public display::Display {
  public:
   MipiDsi(size_t width, size_t height, display::ColorBitness color_depth, uint8_t pixel_mode)
       : width_(width), height_(height), color_depth_(color_depth), pixel_mode_(pixel_mode) {}

--- a/esphome/components/mipi_rgb/mipi_rgb.h
+++ b/esphome/components/mipi_rgb/mipi_rgb.h
@@ -98,9 +98,9 @@ class MipiRgb : public display::Display {
 };
 
 #ifdef USE_SPI
-class MipiRgbSpi : public MipiRgb,
-                   public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
-                                         spi::DATA_RATE_1MHZ> {
+class MipiRgbSpi final : public MipiRgb,
+                         public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                               spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_1MHZ> {
  public:
   MipiRgbSpi(int width, int height) : MipiRgb(width, height) {}
 

--- a/esphome/components/mitsubishi/mitsubishi.h
+++ b/esphome/components/mitsubishi/mitsubishi.h
@@ -38,7 +38,7 @@ enum VerticalDirection {
   VERTICAL_DIRECTION_DOWN = 0x28,
 };
 
-class MitsubishiClimate : public climate_ir::ClimateIR {
+class MitsubishiClimate final : public climate_ir::ClimateIR {
  public:
   MitsubishiClimate()
       : climate_ir::ClimateIR(MITSUBISHI_TEMP_MIN, MITSUBISHI_TEMP_MAX, 1.0f, true, true,

--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.h
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.h
@@ -8,7 +8,7 @@
 
 namespace esphome::mitsubishi_cn105 {
 
-class MitsubishiCN105Climate final : public climate::Climate, public Component, public uart::UARTDevice {
+class MitsubishiCN105Climate : public climate::Climate, public Component, public uart::UARTDevice {
  public:
   explicit MitsubishiCN105Climate() : hp_(*this) {}
 
@@ -37,7 +37,7 @@ class MitsubishiCN105Climate final : public climate::Climate, public Component, 
 };
 
 template<typename... Ts>
-class SetRemoteTemperatureAction final : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
+class SetRemoteTemperatureAction : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
  public:
   TEMPLATABLE_VALUE(float, temperature)
 
@@ -45,7 +45,7 @@ class SetRemoteTemperatureAction final : public Action<Ts...>, public Parented<M
 };
 
 template<typename... Ts>
-class ClearRemoteTemperatureAction final : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
+class ClearRemoteTemperatureAction : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
  public:
   void play(const Ts &...x) override { this->parent_->clear_remote_temperature(); }
 };

--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.h
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.h
@@ -8,7 +8,7 @@
 
 namespace esphome::mitsubishi_cn105 {
 
-class MitsubishiCN105Climate : public climate::Climate, public Component, public uart::UARTDevice {
+class MitsubishiCN105Climate final : public climate::Climate, public Component, public uart::UARTDevice {
  public:
   explicit MitsubishiCN105Climate() : hp_(*this) {}
 
@@ -37,7 +37,7 @@ class MitsubishiCN105Climate : public climate::Climate, public Component, public
 };
 
 template<typename... Ts>
-class SetRemoteTemperatureAction : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
+class SetRemoteTemperatureAction final : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
  public:
   TEMPLATABLE_VALUE(float, temperature)
 
@@ -45,7 +45,7 @@ class SetRemoteTemperatureAction : public Action<Ts...>, public Parented<Mitsubi
 };
 
 template<typename... Ts>
-class ClearRemoteTemperatureAction : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
+class ClearRemoteTemperatureAction final : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
  public:
   void play(const Ts &...x) override { this->parent_->clear_remote_temperature(); }
 };

--- a/esphome/components/mixer/speaker/automation.h
+++ b/esphome/components/mixer/speaker/automation.h
@@ -6,7 +6,7 @@
 #ifdef USE_ESP32
 
 namespace esphome::mixer_speaker {
-template<typename... Ts> class DuckingApplyAction : public Action<Ts...>, public Parented<SourceSpeaker> {
+template<typename... Ts> class DuckingApplyAction final : public Action<Ts...>, public Parented<SourceSpeaker> {
   TEMPLATABLE_VALUE(uint8_t, decibel_reduction);
   TEMPLATABLE_VALUE(uint32_t, duration);
   void play(const Ts &...x) override {

--- a/esphome/components/mixer/speaker/mixer_speaker.h
+++ b/esphome/components/mixer/speaker/mixer_speaker.h
@@ -44,7 +44,7 @@ namespace esphome::mixer_speaker {
 
 class MixerSpeaker;
 
-class SourceSpeaker : public speaker::Speaker, public Component {
+class SourceSpeaker final : public speaker::Speaker, public Component {
  public:
   void dump_config() override;
   void setup() override;
@@ -118,7 +118,7 @@ class SourceSpeaker : public speaker::Speaker, public Component {
   uint32_t stopping_start_ms_{0};
 };
 
-class MixerSpeaker : public Component {
+class MixerSpeaker final : public Component {
  public:
   void dump_config() override;
   void setup() override;

--- a/esphome/components/mlx90393/sensor_mlx90393.h
+++ b/esphome/components/mlx90393/sensor_mlx90393.h
@@ -20,7 +20,7 @@ enum MLX90393Setting {
   MLX90393_LAST,
 };
 
-class MLX90393Cls : public PollingComponent, public i2c::I2CDevice, public MLX90393Hal {
+class MLX90393Cls final : public PollingComponent, public i2c::I2CDevice, public MLX90393Hal {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/mlx90614/mlx90614.h
+++ b/esphome/components/mlx90614/mlx90614.h
@@ -6,7 +6,7 @@
 
 namespace esphome::mlx90614 {
 
-class MLX90614Component : public PollingComponent, public i2c::I2CDevice {
+class MLX90614Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/mmc5603/mmc5603.h
+++ b/esphome/components/mmc5603/mmc5603.h
@@ -12,7 +12,7 @@ enum MMC5603Datarate {
   MMC5603_DATARATE_255_0_HZ,
 };
 
-class MMC5603Component : public PollingComponent, public i2c::I2CDevice {
+class MMC5603Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/mmc5983/mmc5983.h
+++ b/esphome/components/mmc5983/mmc5983.h
@@ -6,7 +6,7 @@
 
 namespace esphome::mmc5983 {
 
-class MMC5983Component : public PollingComponent, public i2c::I2CDevice {
+class MMC5983Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void update() override;
   void setup() override;

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -33,7 +33,7 @@ struct ModbusFrame {
   }
 };
 
-class Modbus : public uart::UARTDevice, public Component {
+class Modbus final : public uart::UARTDevice, public Component {
  public:
   Modbus() = default;
 

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -33,7 +33,7 @@ struct ModbusFrame {
   }
 };
 
-class Modbus final : public uart::UARTDevice, public Component {
+class Modbus : public uart::UARTDevice, public Component {
  public:
   Modbus() = default;
 

--- a/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
+++ b/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
@@ -8,7 +8,7 @@
 
 namespace esphome::modbus_controller {
 
-class ModbusBinarySensor : public Component, public binary_sensor::BinarySensor, public SensorItem {
+class ModbusBinarySensor final : public Component, public binary_sensor::BinarySensor, public SensorItem {
  public:
   ModbusBinarySensor(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint32_t bitmask,
                      uint16_t skip_updates, bool force_new_range) {

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -279,7 +279,7 @@ class ModbusCommandItem {
  * Responses for the commands are dispatched to the modbus sensor items.
  */
 
-class ModbusController : public PollingComponent, public modbus::ModbusClientDevice {
+class ModbusController final : public PollingComponent, public modbus::ModbusClientDevice {
  public:
   void dump_config() override;
   void loop() override;

--- a/esphome/components/modbus_controller/number/modbus_number.h
+++ b/esphome/components/modbus_controller/number/modbus_number.h
@@ -10,7 +10,7 @@ namespace esphome::modbus_controller {
 
 using value_to_data_t = std::function<float>(float);
 
-class ModbusNumber : public number::Number, public Component, public SensorItem {
+class ModbusNumber final : public number::Number, public Component, public SensorItem {
  public:
   ModbusNumber(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint32_t bitmask,
                SensorValueType value_type, int register_count, uint16_t skip_updates, bool force_new_range) {

--- a/esphome/components/modbus_controller/output/modbus_output.h
+++ b/esphome/components/modbus_controller/output/modbus_output.h
@@ -8,7 +8,7 @@
 
 namespace esphome::modbus_controller {
 
-class ModbusFloatOutput : public output::FloatOutput, public Component, public SensorItem {
+class ModbusFloatOutput final : public output::FloatOutput, public Component, public SensorItem {
  public:
   ModbusFloatOutput(uint16_t start_address, uint8_t offset, SensorValueType value_type, int register_count) {
     this->register_type = ModbusRegisterType::HOLDING;
@@ -41,7 +41,7 @@ class ModbusFloatOutput : public output::FloatOutput, public Component, public S
   bool use_write_multiple_{false};
 };
 
-class ModbusBinaryOutput : public output::BinaryOutput, public Component, public SensorItem {
+class ModbusBinaryOutput final : public output::BinaryOutput, public Component, public SensorItem {
  public:
   ModbusBinaryOutput(uint16_t start_address, uint8_t offset) {
     this->register_type = ModbusRegisterType::COIL;

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -9,7 +9,7 @@
 
 namespace esphome::modbus_controller {
 
-class ModbusSelect : public Component, public select::Select, public SensorItem {
+class ModbusSelect final : public Component, public select::Select, public SensorItem {
  public:
   ModbusSelect(SensorValueType sensor_value_type, uint16_t start_address, uint8_t register_count, uint16_t skip_updates,
                bool force_new_range, std::vector<int64_t> mapping) {

--- a/esphome/components/modbus_controller/sensor/modbus_sensor.h
+++ b/esphome/components/modbus_controller/sensor/modbus_sensor.h
@@ -8,7 +8,7 @@
 
 namespace esphome::modbus_controller {
 
-class ModbusSensor : public Component, public sensor::Sensor, public SensorItem {
+class ModbusSensor final : public Component, public sensor::Sensor, public SensorItem {
  public:
   ModbusSensor(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint32_t bitmask,
                SensorValueType value_type, int register_count, uint16_t skip_updates, bool force_new_range) {

--- a/esphome/components/modbus_controller/switch/modbus_switch.h
+++ b/esphome/components/modbus_controller/switch/modbus_switch.h
@@ -8,7 +8,7 @@
 
 namespace esphome::modbus_controller {
 
-class ModbusSwitch : public Component, public switch_::Switch, public SensorItem {
+class ModbusSwitch final : public Component, public switch_::Switch, public SensorItem {
  public:
   ModbusSwitch(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint32_t bitmask,
                uint16_t skip_updates, bool force_new_range) {

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
@@ -10,7 +10,7 @@ namespace esphome::modbus_controller {
 
 enum class RawEncoding { NONE = 0, HEXBYTES = 1, COMMA = 2, ANSI = 3 };
 
-class ModbusTextSensor : public Component, public text_sensor::TextSensor, public SensorItem {
+class ModbusTextSensor final : public Component, public text_sensor::TextSensor, public SensorItem {
  public:
   ModbusTextSensor(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint8_t register_count,
                    uint16_t response_bytes, RawEncoding encode, uint16_t skip_updates, bool force_new_range) {

--- a/esphome/components/modbus_server/modbus_server.h
+++ b/esphome/components/modbus_server/modbus_server.h
@@ -91,7 +91,7 @@ class ServerRegister {
   WriteLambda write_lambda;
 };
 
-class ModbusServer : public Component, public modbus::ModbusServerDevice {
+class ModbusServer final : public Component, public modbus::ModbusServerDevice {
  public:
   void dump_config() override;
 

--- a/esphome/components/monochromatic/monochromatic_light_output.h
+++ b/esphome/components/monochromatic/monochromatic_light_output.h
@@ -6,7 +6,7 @@
 
 namespace esphome::monochromatic {
 
-class MonochromaticLightOutput : public light::LightOutput {
+class MonochromaticLightOutput final : public light::LightOutput {
  public:
   void set_output(output::FloatOutput *output) { output_ = output; }
   light::LightTraits get_traits() override {

--- a/esphome/components/mopeka_ble/mopeka_ble.h
+++ b/esphome/components/mopeka_ble/mopeka_ble.h
@@ -9,7 +9,7 @@
 
 namespace esphome::mopeka_ble {
 
-class MopekaListener : public esp32_ble_tracker::ESPBTDeviceListener {
+class MopekaListener final : public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void set_show_sensors_without_sync(bool show_sensors_without_sync) {

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.h
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.h
@@ -27,7 +27,7 @@ enum SensorType {
 // measurement may be inaccurate.
 enum SensorReadQuality { QUALITY_HIGH = 0x3, QUALITY_MED = 0x2, QUALITY_LOW = 0x1, QUALITY_ZERO = 0x0 };
 
-class MopekaProCheck : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
+class MopekaProCheck final : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
 

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -42,7 +42,7 @@ struct mopeka_std_package {  // NOLINT(readability-identifier-naming,altera-stru
   mopeka_std_values val[3];
 } __attribute__((packed));
 
-class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
+class MopekaStdCheck final : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
 

--- a/esphome/components/motion/motion_component.h
+++ b/esphome/components/motion/motion_component.h
@@ -85,7 +85,7 @@ class MotionComponent : public PollingComponent {
 
 // --- Actions ---
 
-template<typename... Ts> class CalibrateLevelAction : public Action<Ts...> {
+template<typename... Ts> class CalibrateLevelAction final : public Action<Ts...> {
  public:
   explicit CalibrateLevelAction(MotionComponent *parent) : parent_(parent) {}
   void set_save(bool save) { this->save_ = save; }
@@ -110,7 +110,7 @@ template<typename... Ts> class CalibrateLevelAction : public Action<Ts...> {
   bool save_{false};
 };
 
-template<typename... Ts> class CalibrateHeadingAction : public Action<Ts...> {
+template<typename... Ts> class CalibrateHeadingAction final : public Action<Ts...> {
  public:
   explicit CalibrateHeadingAction(MotionComponent *parent) : parent_(parent) {}
   void set_save(bool save) { this->save_ = save; }
@@ -135,7 +135,7 @@ template<typename... Ts> class CalibrateHeadingAction : public Action<Ts...> {
   bool save_{false};
 };
 
-template<typename... Ts> class ClearCalibrationAction : public Action<Ts...> {
+template<typename... Ts> class ClearCalibrationAction final : public Action<Ts...> {
  public:
   explicit ClearCalibrationAction(MotionComponent *parent) : parent_(parent) {}
   void set_save(bool save) { this->save_ = save; }

--- a/esphome/components/mpl3115a2/mpl3115a2.h
+++ b/esphome/components/mpl3115a2/mpl3115a2.h
@@ -80,7 +80,7 @@ enum {
   MPL3115A2_CTRL_REG1_OS128 = 0x38,
 };
 
-class MPL3115A2Component : public PollingComponent, public i2c::I2CDevice {
+class MPL3115A2Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_altitude(sensor::Sensor *altitude) { altitude_ = altitude; }

--- a/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.h
+++ b/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.h
@@ -6,7 +6,9 @@
 
 namespace esphome::mpr121 {
 
-class MPR121BinarySensor : public binary_sensor::BinarySensor, public MPR121Channel, public Parented<MPR121Component> {
+class MPR121BinarySensor final : public binary_sensor::BinarySensor,
+                                 public MPR121Channel,
+                                 public Parented<MPR121Component> {
  public:
   void set_channel(uint8_t channel) { this->channel_ = channel; }
   void set_touch_threshold(uint8_t touch_threshold) { this->touch_threshold_ = touch_threshold; };

--- a/esphome/components/mpr121/mpr121.h
+++ b/esphome/components/mpr121/mpr121.h
@@ -57,7 +57,7 @@ class MPR121Channel {
   virtual void process(uint16_t data) = 0;
 };
 
-class MPR121Component : public Component, public i2c::I2CDevice {
+class MPR121Component final : public Component, public i2c::I2CDevice {
  public:
   void register_channel(MPR121Channel *channel) { this->channels_.push_back(channel); }
   void set_touch_debounce(uint8_t debounce);
@@ -102,7 +102,7 @@ class MPR121Component : public Component, public i2c::I2CDevice {
 };
 
 /// Helper class to expose a MPR121 pin as an internal input GPIO pin.
-class MPR121GPIOPin : public GPIOPin {
+class MPR121GPIOPin final : public GPIOPin {
  public:
   void setup() override;
   void pin_mode(gpio::Flags flags) override;

--- a/esphome/components/mpu6050/mpu6050.h
+++ b/esphome/components/mpu6050/mpu6050.h
@@ -6,7 +6,7 @@
 
 namespace esphome::mpu6050 {
 
-class MPU6050Component : public PollingComponent, public i2c::I2CDevice {
+class MPU6050Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/mpu6886/mpu6886.h
+++ b/esphome/components/mpu6886/mpu6886.h
@@ -6,7 +6,7 @@
 
 namespace esphome::mpu6886 {
 
-class MPU6886Component : public PollingComponent, public i2c::I2CDevice {
+class MPU6886Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/mqtt/mqtt_alarm_control_panel.h
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTAlarmControlPanelComponent : public mqtt::MQTTComponent {
+class MQTTAlarmControlPanelComponent final : public mqtt::MQTTComponent {
  public:
   explicit MQTTAlarmControlPanelComponent(alarm_control_panel::AlarmControlPanel *alarm_control_panel);
 

--- a/esphome/components/mqtt/mqtt_binary_sensor.h
+++ b/esphome/components/mqtt/mqtt_binary_sensor.h
@@ -9,7 +9,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTBinarySensorComponent : public mqtt::MQTTComponent {
+class MQTTBinarySensorComponent final : public mqtt::MQTTComponent {
  public:
   /** Construct a MQTTBinarySensorComponent.
    *

--- a/esphome/components/mqtt/mqtt_button.h
+++ b/esphome/components/mqtt/mqtt_button.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTButtonComponent : public mqtt::MQTTComponent {
+class MQTTButtonComponent final : public mqtt::MQTTComponent {
  public:
   explicit MQTTButtonComponent(button::Button *button);
 

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -99,7 +99,7 @@ enum MQTTClientState {
 
 class MQTTComponent;
 
-class MQTTClientComponent : public Component {
+class MQTTClientComponent final : public Component {
  public:
   MQTTClientComponent();
 
@@ -340,7 +340,7 @@ class MQTTClientComponent : public Component {
 
 extern MQTTClientComponent *global_mqtt_client;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-class MQTTMessageTrigger : public Trigger<std::string>, public Component {
+class MQTTMessageTrigger final : public Trigger<std::string>, public Component {
  public:
   explicit MQTTMessageTrigger(std::string topic);
 
@@ -356,7 +356,7 @@ class MQTTMessageTrigger : public Trigger<std::string>, public Component {
   optional<std::string> payload_;
 };
 
-class MQTTJsonMessageTrigger : public Trigger<JsonObjectConst> {
+class MQTTJsonMessageTrigger final : public Trigger<JsonObjectConst> {
  public:
   explicit MQTTJsonMessageTrigger(const std::string &topic, uint8_t qos) {
     global_mqtt_client->subscribe_json(
@@ -364,21 +364,21 @@ class MQTTJsonMessageTrigger : public Trigger<JsonObjectConst> {
   }
 };
 
-class MQTTConnectTrigger : public Trigger<bool> {
+class MQTTConnectTrigger final : public Trigger<bool> {
  public:
   explicit MQTTConnectTrigger(MQTTClientComponent *client) {
     client->set_on_connect([this](bool session_present) { this->trigger(session_present); });
   }
 };
 
-class MQTTDisconnectTrigger : public Trigger<MQTTClientDisconnectReason> {
+class MQTTDisconnectTrigger final : public Trigger<MQTTClientDisconnectReason> {
  public:
   explicit MQTTDisconnectTrigger(MQTTClientComponent *client) {
     client->set_on_disconnect([this](MQTTClientDisconnectReason reason) { this->trigger(reason); });
   }
 };
 
-template<typename... Ts> class MQTTPublishAction : public Action<Ts...> {
+template<typename... Ts> class MQTTPublishAction final : public Action<Ts...> {
  public:
   MQTTPublishAction(MQTTClientComponent *parent) : parent_(parent) {}
   TEMPLATABLE_VALUE(std::string, topic)
@@ -395,7 +395,7 @@ template<typename... Ts> class MQTTPublishAction : public Action<Ts...> {
   MQTTClientComponent *parent_;
 };
 
-template<typename... Ts> class MQTTPublishJsonAction : public Action<Ts...> {
+template<typename... Ts> class MQTTPublishJsonAction final : public Action<Ts...> {
  public:
   MQTTPublishJsonAction(MQTTClientComponent *parent) : parent_(parent) {}
   TEMPLATABLE_VALUE(std::string, topic)
@@ -417,7 +417,7 @@ template<typename... Ts> class MQTTPublishJsonAction : public Action<Ts...> {
   MQTTClientComponent *parent_;
 };
 
-template<typename... Ts> class MQTTConnectedCondition : public Condition<Ts...> {
+template<typename... Ts> class MQTTConnectedCondition final : public Condition<Ts...> {
  public:
   MQTTConnectedCondition(MQTTClientComponent *parent) : parent_(parent) {}
   bool check(const Ts &...x) override { return this->parent_->is_connected(); }
@@ -426,7 +426,7 @@ template<typename... Ts> class MQTTConnectedCondition : public Condition<Ts...> 
   MQTTClientComponent *parent_;
 };
 
-template<typename... Ts> class MQTTEnableAction : public Action<Ts...> {
+template<typename... Ts> class MQTTEnableAction final : public Action<Ts...> {
  public:
   MQTTEnableAction(MQTTClientComponent *parent) : parent_(parent) {}
 
@@ -436,7 +436,7 @@ template<typename... Ts> class MQTTEnableAction : public Action<Ts...> {
   MQTTClientComponent *parent_;
 };
 
-template<typename... Ts> class MQTTDisableAction : public Action<Ts...> {
+template<typename... Ts> class MQTTDisableAction final : public Action<Ts...> {
  public:
   MQTTDisableAction(MQTTClientComponent *parent) : parent_(parent) {}
 

--- a/esphome/components/mqtt/mqtt_climate.h
+++ b/esphome/components/mqtt/mqtt_climate.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTClimateComponent : public mqtt::MQTTComponent {
+class MQTTClimateComponent final : public mqtt::MQTTComponent {
  public:
   MQTTClimateComponent(climate::Climate *device);
   void send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) override;

--- a/esphome/components/mqtt/mqtt_cover.h
+++ b/esphome/components/mqtt/mqtt_cover.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTCoverComponent : public mqtt::MQTTComponent {
+class MQTTCoverComponent final : public mqtt::MQTTComponent {
  public:
   explicit MQTTCoverComponent(cover::Cover *cover);
 

--- a/esphome/components/mqtt/mqtt_date.h
+++ b/esphome/components/mqtt/mqtt_date.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTDateComponent : public mqtt::MQTTComponent {
+class MQTTDateComponent final : public mqtt::MQTTComponent {
  public:
   /** Construct this MQTTDateComponent instance with the provided friendly_name and date
    *

--- a/esphome/components/mqtt/mqtt_datetime.h
+++ b/esphome/components/mqtt/mqtt_datetime.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTDateTimeComponent : public mqtt::MQTTComponent {
+class MQTTDateTimeComponent final : public mqtt::MQTTComponent {
  public:
   /** Construct this MQTTDateTimeComponent instance with the provided friendly_name and time
    *

--- a/esphome/components/mqtt/mqtt_event.h
+++ b/esphome/components/mqtt/mqtt_event.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTEventComponent : public mqtt::MQTTComponent {
+class MQTTEventComponent final : public mqtt::MQTTComponent {
  public:
   explicit MQTTEventComponent(event::Event *event);
 

--- a/esphome/components/mqtt/mqtt_fan.h
+++ b/esphome/components/mqtt/mqtt_fan.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTFanComponent : public mqtt::MQTTComponent {
+class MQTTFanComponent final : public mqtt::MQTTComponent {
  public:
   explicit MQTTFanComponent(fan::Fan *state);
 

--- a/esphome/components/mqtt/mqtt_light.h
+++ b/esphome/components/mqtt/mqtt_light.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTJSONLightComponent : public mqtt::MQTTComponent, public light::LightRemoteValuesListener {
+class MQTTJSONLightComponent final : public mqtt::MQTTComponent, public light::LightRemoteValuesListener {
  public:
   explicit MQTTJSONLightComponent(light::LightState *state);
 

--- a/esphome/components/mqtt/mqtt_lock.h
+++ b/esphome/components/mqtt/mqtt_lock.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTLockComponent : public mqtt::MQTTComponent {
+class MQTTLockComponent final : public mqtt::MQTTComponent {
  public:
   explicit MQTTLockComponent(lock::Lock *a_lock);
 

--- a/esphome/components/mqtt/mqtt_number.h
+++ b/esphome/components/mqtt/mqtt_number.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTNumberComponent : public mqtt::MQTTComponent {
+class MQTTNumberComponent final : public mqtt::MQTTComponent {
  public:
   /** Construct this MQTTNumberComponent instance with the provided friendly_name and number
    *

--- a/esphome/components/mqtt/mqtt_select.h
+++ b/esphome/components/mqtt/mqtt_select.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTSelectComponent : public mqtt::MQTTComponent {
+class MQTTSelectComponent final : public mqtt::MQTTComponent {
  public:
   /** Construct this MQTTSelectComponent instance with the provided friendly_name and select
    *

--- a/esphome/components/mqtt/mqtt_sensor.h
+++ b/esphome/components/mqtt/mqtt_sensor.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTSensorComponent : public mqtt::MQTTComponent {
+class MQTTSensorComponent final : public mqtt::MQTTComponent {
  public:
   /** Construct this MQTTSensorComponent instance with the provided friendly_name and sensor
    *

--- a/esphome/components/mqtt/mqtt_switch.h
+++ b/esphome/components/mqtt/mqtt_switch.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTSwitchComponent : public mqtt::MQTTComponent {
+class MQTTSwitchComponent final : public mqtt::MQTTComponent {
  public:
   explicit MQTTSwitchComponent(switch_::Switch *a_switch);
 

--- a/esphome/components/mqtt/mqtt_text.h
+++ b/esphome/components/mqtt/mqtt_text.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTTextComponent : public mqtt::MQTTComponent {
+class MQTTTextComponent final : public mqtt::MQTTComponent {
  public:
   /** Construct this MQTTTextComponent instance with the provided friendly_name and text
    *

--- a/esphome/components/mqtt/mqtt_text_sensor.h
+++ b/esphome/components/mqtt/mqtt_text_sensor.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTTextSensor : public mqtt::MQTTComponent {
+class MQTTTextSensor final : public mqtt::MQTTComponent {
  public:
   explicit MQTTTextSensor(text_sensor::TextSensor *sensor);
 

--- a/esphome/components/mqtt/mqtt_time.h
+++ b/esphome/components/mqtt/mqtt_time.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTTimeComponent : public mqtt::MQTTComponent {
+class MQTTTimeComponent final : public mqtt::MQTTComponent {
  public:
   /** Construct this MQTTTimeComponent instance with the provided friendly_name and time
    *

--- a/esphome/components/mqtt/mqtt_update.h
+++ b/esphome/components/mqtt/mqtt_update.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTUpdateComponent : public mqtt::MQTTComponent {
+class MQTTUpdateComponent final : public mqtt::MQTTComponent {
  public:
   explicit MQTTUpdateComponent(update::UpdateEntity *update);
 

--- a/esphome/components/mqtt/mqtt_valve.h
+++ b/esphome/components/mqtt/mqtt_valve.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt {
 
-class MQTTValveComponent : public mqtt::MQTTComponent {
+class MQTTValveComponent final : public mqtt::MQTTComponent {
  public:
   explicit MQTTValveComponent(valve::Valve *valve);
 

--- a/esphome/components/mqtt_subscribe/sensor/mqtt_subscribe_sensor.h
+++ b/esphome/components/mqtt_subscribe/sensor/mqtt_subscribe_sensor.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt_subscribe {
 
-class MQTTSubscribeSensor : public sensor::Sensor, public Component {
+class MQTTSubscribeSensor final : public sensor::Sensor, public Component {
  public:
   void set_parent(mqtt::MQTTClientComponent *parent) { parent_ = parent; }
   void set_topic(const std::string &topic) { topic_ = topic; }

--- a/esphome/components/mqtt_subscribe/text_sensor/mqtt_subscribe_text_sensor.h
+++ b/esphome/components/mqtt_subscribe/text_sensor/mqtt_subscribe_text_sensor.h
@@ -10,7 +10,7 @@
 
 namespace esphome::mqtt_subscribe {
 
-class MQTTSubscribeTextSensor : public text_sensor::TextSensor, public Component {
+class MQTTSubscribeTextSensor final : public text_sensor::TextSensor, public Component {
  public:
   void set_parent(mqtt::MQTTClientComponent *parent) { parent_ = parent; }
   void set_topic(const std::string &topic) { topic_ = topic; }

--- a/esphome/components/ms5611/ms5611.h
+++ b/esphome/components/ms5611/ms5611.h
@@ -6,7 +6,7 @@
 
 namespace esphome::ms5611 {
 
-class MS5611Component : public PollingComponent, public i2c::I2CDevice {
+class MS5611Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/ms8607/ms8607.h
+++ b/esphome/components/ms8607/ms8607.h
@@ -10,7 +10,7 @@ namespace esphome::ms8607 {
  Class for I2CDevice used to communicate with the Humidity sensor
  on the chip. See MS8607Component instead
  */
-class MS8607HumidityDevice : public i2c::I2CDevice {
+class MS8607HumidityDevice final : public i2c::I2CDevice {
  public:
   uint8_t get_address() { return address_; }
 };
@@ -30,7 +30,7 @@ class MS8607HumidityDevice : public i2c::I2CDevice {
  - https://github.com/adafruit/Adafruit_MS8607
  - https://github.com/sparkfun/SparkFun_PHT_MS8607_Arduino_Library
  */
-class MS8607Component : public PollingComponent, public i2c::I2CDevice {
+class MS8607Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   virtual ~MS8607Component() = default;
   void setup() override;

--- a/esphome/components/ms8607/ms8607.h
+++ b/esphome/components/ms8607/ms8607.h
@@ -10,7 +10,7 @@ namespace esphome::ms8607 {
  Class for I2CDevice used to communicate with the Humidity sensor
  on the chip. See MS8607Component instead
  */
-class MS8607HumidityDevice final : public i2c::I2CDevice {
+class MS8607HumidityDevice : public i2c::I2CDevice {
  public:
   uint8_t get_address() { return address_; }
 };
@@ -30,7 +30,7 @@ class MS8607HumidityDevice final : public i2c::I2CDevice {
  - https://github.com/adafruit/Adafruit_MS8607
  - https://github.com/sparkfun/SparkFun_PHT_MS8607_Arduino_Library
  */
-class MS8607Component final : public PollingComponent, public i2c::I2CDevice {
+class MS8607Component : public PollingComponent, public i2c::I2CDevice {
  public:
   virtual ~MS8607Component() = default;
   void setup() override;


### PR DESCRIPTION
# What does this implement/fix?

Adds the C++ `final` specifier to leaf, user-configurable component classes — and to automation action/trigger/condition primitives — so classes that are meant to be terminal can no longer be subclassed by external components. Only classes that are never used as a base anywhere in the ESPHome tree are marked, so no in-tree class is affected.

- **Series:** part 11 of 21
- **Components:** 27 (`microphone` – `ms8607`, alphabetical)
- **Change:** mechanical — adds the `final` keyword only; no behavior, config, or API surface changes
- **Verification:** tree-wide static check that no class in any `.cpp`/`.h` derives from a `final`-marked class, plus representative compiles on esp8266-ard and esp32-idf

> `modbus`, `mitsubishi_cn105`, and `ms8607` were split out of this PR as exceptions and are tracked separately (see #17143): `mitsubishi_cn105` has a C++ unit test that subclasses `MitsubishiCN105Climate`; `modbus` was rewritten on `dev` such that `Modbus` is now a base class (`ModbusClientHub`/`ModbusServerHub`) and can no longer be marked `final`; and `ms8607` has a `virtual` destructor that would trip `clang-diagnostic-unnecessary-virtual-specifier` once the class is `final`, so it needs the `virtual` removed alongside the `final` mark.

<details>
<summary><b>Components in this PR (27)</b></summary>

`microphone`, `micro_wake_word`, `mics_4514`, `midea`, `midea_ir`, `mipi_dsi`, `mipi_rgb`, `mitsubishi`, `mixer`, `mlx90393`, `mlx90614`, `mmc5603`, `mmc5983`, `modbus_controller`, `modbus_server`, `monochromatic`, `mopeka_ble`, `mopeka_pro_check`, `mopeka_std_check`, `motion`, `mpl3115a2`, `mpr121`, `mpu6050`, `mpu6886`, `mqtt`, `mqtt_subscribe`, `ms5611`

</details>

<details>
<summary><b>All 21 PRs in this series</b></summary>

- #16952 — part 1 (`a01nyub` – `aqi`)
- #16953 — part 2 (`as3935_i2c` – `ble_rssi`)
- #16954 — part 3 (`ble_scanner` – `ch423`)
- #16955 — part 4 (`chsc6x` – `dfplayer`)
- #16956 — part 5 (`dfrobot_sen0395` – `esp32_ble_beacon`)
- #16957 — part 6 (`esp32_ble_client` – `fujitsu_general`)
- #16958 — part 7 (`gcja5` – `hlw8032`)
- #16959 — part 8 (`hm3301` – `integration`)
- #16960 — part 9 (`internal_temperature` – `m5stack_8angle`)
- #16961 — part 10 (`matrix_keypad` – `micronova`)
- #16962 — part 11 (`microphone` – `ms8607`) ← **this PR**
- #16963 — part 12 (`msa3xx` – `pm2005`)
- #16964 — part 13 (`pmsa003i` – `rc522`)
- #16965 — part 14 (`rc522_i2c` – `scd4x`)
- #16966 — part 15 (`script` – `slow_pwm`)
- #16967 — part 16 (`sm10bit_base` – `ssd1331_spi`)
- #16968 — part 17 (`ssd1351_spi` – `tem3200`)
- #16969 — part 18 (`template` – `tx20`)
- #16970 — part 19 (`uart` – `wl_134`)
- #16971 — part 20 (`wts01` – `zephyr_ble_server`)
- #16972 — part 21 (`zhlt01` – `zyaura`)

</details>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/developers.esphome.io#157

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
