### PR TITLE
[openthread] Fix InstanceLock releasing the lock twice on try_acquire

### DIFF
--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -227,7 +227,7 @@ bool OpenThreadComponent::teardown() {
       ESP_LOGW(TAG, "Failed to acquire OpenThread lock during teardown, leaking memory");
       return true;
     }
-    otInstance *instance = lock->get_instance();
+    otInstance *instance = lock.get_instance();
     otSrpClientClearHostAndServices(instance);
     otSrpClientBuffersFreeAllServices(instance);
     global_openthread_component = nullptr;

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -86,19 +86,31 @@ class OpenThreadSrpComponent : public Component {
   void *pool_alloc_(size_t size);
 };
 
+// RAII guard for the OpenThread API lock. Modeled on std::unique_lock: the
+// guard may or may not own the lock (try_acquire can fail), so check it with
+// operator bool before use. Non-copyable and non-movable: the factories return
+// by value via guaranteed copy elision, so a guard is never duplicated and the
+// lock is released exactly once, when the owning guard goes out of scope.
 class InstanceLock {
  public:
-  static std::optional<InstanceLock> try_acquire(int delay);
+  // May fail to acquire within delay ms; check the returned guard with operator bool.
+  static InstanceLock try_acquire(int delay);
+  // Blocks until the lock is held.
   static InstanceLock acquire();
+  InstanceLock(const InstanceLock &) = delete;
+  InstanceLock(InstanceLock &&) = delete;
+  InstanceLock &operator=(const InstanceLock &) = delete;
+  InstanceLock &operator=(InstanceLock &&) = delete;
   ~InstanceLock();
+
+  explicit operator bool() const { return this->owns_; }
 
   // Returns the global openthread instance guarded by this lock
   otInstance *get_instance();
 
  private:
-  // Use a private constructor in order to force the handling
-  // of acquisition failure
-  InstanceLock() {}
+  explicit InstanceLock(bool owns) : owns_(owns) {}
+  bool owns_;
 };
 
 }  // namespace esphome::openthread

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -105,7 +105,8 @@ class InstanceLock {
 
   explicit operator bool() const { return this->owns_; }
 
-  // Returns the global openthread instance guarded by this lock
+  // Returns the global openthread instance. Only valid on an owning guard
+  // (operator bool is true); the instance must not be used without the lock held.
   otInstance *get_instance();
 
  private:

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -216,14 +216,11 @@ network::IPAddresses OpenThreadComponent::get_ip_addresses() {
 // not thread safe, only use in read-only use cases
 otInstance *OpenThreadComponent::get_openthread_instance_() { return esp_openthread_get_instance(); }
 
-std::optional<InstanceLock> InstanceLock::try_acquire(int delay) {
+InstanceLock InstanceLock::try_acquire(int delay) {
   if (!global_openthread_component->is_lock_initialized()) {
-    return {};
+    return InstanceLock(false);
   }
-  if (esp_openthread_lock_acquire(delay)) {
-    return InstanceLock();
-  }
-  return {};
+  return InstanceLock(esp_openthread_lock_acquire(delay));
 }
 
 InstanceLock InstanceLock::acquire() {
@@ -242,12 +239,16 @@ InstanceLock InstanceLock::acquire() {
   while (!esp_openthread_lock_acquire(100)) {
     esp_task_wdt_reset();
   }
-  return InstanceLock();
+  return InstanceLock(true);
 }
 
 otInstance *InstanceLock::get_instance() { return esp_openthread_get_instance(); }
 
-InstanceLock::~InstanceLock() { esp_openthread_lock_release(); }
+InstanceLock::~InstanceLock() {
+  if (this->owns_) {
+    esp_openthread_lock_release();
+  }
+}
 
 }  // namespace esphome::openthread
 #endif

--- a/esphome/components/openthread_info/openthread_info_text_sensor.h
+++ b/esphome/components/openthread_info/openthread_info_text_sensor.h
@@ -17,7 +17,7 @@ class OpenThreadInstancePollingComponent : public PollingComponent {
       return;
     }
 
-    this->update_instance(lock->get_instance());
+    this->update_instance(lock.get_instance());
   }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 


### PR DESCRIPTION
# What does this implement/fix?

`InstanceLock::try_acquire()` returned `std::optional<InstanceLock>` and the body did `return InstanceLock();`. Converting the `InstanceLock` prvalue into the `optional` materializes a temporary, so two `InstanceLock` objects exist for a single `esp_openthread_lock_acquire()`. Each one releases the lock in its destructor, so:

- The return temporary is destroyed the moment `try_acquire()` returns, **releasing the lock before the caller's critical section runs**. The `teardown()` SRP calls and the `openthread_info` reads (every sensor update) execute without holding the OpenThread lock, racing the OT task.
- The lock is then released a second time when the caller's value goes out of scope (unbalanced — masked on ESP32 because `esp_openthread_lock_release()` no-ops on a recursive mutex it no longer holds and doesn't holder-check).

`acquire()` was unaffected only by luck: its return type matches, so C++17 guaranteed copy elision means no temporary.

Fix: rework `InstanceLock` into a `std::unique_lock`-style guard that may or may not own the lock (`operator bool`), returned **by value** instead of wrapped in `optional`. The guard is non-copyable and non-movable, so guaranteed copy elision applies on both factories and a guard can never be duplicated — the lock is released exactly once, by the single owning guard, when it goes out of scope. `try_acquire` now reports failure via `operator bool` rather than an empty optional.

Verified: ESP32-C6 `openthread` component compile test passes; a standalone repro of the object lifetime confirms the old code did 1 acquire / 2 releases and the new code is balanced.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF
- [ ] ESP32
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change; fixes internal OpenThread lock handling.
openthread:
  tlv: "..."
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).