### PR TITLE
[ha-addon] Expose the device-builder public port only when port 6052 is mapped

### DIFF
--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
@@ -49,14 +49,17 @@ if bashio::fs.directory_exists '/config/esphome/.esphome'; then
     rm -rf /config/esphome/.esphome
 fi
 
-# Only expose the public port on the LAN when the operator mapped it,
-# matching the legacy dashboard where nginx listened on 6052 only when
-# the port was configured. Combined with leave_front_door_open above,
-# this binds 6052 with no authentication; one without the other stays
-# ingress-only.
+# Only signal device-builder to expose the public LAN port when the operator
+# mapped port 6052, matching the legacy dashboard where nginx listened on the
+# fixed port 6052 only when it was configured. We use the mapping purely as a
+# presence check and don't forward the published value; device-builder binds
+# its default port 6052 (the fixed container port, as the legacy
+# "listen 6052" did). --ha-addon-allow-public is inert on its own: the no-auth
+# gate is the DISABLE_HA_AUTHENTICATION env var set above, so both opt-ins are
+# required to bind 6052 unauthenticated; either alone stays ingress-only.
 set --
 if bashio::var.has_value "$(bashio::addon.port 6052)"; then
-    set -- --port "$(bashio::addon.port 6052)" --ha-addon-allow-public
+    set -- --ha-addon-allow-public
 fi
 
 bashio::log.info "Starting ESPHome Device Builder..."

--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
@@ -49,7 +49,18 @@ if bashio::fs.directory_exists '/config/esphome/.esphome'; then
     rm -rf /config/esphome/.esphome
 fi
 
+# Only expose the public port on the LAN when the operator mapped it,
+# matching the legacy dashboard where nginx listened on 6052 only when
+# the port was configured. Combined with leave_front_door_open above,
+# this binds 6052 with no authentication; one without the other stays
+# ingress-only.
+set --
+if bashio::var.has_value "$(bashio::addon.port 6052)"; then
+    set -- --port "$(bashio::addon.port 6052)" --ha-addon-allow-public
+fi
+
 bashio::log.info "Starting ESPHome Device Builder..."
 exec esphome-device-builder /config/esphome \
     --ha-addon \
-    --ingress-port "$(bashio::addon.ingress_port)"
+    --ingress-port "$(bashio::addon.ingress_port)" \
+    "$@"


### PR DESCRIPTION
# What does this implement/fix?

The HA add-on now passes the device-builder's public-port opt-in only when the operator mapped port 6052. When "Disable external authentication" (`leave_front_door_open`) is on and port 6052 is mapped, the run script passes `--ha-addon-allow-public`, which tells the bundled ESPHome Device Builder to bind the public port on the LAN with no authentication; device-builder binds its default fixed port 6052, so we use the mapping purely as a presence check and don't forward the published value. This restores the classic dashboard behavior where nginx listened on the fixed port 6052 only when the port was mapped, and the front-door option only cleared auth on that direct block. Either opt-in alone stays ingress-only.

This is the add-on side of esphome/device-builder#1613 and esphome/device-builder#1617; the `--ha-addon-allow-public` flag is added there. This must not merge until a bundled device-builder that recognizes the flag ships, otherwise the older bundle errors on the unknown argument; holding as draft until then.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- see https://github.com/esphome/device-builder/issues/1613

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable; this is an HA add-on run-script change, not a component.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

