### PR TITLE
[ci] Push branch-tagged docker images to ghcr.io for local testing

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -22,7 +22,7 @@ on:
       - "script/platformio_install_deps.py"
 
 permissions:
-  contents: read  # actions/checkout only; the build does not push images
+  contents: read  # actions/checkout only
 
 concurrency:
   # yamllint disable-line rule:line-length
@@ -33,6 +33,9 @@ jobs:
   check-docker:
     name: Build docker containers
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read   # actions/checkout to load Dockerfile and build context
+      packages: write  # push branch-tagged images to ghcr.io for local testing
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +44,9 @@ jobs:
           - "ha-addon"
           - "docker"
           # - "lint"
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      push: ${{ steps.tag.outputs.push }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Python
@@ -50,14 +56,75 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - name: Set TAG
+      - name: Determine tag and whether to push
+        id: tag
         run: |
-          echo "TAG=check" >> $GITHUB_ENV
+          # Sanitize the branch name into a valid docker tag
+          branch="${{ github.head_ref || github.ref_name }}"
+          tag="${branch//[^a-zA-Z0-9_.-]/-}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          # Only push branch images for same-repo pull requests. Push events
+          # only fire for dev/beta/release, whose images are owned by the
+          # release pipeline -- never overwrite those from here.
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+            && [ "${{ github.repository }}" = "esphome/esphome" ] \
+            && [ "${{ github.event.pull_request.head.repo.full_name }}" = "esphome/esphome" ]; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to the GitHub container registry
+        if: steps.tag.outputs.push == 'true'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run build
         run: |
           docker/build.py \
-            --tag "${TAG}" \
+            --tag "${{ steps.tag.outputs.tag }}" \
             --arch "${{ matrix.os == 'ubuntu-24.04-arm' && 'aarch64' || 'amd64' }}" \
             --build-type "${{ matrix.build_type }}" \
-            build
+            --registry ghcr \
+            build ${{ steps.tag.outputs.push == 'true' && '--push --no-cache-to' || '' }}
+
+  manifest:
+    name: Push ${{ matrix.build_type }} manifest to ghcr.io
+    needs: [check-docker]
+    if: needs.check-docker.outputs.push == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read   # actions/checkout to run docker/build.py
+      packages: write  # docker manifest push writes the multi-arch tag to ghcr.io
+    env:
+      DOCKER_CLI_EXPERIMENTAL: enabled  # required for `docker manifest`
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type:
+          - "ha-addon"
+          - "docker"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Log in to the GitHub container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          docker/build.py \
+            --tag "${{ needs.check-docker.outputs.tag }}" \
+            --build-type "${{ matrix.build_type }}" \
+            --registry ghcr \
+            manifest

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -59,9 +59,16 @@ jobs:
       - name: Determine tag and whether to push
         id: tag
         run: |
-          # Sanitize the branch name into a valid docker tag
+          # Sanitize the branch name into a valid docker tag: replace invalid
+          # characters, ensure the first character is valid (tags must start
+          # with [A-Za-z0-9_]), and cap the length at 128 characters.
           branch="${{ github.head_ref || github.ref_name }}"
           tag="${branch//[^a-zA-Z0-9_.-]/-}"
+          case "$tag" in
+            [a-zA-Z0-9_]*) ;;
+            *) tag="pr-${tag}" ;;
+          esac
+          tag="${tag:0:128}"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           # Only push branch images for same-repo pull requests. Push events
           # only fire for dev/beta/release, whose images are owned by the
@@ -98,9 +105,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read   # actions/checkout to run docker/build.py
-      packages: write  # docker manifest push writes the multi-arch tag to ghcr.io
-    env:
-      DOCKER_CLI_EXPERIMENTAL: enabled  # required for `docker manifest`
+      packages: write  # buildx imagetools writes the multi-arch tag to ghcr.io
     strategy:
       fail-fast: false
       matrix:
@@ -113,6 +118,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to the GitHub container registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/docker/build.py
+++ b/docker/build.py
@@ -20,6 +20,10 @@ TYPE_HA_ADDON = "ha-addon"
 TYPE_LINT = "lint"
 TYPES = [TYPE_DOCKER, TYPE_HA_ADDON, TYPE_LINT]
 
