### PR TITLE
[ota] Scale ESP-IDF OTA erase watchdog to image size

### DIFF
--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -58,10 +58,16 @@ OTAResponseTypes IDFOTABackend::begin(size_t image_size, ota::OTAType ota_type) 
   }
 
   // esp_ota_begin() erases the destination region, which blocks loopTask and
-  // scales with image size -- a fixed watchdog overruns on large OTA slots.
-  // Budget ~10ms/KiB (conservative ~100 KiB/s erase) over a 15s floor; panic
-  // stays on so a stuck erase still resets rather than hanging forever.
-  const uint32_t erase_budget_ms = 15000 + (image_size >> 10) * 10;
+  // scales with the erase size -- a fixed watchdog overruns on large OTA slots.
+  // An unknown size (0, e.g. web_server uploads) erases the whole partition, so
+  // budget against the bytes actually erased. ~10ms/KiB (conservative
+  // ~100 KiB/s erase) over a 15s floor; panic stays on so a stuck erase still
+  // resets rather than hanging forever.
+  size_t erase_size = image_size;
+  if (erase_size == 0 || erase_size > this->partition_->size) {
+    erase_size = this->partition_->size;
+  }
+  const uint32_t erase_budget_ms = 15000 + (erase_size >> 10) * 10;
   watchdog::WatchdogManager watchdog(erase_budget_ms);
   esp_err_t err = esp_ota_begin(this->partition_, image_size, &this->update_handle_);
 

--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -57,7 +57,12 @@ OTAResponseTypes IDFOTABackend::begin(size_t image_size, ota::OTAType ota_type) 
     return OTA_RESPONSE_ERROR_NO_UPDATE_PARTITION;
   }
 
-  watchdog::WatchdogManager watchdog(15000);
+  // esp_ota_begin() erases the destination region, which blocks loopTask and
+  // scales with image size -- a fixed watchdog overruns on large OTA slots.
+  // Budget ~10ms/KiB (conservative ~100 KiB/s erase) over a 15s floor; panic
+  // stays on so a stuck erase still resets rather than hanging forever.
+  const uint32_t erase_budget_ms = 15000 + (image_size >> 10) * 10;
+  watchdog::WatchdogManager watchdog(erase_budget_ms);
   esp_err_t err = esp_ota_begin(this->partition_, image_size, &this->update_handle_);
 
   if (err != ESP_OK) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes a task-watchdog reset during ESP-IDF OTA on devices with large OTA partitions (reported on an ESP32-S3 with 7.75 MiB slots in #16993).

`IDFOTABackend::begin()` calls `esp_ota_begin()`, which erases the destination OTA region up front. That erase blocks `loopTask` and scales with the image size. The erase was wrapped in a fixed `WatchdogManager(15000)` (15s). On large partitions the erase overruns 15s, and since #16138 (2026.5.0) made `WatchdogManager` honor `CONFIG_ESP_TASK_WDT_PANIC` (default on), the overrun now panics and resets the device mid-OTA instead of just warning.

Backtrace from the reporter:
```
spi_flash_chip_generic_erase_block
esp_flash_erase_region
esp_partition_erase_range
esp_ota_begin                         <- blocking erase
esphome::ota::IDFOTABackend::begin    ota_backend_esp_idf.cpp:61
...
task_wdt: Task watchdog got triggered - loopTask (CPU 1)  -> reset
```

## Fix

Budget the watchdog timeout proportionally to the image being erased instead of a fixed 15s:

```cpp
const uint32_t erase_budget_ms = 15000 + (image_size >> 10) * 10;  // ~10ms/KiB, 15s floor
watchdog::WatchdogManager watchdog(erase_budget_ms);
```

| Image | Budget |
|---|---|
| 1 MiB | 25s |
| 2 MiB | 35s |
| 8 MiB | 97s |

`~10ms/KiB` (~100 KiB/s) is a conservative erase-rate floor; real flash erase is several times faster, so this is generous headroom for a legitimate erase. Panic stays enabled, so a genuinely stuck erase (flash fault) still resets and recovers rather than hanging forever.

Only the app-erase path is touched. The partition-table update erases a 3 KB table (15s is ample), and the OTA write path feeds the watchdog per block, so neither is affected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16993

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32-s3-devkitc-1
  flash_size: 16MB
  framework:
    type: esp-idf

ota:
  - platform: esphome
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).