### PR TITLE
[nrf52] Fix BLE OTA/log device discovery & transport selection on macOS

### DIFF
--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -533,9 +533,11 @@ def show_logs(config: ConfigType, args, devices: list[str]) -> bool:
     if devices[0] == "BLE":
         ble_device = asyncio.run(logger_scan(CORE.name))
         if ble_device:
-            address = ble_device.address
-        else:
-            return True
+            # ble_device.address is a BLE handle (a MAC on Linux/BlueZ, a
+            # CoreBluetooth UUID on macOS); connect to it directly rather than
+            # gating on is_mac_address(), which is False for macOS UUIDs.
+            asyncio.run(logger_connect(ble_device.address))
+        return True
 
     if is_mac_address(address):
         asyncio.run(logger_connect(address))

--- a/esphome/components/nrf52/ota.py
+++ b/esphome/components/nrf52/ota.py
@@ -22,8 +22,7 @@ from smpclient.transport.serial import SMPSerialTransport
 
 from esphome.core import EsphomeError
 from esphome.espota2 import ProgressBar
-
-from .ble_logger import is_mac_address
+from esphome.upload_targets import PortType, get_port_type
 
 SMP_SERVICE_UUID = "8D53DC1D-1DB7-4CD3-868B-8A527460AA84"
 BLE_SCAN_TIMEOUT = 10.0  # seconds
@@ -45,11 +44,32 @@ def _json_state(o: object) -> object:
 
 async def smpmgr_scan(name: str) -> str:
     _LOGGER.info("Scanning bluetooth for %s...", name)
-    for device in await BleakScanner.discover(
-        timeout=BLE_SCAN_TIMEOUT, service_uuids=[SMP_SERVICE_UUID]
-    ):
-        if device.name == name:
+    # Do NOT pass service_uuids= to the scanner. The SMP/OTA service UUID is
+    # carried in the BLE *scan response*, not the primary advertisement: a
+    # 128-bit UUID (18 bytes) plus the complete device name does not fit in the
+    # 31-byte primary advertising payload (see zephyr_ble_server's AD vs SD).
+    # macOS/CoreBluetooth's service-UUID scan filter only matches UUIDs in the
+    # primary advertisement, so filtering on it hides the device entirely even
+    # though it is plainly discoverable by name. Match by name instead (the same
+    # way ble_logger does); the SMP GATT service is verified on connect.
+    smp_uuid = SMP_SERVICE_UUID.lower()
+    fallback: str | None = None
+    devices = await BleakScanner.discover(timeout=BLE_SCAN_TIMEOUT, return_adv=True)
+    for device, adv in devices.values():
+        # Match the live advertised name (local_name) as well as device.name.
+        # On macOS, device.name is the cached GAP "Device Name" from a previous
+        # connection, which goes stale after the firmware's name changes; the
+        # current name is in the advertisement's local_name.
+        if name not in (device.name, adv.local_name):
+            continue
+        # Prefer a device that actually advertises the OTA service (reliable on
+        # backends like BlueZ that report scan-response UUIDs), but fall back to
+        # the name match when the UUID is not visible (e.g. macOS).
+        if smp_uuid in (uuid.lower() for uuid in adv.service_uuids):
             return device.address
+        fallback = device.address
+    if fallback is not None:
+        return fallback
     raise EsphomeError(f"BLE device {name} with OTA service not found")
 
 
@@ -88,10 +108,14 @@ def _get_image_tlv_sha256(file: Path) -> bytes:
 async def _smpmgr_upload(device: str, firmware: Path) -> None:
     image_tlv_sha256 = _get_image_tlv_sha256(firmware)
 
-    if is_mac_address(device):
-        smp_client = SMPClient(SMPBLETransport(), device)
-    else:
+    # Serial ports are filesystem paths (/dev/..., COMx); anything else is a
+    # BLE peripheral. Don't gate on is_mac_address() here: macOS/CoreBluetooth
+    # identifies BLE devices by UUID (not MAC), so a scanned BLE address would
+    # otherwise be misrouted to the serial transport and time out.
+    if get_port_type(device) == PortType.SERIAL:
         smp_client = SMPClient(SMPSerialTransport(), device)
