### PR TITLE
[espidf] Don't fail framework check on broken unrelated PATH tools

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -81,8 +81,13 @@ def _get_idf_tools_path() -> Path:
         Path object pointing to the ESP-IDF tools directory
     """
     if "ESPHOME_ESP_IDF_PREFIX" in os.environ:
-        return Path(get_str_env("ESPHOME_ESP_IDF_PREFIX", None)).expanduser()
-    return CORE.data_dir / "idf"
+        path = Path(get_str_env("ESPHOME_ESP_IDF_PREFIX", None)).expanduser()
+    else:
+        path = CORE.data_dir / "idf"
+    # Resolve so an unnormalized config path (e.g. compiling ``../config/x.yaml``)
+    # doesn't leave ``..`` segments in the IDF_TOOLS_PATH handed to idf.py, which
+    # otherwise warns that the venv interpreter path doesn't match the install.
+    return path.resolve()
 
 
 # Windows' default MAX_PATH is 260 characters. ESP-IDF toolchains nest deeply

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -604,14 +604,21 @@ def _check_esphome_idf_framework_install(
         install = True
         if _check_stamp(env_stamp_file, stamp_info):
             _LOGGER.info("Checking ESP-IDF %s framework installation ...", version)
-            cmd = [
-                get_system_python_path(),
-                str(idf_tools_path),
-                "--non-interactive",
-                "check",
-            ]
-            if run_command_ok(cmd, msg=f"ESP-IDF {version} check", env=env):
+            # Validate the install by resolving the managed tool paths rather than running
+            # ``idf_tools.py check``. ``check`` probes every tool found on the system PATH
+            # first and aborts the whole check if any of them fails to run -- e.g. a broken
+            # Homebrew ``openocd`` (a tool ESPHome never uses) crashing on a missing
+            # libcapstone dylib -- which forced a full toolchain reinstall on every build
+            # for affected (mostly macOS) users. ``_get_idf_tool_paths`` only considers the
+            # tools installed under ``IDF_TOOLS_PATH`` (prefer_system=False) and raises if a
+            # managed tool is missing, so unrelated system tools cannot poison the check.
+            try:
+                _get_idf_tool_paths(framework_path, env)
                 install = False
+            except RuntimeError as err:
+                _LOGGER.debug(
+                    "ESP-IDF %s tool resolution failed, reinstalling: %s", version, err
+                )
 
     # 4. Install framework tools if not installed or needs update
     if install:

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -81,13 +81,8 @@ def _get_idf_tools_path() -> Path:
         Path object pointing to the ESP-IDF tools directory
     """
     if "ESPHOME_ESP_IDF_PREFIX" in os.environ:
-        path = Path(get_str_env("ESPHOME_ESP_IDF_PREFIX", None)).expanduser()
-    else:
-        path = CORE.data_dir / "idf"
-    # Resolve so an unnormalized config path (e.g. compiling ``../config/x.yaml``)
-    # doesn't leave ``..`` segments in the IDF_TOOLS_PATH handed to idf.py, which
-    # otherwise warns that the venv interpreter path doesn't match the install.
-    return path.resolve()
+        return Path(get_str_env("ESPHOME_ESP_IDF_PREFIX", None)).expanduser()
+    return CORE.data_dir / "idf"
 
 
 # Windows' default MAX_PATH is 260 characters. ESP-IDF toolchains nest deeply

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -604,14 +604,9 @@ def _check_esphome_idf_framework_install(
         install = True
         if _check_stamp(env_stamp_file, stamp_info):
             _LOGGER.info("Checking ESP-IDF %s framework installation ...", version)
-            # Validate the install by resolving the managed tool paths rather than running
-            # ``idf_tools.py check``. ``check`` probes every tool found on the system PATH
-            # first and aborts the whole check if any of them fails to run -- e.g. a broken
-            # Homebrew ``openocd`` (a tool ESPHome never uses) crashing on a missing
-            # libcapstone dylib -- which forced a full toolchain reinstall on every build
-            # for affected (mostly macOS) users. ``_get_idf_tool_paths`` only considers the
-            # tools installed under ``IDF_TOOLS_PATH`` (prefer_system=False) and raises if a
-            # managed tool is missing, so unrelated system tools cannot poison the check.
+            # Validate via the managed tool-path resolution, not ``idf_tools.py check``:
+            # ``check`` probes tools on the system PATH and aborts if any fail to run (e.g. a
+            # broken Homebrew openocd), which forced a toolchain reinstall on every build.
             try:
                 _get_idf_tool_paths(framework_path, env)
                 install = False

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -298,6 +298,9 @@ def espidf_mocks(setup_core: Path):
         patch("esphome.espidf.framework.archive_extract_all") as extract,
         patch("esphome.espidf.framework.create_venv") as venv,
         patch("esphome.espidf.framework.run_command_ok", return_value=True) as run_ok,
+        patch(
+            "esphome.espidf.framework._get_idf_tool_paths", return_value=([], {})
+        ) as tool_paths,
         patch("esphome.espidf.framework._clone_idf_with_submodules") as clone,
         patch("esphome.espidf.framework._write_idf_version_txt"),
         patch("esphome.espidf.framework._patch_tools_json_for_linux_arm64"),
@@ -308,7 +311,12 @@ def espidf_mocks(setup_core: Path):
         patch("esphome.espidf.framework.get_system_python_path", return_value="python"),
     ):
         yield SimpleNamespace(
-            download=download, extract=extract, venv=venv, run_ok=run_ok, clone=clone
+            download=download,
+            extract=extract,
+            venv=venv,
+            run_ok=run_ok,
+            tool_paths=tool_paths,
+            clone=clone,
         )
 
 
