### PR TITLE
[audio] Fix mono channel MP3 playback

### DIFF
--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -326,14 +326,8 @@ FileDecoderState AudioDecoder::decode_mp3_() {
   } else if (result == micro_mp3::MP3_NEED_MORE_DATA) {
     return FileDecoderState::MORE_TO_PROCESS;
   } else if (result == micro_mp3::MP3_OUTPUT_BUFFER_TOO_SMALL) {
-    // Reallocate to decode the frame on the next call
-    if (this->mp3_decoder_->get_channels() > 0) {
-      this->free_buffer_required_ =
-          this->mp3_decoder_->get_samples_per_frame() * this->mp3_decoder_->get_channels() * sizeof(int16_t);
-    } else {
-      // Fallback to worst-case size if channel info isn't available
-      this->free_buffer_required_ = this->mp3_decoder_->get_min_output_buffer_bytes();
-    }
+    // Fallback to worst-case size
+    this->free_buffer_required_ = this->mp3_decoder_->get_min_output_buffer_bytes();
     if (!this->output_transfer_buffer_->reallocate(this->free_buffer_required_)) {
       return FileDecoderState::FAILED;
     }


### PR DESCRIPTION
# What does this implement/fix?

The `AudioDecoder` class attempts to reallocate the output buffer to the minimum necessary size needed for decoding a single MP3 frame. The formula used is correct, but the upstream microMP3 library has a bug where it says the output buffer is too small if its less than the worst-case MP3 buffer size, regardless of the actual MP3 format used. I will fix this in microMP3, but the library has gone through several releases that added new features and that shouldn't go in an ESPHome patch release.

This PR changes the `AudioDecoder` behavior to reallocate to the worst case buffer size whenever the MP3 output frame is reported as too small. This is the correct behavior regardless of the bug; recomputing the buffer size needed using the same formula that previously failed will never help!

The bug happens under two scenarios: mono channel MP3s and stereo low sample rate MP3s. Both cases need a smaller output buffer size as predicted by the formula and both run into the same upstream bug.

When microMP3 is updated/fixed, the decoder will not have to go through this two-step reallocation. This PR's changes will still be correct even after the upstream fix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #16829

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Reproducible bug: just always request mono MP3

```yaml
# Example config.yaml

media_player:
  - platform: speaker
    name: None
    id: speaker_media_player
    announcement_pipeline:
      speaker: box_speaker
      format: MP3
      sample_rate: 48000
      num_channels: 1

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
