### PR TITLE
[build] Skip target-platform deps when populating host unit-test config

### DIFF
--- a/script/build_helpers.py
+++ b/script/build_helpers.py
@@ -70,12 +70,15 @@ def populate_dependency_config(
 
     * ``domain.platform`` form (e.g. ``sensor.gpio``) appends
       ``{platform: <name>}`` to ``config[domain]``, creating the list if needed.
-    * Bare components are looked up via ``get_component_fn``. Platform
-      components (``IS_PLATFORM_COMPONENT``) and ``MULTI_CONF`` components are
-      initialised as ``[]`` so the sibling ``domain.platform`` branch can
-      ``append`` into them. Everything else is populated by running the
-      component's schema with ``{}`` so defaults exist; if the schema requires
-      explicit input, an empty ``{}`` is used as a fallback.
+    * Bare components are looked up via ``get_component_fn``. Target-platform
+      components (``is_target_platform``, e.g. ``esp32``) are skipped entirely:
+      a host build targets ``host``, so a foreign target platform's sources are
+      guarded out and its schema must not run here (it would mutate global CORE
+      state as a side effect). Platform components (``IS_PLATFORM_COMPONENT``)
+      and ``MULTI_CONF`` components are initialised as ``[]`` so the sibling
+      ``domain.platform`` branch can ``append`` into them. Everything else is
+      populated by running the component's schema with ``{}`` so defaults exist;
+      if the schema requires explicit input, an empty ``{}`` is used as a fallback.
 
     Platform components must always be a list here even when no
     ``domain.platform`` entry follows, because the ``domain.platform`` branch
@@ -95,6 +98,12 @@ def populate_dependency_config(
         # system, not a real loadable component (get_component returns None)
         component = get_component_fn(component_name)
         if component is None:
+            continue
+        # Skip target platforms (e.g. esp32): a host build targets `host`, so a
+        # foreign target's sources are guarded out, and running its schema with
+        # {} leaks global CORE state (esp32 pins CORE.toolchain to ESP-IDF),
+        # crashing the host compile. See #17035.
+        if component.is_target_platform:
             continue
         if component.multi_conf or component.is_platform_component:
             config.setdefault(component_name, [])

--- a/tests/script/test_build_helpers.py
+++ b/tests/script/test_build_helpers.py
@@ -1,0 +1,76 @@
+"""Unit tests for script/build_helpers.py."""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+# Add the script directory to the path so we can import build_helpers.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "script"))
+
+import build_helpers  # noqa: E402
+
+from esphome.core import CORE  # noqa: E402
+
+
+class _FakeComponent:
+    def __init__(self, config_schema, *, is_target_platform=False):
+        self.multi_conf = False
+        self.is_platform_component = False
+        self.is_target_platform = is_target_platform
+        self.config_schema = config_schema
+
+
+@pytest.fixture(autouse=True)
+def _restore_core_toolchain():
+    """Keep CORE.toolchain changes from leaking between tests."""
+    saved = CORE.toolchain
+    try:
+        yield
+    finally:
+        CORE.toolchain = saved
+
+
+def test_populate_dependency_config_skips_target_platforms() -> None:
+    """Target-platform deps must be skipped, not config-populated, in a host build.
+
+    Regression test for #17035: esp32 (a target platform) appears only as a
+    transitive dependency of a host C++ unit test. Running its schema with {}
+    set ``CORE.toolchain = ESP_IDF`` as a side effect before failing validation,
+    which crashed the host compile with KeyError('esp32'). The fix skips
+    target-platform components entirely so their schema never runs.
+    """
+    CORE.toolchain = None  # the state a host build starts from
+    schema_calls = []
+
+    def leaky_schema(value):
+        # If this ever runs for a target platform, the bug is back.
+        schema_calls.append(value)
+        CORE.toolchain = "esp-idf-leak"
+        raise ValueError("no board or variant")
+
+    config: dict = {}
+    build_helpers.populate_dependency_config(
+        config,
+        ["esp32"],
+        get_component_fn=lambda name: _FakeComponent(
+            leaky_schema, is_target_platform=True
+        ),
+        register_platform_fn=lambda domain: None,
+    )
+
+    assert "esp32" not in config  # skipped: no synthesized entry
+    assert schema_calls == []  # schema never run
+    assert CORE.toolchain is None  # no global side effect leaked
+
+
+def test_populate_dependency_config_populates_defaults() -> None:
+    """A non-target-platform dep still has its schema defaults harvested."""
+    config: dict = {}
+    build_helpers.populate_dependency_config(
+        config,
+        ["ok"],
+        get_component_fn=lambda name: _FakeComponent(lambda value: {"default": 1}),
+        register_platform_fn=lambda domain: None,
+    )
+    assert config["ok"] == {"default": 1}

--- a/tests/script/test_test_helpers.py
+++ b/tests/script/test_test_helpers.py
@@ -266,11 +266,13 @@ def _make_component_stub(
     *,
     multi_conf: bool = False,
     is_platform_component: bool = False,
+    is_target_platform: bool = False,
     config_schema=None,
 ) -> MagicMock:
     stub = MagicMock()
     stub.multi_conf = multi_conf
     stub.is_platform_component = is_platform_component
+    stub.is_target_platform = is_target_platform
     stub.config_schema = config_schema
     return stub
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes host C++ unit tests crashing with `KeyError('esp32')` for any component with a transitive `esp32` dependency (regression from #16910).

`populate_dependency_config()` (used only by the host C++ unit-test / benchmark harness) synthesizes config entries for a test's transitive dependencies so their sources get compiled. For a **target platform** pulled in transitively (e.g. `esp32` via `ble_client → esp32_ble_client → esp32`), it ran the component's schema with `{}` to harvest defaults. esp32's `_resolve_toolchain` sets `CORE.toolchain = ESP_IDF` as a side effect *before* validation fails on the empty config, so the host compile then took the ESP-IDF code path and hit `KeyError('esp32')` (`CORE.data['esp32']` is never initialized).

Before #16910 the leaked value was `Toolchain.PLATFORMIO`, which the host compile path doesn't special-case, so it was harmless. Flipping the default to ESP-IDF activated the latent bug.

A host build targets `host`; a foreign target platform's sources are `USE_*`-guarded out, so its synthesized config entry adds nothing. The fix skips target-platform components (`component.is_target_platform`) entirely, so their side-effecting schema never runs — also covering esp8266/rp2040/libretiny/nrf52, not just esp32.

No built-in component with a transitive `esp32` dependency has host C++ unit tests, which is why CI didn't catch this.

## Validation

Reproduced and verified against the reporter's repro (`ble_client → esp32_ble_client → esp32`):
- `dev` (no fix): `Error compiling unit tests for treadmill_f15: 'esp32'`
- with fix: all 16 C++ unit tests compile and pass

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17035

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

N/A — host build tooling; verified with `script/cpp_unit_test.py`.

## Example entry for `config.yaml`:

```yaml
# N/A — build/test tooling change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).