### PR TITLE
[core] Stop parent git repos from breaking ESP-IDF/PlatformIO builds

### DIFF
--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -14,6 +14,7 @@ from esphome.const import CONF_FRAMEWORK, CONF_SOURCE
 from esphome.core import CORE, EsphomeError
 from esphome.espidf.framework import check_esp_idf_install, get_framework_env
 from esphome.espidf.size_summary import print_summary
+from esphome.helpers import add_git_ceiling_directory
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,12 +84,10 @@ def _get_idf_env(version: str | None = None) -> dict[str, str]:
                 *_get_esphome_esp_idf_paths(version)
             )
 
-        # Stop git from walking above the config directory when ESP-IDF runs
-        # `git describe` for the app version. An uninitialized or corrupt git
-        # repo in a parent directory would otherwise make git error out and
-        # fail the whole build. GIT_CEILING_DIRECTORIES requires absolute
-        # paths; CORE.config_dir is already absolute.
-        env_cache[version]["GIT_CEILING_DIRECTORIES"] = str(CORE.config_dir)
+        # Cap git's repo search at the config directory so ESP-IDF's
+        # `git describe` for the app version can't error out on an
+        # uninitialized or corrupt git repo in a parent directory.
+        add_git_ceiling_directory(env_cache[version], CORE.config_dir)
     return env_cache[version]
 
 

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -82,6 +82,13 @@ def _get_idf_env(version: str | None = None) -> dict[str, str]:
             env_cache[version] |= get_framework_env(
                 *_get_esphome_esp_idf_paths(version)
             )
+
+        # Stop git from walking above the config directory when ESP-IDF runs
+        # `git describe` for the app version. An uninitialized or corrupt git
+        # repo in a parent directory would otherwise make git error out and
+        # fail the whole build. GIT_CEILING_DIRECTORIES requires absolute
+        # paths; CORE.config_dir is already absolute.
+        env_cache[version]["GIT_CEILING_DIRECTORIES"] = str(CORE.config_dir)
     return env_cache[version]
 
 

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from contextlib import suppress
 import ipaddress
 import logging
@@ -372,6 +373,26 @@ def get_int_env(var, default=0):
 
 def is_ha_addon():
     return get_bool_env("ESPHOME_IS_HA_ADDON")
+
+
+def add_git_ceiling_directory(env: MutableMapping[str, str], directory: Path) -> None:
+    """Add ``directory`` to ``env``'s ``GIT_CEILING_DIRECTORIES`` list.
+
+    Git stops walking up the directory tree to find a repository once it reaches
+    a ceiling directory, so this caps the search at ``directory`` (the ESPHome
+    project root). Without it, an uninitialized or corrupt git repo in a parent
+    directory makes the ``git describe`` that build toolchains run for the app
+    version error out and fail the whole build.
+
+    ``GIT_CEILING_DIRECTORIES`` is an ``os.pathsep``-joined list of absolute
+    paths; any existing entries are preserved and duplicates are skipped.
+    """
+    ceiling = str(directory)
+    existing = env.get("GIT_CEILING_DIRECTORIES", "")
+    parts = existing.split(os.pathsep) if existing else []
+    if ceiling not in parts:
+        parts.append(ceiling)
+        env["GIT_CEILING_DIRECTORIES"] = os.pathsep.join(parts)
 
 
 def rmtree(path: Path | str) -> None:

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -53,6 +53,12 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")
     # Increase uv retry count to handle transient network errors (default is 3)
     os.environ.setdefault("UV_HTTP_RETRIES", "10")
+    # Stop git from walking above the config directory when the framework's
+    # build scripts run `git describe` for the app version. An uninitialized or
+    # corrupt git repo in a parent directory would otherwise make git error out
+    # and fail the whole build. GIT_CEILING_DIRECTORIES requires absolute paths;
+    # CORE.config_dir is already absolute.
+    os.environ["GIT_CEILING_DIRECTORIES"] = str(CORE.config_dir)
     # Strip the Windows extended-length path prefix from sys.executable so it
     # doesn't propagate into PlatformIO's $PYTHONEXE and break SCons-emitted
     # command lines run through cmd.exe.

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -7,6 +7,7 @@ import sys
 
 from esphome.const import CONF_COMPILE_PROCESS_LIMIT, CONF_ESPHOME, KEY_CORE
 from esphome.core import CORE, EsphomeError
+from esphome.helpers import add_git_ceiling_directory
 from esphome.util import FlashImage, run_external_process
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,12 +54,10 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")
     # Increase uv retry count to handle transient network errors (default is 3)
     os.environ.setdefault("UV_HTTP_RETRIES", "10")
-    # Stop git from walking above the config directory when the framework's
-    # build scripts run `git describe` for the app version. An uninitialized or
-    # corrupt git repo in a parent directory would otherwise make git error out
-    # and fail the whole build. GIT_CEILING_DIRECTORIES requires absolute paths;
-    # CORE.config_dir is already absolute.
-    os.environ["GIT_CEILING_DIRECTORIES"] = str(CORE.config_dir)
+    # Cap git's repo search at the config directory so the framework's build
+    # scripts running `git describe` for the app version can't error out on an
+    # uninitialized or corrupt git repo in a parent directory.
+    add_git_ceiling_directory(os.environ, CORE.config_dir)
     # Strip the Windows extended-length path prefix from sys.executable so it
     # doesn't propagate into PlatformIO's $PYTHONEXE and break SCons-emitted
     # command lines run through cmd.exe.

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -160,8 +160,8 @@ def test_get_idf_env_sets_git_ceiling_directories(setup_core: Path) -> None:
     # Set IDF_PATH so the framework-install branch is skipped.
     with patch.dict(os.environ, {"IDF_PATH": str(setup_core)}):
         env = toolchain._get_idf_env(version="5.5.4")
