### PR TITLE
[socket] bugfix Set wake-request gate flag on LwIP socket receive event

### DIFF
--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -157,6 +157,8 @@ _Static_assert(offsetof(struct lwip_sock, rcvevent) == ESPHOME_LWIP_SOCK_RCVEVEN
 // Saved original event_callback pointer — written once in first hook_socket(), read from TCP/IP task.
 static netconn_callback s_original_callback = NULL;
 
+extern void esphome_wake_loop_any_context(void);
+
 #ifdef USE_OTA_PLATFORM_ESPHOME
 static struct netconn *s_ota_listener_conn = NULL;
 extern void esphome_wake_ota_component_any_context(void);
@@ -189,10 +191,7 @@ static void esphome_socket_event_callback(struct netconn *conn, enum netconn_evt
       esphome_wake_ota_component_any_context();
     }
 #endif
-    TaskHandle_t task = esphome_main_task_handle;
-    if (task != NULL) {
-      xTaskNotifyGive(task);
-    }
+    esphome_wake_loop_any_context();
   }
 }
 

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -157,7 +157,7 @@ _Static_assert(offsetof(struct lwip_sock, rcvevent) == ESPHOME_LWIP_SOCK_RCVEVEN
 // Saved original event_callback pointer — written once in first hook_socket(), read from TCP/IP task.
 static netconn_callback s_original_callback = NULL;
 
-extern void esphome_wake_loop_any_context(void);
+extern void esphome_wake_loop_threadsafe(void);
 
 #ifdef USE_OTA_PLATFORM_ESPHOME
 static struct netconn *s_ota_listener_conn = NULL;
@@ -191,7 +191,7 @@ static void esphome_socket_event_callback(struct netconn *conn, enum netconn_evt
       esphome_wake_ota_component_any_context();
     }
 #endif
-    esphome_wake_loop_any_context();
+    esphome_wake_loop_threadsafe();
   }
 }
 

--- a/esphome/core/wake/wake_freertos.cpp
+++ b/esphome/core/wake/wake_freertos.cpp
@@ -30,7 +30,7 @@ void IRAM_ATTR wake_loop_any_context() { wake_main_task_any_context(); }
 
 }  // namespace esphome
 
-extern "C" void IRAM_ATTR esphome_wake_loop_any_context() {
+extern "C" void IRAM_ATTR esphome_wake_loop_threadsafe() {
   esphome::wake_request_set();
   esphome_main_task_notify();
 }

--- a/esphome/core/wake/wake_freertos.cpp
+++ b/esphome/core/wake/wake_freertos.cpp
@@ -30,4 +30,9 @@ void IRAM_ATTR wake_loop_any_context() { wake_main_task_any_context(); }
 
 }  // namespace esphome
 
+extern "C" void IRAM_ATTR esphome_wake_loop_any_context() {
+  esphome::wake_request_set();
+  esphome_main_task_notify();
+}
+
 #endif  // USE_ESP32 || USE_LIBRETINY

--- a/esphome/core/wake/wake_freertos.cpp
+++ b/esphome/core/wake/wake_freertos.cpp
@@ -30,7 +30,7 @@ void IRAM_ATTR wake_loop_any_context() { wake_main_task_any_context(); }
 
 }  // namespace esphome
 
