### PR TITLE
2026.6.2

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.6.1
+PROJECT_NUMBER         = 2026.6.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     -r /requirements.txt
 
 # Install the ESPHome Device Builder dashboard.
-RUN uv pip install --no-cache-dir esphome-device-builder==1.0.10
+RUN uv pip install --no-cache-dir esphome-device-builder==1.0.11
 
 RUN \
     platformio settings set enable_telemetry No \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     -r /requirements.txt
 
 # Install the ESPHome Device Builder dashboard.
-RUN uv pip install --no-cache-dir esphome-device-builder==1.0.11
+RUN uv pip install --no-cache-dir esphome-device-builder==1.0.12
 
 RUN \
     platformio settings set enable_telemetry No \

--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
@@ -49,7 +49,21 @@ if bashio::fs.directory_exists '/config/esphome/.esphome'; then
     rm -rf /config/esphome/.esphome
 fi
 
+# Only signal device-builder to expose the public LAN port when the operator
+# mapped port 6052, matching the legacy dashboard where nginx listened on the
+# fixed port 6052 only when it was configured. We use the mapping purely as a
+# presence check and don't forward the published value; device-builder binds
+# its default port 6052 (the fixed container port, as the legacy
+# "listen 6052" did). --ha-addon-allow-public is inert on its own: the no-auth
+# gate is the DISABLE_HA_AUTHENTICATION env var set above, so both opt-ins are
+# required to bind 6052 unauthenticated; either alone stays ingress-only.
+set --
+if bashio::var.has_value "$(bashio::addon.port 6052)"; then
+    set -- --ha-addon-allow-public
+fi
+
 bashio::log.info "Starting ESPHome Device Builder..."
 exec esphome-device-builder /config/esphome \
     --ha-addon \
-    --ingress-port "$(bashio::addon.ingress_port)"
+    --ingress-port "$(bashio::addon.ingress_port)" \
+    "$@"

--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -50,6 +50,11 @@ async def new_fastled_light(config):
             ref="d44c800a9e876a8394caefc2ce4915dd96dac77b",
         )
         cg.add_library("SPI", None)
+        # FastLED's RMT5 driver hard-codes intr_priority=3, which conflicts with
+        # esphome's RMT channels (remote_transmitter etc., priority 0): the IDF
+        # driver rejects FastLED's channel and show() then hangs ~3s with no
+        # output. Override to 0 so it shares the interrupt. See #17063.
+        cg.add_build_flag("-DFL_RMT5_INTERRUPT_LEVEL=0")
     else:
         cg.add_library("fastled/FastLED", "3.9.16")
     await light.register_light(var, config)

--- a/esphome/components/packet_transport/__init__.py
+++ b/esphome/components/packet_transport/__init__.py
@@ -69,7 +69,7 @@ ENCRYPTION_SCHEMA = {
     cv.Optional(CONF_ENCRYPTION): cv.maybe_simple_value(
         cv.Schema(
             {
-                cv.Required(CONF_KEY): cv.string,
+                cv.Required(CONF_KEY): cv.sensitive(cv.string),
             }
         ),
         key=CONF_KEY,

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2026.6.1"
+__version__ = "2026.6.2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -81,8 +81,13 @@ def _get_idf_tools_path() -> Path:
         Path object pointing to the ESP-IDF tools directory
     """
     if "ESPHOME_ESP_IDF_PREFIX" in os.environ:
-        return Path(get_str_env("ESPHOME_ESP_IDF_PREFIX", None)).expanduser()
-    return CORE.data_dir / "idf"
+        path = Path(get_str_env("ESPHOME_ESP_IDF_PREFIX", None)).expanduser()
+    else:
+        path = CORE.data_dir / "idf"
+    # Resolve so an unnormalized config path (e.g. compiling ``../config/x.yaml``)
+    # doesn't leave ``..`` segments in the IDF_TOOLS_PATH handed to idf.py, which
+    # otherwise warns that the venv interpreter path doesn't match the install.
+    return path.resolve()
 
 
 # Windows' default MAX_PATH is 260 characters. ESP-IDF toolchains nest deeply


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [espidf] Resolve IDF tools path to avoid unnormalized path warning [esphome#17055](https://github.com/esphome/esphome/pull/17055)
- [fastled_base] Fix RMT5 intr_priority conflict [esphome#17072](https://github.com/esphome/esphome/pull/17072)
- [packet_transport] Mark encryption key as cv.sensitive [esphome#17066](https://github.com/esphome/esphome/pull/17066)
- Bump bundled esphome-device-builder to 1.0.11 [esphome#17081](https://github.com/esphome/esphome/pull/17081)
- [ha-addon] Expose the device-builder public port only when port 6052 is mapped [esphome#17076](https://github.com/esphome/esphome/pull/17076)
- Bump bundled esphome-device-builder to 1.0.12 [esphome#17091](https://github.com/esphome/esphome/pull/17091)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
