### PR TITLE
[ld2410] Add automatic background noise correction

### DIFF
--- a/esphome/components/ld2410/__init__.py
+++ b/esphome/components/ld2410/__init__.py
@@ -16,6 +16,7 @@ LD2410Component = ld2410_ns.class_("LD2410Component", cg.Component, uart.UARTDev
 CONF_LD2410_ID = "ld2410_id"
 CONF_MAX_MOVE_DISTANCE = "max_move_distance"
 CONF_MAX_STILL_DISTANCE = "max_still_distance"
+CONF_BACKGROUND_CORRECTION_DURATION = "background_correction_duration"
 CONF_MOVE_THRESHOLDS = [f"g{x}_move_threshold" for x in range(9)]
 CONF_STILL_THRESHOLDS = [f"g{x}_still_threshold" for x in range(9)]
 
@@ -36,6 +37,16 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_TIMEOUT): cv.invalid(
             f"The '{CONF_TIMEOUT}' option has been moved to the '{CONF_TIMEOUT}'"
             f" number component"
+        ),
+        # Window the module spends measuring the noise floor when the
+        # background_correction button is pressed (command 0x000B). HiLink's
+        # tool uses 10 s; longer captures intermittent clutter (fans, HVAC).
+        cv.Optional(CONF_BACKGROUND_CORRECTION_DURATION, default="10s"): cv.All(
+            cv.positive_time_period_seconds,
+            cv.Range(
+                min=cv.TimePeriod(seconds=10),
+                max=cv.TimePeriod(seconds=120),
+            ),
         ),
     }
 )
