### PR TITLE
[ci] Smoke-test Arduino framework in esp32 PlatformIO job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -981,6 +981,17 @@ jobs:
           # Run compilation (auto-grouped by test_build_components.py)
           python3 script/test_build_components.py -e compile -t esp32-idf -c "$TEST_COMPONENTS" -f --toolchain platformio
 
+          echo ""
+          echo "ESP-IDF-via-PlatformIO build passed! Starting Arduino smoke test..."
+          echo ""
+
+          # Smoke-test the Arduino framework path (Arduino on esp32 only ever
+          # builds through PlatformIO). Reuses $TEST_COMPONENTS; only the
+          # components with an esp32-ard test (currently heatpumpir, esp32_ble)
+          # are built -- the rest are filtered out as they have no arduino test.
+          python3 script/test_build_components.py -e config -t esp32-ard -c "$TEST_COMPONENTS" -f --toolchain platformio
+          python3 script/test_build_components.py -e compile -t esp32-ard -c "$TEST_COMPONENTS" -f --toolchain platformio
+
   pre-commit-ci-lite:
     name: pre-commit.ci lite
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -971,22 +971,15 @@ jobs:
           echo "Testing components: $TEST_COMPONENTS"
           echo ""
 
-          # Run config validation (auto-grouped by test_build_components.py)
-          python3 script/test_build_components.py -e config -t esp32-idf -c "$TEST_COMPONENTS" -f --toolchain platformio
-
-          echo ""
-          echo "Config validation passed! Starting compilation..."
-          echo ""
-
-          # Run compilation (auto-grouped by test_build_components.py)
+          # compile validates config first, so a separate config pass is
+          # redundant for this smoke test. ESP-IDF framework via PlatformIO:
           python3 script/test_build_components.py -e compile -t esp32-idf -c "$TEST_COMPONENTS" -f --toolchain platformio
 
           echo ""
           echo "ESP-IDF-via-PlatformIO build passed! Starting Arduino smoke test..."
           echo ""
 
-          # Smoke-test the Arduino framework path (only components with an esp32-ard test are built).
-          python3 script/test_build_components.py -e config -t esp32-ard -c "$TEST_COMPONENTS" -f --toolchain platformio
+          # Arduino framework via PlatformIO (only components with an esp32-ard test are built):
           python3 script/test_build_components.py -e compile -t esp32-ard -c "$TEST_COMPONENTS" -f --toolchain platformio
 
   pre-commit-ci-lite:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -985,10 +985,7 @@ jobs:
           echo "ESP-IDF-via-PlatformIO build passed! Starting Arduino smoke test..."
           echo ""
 
-          # Smoke-test the Arduino framework path (Arduino on esp32 only ever
-          # builds through PlatformIO). Reuses $TEST_COMPONENTS; only the
-          # components with an esp32-ard test (currently heatpumpir, esp32_ble)
-          # are built -- the rest are filtered out as they have no arduino test.
+          # Smoke-test the Arduino framework path (only components with an esp32-ard test are built).
           python3 script/test_build_components.py -e config -t esp32-ard -c "$TEST_COMPONENTS" -f --toolchain platformio
           python3 script/test_build_components.py -e compile -t esp32-ard -c "$TEST_COMPONENTS" -f --toolchain platformio
 


### PR DESCRIPTION
# What does this implement/fix?

Adds an Arduino-framework smoke test to the `test-esp32-platformio` CI job.

After the esp32 default toolchain flipped to native ESP-IDF (#16910) and the CI follow-up landed (#16383), the `test-esp32-platformio` job was the dedicated guard for the now-non-default PlatformIO path — but it only built `-t esp32-idf --toolchain platformio` (ESP-IDF framework through PlatformIO).

On esp32 the **Arduino framework only ever builds through PlatformIO**, and it's a genuinely different build (`framework = arduino`, different platform package, different libdeps) — an idf-via-PlatformIO build passing tells you nothing about whether arduino-via-PlatformIO still compiles. That path is otherwise only exercised by the regular component matrix when a component with an `esp32-ard` test changes, so an infra-only PlatformIO change (e.g. `platformio.ini`, `esphome/build_gen/platformio.py`, `esphome/platformio/*`) could break Arduino builds with nothing to catch it.

This adds an `-t esp32-ard --toolchain platformio` config + compile pass to the same job, reusing the existing `$TEST_COMPONENTS` env. The `esp32-ard` platform filter naturally narrows the representative set to the components that have an Arduino test — currently `heatpumpir` and `esp32_ble` (one grouped build) — which is enough for a smoke test. No `determine-jobs.py` changes are needed; triggers and the component list are unchanged.

`--toolchain platformio` is required (not cosmetic): the default toolchain is now esp-idf, and Arduino has no native path, so the flag pins the correct backend.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).