### PR TITLE
[core] Honor transferred address cache in has_resolvable_address

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -505,7 +505,7 @@ def has_resolvable_address() -> bool:
         return True
 
     # The dashboard pre-resolves the device and passes the IPs via
-    # --mdns/--dns-address-cache; honor a cached address even when the
+    # --mdns-address-cache/--dns-address-cache; honor a cached address even when the
     # device has mDNS disabled (e.g. a .local host found via ping).
     if CORE.address_cache and CORE.address_cache.get_addresses(CORE.address):
         return True

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -504,6 +504,12 @@ def has_resolvable_address() -> bool:
     if has_ip_address():
         return True
 
+    # The dashboard pre-resolves the device and passes the IPs via
+    # --mdns/--dns-address-cache; honor a cached address even when the
+    # device has mDNS disabled (e.g. a .local host found via ping).
+    if CORE.address_cache and CORE.address_cache.get_addresses(CORE.address):
+        return True
+
     if has_mdns():
         return True
 

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -689,6 +689,25 @@ def test_choose_upload_log_host_with_ota_device_with_ota_config() -> None:
     assert result == ["192.168.1.100"]
 
 
+def test_choose_upload_log_host_ota_mdns_disabled_uses_address_cache() -> None:
+    """A .local device with mDNS disabled resolves via the dashboard-supplied cache."""
+    setup_core(
+        config={
+            CONF_API: {},
+            CONF_OTA: [{CONF_PLATFORM: CONF_ESPHOME}],
+            CONF_MDNS: {CONF_DISABLED: True},
+        },
+        address="esp32-a1s.local",
+    )
+    CORE.address_cache = AddressCache(mdns_cache={"esp32-a1s.local": ["192.168.1.50"]})
+
+    for purpose in (Purpose.LOGGING, Purpose.UPLOADING):
+        result = choose_upload_log_host(
+            default="OTA", check_default=None, purpose=purpose
+        )
+        assert result == ["192.168.1.50"]
+
+
 def test_choose_upload_log_host_with_ota_device_with_api_config() -> None:
     """Test OTA device when API is configured (no upload without OTA in config)."""
     setup_core(config={CONF_API: {}}, address="192.168.1.100")
@@ -3133,6 +3152,22 @@ def test_has_resolvable_address() -> None:
 
     # Test with no address and mDNS disabled
     setup_core(config={CONF_MDNS: {CONF_DISABLED: True}}, address=None)
+    assert has_resolvable_address() is False
+
+    # mDNS disabled + .local, but the dashboard cached the address -> resolvable
+    setup_core(
+        config={CONF_MDNS: {CONF_DISABLED: True}}, address="esphome-device.local"
+    )
+    CORE.address_cache = AddressCache(
+        mdns_cache={"esphome-device.local": ["192.168.1.100"]}
+    )
+    assert has_resolvable_address() is True
+
+    # mDNS disabled + .local, cache present but missing this host -> not resolvable
+    setup_core(
+        config={CONF_MDNS: {CONF_DISABLED: True}}, address="esphome-device.local"
+    )
+    CORE.address_cache = AddressCache(mdns_cache={"other-device.local": ["10.0.0.1"]})
     assert has_resolvable_address() is False
 
 


### PR DESCRIPTION
# What does this implement/fix?

`esphome` raised `All specified devices ['OTA'] could not be resolved` for a device that has `api` plus `ota` but mDNS disabled and no `use_address`, so `CORE.address` falls back to `<name>.local`. The dashboard had already discovered the device IP via ping and passed it on the CLI as `--mdns-address-cache <name>.local=<ip>`, yet the upload still failed.

The cause is `has_resolvable_address()`; it checked `has_ip_address()`, `has_mdns()`, and the `.local` suffix, but never consulted `CORE.address_cache`. For a `.local` host with mDNS disabled it returned `False`, so the address was dropped before `_resolve_with_cache` (which would have used the cache) ever ran.

This adds a cache check right after the `has_ip_address()` early return; if the dashboard supplied an address for the host, the address is treated as resolvable. No transport gate is touched, so existing behavior is preserved (api-only upload still raises, no-address still raises).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1542

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
