### PR TITLE
[esp32] Support `esphome idedata` with the native ESP-IDF toolchain

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1771,6 +1771,22 @@ def command_update_all(args: ArgsProtocol) -> int | None:
 def command_idedata(args: ArgsProtocol, config: ConfigType) -> int:
     import json
 
+    if CORE.using_toolchain_esp_idf:
+        # The native ESP-IDF toolchain has no `pio run -t idedata`; idedata is
+        # derived from the existing build's compile_commands.json, so the
+        # configuration must already be compiled (returns None otherwise).
+        from esphome.espidf import toolchain as espidf_toolchain
+
+        idedata = espidf_toolchain.get_idedata()
+        if idedata is None:
+            _LOGGER.error(
+                "No idedata available; compile the configuration first",
+            )
+            return 1
+
+        print(json.dumps(idedata, indent=2) + "\n")
+        return 0
+
     if not CORE.using_toolchain_platformio:
         _LOGGER.error(
             "The idedata command is not compatible with %s toolchain",

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1772,9 +1772,8 @@ def command_idedata(args: ArgsProtocol, config: ConfigType) -> int:
     import json
 
     if CORE.using_toolchain_esp_idf:
-        # The native ESP-IDF toolchain has no `pio run -t idedata`; idedata is
-        # derived from the existing build's compile_commands.json, so the
-        # configuration must already be compiled (returns None otherwise).
+        # Native ESP-IDF derives idedata from the build's compile_commands.json,
+        # so the configuration must already be compiled.
         from esphome.espidf import toolchain as espidf_toolchain
 
         idedata = espidf_toolchain.get_idedata()

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -472,6 +472,7 @@ def get_idedata() -> dict | None:
             pass
 
     data = idedata_from_build(compile_commands)
+    data["prog_path"] = str(get_elf_path())
     cache.parent.mkdir(parents=True, exist_ok=True)
     cache.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return data

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -89,8 +89,9 @@ def test_get_idedata_generates_and_caches(setup_core: Path) -> None:
         result = toolchain.get_idedata()
 
     mock_transform.assert_called_once()
-    assert result == {"cxx_path": "g++"}
-    assert json.loads(cache.read_text()) == {"cxx_path": "g++"}
+    prog_path = str(toolchain.get_elf_path())
+    assert result == {"cxx_path": "g++", "prog_path": prog_path}
+    assert json.loads(cache.read_text()) == {"cxx_path": "g++", "prog_path": prog_path}
 
 
 def test_get_idedata_uses_cache_when_valid(setup_core: Path) -> None:
@@ -127,7 +128,7 @@ def test_get_idedata_regenerates_when_compile_commands_newer(setup_core: Path) -
         result = toolchain.get_idedata()
 
     mock_transform.assert_called_once()
-    assert result == {"cxx_path": "fresh"}
+    assert result == {"cxx_path": "fresh", "prog_path": str(toolchain.get_elf_path())}
 
 
 def test_get_idedata_regenerates_on_corrupted_cache(setup_core: Path) -> None:
@@ -147,7 +148,23 @@ def test_get_idedata_regenerates_on_corrupted_cache(setup_core: Path) -> None:
         result = toolchain.get_idedata()
 
     mock_transform.assert_called_once()
-    assert result == {"cxx_path": "regen"}
+    assert result == {"cxx_path": "regen", "prog_path": str(toolchain.get_elf_path())}
+
+
+def test_get_idedata_prog_path_points_at_firmware_elf(setup_core: Path) -> None:
+    """The idedata exposes prog_path (the ELF) so consumers like build-action
+    can locate firmware.factory.bin / firmware.ota.bin as its siblings."""
+    compile_commands, _ = _setup_build(setup_core)
+    compile_commands.parent.mkdir(parents=True, exist_ok=True)
+    compile_commands.write_text("[]")
+
+    with patch(
+        "esphome.espidf.idedata.idedata_from_build",
+        return_value={"cxx_path": "g++"},
+    ):
+        result = toolchain.get_idedata()
+
+    assert result["prog_path"].endswith("build/firmware.elf")
 
 
 def test_get_idf_env_sets_git_ceiling_directories(setup_core: Path) -> None:

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -164,7 +164,10 @@ def test_get_idedata_prog_path_points_at_firmware_elf(setup_core: Path) -> None:
     ):
         result = toolchain.get_idedata()
 
