### PR TITLE
[select] Remove deprecated state member

### DIFF
--- a/esphome/components/select/select.cpp
+++ b/esphome/components/select/select.cpp
@@ -27,10 +27,6 @@ void Select::publish_state(size_t index) {
   const char *option = this->option_at(index);
   this->set_has_state(true);
   this->active_index_ = index;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  this->state = option;  // Update deprecated member for backward compatibility
-#pragma GCC diagnostic pop
   ESP_LOGV(TAG, "'%s' >> %s (%zu)", this->get_name().c_str(), option, index);
   this->state_callback_.call(index);
 #if defined(USE_SELECT) && defined(USE_CONTROLLER_REGISTRY)

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -30,15 +30,8 @@ class Select : public EntityBase {
  public:
   SelectTraits traits;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  /// @deprecated Use current_option() instead. This member will be removed in ESPHome 2026.7.0.
-  ESPDEPRECATED("Use current_option() instead of .state. Will be removed in 2026.7.0", "2026.1.0")
-  std::string state{};
-
   Select() = default;
   ~Select() = default;
-#pragma GCC diagnostic pop
 
   void publish_state(const std::string &state);
   void publish_state(const char *state);

--- a/tests/integration/fixtures/multi_device_preferences.yaml
+++ b/tests/integration/fixtures/multi_device_preferences.yaml
@@ -109,7 +109,7 @@ select:
     set_action:
       - lambda: |-
           ESP_LOGI("test", "Device A Mode set to %s", x.c_str());
-          id(mode_device_a).state = x;
+          id(mode_device_a).publish_state(x);
 
   - platform: template
     name: Mode
@@ -124,7 +124,7 @@ select:
     set_action:
       - lambda: |-
           ESP_LOGI("test", "Device B Mode set to %s", x.c_str());
-          id(mode_device_b).state = x;
+          id(mode_device_b).publish_state(x);
 
   - platform: template
     name: Mode
@@ -138,7 +138,7 @@ select:
     set_action:
       - lambda: |-
           ESP_LOGI("test", "Main Mode set to %s", x.c_str());
-          id(mode_main).state = x;
+          id(mode_main).publish_state(x);
 
 # Button to trigger preference logging test
 button:
@@ -153,9 +153,9 @@ button:
           ESP_LOGI("test", "Device A Setpoint: %.1f", id(setpoint_device_a).state);
           ESP_LOGI("test", "Device B Setpoint: %.1f", id(setpoint_device_b).state);
           ESP_LOGI("test", "Main Setpoint: %.1f", id(setpoint_main).state);
-          ESP_LOGI("test", "Device A Mode: %s", id(mode_device_a).state.c_str());
-          ESP_LOGI("test", "Device B Mode: %s", id(mode_device_b).state.c_str());
-          ESP_LOGI("test", "Main Mode: %s", id(mode_main).state.c_str());
+          ESP_LOGI("test", "Device A Mode: %s", id(mode_device_a).current_option().c_str());
+          ESP_LOGI("test", "Device B Mode: %s", id(mode_device_b).current_option().c_str());
+          ESP_LOGI("test", "Main Mode: %s", id(mode_main).current_option().c_str());
           // Log preference hashes for entities that actually store preferences
           ESP_LOGI("test", "Device A Switch Pref Hash: %u", id(light_device_a).get_preference_hash());
           ESP_LOGI("test", "Device B Switch Pref Hash: %u", id(light_device_b).get_preference_hash());


### PR DESCRIPTION
# What does this implement/fix?

Completes the removal of the deprecated `state` member from the `select` base class, originally deprecated in #11623. It was kept only as a backward compatible mirror of `current_option()` and was marked for removal in 2026.7.0, which has now arrived. Nothing in the codebase still reads it; every consumer already uses `current_option()` or `active_index()`, so the sync write in `publish_state` is dropped as well. The multi device preferences integration fixture is migrated to `publish_state(x)` and `current_option()`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- completes the deprecation from #11623

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
