### PR TITLE
[packet_transport] Mark encryption key as cv.sensitive

### DIFF
--- a/esphome/components/packet_transport/__init__.py
+++ b/esphome/components/packet_transport/__init__.py
@@ -69,7 +69,7 @@ ENCRYPTION_SCHEMA = {
     cv.Optional(CONF_ENCRYPTION): cv.maybe_simple_value(
         cv.Schema(
             {
-                cv.Required(CONF_KEY): cv.string,
+                cv.Required(CONF_KEY): cv.sensitive(cv.string),
             }
         ),
         key=CONF_KEY,


### PR DESCRIPTION
# What does this implement/fix?

`packet_transport` with `encryption:` emitted:

> WARNING Field 'key' is being redacted by a legacy substring heuristic. Mark this field's schema validator with cv.sensitive(...) for deterministic redaction; the heuristic will be removed in 2026.12.0.

The provider encryption `key` was only being redacted by the legacy field-name substring heuristic (`(\w+_)?(password|key|psk|ssid)`). This marks it with `cv.sensitive()` so it's redacted deterministically — same pattern already used by `api`, `wifi`, `mqtt`, and `web_server`. Also ensures the key keeps being redacted after the heuristic is removed in 2026.12.0.

```python
cv.Required(CONF_KEY): cv.sensitive(cv.string),
```

## Verification

`esphome config` on a `packet_transport` config with `encryption:`:
- before: `WARNING Field 'key' is being redacted by a legacy substring heuristic`
- after: no warning, and the key is deterministically redacted in the dumped config

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17058

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
packet_transport:
  platform: udp
  providers:
    - name: rele-boiler
      encryption: "secret-key"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).