### PR TITLE
Add THREAT_MODEL.md

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,0 +1,105 @@
+# ESPHome Threat Model
+
+This document defines the trust boundary for the **ESPHome** repository — the
+Python compiler/CLI and the device firmware it generates — so that real security
+bugs can be told apart from defense-in-depth improvements. It gives contributors,
+reviewers, and security researchers a clear answer to one question:
+**does this issue let an _unauthenticated_ attacker do something they shouldn't?**
+
+Related documents:
+
+- Deployment guidance for operators:
+  https://esphome.io/guides/security_best_practices/
+- The **dashboard / device-builder** (the web UI, its authentication, ingress,
+  Origin/Host gates, and peer-link pairing) lives in a separate repository and
+  has its own threat model. If your report concerns any of that, please read and
+  report there instead:
+  https://github.com/esphome/device-builder/blob/main/docs/THREAT_MODEL.md
+
+## The trust boundary
+
+For this repository there are two trusted inputs by design:
+
+1. **The configuration.** Anyone who can supply or edit a YAML config is trusted
+   (see below).
+2. **Authenticated peers of a running device** — clients holding the device's
+   API encryption key / password, OTA password, or web server credentials.
+
+The security boundary is therefore **unauthenticated network traffic vs. those
+trusted inputs.** A bug that lets an unauthenticated attacker cross it is a
+security bug.
+
+## Config authors are host-equivalent by design
+
+Anyone who can supply or edit a configuration is **trusted with full code
+execution on the host that runs `esphome`**, on purpose. This is what the product
+does, not a flaw. A config author can already, through fully supported features:
+
+- Run arbitrary **Python** at validation/compile time via `external_components:`
+  (and other component-import mechanisms) — ESPHome imports those packages as
+  ordinary Python.
+- Run arbitrary **shell** commands through the compile/validate/flash toolchain
+  that ESPHome invokes as subprocesses.
+- Read and write arbitrary files reachable by the process (e.g. via `!include`,
+  `packages:`, `dashboard_import:`, and generated build output).
+
+Because of this, a malicious config author is equivalent to shell access on the
+host running the build.
+
+## What is *not* a security vulnerability
+
+If exploiting an issue requires the ability to supply or edit configuration, it
+is **not** a vulnerability in ESPHome, because that ability already grants host
+code execution. This explicitly includes, among others:
+
+- Template / expression injection in substitutions or any YAML string value
+  (e.g. Jinja `${...}` evaluation reaching Python internals). This grants no
+  capability a config author lacks.
+- `!include` / `packages:` / `dashboard_import:` reading or fetching content
+  from surprising or remote locations.
+- The validator or compiler crashing or behaving unexpectedly on adversarial
+  YAML.
+- ESPHome running as root in the official container — that is the documented
+  deployment posture, reachable by the same caller through the features above.
+
+These do not warrant a CVE or coordinated disclosure. Hardening in these areas
+(for example, sandboxing template evaluation as least-surprise defense-in-depth)
+is welcome as a normal enhancement PR, framed as cleanliness rather than a
+security fix — not as a vulnerability remediation.
+
+## What we do defend
+
+These *are* security bugs in this repo, and we want to hear about them privately:
+
+- Memory-safety or protocol bugs in the generated **device firmware** that are
+  remotely triggerable over the network (native API, web server, OTA, BLE,
+  captive portal, etc.) **without** valid credentials.
+- Authentication or encryption bypass on the device — reaching API calls, OTA
+  updates, or the web server without the configured key/password.
+- Flaws that weaken the device's API encryption (Noise), OTA, or web server auth
+  below their documented guarantees.
+
+## Explicitly out of scope
+
+- Local attackers who already have shell access on the host that runs `esphome`.
+- Supply-chain attacks against ESPHome or its dependencies.
+- Operator-supplied hostile YAML (covered above — config authoring is trusted).
+- Attacks that require an already-authenticated device peer (someone who already
+  holds the API key / OTA / web credentials).
+- Anything in the dashboard / device-builder — report that in its own repository
+  (linked at the top).
+- The legacy bundled dashboard in this repo (`esphome/dashboard/`) — it is
+  retired, unsupported, and slated for removal from this repository. It is
+  superseded by device-builder; report dashboard issues there.
+- Deployments where the operator removed protections or exposed credentials. See
+  the security best practices guide:
+  https://esphome.io/guides/security_best_practices/
+
+## Reporting a vulnerability
+
+If you believe you've found an issue that crosses the unauthenticated boundary
+above, please report it privately via GitHub Security Advisories rather than a
+public issue. For issues that require config-write access, please review this
+document first — they are very likely out of scope by design. For dashboard /
+device-builder issues, report against that repository and consult its threat
+model (linked at the top).


### PR DESCRIPTION
# What does this implement/fix?

Adds a top-level `THREAT_MODEL.md` documenting ESPHome's security trust boundary, so real security bugs can be distinguished from defense-in-depth hardening — and so the recurring class of "config can run code" reports can be triaged consistently.

The core point: anyone who can supply or edit a configuration is **trusted with full code execution on the host by design**. A config author can already run arbitrary Python via `external_components:` and arbitrary shell through the compile/validate toolchain. Therefore issues that only require config-write access — e.g. Jinja `${...}` substitution/template injection, `!include`/`packages:`/`dashboard_import:` behavior, validator crashes on hostile YAML, or "runs as root in the container" — are out of scope and not vulnerabilities. The document also states what *is* defended (unauthenticated, remotely triggerable bugs in the generated firmware over API/OTA/web/BLE; device auth/encryption bypass) and what is explicitly out of scope (the dashboard/device-builder, which has its own threat model, and the retired bundled `esphome/dashboard/`).

This mirrors and links the existing [device-builder threat model](https://github.com/esphome/device-builder/blob/main/docs/THREAT_MODEL.md) and the [security best practices guide](https://esphome.io/guides/security_best_practices/).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A (documentation only)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — documentation only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)