### PR TITLE
[espidf] Resolve IDF tools path to avoid unnormalized path warning

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -81,8 +81,13 @@ def _get_idf_tools_path() -> Path:
         Path object pointing to the ESP-IDF tools directory
     """
     if "ESPHOME_ESP_IDF_PREFIX" in os.environ:
-        return Path(get_str_env("ESPHOME_ESP_IDF_PREFIX", None)).expanduser()
-    return CORE.data_dir / "idf"
+        path = Path(get_str_env("ESPHOME_ESP_IDF_PREFIX", None)).expanduser()
+    else:
+        path = CORE.data_dir / "idf"
+    # Resolve so an unnormalized config path (e.g. compiling ``../config/x.yaml``)
+    # doesn't leave ``..`` segments in the IDF_TOOLS_PATH handed to idf.py, which
+    # otherwise warns that the venv interpreter path doesn't match the install.
+    return path.resolve()
 
 
 # Windows' default MAX_PATH is 260 characters. ESP-IDF toolchains nest deeply


### PR DESCRIPTION
# What does this implement/fix?

`_get_idf_tools_path()` returns `CORE.data_dir / "idf"` without normalizing it. When ESPHome is run with an unnormalized config path (e.g. `esphome compile ../config/device.yaml`), the `..` is never collapsed and flows into `IDF_TOOLS_PATH` and the Python venv path handed to `idf.py`. `idf.py` resolves its actual interpreter path and compares it textually to that unnormalized venv path, so it warns even though they're the same directory:

```
WARNING: Python interpreter ".../config/.esphome/idf/penvs/5.5.4/bin/python" used to start
idf.py is not from installed venv ".../esphome-worktree/../config/.esphome/idf/penvs/5.5.4"
```

`.resolve()` the tools path so no `..` segments reach `idf.py`. The interpreter `idf.py` checks is itself resolved, so resolving here makes the comparison match.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change. Triggered by invoking esphome with an unnormalized path, e.g.
#   esphome compile ../config/device.yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).