### PR TITLE
[fastled_base] Fix RMT5 intr_priority conflict

### DIFF
--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -50,6 +50,11 @@ async def new_fastled_light(config):
             ref="d44c800a9e876a8394caefc2ce4915dd96dac77b",
         )
         cg.add_library("SPI", None)
+        # FastLED's RMT5 driver hard-codes intr_priority=3, which conflicts with
+        # esphome's RMT channels (remote_transmitter etc., priority 0): the IDF
+        # driver rejects FastLED's channel and show() then hangs ~3s with no
+        # output. Override to 0 so it shares the interrupt. See #17063.
+        cg.add_build_flag("-DFL_RMT5_INTERRUPT_LEVEL=0")
     else:
         cg.add_library("fastled/FastLED", "3.9.16")
     await light.register_light(var, config)


### PR DESCRIPTION
# What does this implement/fix?

FastLED 3.10's RMT5 driver hard-codes its TX channel to `intr_priority = 3` (`FL_RMT5_INTERRUPT_LEVEL`), while esphome creates its RMT channels (`remote_transmitter`, `remote_receiver`, `esp32_rmt_led_strip`) with `intr_priority = 0`. When an esphome channel is set up first, the IDF rmt driver locks the shared interrupt at a different level and rejects FastLED's channel (`rmt_new_tx_channel: intr_priority conflict`). FastLED's channel is never created, so `show()` blocks ~3s and the LEDs stay dark.

This is the 2026.6.0 regression (#16804, the FastLED 3.10 IDF component move) that breaks FastLED on ESP32 alongside IR/other RMT users — e.g. the M5Stack Atom Matrix.

`FL_RMT5_INTERRUPT_LEVEL` is `#ifndef`-guarded, so override it to `0` (any) to match esphome's channels and share the interrupt. Verified on a bench ESP32 via a loopback `remote_receiver`: broken = no waveform + 3s hang; fixed = clean frame like 3.9. Trade-off: the refill ISR runs at the IDF default level instead of 3 (same as 3.9).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17063

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
remote_transmitter:
  pin: GPIO12
  carrier_duty_percent: 50%

light:
  - platform: fastled_clockless
    chipset: WS2812B
    pin: GPIO27
    num_leds: 25
    rgb_order: GRB
    name: "Matrix"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Existing `fastled_clockless` / `fastled_spi` ESP32 compile tests exercise the build path; the conflict is a runtime RMT failure a compile test can't reproduce.