### PR TITLE
[uptime] Revert timestamp sensor device_class to timestamp

### DIFF
--- a/esphome/components/uptime/sensor/__init__.py
+++ b/esphome/components/uptime/sensor/__init__.py
@@ -4,7 +4,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_TIME_ID,
     DEVICE_CLASS_DURATION,
-    DEVICE_CLASS_UPTIME,
+    DEVICE_CLASS_TIMESTAMP,
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_TIMER,
     STATE_CLASS_TOTAL_INCREASING,
@@ -33,8 +33,9 @@ CONFIG_SCHEMA = cv.typed_schema(
         ).extend(cv.polling_component_schema("60s")),
         "timestamp": sensor.sensor_schema(
             UptimeTimestampSensor,
+            icon=ICON_TIMER,
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_UPTIME,
+            device_class=DEVICE_CLASS_TIMESTAMP,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         )
         .extend(


### PR DESCRIPTION
# What does this implement/fix?

#16434 changed the `type: timestamp` uptime sensor's `device_class` from `timestamp` to `uptime`. The device publishes its boot time as a numeric float epoch over the API, and Home Assistant's ESPHome integration only converts that float to a `datetime` when `device_class == timestamp`. The `uptime` device class also requires a `datetime` value, so HA receives a raw float and rejects it — the entity becomes **unavailable** (#17031).

This reverts the `timestamp` variant back to `device_class: timestamp` (and restores its `icon`) so the value is converted again. The `seconds` variant (`duration`) is unaffected.

Note: `uptime` is arguably the more correct semantic class for a boot-time sensor, but it can only be used once HA's ESPHome integration converts the epoch for it too (proposed separately in home-assistant/core). Until then, `timestamp` is the class that works on all HA versions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17031

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
time:
  - platform: homeassistant
    id: esptime

sensor:
  - platform: uptime
    name: "Uptime"
    type: timestamp
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).