### PR TITLE
[esp32] Remove framework migration notice

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1535,65 +1535,12 @@ FRAMEWORK_SCHEMA = cv.Schema(
 )
 
 
-# Remove this class in 2026.7.0
-class _FrameworkMigrationWarning:
-    shown = False
-
-
-def _show_framework_migration_message(name: str, variant: str) -> None:
-    """Show a message about the framework default change and how to switch back to Arduino."""
-    # Remove this function in 2026.7.0
-    if _FrameworkMigrationWarning.shown:
-        return
-    _FrameworkMigrationWarning.shown = True
-
-    from esphome.log import AnsiFore, color
-
-    message = (
-        color(
-            AnsiFore.BOLD_CYAN,
-            f"💡 NOTICE: {name} does not have a framework specified.",
-        )
-        + "\n\n"
-        + f"Starting with ESPHome 2026.1.0, the default framework for {variant} is ESP-IDF.\n"
-        + "(We've been warning about this change since ESPHome 2025.8.0)\n"
-        + "\n"
-        + "Why we made this change:\n"
-        + color(AnsiFore.GREEN, "  ✨ Smaller firmware binaries\n")
-        + color(AnsiFore.GREEN, "  ⚡ Faster compile times\n")
-        + color(AnsiFore.GREEN, "  🚀 Better performance and newer features\n")
-        + color(AnsiFore.GREEN, "  🔧 More actively maintained by ESPHome\n")
-        + "\n"
-        + "To continue using Arduino, add this to your YAML under 'esp32:':\n"
-        + color(AnsiFore.WHITE, "    framework:\n")
-        + color(AnsiFore.WHITE, "      type: arduino\n")
-        + "\n"
-        + "To silence this message with ESP-IDF, explicitly set:\n"
-        + color(AnsiFore.WHITE, "    framework:\n")
-        + color(AnsiFore.WHITE, "      type: esp-idf\n")
-        + "\n"
-        + "Migration guide: "
-        + color(
-            AnsiFore.BLUE,
-            "https://esphome.io/guides/esp32_arduino_to_idf/",
-        )
-    )
-    _LOGGER.warning(message)
-
-
 def _set_default_framework(config):
     config = config.copy()
     if CONF_FRAMEWORK not in config:
         config[CONF_FRAMEWORK] = FRAMEWORK_SCHEMA({})
     if CONF_TYPE not in config[CONF_FRAMEWORK]:
-        variant = config[CONF_VARIANT]
         config[CONF_FRAMEWORK][CONF_TYPE] = FRAMEWORK_ESP_IDF
-        # Show migration message for variants that previously defaulted to Arduino
-        # Remove this message in 2026.7.0
-        if variant in ARDUINO_ALLOWED_VARIANTS:
-            _show_framework_migration_message(
-                config.get(CONF_NAME, "This device"), variant
-            )
 
     return config
 


### PR DESCRIPTION
# What does this implement/fix?

Removes the transitional notice shown when an `esp32:` config doesn't specify a framework `type:`.

The default ESP32 framework changed to ESP-IDF in ESPHome 2026.1.0, and since then a one-time `💡 NOTICE: <device> does not have a framework specified` message has been logged (for variants that previously defaulted to Arduino) to point users at the migration guide. The code was explicitly tagged "Remove this in 2026.7.0" in three places — that release is the next one, so this drops it on schedule.

Changes (all in `esphome/components/esp32/__init__.py`):
- Remove the `_FrameworkMigrationWarning` class
- Remove the `_show_framework_migration_message()` helper
- Drop its call in `_set_default_framework()`, which now just defaults the framework type to ESP-IDF silently

Configs with no framework specified still validate and default to `type: esp-idf` — only the log notice is gone.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No NOTICE is logged for this config anymore; framework defaults to esp-idf
esphome:
  name: test-device
esp32:
  board: esp32dev
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).