+    else:
+        smp_client = SMPClient(SMPBLETransport(), device)
 
     _LOGGER.info("Connecting %s...", device)
     try:

--- a/tests/unit_tests/test_nrf52_ota.py
+++ b/tests/unit_tests/test_nrf52_ota.py
@@ -1,0 +1,132 @@
+"""Tests for nRF52 BLE OTA discovery and transport selection.
+
+Lock in the macOS-specific fixes:
+  * smpmgr_scan() matches the live advertised name as well as the (possibly
+    stale) GAP device name, prefers a device that advertises the SMP/OTA
+    service UUID, and falls back to the name match when the UUID is not
+    visible in the scan response.
+  * _smpmgr_upload() routes by port type: serial transport only for
+    filesystem paths (/dev/..., COMx), BLE transport for everything else
+    (macOS identifies BLE peripherals by a CoreBluetooth UUID, not a MAC).
+"""
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from esphome.components.nrf52 import ota
+from esphome.core import EsphomeError
+
+SMP_UUID = ota.SMP_SERVICE_UUID.lower()
+
+
+def _device(address: str, name: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(address=address, name=name)
+
+
+def _adv(
+    local_name: str | None = None, service_uuids: list[str] | None = None
+) -> SimpleNamespace:
+    return SimpleNamespace(local_name=local_name, service_uuids=service_uuids or [])
+
+
+def _run_scan(monkeypatch, discovered: dict, name: str = "my-device") -> str:
+    monkeypatch.setattr(
+        ota.BleakScanner, "discover", AsyncMock(return_value=discovered)
+    )
+    return asyncio.run(ota.smpmgr_scan(name))
+
+
+def test_scan_matches_advertised_local_name(monkeypatch) -> None:
+    """macOS: device.name is a stale cached name, the live name is in adv.local_name."""
+    discovered = {
+        "AA:BB": (
+            _device("AA:BB", name="stale-old-name"),
+            _adv(local_name="my-device"),
+        ),
+    }
+    assert _run_scan(monkeypatch, discovered) == "AA:BB"
+
+
+def test_scan_matches_device_name(monkeypatch) -> None:
+    """The cached GAP device name still counts as a match when local_name is absent."""
+    discovered = {
+        "CC:DD": (_device("CC:DD", name="my-device"), _adv(local_name=None)),
+    }
+    assert _run_scan(monkeypatch, discovered) == "CC:DD"
+
+
+def test_scan_prefers_device_advertising_smp_uuid(monkeypatch) -> None:
+    """When the SMP UUID is visible (e.g. BlueZ) prefer it over a name-only fallback."""
+    discovered = {
+        "AA:AA": (_device("AA:AA", name="my-device"), _adv(local_name="my-device")),
+        "BB:BB": (
+            _device("BB:BB", name="my-device"),
+            # advertised in upper case to confirm case-insensitive UUID matching
+            _adv(local_name="my-device", service_uuids=[ota.SMP_SERVICE_UUID]),
+        ),
+    }
+    assert _run_scan(monkeypatch, discovered) == "BB:BB"
+
+
+def test_scan_ignores_uuid_when_name_does_not_match(monkeypatch) -> None:
+    """A device advertising the SMP UUID under a different name is not our target."""
+    discovered = {
+        "EE:EE": (
+            _device("EE:EE", name="someone-else"),
+            _adv(local_name="someone-else", service_uuids=[SMP_UUID]),
+        ),
+    }
+    with pytest.raises(EsphomeError, match="OTA service not found"):
+        _run_scan(monkeypatch, discovered)
+
+
+def test_scan_raises_when_no_device_found(monkeypatch) -> None:
+    with pytest.raises(EsphomeError, match="OTA service not found"):
+        _run_scan(monkeypatch, {})
+
+
+def _capture_upload_transport(monkeypatch, device: str):
+    """Run _smpmgr_upload with the SMP machinery stubbed, return the transport used."""
+    serial_sentinel = object()
+    ble_sentinel = object()
+    captured: dict = {}
+
+    class FakeClient:
+        def __init__(self, transport, address):
+            captured["transport"] = transport
+            captured["address"] = address
+
+        async def connect(self) -> None:
+            pass
+
+        async def disconnect(self) -> None:
+            pass
+
+    monkeypatch.setattr(ota, "_get_image_tlv_sha256", lambda firmware: b"")
+    monkeypatch.setattr(ota, "_smpmgr_upload_connected", AsyncMock())
+    monkeypatch.setattr(ota, "SMPSerialTransport", lambda: serial_sentinel)
+    monkeypatch.setattr(ota, "SMPBLETransport", lambda: ble_sentinel)
+    monkeypatch.setattr(ota, "SMPClient", FakeClient)
+
+    asyncio.run(ota._smpmgr_upload(device, Path("firmware.bin")))
+    return captured, serial_sentinel, ble_sentinel
+
+
+def test_upload_routes_serial_path_to_serial_transport(monkeypatch) -> None:
+    captured, serial_sentinel, _ = _capture_upload_transport(
+        monkeypatch, "/dev/ttyACM0"
+    )
+    assert captured["transport"] is serial_sentinel
+    assert captured["address"] == "/dev/ttyACM0"
+
+
+def test_upload_routes_ble_handle_to_ble_transport(monkeypatch) -> None:
+    """A macOS CoreBluetooth UUID is not a serial path -> BLE transport."""
+    ble_handle = "0FA1B2C3-D4E5-F607-1829-3A4B5C6D7E8F"
+    captured, _, ble_sentinel = _capture_upload_transport(monkeypatch, ble_handle)
+    assert captured["transport"] is ble_sentinel
+    assert captured["address"] == ble_handle


### PR DESCRIPTION
# What does this implement/fix?

Fixes BLE OTA and BLE log device discovery for the nRF52 (`zephyr_mcumgr`)
platform on macOS. Previously, `esphome upload --device BLE` and
`esphome logs --device BLE` failed against a board that was advertising
perfectly well, reporting `BLE device <name> with OTA service not found`
or silently timing out. These are three related, self-contained fixes
with no behavioral change on Linux/BlueZ.

**a. Scan by name, not service-UUID filter.** The SMP/OTA 128-bit service
UUID (`8D53DC1D-…`) is carried in the BLE *scan response*, not the primary
advertisement — a 128-bit UUID plus the complete device name does not fit
in the 31-byte primary advertising payload. macOS/CoreBluetooth's
`scanForPeripheralsWithServices` filter only matches UUIDs in the primary
advertisement, so `BleakScanner.discover(service_uuids=[…])` returned
nothing and the device was hidden entirely. `smpmgr_scan()` now scans
unfiltered with `return_adv=True` and matches on `device.name` **or**
`adv.local_name` (macOS caches a stale GAP "Device Name" from a prior
connection, so the live name is only in the advertisement). It still
prefers a device that actually advertises the OTA service UUID (reliable
on BlueZ, which reports scan-response UUIDs) and falls back to the name
match where the UUID is not visible (macOS). The SMP GATT service is
verified on connect regardless.

**b. Route transport by port type, not `is_mac_address()`.** macOS
identifies BLE peripherals by a CoreBluetooth UUID, not a MAC address, so
a scanned BLE handle was misrouted to the serial transport and timed out.
`_smpmgr_upload()` now selects the serial transport only when
`get_port_type(device) == PortType.SERIAL` (filesystem paths like
`/dev/…`, `COMx`) and uses the BLE transport otherwise.

**c. `show_logs()` connects to the BLE handle directly** instead of gating
on `is_mac_address()`, which is `False` for macOS UUIDs.

This also drops the `from .ble_logger import is_mac_address` dependency in
`ota.py` and adds `from esphome.upload_targets import PortType,
get_port_type`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (no user-facing configuration or documented behavior changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change. Build with zephyr_mcumgr OTA enabled, then:
#   esphome upload  device.yaml --device BLE
#   esphome logs    device.yaml --device BLE
# on macOS — both now discover and connect to the board.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - `tests/unit_tests/test_nrf52_ota.py`: `smpmgr_scan()` name/local_name matching, SMP-UUID preference with name fallback, and `_smpmgr_upload()` serial-vs-BLE transport routing by port type.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