-extern "C" void IRAM_ATTR esphome_wake_loop_threadsafe() {
+extern "C" void esphome_wake_loop_threadsafe() {
   esphome::wake_request_set();
   esphome_main_task_notify();
 }

--- a/esphome/core/wake/wake_host.cpp
+++ b/esphome/core/wake/wake_host.cpp
@@ -123,6 +123,14 @@ void wakeable_delay(uint32_t ms) {
       if (ms == 0) [[unlikely]] {
         yield();
       }
+      // A socket woke select() early — open the component-phase gate so the
+      // owning component's loop() drains the data on this tick rather than
+      // waiting up to loop_interval_ ms. Idempotent if wake_loop_threadsafe()
+      // already set the flag (wake socket fired); required when an application
+      // socket fired and nothing else set the flag.
+      if (ret > 0) {
+        wake_request_set();
+      }
       return;
     }
     // ret < 0: error (EINTR is normal, anything else is unexpected).

--- a/tests/integration/fixtures/socket_wake_gate_tcp.yaml
+++ b/tests/integration/fixtures/socket_wake_gate_tcp.yaml
@@ -1,0 +1,27 @@
+esphome:
+  name: socket-wake-gate-tcp
+  on_boot:
+    priority: -100
+    then:
+      - lambda: |-
+          // Raise loop_interval_ to 2000ms. Without wake_request_set() being
+          // called when select() returns due to socket data, the component
+          // phase would be gated for up to 2000ms after a TCP request arrives.
+          App.set_loop_interval(2000);
+      # Let boot transients and API handshake settle.
+      - delay: 500ms
+      - lambda: |-
+          ESP_LOGI("test", "BOOT_DONE");
+
+host:
+
+api:
+  actions:
+    - action: ping
+      then:
+        - logger.log:
+            format: "PONG"
+            level: INFO
+
+logger:
+  level: INFO

--- a/tests/integration/test_socket_wake_gate_tcp.py
+++ b/tests/integration/test_socket_wake_gate_tcp.py
@@ -1,0 +1,75 @@
+"""Test that a TCP socket receive opens the component-phase gate immediately.
+
+Regression test for the wake-request flag not being set when select() returns
+due to socket data on the host platform (wake_host.cpp wakeable_delay fix).
+
+The API server's accepted connection sockets use accept_loop_monitored(), so
+they are registered with the host select() loop. A service call from the Python
+client arrives on that socket. Without the fix, select() returning early did not
+set g_wake_requested, so Application::loop()'s Phase B gate stayed closed until
+loop_interval_ expired. With the fix, the gate opens immediately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_socket_wake_gate_tcp(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """TCP socket receive must open the component-phase gate immediately,
+    even with loop_interval_ raised to 2000ms."""
+    loop = asyncio.get_running_loop()
+    boot_done: asyncio.Future[None] = loop.create_future()
+    pong: asyncio.Future[None] = loop.create_future()
+
+    def on_log_line(line: str) -> None:
+        if "BOOT_DONE" in line and not boot_done.done():
+            boot_done.set_result(None)
+        if "PONG" in line and not pong.done():
+            pong.set_result(None)
+
+    async with (
+        run_compiled(yaml_config, line_callback=on_log_line),
+        api_client_connected() as client,
+    ):
+        device_info = await client.device_info()
+        assert device_info is not None
+        assert device_info.name == "socket-wake-gate-tcp"
+
+        try:
+            await asyncio.wait_for(boot_done, timeout=15.0)
+        except TimeoutError:
+            pytest.fail("BOOT_DONE never appeared — device did not complete boot")
+
+        _, services = await client.list_entities_services()
+        ping_service = next((s for s in services if s.name == "ping"), None)
+        assert ping_service is not None, "ping service not found"
+
+        # Execute the service and time how long until PONG appears in logs.
+        # The request bytes arrive on an accept_loop_monitored() TCP socket,
+        # which is registered with the host select() loop.
+        t_send = time.monotonic()
+        await client.execute_service(ping_service, {})
+
+        try:
+            await asyncio.wait_for(pong, timeout=5.0)
+        except TimeoutError:
+            pytest.fail("PONG never appeared — service did not execute")
+
+        elapsed_ms = (time.monotonic() - t_send) * 1000
+        # Without the fix the gate stays closed for up to loop_interval_=2000ms.
+        # With the fix the gate opens on the next tick; 500ms gives ample CI headroom.
+        assert elapsed_ms < 500, (
+            f"Service response took {elapsed_ms:.0f}ms with loop_interval_=2000ms — "
+            f"expected < 500ms; without the wake-request fix this would take up to 2000ms"
+        )


### PR DESCRIPTION
# What does this implement/fix?

## ESP32 / LibreTiny (lwip_fast_select.c)

`esphome_socket_event_callback` in `lwip_fast_select.c` called `xTaskNotifyGive` directly on `NETCONN_EVT_RCVPLUS`, which wakes the main loop task from `ulTaskNotifyTake` but does not set `g_wake_requested`. The `Application::loop()` gate check (`wake_request_take() || is_high_frequency() || interval_elapsed`) therefore saw the flag as false, and when `loop_interval_` is raised above the default (e.g. via `App.set_loop_interval()` in a lambda), `do_component_phase` was skipped until the interval expired — leaving incoming socket data unprocessed for up to `loop_interval_` milliseconds.

Fix: add `esphome_wake_loop_thread_safe()`, a C-callable `extern "C"` wrapper in `wake_freertos.cpp` that calls `wake_request_set()` (always_inline) then `esphome_main_task_notify()` (always_inline), preserving the same call-frame depth as the original direct `xTaskNotifyGive`. Replace the manual task-notify block in the callback with this single call.

## Host platform (wake_host.cpp)

The same gate bug existed on the host platform: when `select()` in `wakeable_delay()` returned early because a registered socket had data ready, `wake_request_set()` was not called. The fix adds `wake_request_set()` in the `ret > 0` branch — idempotent when `wake_loop_threadsafe()` already set the flag (wake socket fired), required when an application socket fired and nothing else set the flag.

## Components affected

Any component whose socket is registered via `socket_loop_monitored()` / `accept_loop_monitored()` benefits. At the default 16 ms `loop_interval_` the latency impact was imperceptible; with a raised interval it was clearly broken. Affected components:

| Component | Transport |
|-----------|-----------|
| Native API server | TCP (listen + accepted connections) |
| OTA (esphome) | TCP (listen + accepted connection) |
| MQTT | TCP via `async_tcp` |
| Web server | TCP via `async_tcp` / `web_server_base` |
| Captive portal DNS | UDP (ESP32-IDF only) |

Every other background wake source (ESP-NOW, BLE, USB, lwip_raw_tcp) already calls `wake_loop_any_context()` or `wake_loop_threadsafe()`, which sets the flag. BSD sockets going through `esphome_socket_event_callback` were the only exception.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

## Test Environment

- [x] ESP32 IDF (hardware — native API + CoAP/UDP under raised loop_interval_)
- [x] Host (integration test — TCP service call under 2000 ms loop_interval_)

## Example entry for `config.yaml`:

```yaml
esphome:
  name: my-device
  on_boot:
    priority: -100
    then:
      - lambda: App.set_loop_interval(500);  # raised interval — sockets now processed promptly on data arrival
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).