+REGISTRY_GHCR = "ghcr"
+REGISTRY_DOCKERHUB = "dockerhub"
+REGISTRIES = [REGISTRY_GHCR, REGISTRY_DOCKERHUB]
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -35,6 +39,12 @@ parser.add_argument(
     "--build-type", choices=TYPES, required=True, help="The type of build to run"
 )
 parser.add_argument(
+    "--registry",
+    choices=REGISTRIES,
+    action="append",
+    help="Restrict to specific registries (default: all). May be passed multiple times.",
+)
+parser.add_argument(
     "--dry-run", action="store_true", help="Don't run any commands, just print them"
 )
 subparsers = parser.add_subparsers(
@@ -44,6 +54,11 @@ build_parser = subparsers.add_parser("build", help="Build the image")
 build_parser.add_argument("--push", help="Also push the images", action="store_true")
 build_parser.add_argument(
     "--load", help="Load the docker image locally", action="store_true"
+)
+build_parser.add_argument(
+    "--no-cache-to",
+    help="Don't write the build cache (avoids polluting the shared cache)",
+    action="store_true",
 )
 manifest_parser = subparsers.add_parser(
     "manifest", help="Create a manifest from already pushed images"
@@ -95,11 +110,14 @@ def main():
                 print("Command failed")
                 sys.exit(1)
 
+    registries = args.registry or REGISTRIES
+
     # detect channel from tag
     match = re.match(r"^(\d+\.\d+)(?:\.\d+)?(b\d+)?$", args.tag)
     major_minor_version = None
     if match is None:
-        channel = CHANNEL_DEV
+        # Custom tag (e.g. a branch name) -- push only the tag itself
+        channel = None
     elif match.group(2) is None:
         major_minor_version = match.group(1)
         channel = CHANNEL_RELEASE
@@ -128,11 +146,14 @@ def main():
             CHANNEL_DEV: "cache-dev",
             CHANNEL_BETA: "cache-beta",
             CHANNEL_RELEASE: "cache-latest",
-        }[channel]
+        }.get(channel, "cache-dev")
         cache_img = f"ghcr.io/{params.build_to}:{cache_tag}"
 
-        imgs = [f"{params.build_to}:{tag}" for tag in tags_to_push]
-        imgs += [f"ghcr.io/{params.build_to}:{tag}" for tag in tags_to_push]
+        imgs = []
+        if REGISTRY_DOCKERHUB in registries:
+            imgs += [f"{params.build_to}:{tag}" for tag in tags_to_push]
+        if REGISTRY_GHCR in registries:
+            imgs += [f"ghcr.io/{params.build_to}:{tag}" for tag in tags_to_push]
 
         # 3. build
         cmd = [
@@ -155,7 +176,9 @@ def main():
         for img in imgs:
             cmd += ["--tag", img]
         if args.push:
-            cmd += ["--push", "--cache-to", f"type=registry,ref={cache_img},mode=max"]
+            cmd += ["--push"]
+            if not args.no_cache_to:
+                cmd += ["--cache-to", f"type=registry,ref={cache_img},mode=max"]
         if args.load:
             cmd += ["--load"]
 
@@ -163,8 +186,11 @@ def main():
     elif args.command == "manifest":
         manifest = DockerParams.for_type_arch(args.build_type, ARCH_AMD64).manifest_to
 
-        targets = [f"{manifest}:{tag}" for tag in tags_to_push]
-        targets += [f"ghcr.io/{manifest}:{tag}" for tag in tags_to_push]
+        targets = []
+        if REGISTRY_DOCKERHUB in registries:
+            targets += [f"{manifest}:{tag}" for tag in tags_to_push]
+        if REGISTRY_GHCR in registries:
+            targets += [f"ghcr.io/{manifest}:{tag}" for tag in tags_to_push]
         # 1. Create manifests
         for target in targets:
             cmd = ["docker", "manifest", "create", target]

--- a/docker/build.py
+++ b/docker/build.py
@@ -147,7 +147,11 @@ def main():
             CHANNEL_BETA: "cache-beta",
             CHANNEL_RELEASE: "cache-latest",
         }.get(channel, "cache-dev")
-        cache_img = f"ghcr.io/{params.build_to}:{cache_tag}"
+        # Cache images live alongside the pushed images; prefer GHCR when it is
+        # one of the selected registries, otherwise fall back to Docker Hub so a
+        # registry-restricted build doesn't need GHCR auth.
+        cache_prefix = "ghcr.io/" if REGISTRY_GHCR in registries else ""
+        cache_img = f"{cache_prefix}{params.build_to}:{cache_tag}"
 
         imgs = []
         if REGISTRY_DOCKERHUB in registries:
