### PR TITLE
[esp-idf] Enable ccache for native IDF builds when available

### DIFF
--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -14,7 +14,7 @@ from esphome.const import CONF_FRAMEWORK, CONF_SOURCE
 from esphome.core import CORE, EsphomeError
 from esphome.espidf.framework import check_esp_idf_install, get_framework_env
 from esphome.espidf.size_summary import print_summary
-from esphome.helpers import add_git_ceiling_directory
+from esphome.helpers import IS_WINDOWS, add_git_ceiling_directory
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,6 +88,21 @@ def _get_idf_env(version: str | None = None) -> dict[str, str]:
         # `git describe` for the app version can't error out on an
         # uninitialized or corrupt git repo in a parent directory.
         add_git_ceiling_directory(env_cache[version], CORE.config_dir)
+
+        # Enable ccache when available -- a large rebuild speedup. idf.py
+        # leaves ccache off by default, so opt in via IDF_CCACHE_ENABLE (idf.py
+        # turns that into -DCCACHE_ENABLE=1). Guards:
+        #  - respect an explicit user IDF_CCACHE_ENABLE (don't override their choice)
+        #  - skip on Windows, where ccache hits long-path/temp-file failures
+        #  - only when ccache is actually installed
+        #  - bound the cache so it can't silently fill the disk
+        if (
+            not IS_WINDOWS
+            and "IDF_CCACHE_ENABLE" not in os.environ
+            and shutil.which("ccache") is not None
+        ):
+            env_cache[version]["IDF_CCACHE_ENABLE"] = "1"
+            env_cache[version].setdefault("CCACHE_MAXSIZE", "2G")
     return env_cache[version]
 
 

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -191,3 +191,57 @@ def test_get_core_framework_version_from_core_data():
 
     CORE.data = {KEY_ESP32: {KEY_IDF_VERSION: cv.Version(5, 5, 4)}}
     assert toolchain._get_core_framework_version() == "5.5.4"
+
+
+def test_get_idf_env_enables_ccache_when_available(setup_core: Path) -> None:
+    """Opt in to ccache (with a bounded cache) when installed on a non-Windows host."""
+    toolchain._cache().env.clear()
+    with (
+        patch.dict(os.environ, {"IDF_PATH": str(setup_core)}, clear=True),
+        patch.object(toolchain, "IS_WINDOWS", False),
+        patch.object(toolchain.shutil, "which", return_value="/usr/bin/ccache"),
+    ):
+        env = toolchain._get_idf_env(version="5.5.4")
+    assert env["IDF_CCACHE_ENABLE"] == "1"
+    assert env["CCACHE_MAXSIZE"] == "2G"
+
+
+def test_get_idf_env_no_ccache_when_not_installed(setup_core: Path) -> None:
+    """No ccache on PATH -> the env var is not set."""
+    toolchain._cache().env.clear()
+    with (
+        patch.dict(os.environ, {"IDF_PATH": str(setup_core)}, clear=True),
+        patch.object(toolchain, "IS_WINDOWS", False),
+        patch.object(toolchain.shutil, "which", return_value=None),
+    ):
+        env = toolchain._get_idf_env(version="5.5.4")
+    assert "IDF_CCACHE_ENABLE" not in env
+
+
+def test_get_idf_env_no_ccache_on_windows(setup_core: Path) -> None:
+    """Skip ccache on Windows (long-path/temp-file failures)."""
+    toolchain._cache().env.clear()
+    with (
+        patch.dict(os.environ, {"IDF_PATH": str(setup_core)}, clear=True),
+        patch.object(toolchain, "IS_WINDOWS", True),
+        patch.object(toolchain.shutil, "which", return_value="C:\\ccache.exe"),
+    ):
+        env = toolchain._get_idf_env(version="5.5.4")
+    assert "IDF_CCACHE_ENABLE" not in env
+
+
+def test_get_idf_env_respects_explicit_ccache_setting(setup_core: Path) -> None:
+    """An explicit IDF_CCACHE_ENABLE is left untouched (user choice wins)."""
+    toolchain._cache().env.clear()
+    with (
+        patch.dict(
+            os.environ,
+            {"IDF_PATH": str(setup_core), "IDF_CCACHE_ENABLE": "0"},
+            clear=True,
+        ),
+        patch.object(toolchain, "IS_WINDOWS", False),
+        patch.object(toolchain.shutil, "which", return_value="/usr/bin/ccache"),
+    ):
+        env = toolchain._get_idf_env(version="5.5.4")
+    assert env["IDF_CCACHE_ENABLE"] == "0"
+    assert "CCACHE_MAXSIZE" not in env


### PR DESCRIPTION
> **Draft / experiment** — opening to test build-time impact and shake out issues before proposing for real.

# What does this implement/fix?

After the esp32 default flipped to the native ESP-IDF toolchain (#16910), builds lost ccache acceleration: `idf.py` leaves ccache **off by default** (`tools/idf_py_actions/core_ext.py`: *"Use ccache in build. Disabled by default."*, env var `IDF_CCACHE_ENABLE`), and ESPHome doesn't enable it anywhere. Users coming from the PlatformIO path noticed much slower rebuilds.

This opts ccache in from `espidf/toolchain._get_idf_env()` by setting `IDF_CCACHE_ENABLE=1` in the build environment (which `idf.py` turns into `-DCCACHE_ENABLE=1`), with guards:

- **Respects an explicit `IDF_CCACHE_ENABLE`** — never overrides a user's choice.
- **Skips on Windows** — IDF itself warns ccache hits long-path/temp-file failures there (`hints.yml`).
- **Only when `ccache` is on `PATH`.**
- **Bounds the cache** (`CCACHE_MAXSIZE=2G`) so it can't silently fill the disk.

## Open questions for review / testing
- **Build-time impact** — main reason this is a draft; want real before/after numbers on a representative rebuild.
- **Cache location** — currently uses ccache's default dir (`~/.ccache`). Should it live under the ESPHome data dir, and is 2 GB a sane cap (esp. for the HA add-on / containers with limited storage)?
- **Default-on vs opt-in** — IDF keeps it opt-in deliberately (disk growth, Windows). Is auto-enabling-when-present the right default, or should this be a documented toggle?

## Risks (low correctness, mostly operational)
- Correctness is low: ccache keys on preprocessed source + flags + compiler; config changes invalidate correctly, and build timestamps stay correct (passed as a define / `__TIME__` files aren't cached by default).
- Operational: disk usage (mitigated by the cap), Windows (excluded), and rare cache corruption (recoverable with `ccache -C`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Other

**Related issue or feature (if applicable):**

- Follow-up to #16910 (default toolchain → ESP-IDF)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — build environment change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).