-    assert env["GIT_CEILING_DIRECTORIES"] == str(CORE.config_dir)
-    assert env["GIT_CEILING_DIRECTORIES"] == str(setup_core)
+    assert CORE.config_dir == setup_core
+    assert str(CORE.config_dir) in env["GIT_CEILING_DIRECTORIES"].split(os.pathsep)
 
 
 def test_get_core_framework_version_from_core_data():

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -150,6 +150,20 @@ def test_get_idedata_regenerates_on_corrupted_cache(setup_core: Path) -> None:
     assert result == {"cxx_path": "regen"}
 
 
+def test_get_idf_env_sets_git_ceiling_directories(setup_core: Path) -> None:
+    """The IDF env caps git's upward search at the config directory.
+
+    This stops ESP-IDF's `git describe` from walking into an uninitialized or
+    corrupt git repo in a parent directory and failing the build.
+    """
+    toolchain._cache().env.clear()
+    # Set IDF_PATH so the framework-install branch is skipped.
+    with patch.dict(os.environ, {"IDF_PATH": str(setup_core)}):
+        env = toolchain._get_idf_env(version="5.5.4")
+    assert env["GIT_CEILING_DIRECTORIES"] == str(CORE.config_dir)
+    assert env["GIT_CEILING_DIRECTORIES"] == str(setup_core)
+
+
 def test_get_core_framework_version_from_core_data():
     """The version is read from CORE.data when validation populated it."""
     from esphome.components.esp32.const import KEY_ESP32, KEY_IDF_VERSION

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -196,6 +196,33 @@ def test_is_ha_addon(monkeypatch, value, expected):
     assert actual == expected
 
 
+def test_add_git_ceiling_directory_sets_when_unset():
+    """An empty env gets GIT_CEILING_DIRECTORIES set to the directory."""
+    env: dict[str, str] = {}
+    directory = Path("/home/user/config")
+    helpers.add_git_ceiling_directory(env, directory)
+    assert env["GIT_CEILING_DIRECTORIES"] == str(directory)
+
+
+def test_add_git_ceiling_directory_appends_to_existing():
+    """An existing value is preserved and the new directory is appended."""
+    env = {"GIT_CEILING_DIRECTORIES": str(Path("/some/ceiling"))}
+    directory = Path("/home/user/config")
+    helpers.add_git_ceiling_directory(env, directory)
+    assert env["GIT_CEILING_DIRECTORIES"].split(os.pathsep) == [
+        str(Path("/some/ceiling")),
+        str(directory),
+    ]
+
+
+def test_add_git_ceiling_directory_skips_duplicate():
+    """A directory already in the list is not appended again."""
+    directory = Path("/home/user/config")
+    env = {"GIT_CEILING_DIRECTORIES": str(directory)}
+    helpers.add_git_ceiling_directory(env, directory)
+    assert env["GIT_CEILING_DIRECTORIES"] == str(directory)
+
+
 def test_walk_files(fixture_path):
     path = fixture_path / "helpers"
 

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -304,6 +304,9 @@ def test_run_platformio_cli_sets_environment_variables(
         )
         assert "PLATFORMIO_LIBDEPS_DIR" in os.environ
         assert "PYTHONWARNINGS" in os.environ
+        # Caps git's upward search at the config dir so an uninitialized or
+        # corrupt parent git repo can't break the framework's `git describe`.
+        assert os.environ["GIT_CEILING_DIRECTORIES"] == str(CORE.config_dir)
 
         # Check command was called correctly — runs PlatformIO as a subprocess
         # via the esphome.platformio.runner entry point.

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -306,7 +306,9 @@ def test_run_platformio_cli_sets_environment_variables(
         assert "PYTHONWARNINGS" in os.environ
         # Caps git's upward search at the config dir so an uninitialized or
         # corrupt parent git repo can't break the framework's `git describe`.
-        assert os.environ["GIT_CEILING_DIRECTORIES"] == str(CORE.config_dir)
+        assert str(CORE.config_dir) in os.environ["GIT_CEILING_DIRECTORIES"].split(
+            os.pathsep
+        )
 
         # Check command was called correctly — runs PlatformIO as a subprocess
         # via the esphome.platformio.runner entry point.


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF and the PlatformIO framework build scripts run `git describe` from the project directory to derive the firmware app version. Git walks *up* the directory tree looking for a `.git`. If a parent directory of the config contains an uninitialized or corrupt git repo, git errors out and the whole compile fails.

This sets `GIT_CEILING_DIRECTORIES` to `CORE.config_dir` for both toolchains, which stops git's upward search before it leaves the ESPHome project tree. The ceiling is applied in the single chokepoint each toolchain uses to build its subprocess environment: `_get_idf_env()` for native ESP-IDF, and `run_platformio_cli()` (via `os.environ`, inherited by the subprocess) for PlatformIO.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).