-    assert result["prog_path"].endswith("build/firmware.elf")
+    # Use Path semantics so the contract holds on Windows too (backslashes).
+    prog_path = Path(result["prog_path"])
+    assert prog_path.name == "firmware.elf"
+    assert prog_path.parent.name == "build"
 
 
 def test_get_idf_env_sets_git_ceiling_directories(setup_core: Path) -> None:

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -32,6 +32,7 @@ from esphome.__main__ import (
     command_clean_all,
     command_config,
     command_config_hash,
+    command_idedata,
     command_rename,
     command_run,
     command_update_all,
@@ -6257,3 +6258,28 @@ def test_command_run_defaults_subscribe_states_true(
     mock_run_logs.assert_called_once_with(
         CORE.config, ["192.168.1.100"], subscribe_states=True
     )
+
+
+def test_command_idedata_esp_idf_prints_json(capsys: CaptureFixture) -> None:
+    """Under the native ESP-IDF toolchain, idedata is emitted as JSON."""
+    setup_core()
+    CORE.toolchain = Toolchain.ESP_IDF
+    data = {"cxx_path": "g++", "prog_path": "/build/firmware.elf"}
+
+    with patch("esphome.espidf.toolchain.get_idedata", return_value=data) as mock_get:
+        result = command_idedata(MagicMock(), CORE.config)
+
+    assert result == 0
+    mock_get.assert_called_once_with()
+    assert json.loads(capsys.readouterr().out) == data
+
+
+def test_command_idedata_esp_idf_no_build_errors() -> None:
+    """Under ESP-IDF, a missing build (no idedata) returns an error, not a crash."""
+    setup_core()
+    CORE.toolchain = Toolchain.ESP_IDF
+
+    with patch("esphome.espidf.toolchain.get_idedata", return_value=None):
+        result = command_idedata(MagicMock(), CORE.config)
+
+    assert result == 1


### PR DESCRIPTION
# What does this implement/fix?

`esphome idedata` returned `ERROR The idedata command is not compatible with esp-idf toolchain` and exited 1 whenever the native ESP-IDF toolchain was active — now the default since #16910. This breaks the [esphome/build-action](https://github.com/esphome/build-action)'s "Get IDEData" step, which runs `esphome idedata` and reads `idedata["prog_path"]` to locate the firmware binaries to publish (the action compiles first, then calls idedata — so it's the idedata step, not the build, that fails).

Two changes:

- **`command_idedata`** now dispatches to the espidf toolchain when the ESP-IDF toolchain is active (it already derives idedata from the build's `compile_commands.json`), keeps the existing PlatformIO path, and only rejects genuinely-unsupported toolchains. With no build yet it asks for a compile rather than rejecting the toolchain outright.
- **espidf `get_idedata()`** now includes **`prog_path`** = `<build>/build/firmware.elf` (the copy created by `create_elf_copy`), whose siblings are exactly `firmware.factory.bin` / `firmware.ota.bin` — matching the PlatformIO idedata shape the build-action consumes. This fixes the action without any change on its side.

Native ESP-IDF idedata is read from an existing build, so the configuration must be compiled first; the build-action always compiles before calling idedata, so this is transparent there. (A leftover idedata cache from before this change won't contain `prog_path` until the next compile/clean — only relevant to manual standalone use.)

## Validation

Verified against the reporter's config (`esp32-s3` / `esp32-c3`, esp-idf):
- `esphome idedata <config>` now emits valid JSON including `"prog_path": ".../build/firmware.elf"` instead of erroring
- all three siblings (`firmware.elf`, `firmware.factory.bin`, `firmware.ota.bin`) exist at that path, so the build-action's copy step works unchanged
- `tests/unit_tests/test_espidf_toolchain.py`: 14 passed (4 updated for the new `prog_path` field + 1 new test pinning the `prog_path` → `firmware.elf` contract)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #16910 (default toolchain → ESP-IDF)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — CLI/toolchain fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).