### PR TITLE
[docker] Remove alpine base, build only on debian

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -15,11 +15,6 @@ inputs:
     description: "Version to build"
     required: true
     example: "2023.12.0"
-  base_os:
-    description: "Base OS to use"
-    required: false
-    default: "debian"
-    example: "debian"
 runs:
   using: "composite"
   steps:
@@ -60,7 +55,6 @@ runs:
         build-args: |
           BUILD_TYPE=${{ inputs.build_type }}
           BUILD_VERSION=${{ inputs.version }}
-          BUILD_OS=${{ inputs.base_os }}
         outputs: |
           type=image,name=ghcr.io/${{ steps.tags.outputs.image_name }},push-by-digest=true,name-canonical=true,push=true
 
@@ -86,7 +80,6 @@ runs:
         build-args: |
           BUILD_TYPE=${{ inputs.build_type }}
           BUILD_VERSION=${{ inputs.version }}
-          BUILD_OS=${{ inputs.base_os }}
         outputs: |
           type=image,name=docker.io/${{ steps.tags.outputs.image_name }},push-by-digest=true,name-canonical=true,push=true
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,9 @@
 ARG BUILD_VERSION=dev
-ARG BUILD_OS=alpine
 ARG BUILD_BASE_VERSION=2025.04.0
 ARG BUILD_TYPE=docker
 
-FROM ghcr.io/esphome/docker-base:${BUILD_OS}-${BUILD_BASE_VERSION} AS base-source-docker
-FROM ghcr.io/esphome/docker-base:${BUILD_OS}-ha-addon-${BUILD_BASE_VERSION} AS base-source-ha-addon
+FROM ghcr.io/esphome/docker-base:debian-${BUILD_BASE_VERSION} AS base-source-docker
+FROM ghcr.io/esphome/docker-base:debian-ha-addon-${BUILD_BASE_VERSION} AS base-source-ha-addon
 
 ARG BUILD_TYPE
 FROM base-source-${BUILD_TYPE} AS base
@@ -18,13 +17,9 @@ RUN git config --system --add safe.directory "*" \
 # validate openocd-esp32 (it dynamically links libusb-1.0.so.0); without
 # it idf_tools.py rejects the openocd install with exit 127 and aborts
 # the whole framework setup.
-RUN if command -v apk > /dev/null; then \
-        apk add --no-cache build-base libusb; \
-    else \
-        apt-get update \
-        && apt-get install -y --no-install-recommends build-essential libusb-1.0-0 \
-        && rm -rf /var/lib/apt/lists/*; \
-    fi
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libusb-1.0-0 \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 


### PR DESCRIPTION
# What does this implement/fix?

Alpine's musl-based toolchain doesn't work with the ESPHome build toolchains, so this removes alpine as a base-image option entirely. The `BUILD_OS` build-arg and its variant selection are dropped from `docker/Dockerfile` in favour of hardcoding the `debian` base images, and the package-install step collapses to the apt-only path (the `apk` branch is gone). The release pipeline already defaulted to debian, so the matching `base_os` input and `BUILD_OS` build-arg are removed from the `build-image` composite action.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).