### PR TITLE
[mipi_rgb] Fix offsets for Wave 5 1024x600

### DIFF
--- a/esphome/components/mipi/__init__.py
+++ b/esphome/components/mipi/__init__.py
@@ -322,6 +322,9 @@ class DriverChip:
                     - defaults.get(CONF_OFFSET_WIDTH, 0)
                     - defaults.get(CONF_PAD_WIDTH, 0)
                 )
+            elif defaults[CONF_WIDTH] > defaults[CONF_NATIVE_WIDTH]:
+                defaults[CONF_NATIVE_WIDTH] = defaults[CONF_WIDTH]
+
         else:
             native_width = (
                 defaults.get(CONF_WIDTH, 0)
@@ -337,6 +340,8 @@ class DriverChip:
                     - defaults.get(CONF_OFFSET_HEIGHT, 0)
                     - defaults.get(CONF_PAD_HEIGHT, 0)
                 )
+            elif defaults[CONF_HEIGHT] > defaults[CONF_NATIVE_HEIGHT]:
+                defaults[CONF_NATIVE_HEIGHT] = defaults[CONF_HEIGHT]
         else:
             native_height = (
                 defaults.get(CONF_HEIGHT, 0)

--- a/tests/components/mipi_rgb/test.esp32-s3-idf.yaml
+++ b/tests/components/mipi_rgb/test.esp32-s3-idf.yaml
@@ -1,7 +1,11 @@
 packages:
-  spi: !include ../../test_build_components/common/spi/esp32-s3-idf.yaml
+  - !include ../../test_build_components/common/i2c/esp32-s3-idf.yaml
 
 psram:
   mode: octal
 
-<<: !include common.yaml
+ch422g:
+
+display:
+  - platform: mipi_rgb
+    model: WAVESHARE-5-1024X600


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Recent changes meant that extending a display model with altered dimensions causes offsets to be applied, which doesn't work when the new dimensions are larger.
	


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1517196935805669587/1517220644759273616

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