@@ -403,10 +411,10 @@ def test_check_esp_idf_install_stamp_mismatch_reinstalls(
 def test_check_esp_idf_install_check_command_failure_reinstalls(
     espidf_mocks: SimpleNamespace,
 ) -> None:
-    """A failing idf_tools check reinstalls tools (marker present, no re-extract)."""
+    """A failing tool-path resolution reinstalls tools (marker present, no re-extract)."""
     _mark_installed()
-    # idf_tools check fails -> install stays True; the later installs succeed.
-    espidf_mocks.run_ok.side_effect = [False, True, True, True]
+    # Managed tool resolution fails -> install stays True; the later installs succeed.
+    espidf_mocks.tool_paths.side_effect = RuntimeError("missing ESP-IDF tool")
     check_esp_idf_install(_IDF_VERSION, features=["fb"])
 
     espidf_mocks.extract.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

ESPHome validates an existing native ESP-IDF install by running `idf_tools.py check` (`esphome/espidf/framework.py`). That command probes **every tool found on the system PATH** first and aborts the whole check (`SystemExit(1)`) if any of them fails to run — even tools ESPHome never uses.

On macOS this bites users with a Homebrew `openocd` on PATH: after a `brew upgrade` bumps `capstone` (4 → 5), the old `openocd` is left linked against the now-removed `libcapstone.4.dylib` and aborts on launch:

```
ERROR: tool openocd-esp32 is found in PATH, but has failed: non-zero exit code (-6) with message:
  dyld[...]: Library not loaded: /opt/homebrew/opt/capstone/lib/libcapstone.4.dylib
```

So the check fails and ESPHome treats the toolchain as not installed, re-running the tool install (tools are already present, so mostly skipped) and — because the framework step reports a reinstall — **force-reinstalling the Python environment (pip deps) on every build**. That forced `pip install` is the slow part; the framework itself is not re-downloaded (the extracted marker short-circuits that). It never converges because the broken `openocd` stays on PATH.

This switches the install-validity gate to the **managed tool-path resolution** (`_get_idf_tool_paths` → `get_idf_tool_paths.py`, `prefer_system=False`), which only inspects the tools installed under `IDF_TOOLS_PATH` and tolerates a broken/irrelevant system tool. It's the same resolution already used to build the compile environment, so a healthy install is unaffected.

Note: `idf_tools.py check` has no option to skip the system-PATH probe, and excluding `openocd`/`gdb` from the tool set doesn't help (the check scopes by target + install-type, and those are `install: always`).

## Verification

Reproduced and verified hardware-free on Linux with a fake `openocd` on PATH that mimics the failure exactly (exit 134, `libcapstone.4.dylib`):

- old gate `idf_tools.py check` → **exit 1** (reproduces the reinstall loop)
- new gate `get_idf_tool_paths.py` → **exit 0** (resolves the managed `openocd-esp32`, broken fake still on PATH)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change. Affects the native ESP-IDF toolchain install/validation step.
esp32:
  board: esp32dev
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