@@ -73,6 +84,11 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+    cg.add(
+        var.set_background_correction_duration(
+            config[CONF_BACKGROUND_CORRECTION_DURATION].total_seconds
+        )
+    )
 
 
 CALIBRATION_ACTION_SCHEMA = maybe_simple_id(

--- a/esphome/components/ld2410/binary_sensor.py
+++ b/esphome/components/ld2410/binary_sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_CALIBRATION,
     CONF_HAS_MOVING_TARGET,
     CONF_HAS_STILL_TARGET,
     CONF_HAS_TARGET,
@@ -9,6 +10,7 @@ from esphome.const import (
     DEVICE_CLASS_MOTION,
     DEVICE_CLASS_OCCUPANCY,
     DEVICE_CLASS_PRESENCE,
+    DEVICE_CLASS_RUNNING,
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_ACCOUNT,
     ICON_MOTION_SENSOR,
@@ -43,6 +45,10 @@ CONFIG_SCHEMA = {
         filters=[{"settle": cv.TimePeriod(milliseconds=1000)}],
         icon=ICON_ACCOUNT,
     ),
+    cv.Optional(CONF_CALIBRATION): binary_sensor.binary_sensor_schema(
+        device_class=DEVICE_CLASS_RUNNING,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
 }
 
 
@@ -60,3 +66,6 @@ async def to_code(config):
     if out_pin_presence_status_config := config.get(CONF_OUT_PIN_PRESENCE_STATUS):
         sens = await binary_sensor.new_binary_sensor(out_pin_presence_status_config)
         cg.add(ld2410_component.set_out_pin_presence_status_binary_sensor(sens))
+    if calibration_config := config.get(CONF_CALIBRATION):
+        sens = await binary_sensor.new_binary_sensor(calibration_config)
+        cg.add(ld2410_component.set_calibration_binary_sensor(sens))

--- a/esphome/components/ld2410/button/__init__.py
+++ b/esphome/components/ld2410/button/__init__.py
@@ -18,8 +18,12 @@ from .. import CONF_LD2410_ID, LD2410Component, ld2410_ns
 FactoryResetButton = ld2410_ns.class_("FactoryResetButton", button.Button)
 QueryButton = ld2410_ns.class_("QueryButton", button.Button)
 RestartButton = ld2410_ns.class_("RestartButton", button.Button)
+BackgroundCorrectionButton = ld2410_ns.class_(
+    "BackgroundCorrectionButton", button.Button
+)
 
 CONF_QUERY_PARAMS = "query_params"
+CONF_BACKGROUND_CORRECTION = "background_correction"
 
 CONFIG_SCHEMA = {
     cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
@@ -41,6 +45,11 @@ CONFIG_SCHEMA = {
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         icon=ICON_DATABASE,
     ),
+    cv.Optional(CONF_BACKGROUND_CORRECTION): button.button_schema(
+        BackgroundCorrectionButton,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:broom",
+    ),
 }
 
 
@@ -58,3 +67,7 @@ async def to_code(config):
         b = await button.new_button(query_params_config)
         await cg.register_parented(b, config[CONF_LD2410_ID])
         cg.add(ld2410_component.set_query_button(b))
+    if background_correction_config := config.get(CONF_BACKGROUND_CORRECTION):
+        b = await button.new_button(background_correction_config)
+        await cg.register_parented(b, config[CONF_LD2410_ID])
+        cg.add(ld2410_component.set_background_correction_button(b))

--- a/esphome/components/ld2410/button/background_correction_button.cpp
+++ b/esphome/components/ld2410/button/background_correction_button.cpp
@@ -1,0 +1,7 @@
+#include "background_correction_button.h"
+
+namespace esphome::ld2410 {
+
+void BackgroundCorrectionButton::press_action() { this->parent_->start_background_correction(); }
+
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/button/background_correction_button.h
+++ b/esphome/components/ld2410/button/background_correction_button.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "../ld2410.h"
+
+namespace esphome::ld2410 {
+
+class BackgroundCorrectionButton : public button::Button, public Parented<LD2410Component> {
+ public:
+  BackgroundCorrectionButton() = default;
+
+ protected:
+  void press_action() override;
+};
+
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -155,6 +155,18 @@ static constexpr uint8_t CMD_QUERY_MAC_ADDRESS = 0xA5;
 static constexpr uint8_t CMD_RESET = 0xA2;
 static constexpr uint8_t CMD_RESTART = 0xA3;
 static constexpr uint8_t CMD_BLUETOOTH = 0xA4;
+// Automatic background-noise correction (firmware >= V2.44, common to LD2410 /
+// LD2410B / LD2410C). 0x0B starts the routine; 0x1B queries its progress.
+static constexpr uint8_t CMD_BG_CORRECTION_START = 0x0B;
+static constexpr uint8_t CMD_BG_CORRECTION_QUERY = 0x1B;
+// Status byte returned in the 0x1B query ACK: 0 = idle, 1 = in progress, 2 = done.
+static constexpr uint8_t BG_CORRECTION_COMPLETED = 0x02;
+// How often we poll 0x1B while a correction is running, and the scheduler keys
+// used to cancel the poll / safety timers.
+static constexpr uint32_t BG_CORRECTION_POLL_INTERVAL_MS = 1000;
+static constexpr uint32_t BG_CORRECTION_SAFETY_MARGIN_MS = 3000;
+static const char *const BG_CORRECTION_POLL = "ld2410_bg_poll";
+static const char *const BG_CORRECTION_SAFETY = "ld2410_bg_safety";
 // Commands values
 static constexpr uint8_t CMD_MAX_MOVE_VALUE = 0x00;
 static constexpr uint8_t CMD_MAX_STILL_VALUE = 0x01;
@@ -193,6 +205,7 @@ void LD2410Component::dump_config() {
   LOG_BINARY_SENSOR("  ", "MovingTarget", this->moving_target_binary_sensor_);
   LOG_BINARY_SENSOR("  ", "StillTarget", this->still_target_binary_sensor_);
   LOG_BINARY_SENSOR("  ", "OutPinPresenceStatus", this->out_pin_presence_status_binary_sensor_);
+  LOG_BINARY_SENSOR("  ", "Calibration", this->calibration_binary_sensor_);
 #endif
 #ifdef USE_SENSOR
   ESP_LOGCONFIG(TAG, "Sensors:");
@@ -244,6 +257,7 @@ void LD2410Component::dump_config() {
   LOG_BUTTON("  ", "FactoryReset", this->factory_reset_button_);
   LOG_BUTTON("  ", "Query", this->query_button_);
   LOG_BUTTON("  ", "Restart", this->restart_button_);
+  LOG_BUTTON("  ", "BackgroundCorrection", this->background_correction_button_);
 #endif
 }
 
@@ -531,6 +545,20 @@ bool LD2410Component::handle_ack_data_() {
       ESP_LOGV(TAG, "Sensitivity");
       break;
 
+    case CMD_BG_CORRECTION_START:
+      ESP_LOGV(TAG, "Background correction started");
+      break;
+
+    case CMD_BG_CORRECTION_QUERY: {
+      // First value byte holds the routine's state: 0 idle, 1 running, 2 done.
+      const uint8_t status = this->buffer_data_[10];
+      ESP_LOGV(TAG, "Background correction status: %u", status);
+      if (status == BG_CORRECTION_COMPLETED) {
+        this->finish_background_correction_(true);
+      }
+      break;
+    }
+
     case CMD_BLUETOOTH:
       ESP_LOGV(TAG, "Bluetooth");
       break;
@@ -691,6 +719,64 @@ void LD2410Component::get_mac_() {
 void LD2410Component::get_distance_resolution_() { this->send_command_(CMD_QUERY_DISTANCE_RESOLUTION, nullptr, 0); }
 
 void LD2410Component::query_light_control_() { this->send_command_(CMD_QUERY_LIGHT_CONTROL, nullptr, 0); }
+
+void LD2410Component::start_background_correction() {
+  if (this->bg_correction_running_) {
+    ESP_LOGW(TAG, "Background correction already running; ignoring request");
+    return;
+  }
+  ESP_LOGI(TAG, "Starting background correction (%u s). People must be absent; leave other clutter in place",
+           this->bg_correction_duration_);
+  // The module runs the routine in normal reporting mode, so open config only
+  // long enough to issue the command, then close it again.
+  this->set_config_mode_(true);
+  const uint8_t value[2] = {lowbyte(this->bg_correction_duration_), highbyte(this->bg_correction_duration_)};
+  this->send_command_(CMD_BG_CORRECTION_START, value, sizeof(value));
+  this->set_config_mode_(false);
+  this->set_background_correction_running_(true);
+  // Poll the module for real completion instead of trusting a fixed timer.
+  this->set_interval(BG_CORRECTION_POLL, BG_CORRECTION_POLL_INTERVAL_MS,
+                     [this]() { this->query_background_correction_(); });
+  // Safety net: clear the indicator even if completion is never reported (e.g.
+  // firmware predating 0x1B), so it can never latch on forever.
+  this->set_timeout(BG_CORRECTION_SAFETY,
+                    (uint32_t) this->bg_correction_duration_ * 1000 + BG_CORRECTION_SAFETY_MARGIN_MS,
+                    [this]() { this->finish_background_correction_(false); });
+}
+
+void LD2410Component::query_background_correction_() {
+  this->set_config_mode_(true);
+  this->send_command_(CMD_BG_CORRECTION_QUERY, nullptr, 0);
+  this->set_config_mode_(false);
+}
+
+void LD2410Component::finish_background_correction_(bool completed) {
+  if (!this->bg_correction_running_) {
+    return;
+  }
+  this->cancel_interval(BG_CORRECTION_POLL);
+  this->cancel_timeout(BG_CORRECTION_SAFETY);
+  this->set_background_correction_running_(false);
+  if (completed) {
+    ESP_LOGI(TAG, "Background correction complete; refreshing thresholds");
+    // The module just rewrote its gate thresholds; re-read them so any exposed
+    // number entities reflect the new values.
+    this->set_config_mode_(true);
+    this->query_parameters_();
+    this->set_config_mode_(false);
+  } else {
+    ESP_LOGW(TAG, "Background correction window elapsed without a completion report");
+  }
+}
+
+void LD2410Component::set_background_correction_running_(bool running) {
+  this->bg_correction_running_ = running;
+#ifdef USE_BINARY_SENSOR
+  if (this->calibration_binary_sensor_ != nullptr) {
+    this->calibration_binary_sensor_->publish_state(running);
+  }
+#endif
+}
 
 #ifdef USE_NUMBER
 void LD2410Component::set_max_distances_timeout() {

--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -165,6 +165,10 @@ static constexpr uint8_t BG_CORRECTION_COMPLETED = 0x02;
 // used to cancel the poll / safety timers.
 static constexpr uint32_t BG_CORRECTION_POLL_INTERVAL_MS = 1000;
 static constexpr uint32_t BG_CORRECTION_SAFETY_MARGIN_MS = 3000;
+// After accepting 0x0B the module waits a fixed ~10 s warm-up before it begins
+// measuring, so the safety timeout must allow for it on top of the requested window;
+// otherwise it fires before the module can ever report completion.
+static constexpr uint32_t BG_CORRECTION_WARMUP_MS = 10000;
 static const char *const BG_CORRECTION_POLL = "ld2410_bg_poll";
 static const char *const BG_CORRECTION_SAFETY = "ld2410_bg_safety";
 // Commands values
@@ -174,6 +178,11 @@ static constexpr uint8_t CMD_DURATION_VALUE = 0x02;
 // Bitmasks for target states
 static constexpr uint8_t MOVE_BITMASK = 0x01;
 static constexpr uint8_t STILL_BITMASK = 0x02;
+// While background correction runs, the module repurposes the target-state byte to
+// report calibration progress (0x04 running, 0x05 success, 0x06 failure) instead of
+// real presence. Normal presence only uses 0x00-0x03, so any value >= this is a
+// calibration status frame and must not drive the target sensors.
+static constexpr uint8_t TARGET_STATE_CALIBRATING_MIN = 0x04;
 // Header & Footer size
 static constexpr uint8_t HEADER_FOOTER_SIZE = 4;
 // Command Header & Footer
@@ -354,15 +363,20 @@ void LD2410Component::handle_periodic_data_() {
     0x02 = Still targets
     0x03 = Moving+Still targets
   */
-  char target_state = this->buffer_data_[TARGET_STATES];
-  if (this->target_binary_sensor_ != nullptr) {
-    this->target_binary_sensor_->publish_state(target_state != 0x00);
-  }
-  if (this->moving_target_binary_sensor_ != nullptr) {
-    this->moving_target_binary_sensor_->publish_state(target_state & MOVE_BITMASK);
-  }
-  if (this->still_target_binary_sensor_ != nullptr) {
-    this->still_target_binary_sensor_->publish_state(target_state & STILL_BITMASK);
+  uint8_t target_state = this->buffer_data_[TARGET_STATES];
+  // During background correction the module reports calibration progress in this byte
+  // (>= 0x04) rather than real presence. Skip those frames so an empty room being
+  // calibrated isn't published as occupied and doesn't trigger presence automations.
+  if (target_state < TARGET_STATE_CALIBRATING_MIN) {
+    if (this->target_binary_sensor_ != nullptr) {
+      this->target_binary_sensor_->publish_state(target_state != 0x00);
+    }
+    if (this->moving_target_binary_sensor_ != nullptr) {
+      this->moving_target_binary_sensor_->publish_state(target_state & MOVE_BITMASK);
+    }
+    if (this->still_target_binary_sensor_ != nullptr) {
+      this->still_target_binary_sensor_->publish_state(target_state & STILL_BITMASK);
+    }
   }
 #endif
   /*
@@ -739,9 +753,10 @@ void LD2410Component::start_background_correction() {
                      [this]() { this->query_background_correction_(); });
   // Safety net: clear the indicator even if completion is never reported (e.g.
   // firmware predating 0x1B), so it can never latch on forever.
-  this->set_timeout(BG_CORRECTION_SAFETY,
-                    (uint32_t) this->bg_correction_duration_ * 1000 + BG_CORRECTION_SAFETY_MARGIN_MS,
-                    [this]() { this->finish_background_correction_(false); });
+  this->set_timeout(
+      BG_CORRECTION_SAFETY,
+      (uint32_t) this->bg_correction_duration_ * 1000 + BG_CORRECTION_WARMUP_MS + BG_CORRECTION_SAFETY_MARGIN_MS,
+      [this]() { this->finish_background_correction_(false); });
 }
 
 void LD2410Component::query_background_correction_() {

--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -161,16 +161,13 @@ static constexpr uint8_t CMD_BG_CORRECTION_START = 0x0B;
 static constexpr uint8_t CMD_BG_CORRECTION_QUERY = 0x1B;
 // Status byte returned in the 0x1B query ACK: 0 = idle, 1 = in progress, 2 = done.
 static constexpr uint8_t BG_CORRECTION_COMPLETED = 0x02;
-// How often we poll 0x1B while a correction is running, and the scheduler keys
-// used to cancel the poll / safety timers.
+// How often we poll 0x1B from loop() while a correction is running.
 static constexpr uint32_t BG_CORRECTION_POLL_INTERVAL_MS = 1000;
 static constexpr uint32_t BG_CORRECTION_SAFETY_MARGIN_MS = 3000;
 // After accepting 0x0B the module waits a fixed ~10 s warm-up before it begins
-// measuring, so the safety timeout must allow for it on top of the requested window;
-// otherwise it fires before the module can ever report completion.
+// measuring, so the safety deadline must allow for it on top of the requested window;
+// otherwise it elapses before the module can ever report completion.
 static constexpr uint32_t BG_CORRECTION_WARMUP_MS = 10000;
-static const char *const BG_CORRECTION_POLL = "ld2410_bg_poll";
-static const char *const BG_CORRECTION_SAFETY = "ld2410_bg_safety";
 // Commands values
 static constexpr uint8_t CMD_MAX_MOVE_VALUE = 0x00;
 static constexpr uint8_t CMD_MAX_STILL_VALUE = 0x01;
@@ -296,6 +293,19 @@ void LD2410Component::restart_and_read_all_info() {
 }
 
 void LD2410Component::loop() {
+  // Drive background-correction polling here instead of the scheduler to avoid
+  // runtime heap allocation (set_interval/set_timeout allocate a SchedulerItem).
+  if (this->bg_correction_running_) {
+    const uint32_t now = millis();
+    if ((int32_t) (now - this->bg_correction_deadline_) >= 0) {
+      // Completion was never reported (e.g. firmware predating 0x1B); clear the
+      // indicator so it can never latch on forever.
+      this->finish_background_correction_(false);
+    } else if ((int32_t) (now - this->bg_correction_next_poll_) >= 0) {
+      this->bg_correction_next_poll_ = now + BG_CORRECTION_POLL_INTERVAL_MS;
+      this->query_background_correction_();
+    }
+  }
   // Read all available bytes in batches to reduce UART call overhead.
   size_t avail = this->available();
   uint8_t buf[MAX_LINE_LENGTH];
@@ -739,7 +749,7 @@ void LD2410Component::start_background_correction() {
     ESP_LOGW(TAG, "Background correction already running; ignoring request");
     return;
   }
-  ESP_LOGI(TAG, "Starting background correction (%u s). People must be absent; leave other clutter in place",
+  ESP_LOGI(TAG, "Starting background correction (%u s); room must be empty (leave fixed clutter in place)",
            this->bg_correction_duration_);
   // The module runs the routine in normal reporting mode, so open config only
   // long enough to issue the command, then close it again.
@@ -748,15 +758,14 @@ void LD2410Component::start_background_correction() {
   this->send_command_(CMD_BG_CORRECTION_START, value, sizeof(value));
   this->set_config_mode_(false);
   this->set_background_correction_running_(true);
-  // Poll the module for real completion instead of trusting a fixed timer.
-  this->set_interval(BG_CORRECTION_POLL, BG_CORRECTION_POLL_INTERVAL_MS,
-                     [this]() { this->query_background_correction_(); });
-  // Safety net: clear the indicator even if completion is never reported (e.g.
-  // firmware predating 0x1B), so it can never latch on forever.
-  this->set_timeout(
-      BG_CORRECTION_SAFETY,
-      (uint32_t) this->bg_correction_duration_ * 1000 + BG_CORRECTION_WARMUP_MS + BG_CORRECTION_SAFETY_MARGIN_MS,
-      [this]() { this->finish_background_correction_(false); });
+  // Poll the module for real completion from loop() instead of trusting a fixed
+  // timer. The safety deadline clears the indicator if completion is never reported
+  // (e.g. firmware predating 0x1B); it includes the module's fixed warm-up so it
+  // can't elapse before the routine has even started measuring.
+  const uint32_t now = millis();
+  this->bg_correction_next_poll_ = now + BG_CORRECTION_POLL_INTERVAL_MS;
+  this->bg_correction_deadline_ =
+      now + (uint32_t) this->bg_correction_duration_ * 1000 + BG_CORRECTION_WARMUP_MS + BG_CORRECTION_SAFETY_MARGIN_MS;
 }
 
 void LD2410Component::query_background_correction_() {
@@ -769,8 +778,7 @@ void LD2410Component::finish_background_correction_(bool completed) {
   if (!this->bg_correction_running_) {
     return;
   }
-  this->cancel_interval(BG_CORRECTION_POLL);
-  this->cancel_timeout(BG_CORRECTION_SAFETY);
+  // Clearing the flag stops the poll/deadline checks in loop().
   this->set_background_correction_running_(false);
   if (completed) {
     ESP_LOGI(TAG, "Background correction complete; refreshing thresholds");

--- a/esphome/components/ld2410/ld2410.h
+++ b/esphome/components/ld2410/ld2410.h
@@ -44,6 +44,7 @@ class LD2410Component : public Component, public uart::UARTDevice {
   SUB_BINARY_SENSOR(moving_target)
   SUB_BINARY_SENSOR(still_target)
   SUB_BINARY_SENSOR(target)
+  SUB_BINARY_SENSOR(calibration)
 #endif
 #ifdef USE_SENSOR
   SUB_SENSOR_WITH_DEDUP(light, uint8_t)
@@ -77,6 +78,7 @@ class LD2410Component : public Component, public uart::UARTDevice {
   SUB_BUTTON(factory_reset)
   SUB_BUTTON(query)
   SUB_BUTTON(restart)
+  SUB_BUTTON(background_correction)
 #endif
 
  public:
@@ -102,6 +104,15 @@ class LD2410Component : public Component, public uart::UARTDevice {
   void set_distance_resolution(const char *state);
   void set_baud_rate(const char *state);
   void factory_reset();
+  // Duration (in seconds) the module measures the background noise floor before
+  // it rewrites every gate threshold; see start_background_correction().
+  void set_background_correction_duration(uint16_t seconds) { this->bg_correction_duration_ = seconds; }
+  // Kick off the module's native automatic background-noise correction (command
+  // 0x000B). The module measures the noise floor for the configured duration and
+  // rewrites its gate thresholds. Progress is polled via command 0x001B so the
+  // optional calibration binary sensor reflects the module's real state rather
+  // than a fixed timer. No-op if a correction is already running.
+  void start_background_correction();
 
  protected:
   void send_command_(uint8_t command_str, const uint8_t *command_value, uint8_t command_value_len);
@@ -115,6 +126,9 @@ class LD2410Component : public Component, public uart::UARTDevice {
   void get_distance_resolution_();
   void query_light_control_();
   void restart_();
+  void query_background_correction_();
+  void finish_background_correction_(bool completed);
+  void set_background_correction_running_(bool running);
 
   uint8_t light_function_ = 0;
   uint8_t light_threshold_ = 0;
@@ -124,6 +138,8 @@ class LD2410Component : public Component, public uart::UARTDevice {
   uint8_t mac_address_[6] = {0, 0, 0, 0, 0, 0};
   uint8_t version_[6] = {0, 0, 0, 0, 0, 0};
   bool bluetooth_on_{false};
+  uint16_t bg_correction_duration_{10};  // seconds; HiLink's tool default
+  bool bg_correction_running_{false};
 #ifdef USE_NUMBER
   std::array<number::Number *, TOTAL_GATES> gate_move_threshold_numbers_{};
   std::array<number::Number *, TOTAL_GATES> gate_still_threshold_numbers_{};

--- a/esphome/components/ld2410/ld2410.h
+++ b/esphome/components/ld2410/ld2410.h
@@ -140,6 +140,8 @@ class LD2410Component : public Component, public uart::UARTDevice {
   bool bluetooth_on_{false};
   uint16_t bg_correction_duration_{10};  // seconds; HiLink's tool default
   bool bg_correction_running_{false};
+  uint32_t bg_correction_next_poll_{0};  // millis() of next 0x1B poll while running
+  uint32_t bg_correction_deadline_{0};   // millis() after which we stop waiting
 #ifdef USE_NUMBER
   std::array<number::Number *, TOTAL_GATES> gate_move_threshold_numbers_{};
   std::array<number::Number *, TOTAL_GATES> gate_still_threshold_numbers_{};

--- a/tests/components/ld2410/common.yaml
+++ b/tests/components/ld2410/common.yaml
@@ -1,5 +1,6 @@
 ld2410:
   id: my_ld2410
+  background_correction_duration: 60s
 
 binary_sensor:
   - platform: ld2410
@@ -12,6 +13,8 @@ binary_sensor:
       name: still
     out_pin_presence_status:
       name: out pin presence status
+    calibration:
+      name: calibration running
 
 button:
   - platform: ld2410
@@ -22,6 +25,8 @@ button:
       name: restart
     query_params:
       name: query params
+    background_correction:
+      name: calibrate radar
 
 number:
   - platform: ld2410


### PR DESCRIPTION
# What does this implement/fix?

Exposes the LD2410's native **automatic background-noise correction** routine (available on firmware ≥ V2.44, common to LD2410/LD2410B/LD2410C — command `0x000B` to start, `0x001B` to query progress). This lets users self-calibrate gate thresholds against the current environment without HiLink's PC tool.

Adds three new optional entities/options:

- **`background_correction` button** — triggers the routine. The module measures the noise floor for a configurable window (people must be absent; other clutter such as fans/HVAC should be left in place) and rewrites all gate thresholds.
- **`calibration` binary sensor** (`device_class: running`) — reflects the module's *real* running state. Progress is polled via command `0x001B` once per second rather than trusting a fixed timer, so the indicator clears when the module actually reports completion (status `2`).
- **`background_correction_duration` option** on the main `ld2410:` component (10 s–120 s, default 10 s — matching HiLink's tool). Sent as the duration parameter of the `0x000B` command.

On completion the component re-queries the gate parameters (`query_parameters_()`) so any exposed `number` entities reflect the freshly written thresholds. A safety timeout clears the running indicator if a firmware predating the `0x001B` query never reports completion, so the sensor can never latch on permanently.

The start/query command framing, the duration parameter on `0x000B`, the config-mode toggle around each command, and the `0/1/2 = idle/in-progress/completed` status byte were verified against the [MyLD2410](https://github.com/iavorvel/MyLD2410) reference implementation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- relates to https://github.com/esphome/feature-requests/issues/3161

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6820

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
ld2410:
  id: my_ld2410
  background_correction_duration: 10s   # 10s-120s, default 10s

binary_sensor:
  - platform: ld2410
    calibration:
      name: Calibration running

button:
  - platform: ld2410
    background_correction:
      name: Calibrate radar
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io): esphome/esphome.io#6820

