### PR TITLE
[nrf52] Add MCUboot as a bootloader for any nRF52840 board

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,6 @@ recursive-include esphome *.yaml
 recursive-include esphome *.cpp *.h *.tcc *.c
 recursive-include esphome *.py.script
 recursive-include esphome *.jinja
+recursive-include esphome *.conf *.overlay
 recursive-include esphome LICENSE.txt
 recursive-include esphome requirements.txt

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -312,10 +312,9 @@ def _final_validate(config):
 
     if CONF_DFU in config:
         _validate_mcumgr(config)
-    if (
-        config[KEY_BOOTLOADER] == BOOTLOADER_MCUBOOT
-        and CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] < cv.Version(2, 9, 2)
-    ):
+    if config[KEY_BOOTLOADER] == BOOTLOADER_MCUBOOT and CORE.data[KEY_CORE][
+        KEY_FRAMEWORK_VERSION
+    ] < cv.Version(2, 9, 2):
         # The MCUboot image is configured through sysbuild, which replaced the
         # zephyr/child_image/ mechanism in NCS 2.9.2. On an older SDK the
         # fragments are silently ignored and the board comes out with no

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -10,11 +10,14 @@ import subprocess
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components.zephyr import (
+    Section,
+    add_extra_build_file,
     add_extra_script,
     copy_files as zephyr_copy_files,
     zephyr_add_overlay,
     zephyr_add_pm_static,
     zephyr_add_prj_conf,
+    zephyr_add_sysbuild_conf,
     zephyr_data,
     zephyr_set_core_data,
     zephyr_setup_preferences,
@@ -25,6 +28,7 @@ from esphome.components.zephyr.const import (
     CONF_CDC_ACM,
     KEY_BOARD,
     KEY_BOOTLOADER,
+    KEY_SYSBUILD,
     KEY_ZEPHYR,
     CdcAcm,
 )
@@ -88,6 +92,22 @@ _LOGGER = logging.getLogger(__name__)
 # sdk-nrf install cache and pins the clang-tidy project's SDK.
 RECOMMENDED_PLATFORMIO_VERSION = "2.6.1-b"
 RECOMMENDED_SDK_NRF_VERSION = "2.9.2"
+
+XIAO_BLE = "xiao_ble"
+
+# Flash layout for `bootloader: mcuboot`, where MCUboot owns the device from the
+# reset vector. Every nRF52840 has 1 MB, and it is the only nRF52 with the USB
+# device that MCUboot's serial recovery needs. A part with different flash makes
+# the Partition Manager reject the map at build time rather than quietly
+# producing a wrong one, so this is a safe assumption to state here.
+NRF52840_FLASH_SIZE = 0x100000
+FLASH_SECTOR_SIZE = 0x1000
+# Enough for MCUboot with USB-CDC serial recovery and the management groups that
+# make a board which will not boot diagnosable over that same connection. The
+# build measures around 53 KB; dropping serial recovery would fit half this.
+MCUBOOT_PARTITION_SIZE = 0x10000
+# Zephyr NVS, behind esphome's preferences.
+SETTINGS_PARTITION_SIZE = 0xA000
 
 FAKE_BOARD_MANIFEST = """
 {
@@ -292,6 +312,19 @@ def _final_validate(config):
 
     if CONF_DFU in config:
         _validate_mcumgr(config)
+    if (
+        config[KEY_BOOTLOADER] == BOOTLOADER_MCUBOOT
+        and CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] < cv.Version(2, 9, 2)
+    ):
+        # The MCUboot image is configured through sysbuild, which replaced the
+        # zephyr/child_image/ mechanism in NCS 2.9.2. On an older SDK the
+        # fragments are silently ignored and the board comes out with no
+        # bootloader at all, so refuse the config instead.
+        raise cv.Invalid(
+            f"'{BOOTLOADER_MCUBOOT}' requires nRF Connect SDK 2.9.2 or newer. "
+            "Use 'toolchain: sdk-nrf', or set 'framework: version:' to 2.9.2 "
+            "or later."
+        )
     if config[KEY_BOOTLOADER] == BOOTLOADER_ADAFRUIT:
         _LOGGER.warning(
             "Selected generic Adafruit bootloader. The board might crash. Consider settings `bootloader:`"
@@ -324,6 +357,121 @@ def _final_validate(config):
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate
+
+
+def _mcuboot_to_code() -> None:
+    """Configure a two-slot MCUboot that owns the device from the reset vector.
+
+    This *replaces* any factory bootloader rather than chaining behind it, so
+    the board is flashed once over SWD with merged.hex and every update after
+    that is an MCUboot image upload (BLE or USB-CDC serial recovery). In
+    exchange there is no SoftDevice reservation, the whole part is available,
+    and nothing on the device ever rewrites UICR.
+
+    The flash map is derived from the partition sizes above rather than written
+    out per board. On a 1 MB nRF52840 it comes out as:
+
+        mcuboot    0x00000..0x10000    64 KiB
+        primary    0x10000..0x83000   460 KiB   <- the gap
+        secondary  0x83000..0xF6000   460 KiB
+        settings   0xF6000..0x100000   40 KiB
+
+    Only the primary slot is left implicit: the Partition Manager fills the
+    single gap with it. Everything else is stated, because left to itself PM
+    sizes the two application slots first and hands settings_storage whatever
+    remains -- a single 0x2000, the bare two sectors Zephyr NVS will accept.
+    """
+    slot_size = (
+        NRF52840_FLASH_SIZE - MCUBOOT_PARTITION_SIZE - SETTINGS_PARTITION_SIZE
+    ) // 2
+    slot_size -= slot_size % FLASH_SECTOR_SIZE
+    slot0_address = MCUBOOT_PARTITION_SIZE
+    slot1_address = slot0_address + slot_size
+    settings_address = NRF52840_FLASH_SIZE - SETTINGS_PARTITION_SIZE
+
+    # Build the app as an MCUboot image (signed, linked into the primary slot)
+    # and pull in the MCUboot sysbuild image. The bootloader selection has to do
+    # this itself: a config with no zephyr_mcumgr OTA still needs a bootloader
+    # to boot at all, and without it the app links as a plain application at 0x0
+    # and MCUboot is never built.
+    zephyr_add_prj_conf("BOOTLOADER_MCUBOOT", True)
+    zephyr_data()[KEY_SYSBUILD] = True
+
+    # Board defconfigs turn on UF2 output for the Adafruit bootloader, which
+    # consumes it. There is no Adafruit bootloader here, and the UF2 that would
+    # be emitted carries the app's new load address rather than the one the
+    # factory bootloader expects, so it is actively misleading. Dropping it also
+    # lets get_download_types() offer merged.hex and app_update.bin instead.
+    zephyr_add_prj_conf("BUILD_OUTPUT_UF2", False)
+
+    zephyr_add_pm_static(
+        [
+            Section("mcuboot", 0x0, MCUBOOT_PARTITION_SIZE, "flash_primary"),
+            Section("mcuboot_secondary", slot1_address, slot_size, "flash_primary"),
+            Section(
+                "settings_storage",
+                settings_address,
+                SETTINGS_PARTITION_SIZE,
+                "flash_primary",
+            ),
+        ]
+    )
+
+    # Hash-only image validation (signature type "none"). ECDSA-P256, the
+    # nRF52840 sysbuild default, does fit this partition -- but the key it signs
+    # with is MCUboot's published sample key, which every copy of the SDK ships.
+    # Verifying against a keypair anyone can obtain buys no authenticity, so
+    # rather than imply a guarantee that isn't there, check integrity only and
+    # say so. Real signing needs a user-supplied key, which is worth adding as
+    # an explicit option rather than defaulting to a public one.
+    #
+    # Under sysbuild the signature type is chosen at the sysbuild level: the
+    # mcuboot image inherits it and the app is signed to match.
+    zephyr_add_sysbuild_conf("BOOT_SIGNATURE_TYPE_NONE", True)
+    # Overwrite-only upgrades: no swap, no revert, no trailer state, so a board
+    # cannot get stuck re-running a revert (an MCUboot v2.1.0 defect fixed only
+    # in v2.2.0, which is newer than the SDK this builds against). The trade is
+    # no automatic rollback; recovery is USB-CDC serial recovery, or SWD.
+    #
+    # Both of these MUST be set at the sysbuild level. The upgrade mode is a
+    # Kconfig *choice*, and sysbuild force-writes every member of that choice
+    # into the image's FORCED_CONF_FILE -- so CONFIG_BOOT_UPGRADE_ONLY=y in the
+    # image's own fragment is applied and then silently overridden back to n.
+    zephyr_add_sysbuild_conf("MCUBOOT_MODE_OVERWRITE_ONLY", True)
+
+    # Deliver the MCUboot Kconfig fragment and devicetree overlay to the MCUboot
+    # sysbuild image; sysbuild reads them from ${APP_DIR}/sysbuild/<image>.*.
+    add_extra_build_file(
+        "zephyr/sysbuild/mcuboot.conf",
+        Path(__file__).parent / "mcuboot.conf",
+    )
+    zephyr_add_overlay(
+        (Path(__file__).parent / "mcuboot.overlay").read_text(),
+        image="mcuboot",
+    )
+
+    # slot0_partition / slot1_partition devicetree labels. MCUboot's CMakeLists
+    # reads erase-block-size / write-block-size and the sector count from these
+    # at configure time, and NCS's image-signing step reads slot0_partition
+    # (REQUIRED) to size the signed app image -- so both images need them.
+    # Board DTS files ship a factory-bootloader layout and define neither, and
+    # without them the devicetree configure step fails outright.
+    mcuboot_slots = f"""
+        &flash0 {{
+            partitions {{
+                slot0_partition: partition@{slot0_address:x} {{
+                    label = "image-0";
+                    reg = <0x{slot0_address:08x} 0x{slot_size:08x}>;
+                }};
+                slot1_partition: partition@{slot1_address:x} {{
+                    label = "image-1";
+                    reg = <0x{slot1_address:08x} 0x{slot_size:08x}>;
+                }};
+            }};
+        }};
+    """
+    zephyr_add_overlay(mcuboot_slots, image="mcuboot")
+    zephyr_add_overlay(mcuboot_slots, image="")
 
 
 @coroutine_with_priority(CoroPriority.PLATFORM)
@@ -367,6 +515,7 @@ async def to_code(config: ConfigType) -> None:
 
     if config[KEY_BOOTLOADER] == BOOTLOADER_MCUBOOT:
         cg.add_define("USE_BOOTLOADER_MCUBOOT")
+        _mcuboot_to_code()
     elif "_sd" in config[KEY_BOOTLOADER]:
         bootloader = config[KEY_BOOTLOADER].split("_")
         sd_id = bootloader[2][2:]
@@ -461,7 +610,7 @@ def copy_files() -> None:
 
     if CORE.using_toolchain_platformio and (
         zephyr_data()[KEY_BOOTLOADER] == BOOTLOADER_MCUBOOT
-        or zephyr_data()[KEY_BOARD] == "xiao_ble"
+        or zephyr_data()[KEY_BOARD] == XIAO_BLE
     ):
         write_file_if_changed(
             CORE.relative_build_path(f"boards/{zephyr_data()[KEY_BOARD]}.json"),

--- a/esphome/components/nrf52/boards.py
+++ b/esphome/components/nrf52/boards.py
@@ -1,5 +1,5 @@
 from esphome.components.zephyr import Section
-from esphome.components.zephyr.const import KEY_BOOTLOADER
+from esphome.components.zephyr.const import BOOTLOADER_MCUBOOT, KEY_BOOTLOADER
 
 from .const import (
     BOOTLOADER_ADAFRUIT,
@@ -8,6 +8,10 @@ from .const import (
     BOOTLOADER_ADAFRUIT_NRF52_SD140_V7,
 )
 
+# MCUboot is listed last for every board, so no board's default changes: it
+# replaces the factory bootloader at 0x0 and has to be flashed over SWD once,
+# so it can only ever be an explicit opt-in. Boards absent from this table
+# already default to it (see _detect_bootloader).
 BOARDS_ZEPHYR = {
     "adafruit_itsybitsy_nrf52840": {
         KEY_BOOTLOADER: [
@@ -15,6 +19,7 @@ BOARDS_ZEPHYR = {
             BOOTLOADER_ADAFRUIT,
             BOOTLOADER_ADAFRUIT_NRF52_SD132,
             BOOTLOADER_ADAFRUIT_NRF52_SD140_V7,
+            BOOTLOADER_MCUBOOT,
         ]
     },
     "xiao_ble": {
@@ -23,6 +28,7 @@ BOARDS_ZEPHYR = {
             BOOTLOADER_ADAFRUIT,
             BOOTLOADER_ADAFRUIT_NRF52_SD132,
             BOOTLOADER_ADAFRUIT_NRF52_SD140_V6,
+            BOOTLOADER_MCUBOOT,
         ]
     },
     "adafruit_itsybitsy": {
@@ -31,6 +37,7 @@ BOARDS_ZEPHYR = {
             BOOTLOADER_ADAFRUIT,
             BOOTLOADER_ADAFRUIT_NRF52_SD132,
             BOOTLOADER_ADAFRUIT_NRF52_SD140_V7,
+            BOOTLOADER_MCUBOOT,
         ]
     },
 }

--- a/esphome/components/nrf52/mcuboot.conf
+++ b/esphome/components/nrf52/mcuboot.conf
@@ -1,0 +1,96 @@
+# MCUboot as the only bootloader (mcuboot sysbuild image).
+#
+# Two slots, so BLE/USB OTA works, but OVERWRITE-ONLY rather than swap. MCUboot
+# lives at 0x0 and the SoC boots it straight off the reset vector; the flash map
+# is derived and stated as a pm_static in __init__.py.
+#
+# It keeps a USB-CDC serial-recovery interface: a board with an empty or invalid
+# primary slot drops into recovery, where an image can be uploaded over USB with
+# no SWD probe attached.
+
+# The board defconfig builds a UF2 for the Adafruit bootloader, at the load
+# address that bootloader expects (0x27000). MCUboot is linked at 0x0 and there
+# is no Adafruit bootloader left to consume the file, so what gets emitted is an
+# image that would write the bootloader 156 KB into flash. Don't produce it.
+CONFIG_BUILD_OUTPUT_UF2=n
+
+CONFIG_CONSOLE=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n
+CONFIG_PRINTK=n
+CONFIG_HW_CC3XX=n
+CONFIG_BOOT_BANNER=n
+
+# Two slots, overwrite-only: the secondary image is copied over the primary and
+# the secondary is erased. There is no swap, no revert and no trailer state, so
+# the class of failure where a board is stuck re-running a revert cannot happen
+# -- which is what MCUboot v2.1.0 (NCS 2.9.2) is vulnerable to, fixed upstream
+# only in v2.2.0. The trade is no automatic rollback: a bad image is recovered
+# through USB-CDC serial recovery below, or over SWD.
+#
+# An OTA client must therefore mark uploads CONFIRMED, not TEST -- a test
+# marking has nothing to fall back to.
+#
+# The mode itself is NOT set here. It is a Kconfig choice, and sysbuild's
+# BOOTLOADER_image_default.cmake force-writes every member of that choice from
+# SB_CONFIG_MCUBOOT_MODE_* into this image's FORCED_CONF_FILE, which silently
+# overrides anything this fragment says. Setting CONFIG_BOOT_UPGRADE_ONLY=y here
+# looks like it works and does nothing. See zephyr_add_sysbuild_conf(
+# "MCUBOOT_MODE_OVERWRITE_ONLY") in __init__.py.
+CONFIG_SINGLE_APPLICATION_SLOT=n
+
+# Hash-only validation to fit the bootloader budget. Integrity is still checked
+# (SHA256 over the image) -- what is given up is authenticity.
+CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
+CONFIG_BOOT_SIGNATURE_KEY_FILE="root-ec-p256.pem"
+CONFIG_BOOT_VALIDATE_SLOT0=y
+
+# USB-CDC serial recovery. USB_DEVICE_INITIALIZE_AT_BOOT=n and the
+# BOOT_MAX_LINE_INPUT_LEN / BOOT_LINE_BUFS settings are the load-bearing fixes.
+CONFIG_MCUBOOT_SERIAL=y
+CONFIG_BOOT_SERIAL_ENTRANCE_GPIO=n
+CONFIG_BOOT_SERIAL_CDC_ACM=y
+CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=n
+CONFIG_BOOT_SERIAL_UNALIGNED_BUFFER_SIZE=32
+CONFIG_BOOT_MAX_LINE_INPUT_LEN=512
+CONFIG_BOOT_LINE_BUFS=2
+CONFIG_BOOT_SERIAL_MAX_RECEIVE_SIZE=512
+CONFIG_BOOT_SERIAL_WAIT_FOR_DFU=y
+CONFIG_BOOT_SERIAL_WAIT_FOR_DFU_TIMEOUT=30000
+CONFIG_BOOT_SERIAL_NO_APPLICATION=y
+CONFIG_BOOT_ERASE_PROGRESSIVELY=y
+CONFIG_BOOT_WATCHDOG_FEED=n
+
+# Serial-recovery management commands. Without these the bootloader can be
+# talked to but not interrogated: it accepts an upload and otherwise answers
+# ENOTSUP, so a board that refuses to boot gives no clue why. IMAGE_STATE and
+# SLOT_INFO make the slot contents readable over the same USB connection, and
+# IMG_GRP_HASH puts image hashes in those replies so a slot can be identified
+# (esphome's ota.py addresses images by hash). DIRECT_IMAGE_UPLOAD allows
+# targeting a specific slot rather than only the primary.
+CONFIG_BOOT_SERIAL_IMG_GRP_HASH=y
+CONFIG_BOOT_SERIAL_IMG_GRP_IMAGE_STATE=y
+CONFIG_BOOT_SERIAL_IMG_GRP_SLOT_INFO=y
+CONFIG_MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD=y
+
+# Footprint trims. These are what let the bootloader stay well inside its
+# partition without a board-specific overlay disabling peripherals one by one.
+CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL=n
+CONFIG_MCUBOOT_CLEANUP_ARM_CORE=n
+CONFIG_MCUBOOT_CLEANUP_UNUSABLE_SECONDARY=n
+CONFIG_FPROTECT=n
+CONFIG_TIMESLICING=n
+CONFIG_TIMEOUT_64BIT=n
+# CONFIG_MINIMAL_LIBC_MALLOC/CALLOC/REALLOCARRAY were footprint trims valid on
+# NCS 2.6.1 but are undefined symbols on 2.9.2 -- assigning to an undefined symbol
+# is the one Kconfig warning NCS escalates to a fatal "Aborting due to Kconfig
+# warnings", so they are dropped (no-ops on 2.9.2 anyway). MINIMAL_LIBC_TIME still
+# exists on 2.9.2 and is kept.
+CONFIG_MINIMAL_LIBC_TIME=n
+CONFIG_ZCBOR_MAX_STR_LEN=96
+CONFIG_USB_MAX_NUM_TRANSFERS=2
+CONFIG_USB_NRFX_EVT_QUEUE_SIZE=8
+CONFIG_USB_CDC_ACM_RINGBUF_SIZE=256
+CONFIG_CBPRINTF_FULL_INTEGRAL=n
+CONFIG_CBPRINTF_REDUCED_INTEGRAL=y
+CONFIG_CBPRINTF_LIBC_SUBSTS=n

--- a/esphome/components/nrf52/mcuboot.overlay
+++ b/esphome/components/nrf52/mcuboot.overlay
@@ -1,0 +1,25 @@
+/*
+ * MCUboot devicetree overlay (mcuboot sysbuild image).
+ *
+ * MCUboot's serial recovery runs over a USB CDC ACM UART, so a board whose
+ * primary slot is empty or invalid can still be given an image over USB with
+ * no SWD probe attached.
+ *
+ * The CDC ACM node is declared here rather than borrowed from the board. Board
+ * DTS files name theirs inconsistently -- xiao_ble calls it usb_cdc_acm_uart,
+ * the Adafruit nRF52840 boards call it cdc_acm_uart0 -- so referencing the
+ * board's label would tie this file to one board. All this needs is
+ * zephyr_udc0, which every nRF52840 has.
+ */
+/ {
+    chosen {
+        zephyr,cdc-acm-uart = &mcuboot_cdc_acm;
+        zephyr,uart-mcumgr = &mcuboot_cdc_acm;
+    };
+};
+&zephyr_udc0 {
+    status = "okay";
+    mcuboot_cdc_acm: mcuboot_cdc_acm {
+        compatible = "zephyr,cdc-acm-uart";
+    };
+};

--- a/esphome/components/zephyr/__init__.py
+++ b/esphome/components/zephyr/__init__.py
@@ -19,6 +19,7 @@ from .const import (
     KEY_PM_STATIC,
     KEY_PRJ_CONF,
     KEY_SYSBUILD,
+    KEY_SYSBUILD_CONF,
     KEY_USER,
     KEY_ZEPHYR,
     zephyr_ns,
@@ -76,6 +77,7 @@ class ZephyrData(TypedDict):
     user: dict[str, list[str]]
     kconfig: str
     sysbuild: bool
+    sysbuild_conf: dict[str, PrjConfValueType]
 
 
 def zephyr_set_core_data(config: ConfigType) -> None:
@@ -94,6 +96,7 @@ def zephyr_set_core_data(config: ConfigType) -> None:
         # config says `bootloader: mcuboot`, so the image can be smaller. This was
         # the default behaviour in SDK 2.6.1.
         sysbuild=False,
+        sysbuild_conf={},
     )
 
 
@@ -222,6 +225,27 @@ def zephyr_add_pm_static(sections: list[Section]) -> None:
     zephyr_data()[KEY_PM_STATIC].extend(sections)
 
 
+def zephyr_add_sysbuild_conf(name: str, value: PrjConfValueType) -> None:
+    """Set a sysbuild-level Kconfig option (written to zephyr/sysbuild.conf).
+
+    These SB_CONFIG_* options drive the sysbuild image assembly itself -- which
+    bootloader is built, how it signs images, which upgrade mode it uses. They
+    cannot be set from an image's own Kconfig fragment: sysbuild force-writes
+    them into each image's FORCED_CONF_FILE, which is applied last and silently
+    overrides whatever the fragment asked for.
+
+    Only written when sysbuild is actually in use (see KEY_SYSBUILD).
+    """
+    if not name.startswith("SB_CONFIG_"):
+        name = "SB_CONFIG_" + name
+    conf = zephyr_data()[KEY_SYSBUILD_CONF]
+    if name in conf and conf[name] != value:
+        raise ValueError(
+            f"{name} already set with value '{conf[name]}', cannot set again to '{value}'"
+        )
+    conf[name] = value
+
+
 def zephyr_add_user(key, value):
     user = zephyr_data()[KEY_USER]
     if key not in user:
@@ -314,6 +338,8 @@ def copy_files() -> None:
     sysbuild_conf = ""
     if zephyr_data()[KEY_SYSBUILD]:
         sysbuild_conf = "SB_CONFIG_BOOTLOADER_MCUBOOT=y\n"
+        for name, value in sorted(zephyr_data()[KEY_SYSBUILD_CONF].items()):
+            sysbuild_conf += f"{name}={_format_prj_conf_val(value)}\n"
     changed |= _write_file_if_changed_or_remove_when_empty(
         CORE.relative_build_path("zephyr/sysbuild.conf"), sysbuild_conf
     )

--- a/esphome/components/zephyr/const.py
+++ b/esphome/components/zephyr/const.py
@@ -14,6 +14,7 @@ KEY_ZEPHYR = "zephyr"
 KEY_BOARD: Final = "board"
 KEY_USER: Final = "user"
 KEY_SYSBUILD: Final = "sysbuild"
+KEY_SYSBUILD_CONF: Final = "sysbuild_conf"
 
 zephyr_ns = cg.esphome_ns.namespace("zephyr")
 CdcAcm = zephyr_ns.class_("CdcAcm", cg.Component)

--- a/tests/components/ota/test.nrf52-itsybitsy-mcuboot.yaml
+++ b/tests/components/ota/test.nrf52-itsybitsy-mcuboot.yaml
@@ -1,0 +1,26 @@
+zephyr_ble_server:
+
+ota:
+  - platform: zephyr_mcumgr
+    transport:
+      ble: true
+    on_begin:
+      then:
+        - logger.log: "OTA start"
+    on_progress:
+      then:
+        - logger.log:
+            format: "OTA progress %0.1f%%"
+            args: ["x"]
+    on_end:
+      then:
+        - logger.log: "OTA end"
+    on_error:
+      then:
+        - logger.log:
+            format: "OTA update error %d"
+            args: ["x"]
+    on_state_change:
+      then:
+        lambda: >-
+          ESP_LOGD("ota", "State %d", state);

--- a/tests/components/ota/test.nrf52-xiao-mcuboot.yaml
+++ b/tests/components/ota/test.nrf52-xiao-mcuboot.yaml
@@ -1,0 +1,26 @@
+zephyr_ble_server:
+
+ota:
+  - platform: zephyr_mcumgr
+    transport:
+      ble: true
+    on_begin:
+      then:
+        - logger.log: "OTA start"
+    on_progress:
+      then:
+        - logger.log:
+            format: "OTA progress %0.1f%%"
+            args: ["x"]
+    on_end:
+      then:
+        - logger.log: "OTA end"
+    on_error:
+      then:
+        - logger.log:
+            format: "OTA update error %d"
+            args: ["x"]
+    on_state_change:
+      then:
+        lambda: >-
+          ESP_LOGD("ota", "State %d", state);

--- a/tests/test_build_components/build_components_base.nrf52-itsybitsy-mcuboot.yaml
+++ b/tests/test_build_components/build_components_base.nrf52-itsybitsy-mcuboot.yaml
@@ -1,0 +1,20 @@
+esphome:
+  name: componenttestnrf52
+  friendly_name: $component_name
+
+# Second board for the same bootloader: nothing about `bootloader: mcuboot` is
+# board-specific, and this build is what proves it. Its devicetree names the USB
+# CDC node cdc_acm_uart0 where xiao_ble calls it usb_cdc_acm_uart, so a
+# bootloader overlay that referenced the board's label would fail here.
+nrf52:
+  board: adafruit_itsybitsy_nrf52840
+  bootloader: mcuboot
+
+logger:
+  level: VERY_VERBOSE
+
+packages:
+  component_under_test: !include
+    file: $component_test_file
+    vars:
+      component_test_file: $component_test_file

--- a/tests/test_build_components/build_components_base.nrf52-xiao-mcuboot.yaml
+++ b/tests/test_build_components/build_components_base.nrf52-xiao-mcuboot.yaml
@@ -1,0 +1,16 @@
+esphome:
+  name: componenttestnrf52
+  friendly_name: $component_name
+
+nrf52:
+  board: xiao_ble
+  bootloader: mcuboot
+
+logger:
+  level: VERY_VERBOSE
+
+packages:
+  component_under_test: !include
+    file: $component_test_file
+    vars:
+      component_test_file: $component_test_file

--- a/tests/unit_tests/test_nrf52_bootloader.py
+++ b/tests/unit_tests/test_nrf52_bootloader.py
@@ -1,0 +1,143 @@
+"""Tests for nRF52 per-board bootloader selection and validation."""
+
+import pytest
+
+from esphome.components import nrf52
+from esphome.components.nrf52 import boards
+from esphome.components.nrf52.const import BOOTLOADER_ADAFRUIT
+from esphome.components.zephyr import zephyr_data, zephyr_set_core_data
+from esphome.components.zephyr.const import (
+    BOOTLOADER_MCUBOOT,
+    KEY_BOOTLOADER,
+    KEY_EXTRA_BUILD_FILES,
+    KEY_OVERLAY,
+    KEY_PM_STATIC,
+    KEY_PRJ_CONF,
+    KEY_SYSBUILD,
+    KEY_SYSBUILD_CONF,
+)
+import esphome.config_validation as cv
+from esphome.const import CONF_BOARD
+
+
+def test_xiao_ble_accepts_mcuboot_bootloader() -> None:
+    """xiao_ble lists mcuboot as a supported two-slot bootloader."""
+    config = nrf52._detect_bootloader(
+        {CONF_BOARD: "xiao_ble", KEY_BOOTLOADER: BOOTLOADER_MCUBOOT}
+    )
+
+    assert config[KEY_BOOTLOADER] == BOOTLOADER_MCUBOOT
+
+
+def test_board_rejects_a_bootloader_it_does_not_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every board in the real table now lists mcuboot, so use a stand-in.
+
+    This covers the guard itself rather than a fact about any one board: a board
+    that offers a restricted set must still refuse anything outside it.
+    """
+    monkeypatch.setitem(
+        boards.BOARDS_ZEPHYR, "restricted_board", {KEY_BOOTLOADER: [BOOTLOADER_ADAFRUIT]}
+    )
+
+    with pytest.raises(cv.Invalid, match="does not support"):
+        nrf52._detect_bootloader(
+            {CONF_BOARD: "restricted_board", KEY_BOOTLOADER: BOOTLOADER_MCUBOOT}
+        )
+
+
+def test_xiao_ble_default_bootloader_is_not_mcuboot() -> None:
+    """Without an explicit selection xiao_ble keeps its first (Adafruit) default."""
+    config = nrf52._detect_bootloader({CONF_BOARD: "xiao_ble"})
+
+    assert config[KEY_BOOTLOADER] != BOOTLOADER_MCUBOOT
+
+
+@pytest.fixture(params=["xiao_ble", "adafruit_itsybitsy_nrf52840", "some_other_board"])
+def xiao_ble_mcuboot(request: pytest.FixtureRequest) -> None:
+    """The MCUboot setup is board-agnostic, so assert it on more than one."""
+    zephyr_set_core_data(
+        {CONF_BOARD: request.param, KEY_BOOTLOADER: BOOTLOADER_MCUBOOT}
+    )
+    nrf52._mcuboot_to_code()
+
+
+def test_every_known_board_can_select_mcuboot() -> None:
+    """The codeowner asked for any board, not just the one this started on."""
+    for board in boards.BOARDS_ZEPHYR:
+        config = nrf52._detect_bootloader(
+            {CONF_BOARD: board, KEY_BOOTLOADER: BOOTLOADER_MCUBOOT}
+        )
+        assert config[KEY_BOOTLOADER] == BOOTLOADER_MCUBOOT
+        # ...without becoming any board's default, which would silently change
+        # what an existing config builds.
+        assert nrf52._detect_bootloader({CONF_BOARD: board})[KEY_BOOTLOADER] != (
+            BOOTLOADER_MCUBOOT
+        )
+
+
+def test_mcuboot_image_is_built(xiao_ble_mcuboot: None) -> None:
+    """The app links into a slot and sysbuild builds the bootloader alongside it."""
+    app_conf = zephyr_data()[KEY_PRJ_CONF][""]
+
+    assert zephyr_data()[KEY_SYSBUILD] is True
+    assert app_conf["CONFIG_BOOTLOADER_MCUBOOT"][0] is True
+    # No Adafruit bootloader is left to consume a UF2, and the one that would be
+    # emitted carries the wrong load address.
+    assert app_conf["CONFIG_BUILD_OUTPUT_UF2"][0] is False
+
+
+def test_upgrade_mode_and_signing_are_set_at_sysbuild_level(
+    xiao_ble_mcuboot: None,
+) -> None:
+    """Set anywhere else, sysbuild's FORCED_CONF_FILE silently overrides them."""
+    assert zephyr_data()[KEY_SYSBUILD_CONF] == {
+        "SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE": True,
+        "SB_CONFIG_MCUBOOT_MODE_OVERWRITE_ONLY": True,
+    }
+
+
+def test_flash_map_leaves_one_gap_for_the_primary_slot(xiao_ble_mcuboot: None) -> None:
+    """The Partition Manager fills the single hole; everything else is pinned."""
+    sections = {s.name: s for s in zephyr_data()[KEY_PM_STATIC]}
+
+    assert set(sections) == {"mcuboot", "mcuboot_secondary", "settings_storage"}
+    # The gap between the bootloader and the secondary slot is the primary slot,
+    # and it has to be the same size as the secondary or an image that fits one
+    # will not fit the other.
+    primary_start = sections["mcuboot"].end_address
+    primary_size = sections["mcuboot_secondary"].address - primary_start
+    assert primary_start == nrf52.MCUBOOT_PARTITION_SIZE
+    assert primary_size == sections["mcuboot_secondary"].size
+    assert primary_size % nrf52.FLASH_SECTOR_SIZE == 0
+    # Settings run to the end of the part, and PM would otherwise squeeze them
+    # down to the two sectors NVS needs.
+    assert sections["settings_storage"].end_address == nrf52.NRF52840_FLASH_SIZE
+    assert sections["settings_storage"].size == nrf52.SETTINGS_PARTITION_SIZE
+    # Nothing overlaps and nothing is stranded past the end of flash.
+    assert primary_start + 2 * primary_size == sections["settings_storage"].address
+
+
+def test_slot_labels_reach_both_images(xiao_ble_mcuboot: None) -> None:
+    """MCUboot sizes its sectors from them; image signing sizes the app from them."""
+    overlays = zephyr_data()[KEY_OVERLAY]
+    sections = {s.name: s for s in zephyr_data()[KEY_PM_STATIC]}
+
+    for image in ("", "mcuboot"):
+        # The labels must agree with the pm_static map or MCUboot computes its
+        # sector maths against a layout the device does not have.
+        assert f"partition@{nrf52.MCUBOOT_PARTITION_SIZE:x}" in overlays[image]
+        assert f"partition@{sections['mcuboot_secondary'].address:x}" in overlays[image]
+    # Serial recovery over USB CDC only reaches the bootloader, and it binds to
+    # a CDC node the overlay declares rather than a board-specific label.
+    assert "zephyr,uart-mcumgr = &mcuboot_cdc_acm" in overlays["mcuboot"]
+    assert "zephyr,uart-mcumgr" not in overlays[""]
+
+
+def test_bootloader_kconfig_fragment_is_delivered(xiao_ble_mcuboot: None) -> None:
+    """Sysbuild reads the MCUboot image's fragment from ${APP_DIR}/sysbuild/."""
+    extra = zephyr_data()[KEY_EXTRA_BUILD_FILES]
+
+    assert "zephyr/sysbuild/mcuboot.conf" in extra
+    assert extra["zephyr/sysbuild/mcuboot.conf"].is_file()

--- a/tests/unit_tests/test_nrf52_bootloader.py
+++ b/tests/unit_tests/test_nrf52_bootloader.py
@@ -38,7 +38,9 @@ def test_board_rejects_a_bootloader_it_does_not_list(
     that offers a restricted set must still refuse anything outside it.
     """
     monkeypatch.setitem(
-        boards.BOARDS_ZEPHYR, "restricted_board", {KEY_BOOTLOADER: [BOOTLOADER_ADAFRUIT]}
+        boards.BOARDS_ZEPHYR,
+        "restricted_board",
+        {KEY_BOOTLOADER: [BOOTLOADER_ADAFRUIT]},
     )
 
     with pytest.raises(cv.Invalid, match="does not support"):

--- a/tests/unit_tests/test_zephyr_sysbuild_conf.py
+++ b/tests/unit_tests/test_zephyr_sysbuild_conf.py
@@ -42,7 +42,9 @@ def test_setting_the_same_value_twice_is_allowed() -> None:
     zephyr_add_sysbuild_conf("BOOT_SIGNATURE_TYPE_NONE", True)
     zephyr_add_sysbuild_conf("BOOT_SIGNATURE_TYPE_NONE", True)
 
-    assert zephyr_data()[KEY_SYSBUILD_CONF]["SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE"] is True
+    assert (
+        zephyr_data()[KEY_SYSBUILD_CONF]["SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE"] is True
+    )
 
 
 def test_conflicting_value_raises() -> None:

--- a/tests/unit_tests/test_zephyr_sysbuild_conf.py
+++ b/tests/unit_tests/test_zephyr_sysbuild_conf.py
@@ -1,0 +1,70 @@
+"""Tests for sysbuild-level Kconfig options (SB_CONFIG_*)."""
+
+import pytest
+
+from esphome.components.zephyr import (
+    HexValue,
+    zephyr_add_sysbuild_conf,
+    zephyr_data,
+    zephyr_set_core_data,
+)
+from esphome.components.zephyr.const import (
+    BOOTLOADER_MCUBOOT,
+    KEY_BOOTLOADER,
+    KEY_SYSBUILD_CONF,
+)
+from esphome.const import CONF_BOARD
+
+
+@pytest.fixture(autouse=True)
+def zephyr_core() -> None:
+    zephyr_set_core_data({CONF_BOARD: "xiao_ble", KEY_BOOTLOADER: BOOTLOADER_MCUBOOT})
+
+
+def test_prefix_is_added_when_missing() -> None:
+    """A bare name is stored under its SB_CONFIG_ prefix."""
+    zephyr_add_sysbuild_conf("MCUBOOT_MODE_OVERWRITE_ONLY", True)
+
+    assert zephyr_data()[KEY_SYSBUILD_CONF] == {
+        "SB_CONFIG_MCUBOOT_MODE_OVERWRITE_ONLY": True
+    }
+
+
+def test_prefix_is_not_doubled() -> None:
+    """An already-prefixed name is stored as-is."""
+    zephyr_add_sysbuild_conf("SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE", True)
+
+    assert "SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE" in zephyr_data()[KEY_SYSBUILD_CONF]
+
+
+def test_setting_the_same_value_twice_is_allowed() -> None:
+    """Two components asking for the same option agree, so it is not an error."""
+    zephyr_add_sysbuild_conf("BOOT_SIGNATURE_TYPE_NONE", True)
+    zephyr_add_sysbuild_conf("BOOT_SIGNATURE_TYPE_NONE", True)
+
+    assert zephyr_data()[KEY_SYSBUILD_CONF]["SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE"] is True
+
+
+def test_conflicting_value_raises() -> None:
+    """A silent override here would change how every image is built."""
+    zephyr_add_sysbuild_conf("BOOT_SIGNATURE_TYPE_NONE", True)
+
+    with pytest.raises(ValueError, match="already set"):
+        zephyr_add_sysbuild_conf("BOOT_SIGNATURE_TYPE_NONE", False)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, "y"),
+        (False, "n"),
+        (42, "42"),
+        (HexValue(0xA000), "0xa000"),
+        ("text", '"text"'),
+    ],
+)
+def test_values_are_formatted_for_kconfig(value, expected: str) -> None:
+    """sysbuild.conf uses the same value formatting as prj.conf."""
+    from esphome.components.zephyr import _format_prj_conf_val
+
+    assert _format_prj_conf_val(value) == expected


### PR DESCRIPTION
# What does this implement/fix?

Makes `bootloader: mcuboot` a usable option on nRF52840 boards, with MCUboot as the *only* bootloader: it lives at `0x0` and the SoC boots it straight off the reset vector, rather than chaining behind a factory bootloader as #17381 does for the Adafruit layouts.

The board is flashed once over SWD with `merged.hex`; every update after that is an MCUboot image upload over BLE (`zephyr_mcumgr`) or over USB-CDC serial recovery.

This replaces the earlier revision of this PR entirely. @tomaszduda23 asked that it support any board rather than only `xiao_ble`, and nothing in the implementation is board-specific now:

- **The flash map is derived**, not written out: `slot = align_down((flash − mcuboot − settings) / 2, 0x1000)`.
- **The bootloader declares its own USB CDC ACM node** instead of borrowing the board's. `xiao_ble` names that node `usb_cdc_acm_uart`; the Adafruit nRF52840 boards name it `cdc_acm_uart0`. Referencing either would pin the overlay to one board. All it needs is `zephyr_udc0`.

Verified by building the same config on **`xiao_ble`** and **`adafruit_itsybitsy_nrf52840`**: identical partition maps, bootloader at 80.9% and 78.4% of its partition. Both are covered under `tests/test_build_components`.

MCUboot is listed **last** for every board in `BOARDS_ZEPHYR`, so no board's default changes — replacing the factory bootloader needs a probe, so it stays an explicit opt-in.

Upgrades are overwrite-only (no swap, no revert) and images are validated by hash. Requires NCS >= 2.9.2 for sysbuild; older SDKs are rejected at validation rather than silently building without a bootloader. Happy to discuss any of those defaults.

## Flash map

On a 1 MB nRF52840, with the Partition Manager filling the single remaining gap as the primary slot:

```
mcuboot            0x00000 .. 0x10000    65,536 B
mcuboot_pad        0x10000 .. 0x10200
app  (primary)     0x10200 .. 0x83000   470,528 B   <- the gap
mcuboot_secondary  0x83000 .. 0xF6000   471,040 B
settings_storage   0xF6000 .. 0x100000   40,960 B
```

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6817

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
nrf52:
  board: xiao_ble
  bootloader: mcuboot

zephyr_ble_server:

ota:
  - platform: zephyr_mcumgr
    transport:
      ble: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

  - `build_components_base.nrf52-xiao-mcuboot.yaml` and `...nrf52-itsybitsy-mcuboot.yaml`, with matching `tests/components/ota/test.nrf52-*-mcuboot.yaml` — two different boards on the same bootloader, which is what demonstrates the board-independence.
  - `tests/unit_tests/test_nrf52_bootloader.py` — bootloader selection per board, the derived flash map, the sysbuild-level options, and the slot labels reaching both images.
  - `tests/unit_tests/test_zephyr_sysbuild_conf.py` — `zephyr_add_sysbuild_conf()` prefixing, conflict rejection and value formatting.
