### PR TITLE
[ci] Fail CI Status job when workflow is cancelled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1369,4 +1369,7 @@ jobs:
           # 1. The target branch has a build issue independent of this PR
           # 2. This PR fixes a build issue on the target branch
           # In either case, we only care that the PR branch builds successfully.
-          echo "$NEEDS_JSON" | jq -e 'del(.["memory-impact-target-branch"]) | all(.result != "failure")'
+          # Every other job must have succeeded or been skipped; a "cancelled" or
+          # "failure" result fails this check so CI is not reported green when the
+          # workflow was cancelled.
+          echo "$NEEDS_JSON" | jq -e 'del(.["memory-impact-target-branch"]) | all(.result == "success" or .result == "skipped")'


### PR DESCRIPTION
# What does this implement/fix?

The final `CI Status` job is the required status gate for the CI workflow. Its check was `all(.result != "failure")`, which only catches jobs that actually *failed*. GitHub job results can also be `cancelled` or `skipped`, and a cancelled job has `result == "cancelled"` — which passes the `!= "failure"` test. As a result, when the whole workflow is cancelled, every job reports `cancelled`, the check passes, and the gate goes green even though CI never actually completed.

This changes the check to require every non-exempt job to be `success` or `skipped`, so a `cancelled` (or `failure`) result now fails the gate. The existing `memory-impact-target-branch` exemption (allowed to fail without blocking CI) is unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).