@@ -191,18 +195,17 @@ def main():
             targets += [f"{manifest}:{tag}" for tag in tags_to_push]
         if REGISTRY_GHCR in registries:
             targets += [f"ghcr.io/{manifest}:{tag}" for tag in tags_to_push]
-        # 1. Create manifests
+        # Use buildx imagetools (not `docker manifest`) so the per-arch sources,
+        # which buildx pushes as single-platform manifest lists, are combined
+        # and pushed correctly in one step.
         for target in targets:
-            cmd = ["docker", "manifest", "create", target]
+            cmd = ["docker", "buildx", "imagetools", "create", "--tag", target]
             for arch in ARCHS:
                 src = f"{DockerParams.for_type_arch(args.build_type, arch).build_to}:{args.tag}"
                 if target.startswith("ghcr.io"):
                     src = f"ghcr.io/{src}"
                 cmd.append(src)
             run_command(*cmd)
-        # 2. Push manifests
-        for target in targets:
-            run_command("docker", "manifest", "push", target)
 
 
 if __name__ == "__main__":

--- a/tests/script/test_docker_build.py
+++ b/tests/script/test_docker_build.py
@@ -1,0 +1,166 @@
+"""Unit tests for docker/build.py command generation."""
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+_BUILD_PY = Path(__file__).parents[2] / "docker" / "build.py"
+_spec = importlib.util.spec_from_file_location("docker_build", _BUILD_PY)
+docker_build = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(docker_build)
+
+
+def _run(capsys: pytest.CaptureFixture[str], *argv: str) -> list[str]:
+    """Run build.py main() in dry-run mode and return the emitted commands."""
+    full_argv = ["build.py", "--dry-run", *argv]
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sys, "argv", full_argv)
+        docker_build.main()
+    out = capsys.readouterr().out
+    return [line[2:] for line in out.splitlines() if line.startswith("$ ")]
+
+
+def test_branch_build_pushes_single_ghcr_tag_without_cache_to(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    commands = _run(
+        capsys,
+        "--tag",
+        "my-branch",
+        "--arch",
+        "amd64",
+        "--build-type",
+        "docker",
+        "--registry",
+        "ghcr",
+        "build",
+        "--push",
+        "--no-cache-to",
+    )
+
+    assert len(commands) == 1
+    cmd = commands[0]
+    # Custom tag -> only the tag itself, no companion "dev"/"latest" tags
+    assert "--tag ghcr.io/esphome/esphome-amd64:my-branch" in cmd
+    assert ":dev" not in cmd
+    # ghcr only -> no Docker Hub image name
+    assert "--tag esphome/esphome-amd64:my-branch" not in cmd
+    # custom tag falls back to the dev cache for reads
+    assert (
+        "--cache-from type=registry,ref=ghcr.io/esphome/esphome-amd64:cache-dev" in cmd
+    )
+    assert "--push" in cmd
+    # --no-cache-to must suppress the cache write
+    assert "--cache-to" not in cmd
+
+
+def test_branch_manifest_targets_ghcr_only(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    commands = _run(
+        capsys,
+        "--tag",
+        "my-branch",
+        "--build-type",
+        "ha-addon",
+        "--registry",
+        "ghcr",
+        "manifest",
+    )
+
+    create, push = commands
+    assert create == (
+        "docker manifest create ghcr.io/esphome/esphome-hassio:my-branch "
+        "ghcr.io/esphome/esphome-hassio-amd64:my-branch "
+        "ghcr.io/esphome/esphome-hassio-aarch64:my-branch"
+    )
+    assert push == "docker manifest push ghcr.io/esphome/esphome-hassio:my-branch"
+
+
+def test_release_build_keeps_both_registries_and_cache_to(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    commands = _run(
+        capsys,
+        "--tag",
+        "2025.6.0",
+        "--arch",
+        "amd64",
+        "--build-type",
+        "docker",
+        "build",
+        "--push",
+    )
+
+    cmd = commands[0]
+    # Default (no --registry) keeps both Docker Hub and ghcr image names
+    assert "--tag esphome/esphome-amd64:2025.6.0" in cmd
+    assert "--tag ghcr.io/esphome/esphome-amd64:2025.6.0" in cmd
+    # Release channel still gets its companion tags
+    assert "--tag esphome/esphome-amd64:latest" in cmd
+    # Without --no-cache-to the cache write is preserved
+    assert (
+        "--cache-to type=registry,ref=ghcr.io/esphome/esphome-amd64:cache-latest,mode=max"
+        in cmd
+    )
+
+
+def test_build_no_push_omits_push_and_cache(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    commands = _run(
+        capsys,
+        "--tag",
+        "my-branch",
+        "--arch",
+        "amd64",
+        "--build-type",
+        "docker",
+        "--registry",
+        "ghcr",
+        "build",
+    )
+
+    cmd = commands[0]
+    assert "--tag ghcr.io/esphome/esphome-amd64:my-branch" in cmd
+    assert "--push" not in cmd
+    assert "--cache-to" not in cmd
+
+
+def test_build_dockerhub_only(capsys: pytest.CaptureFixture[str]) -> None:
+    commands = _run(
+        capsys,
+        "--tag",
+        "my-branch",
+        "--arch",
+        "amd64",
+        "--build-type",
+        "docker",
+        "--registry",
+        "dockerhub",
+        "build",
+        "--push",
+    )
+
+    cmd = commands[0]
+    assert "--tag esphome/esphome-amd64:my-branch" in cmd
+    assert "ghcr.io/esphome/esphome-amd64:my-branch" not in cmd
+
+
+def test_manifest_dockerhub_only(capsys: pytest.CaptureFixture[str]) -> None:
+    commands = _run(
+        capsys,
+        "--tag",
+        "my-branch",
+        "--build-type",
+        "docker",
+        "--registry",
+        "dockerhub",
+        "manifest",
+    )
+
+    create = commands[0]
+    assert create.startswith("docker manifest create esphome/esphome:my-branch ")
+    assert "ghcr.io" not in create

--- a/tests/script/test_docker_build.py
+++ b/tests/script/test_docker_build.py
@@ -70,13 +70,12 @@ def test_branch_manifest_targets_ghcr_only(
         "manifest",
     )
 
-    create, push = commands
-    assert create == (
-        "docker manifest create ghcr.io/esphome/esphome-hassio:my-branch "
+    assert commands == [
+        "docker buildx imagetools create "
+        "--tag ghcr.io/esphome/esphome-hassio:my-branch "
         "ghcr.io/esphome/esphome-hassio-amd64:my-branch "
         "ghcr.io/esphome/esphome-hassio-aarch64:my-branch"
-    )
-    assert push == "docker manifest push ghcr.io/esphome/esphome-hassio:my-branch"
+    ]
 
 
 def test_release_build_keeps_both_registries_and_cache_to(
@@ -146,7 +145,9 @@ def test_build_dockerhub_only(capsys: pytest.CaptureFixture[str]) -> None:
 
     cmd = commands[0]
     assert "--tag esphome/esphome-amd64:my-branch" in cmd
-    assert "ghcr.io/esphome/esphome-amd64:my-branch" not in cmd
+    assert "ghcr.io" not in cmd
+    # Cache reference falls back to Docker Hub when GHCR isn't selected
+    assert "--cache-from type=registry,ref=esphome/esphome-amd64:cache-dev" in cmd
 
 
 def test_manifest_dockerhub_only(capsys: pytest.CaptureFixture[str]) -> None:
@@ -162,5 +163,7 @@ def test_manifest_dockerhub_only(capsys: pytest.CaptureFixture[str]) -> None:
     )
 
     create = commands[0]
-    assert create.startswith("docker manifest create esphome/esphome:my-branch ")
+    assert create.startswith(
+        "docker buildx imagetools create --tag esphome/esphome:my-branch "
+    )
     assert "ghcr.io" not in create


### PR DESCRIPTION
# What does this implement/fix?

When `ci-docker` runs for a same-repo pull request that touches the docker paths, it now builds and pushes per-arch images to ghcr.io and assembles multi-arch manifests, tagged with the (sanitized) branch name. This makes it easy to pull and run a PR's image locally: `docker pull ghcr.io/esphome/esphome:<branch>` (and `esphome-hassio:<branch>`).

To support this, `docker/build.py` gains a `--registry {ghcr,dockerhub}` filter and a `--no-cache-to` flag, and a custom (non-version) tag is now treated as a single push target instead of also pushing the `dev`/`beta`/`latest` companion tags — so branch builds can never clobber the release pipeline's images. The push is gated to same-repo pull requests only: push events fire just for dev/beta/release (owned by the release pipeline), and fork PRs get a read-only token, so both are skipped and simply run the existing build-as-check.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).