### PR TITLE
[esp32] Don't overwrite PlatformIO's factory.bin

### DIFF
--- a/esphome/components/esp32/post_build.py.script
+++ b/esphome/components/esp32/post_build.py.script
@@ -235,7 +235,10 @@ def merge_factory_bin(source, target, env):
             for addr, fname in sorted(
                 flash_data["flash_files"].items(), key=lambda kv: int(kv[0], 16)
             ):
+                # flasher_args.json paths are relative to build_dir
                 file_path = pathlib.Path(fname)
+                if not file_path.is_absolute():
+                    file_path = build_dir / file_path
                 if file_path.exists():
                     sections.append((addr, str(file_path)))
                 else:

--- a/esphome/components/esp32/post_build.py.script
+++ b/esphome/components/esp32/post_build.py.script
@@ -224,6 +224,17 @@ def merge_factory_bin(source, target, env):
     flash_size = env.BoardConfig().get("upload.flash_size", "4MB")
     chip = env.BoardConfig().get("build.mcu", "esp32")
 
+    # PlatformIO's esp-idf builder already creates a correct firmware.factory.bin (right
+    # artifact names and partition offsets, including custom partition tables). The merge
+    # below is only a fallback and cannot honor custom layouts, so don't overwrite an image
+    # PlatformIO already produced. Post-build actions only run when firmware.bin is rebuilt,
+    # and PlatformIO's combined-image builder runs before us in that batch, so an existing
+    # file here is current.
+    output_path = firmware_path.with_suffix(".factory.bin")
+    if output_path.exists():
+        print(f"{output_path.name} already created by PlatformIO - skipping merge")
+        return
+
     sections = []
     flasher_args_path = build_dir / "flasher_args.json"
 
@@ -235,10 +246,7 @@ def merge_factory_bin(source, target, env):
             for addr, fname in sorted(
                 flash_data["flash_files"].items(), key=lambda kv: int(kv[0], 16)
             ):
-                # flasher_args.json paths are relative to build_dir
                 file_path = pathlib.Path(fname)
-                if not file_path.is_absolute():
-                    file_path = build_dir / file_path
                 if file_path.exists():
                     sections.append((addr, str(file_path)))
                 else:
@@ -294,7 +302,6 @@ def merge_factory_bin(source, target, env):
         print("No valid flash sections found — skipping .factory.bin creation.")
         return
 
-    output_path = firmware_path.with_suffix(".factory.bin")
     python_exe = f'"{env.subst("$PYTHONEXE")}"'
     cmd = [
         python_exe,


### PR DESCRIPTION
# What does this implement/fix?

On the **PlatformIO** toolchain, PlatformIO's esp-idf builder already produces a correct `firmware.factory.bin` — right artifact names and partition offsets, including **custom partition tables** (e.g. app at `0x20000`):

```
Creating binary "firmware.factory.bin" with:
 -  0x0      | bootloader.bin
 -  0x8000   | partitions.bin
 -  0xf000   | ota_data_initial.bin
 -  0x20000  | firmware.bin
Successfully created combined binary image.
```

ESPHome's `merge_factory_bin` post-build step then ran and **overwrote** it. With a custom partition table that merge either:
- failed with an esptool overlap at the hardcoded `0x10000` app offset (`Detected overlap at address: 0x10000`), or
- merged an incomplete set of sections (the `flasher_args.json` paths/names — `bootloader/bootloader.bin`, `partition_table/partition-table.bin`, `<project>.bin` — don't match PlatformIO's flattened/renamed artifacts `bootloader.bin`/`partitions.bin`/`firmware.bin`), producing a truncated image.

Either way, PlatformIO's valid factory image was clobbered (#17041).

## Background: why `merge_factory_bin` exists

`firmware.factory.bin` is the single flash-at-`0x0` image (bootloader + partition table + otadata + app) used by the dashboard factory download, serial/esptool flashing, and the web installer.

It was added in #3003 (as `esp32_create_combined_bin`, later rewritten into `merge_factory_bin` in #9578) back when the ESP32 **Arduino** framework on PlatformIO did **not** emit a combined image — so ESPHome merged the pieces itself with esptool. The app offset was hardcoded to `0x10000` because the standard Arduino layout always places the app there; custom partition tables weren't a consideration.

Since then the esp-idf framework + newer pioarduino platform changed this: the platform's esp-idf builder now generates `firmware.factory.bin` itself, correctly honoring custom partition offsets. So on this path ESPHome's merge is **redundant**, and its inherited `0x10000` / `FLASH_EXTRA_IMAGES` assumptions actively break custom partition tables.

## Fix

**Skip the merge when `firmware.factory.bin` already exists** — i.e. when PlatformIO already produced it. Post-build actions only run when `firmware.bin` is rebuilt, and PlatformIO's combined-image builder runs before this step in the same batch, so an existing file is always current. ESPHome's merge stays as a fallback for builds where PlatformIO does not emit a combined image (historically the Arduino framework, its original reason to exist).

Only affects the PlatformIO toolchain; the native ESP-IDF toolchain has its own correct `create_factory_bin()`.

### Verified locally (ESP32-S3, esp-idf framework, PlatformIO toolchain, custom partition table with app at `0x20000`)

- Before: `merge_factory_bin` overwrote PlatformIO's image with a 68 KiB (`0x11000`) truncated `firmware.factory.bin`.
- After: `firmware.factory.bin already created by PlatformIO - skipping merge`; final image is the full 805504-byte PlatformIO image, with the ESP image magic `0xe9` present at both `0x0` and `0x20000`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17041

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32-s3-devkitc-1
  flash_size: 16MB
  variant: esp32s3
  partitions: partitions.csv
  framework:
    type: esp-idf

# partitions.csv (app at 0x20000)
# nvs,      data, nvs,     0x9000,   0x6000,
# otadata,  data, ota,     0xF000,   0x2000,
# phy_init, data, phy,     0x11000,  0x1000,
# app0,     app,  ota_0,   0x20000,  0x500000,
# app1,     app,  ota_1,   0x520000, 0x500000,
# data,     data, 0x40,    0xA20000, 0x5E0000,
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).