### PR TITLE
[api] Remove pre-1.14 object_id backward-compat code

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -375,7 +375,7 @@ void APIConnection::finalize_iterator_sync_() {
 
 void APIConnection::process_iterator_batch_(ComponentIterator &iterator) {
   size_t initial_size = this->deferred_batch_.size();
-  size_t max_batch = this->get_max_batch_size_();
+  size_t max_batch = MAX_INITIAL_PER_BATCH;
   while (!iterator.completed() && (this->deferred_batch_.size() - initial_size) < max_batch) {
     iterator.advance();
   }
@@ -417,16 +417,6 @@ uint16_t APIConnection::fill_and_encode_entity_info(EntityBase *entity, InfoResp
                                                     APIConnection *conn, uint32_t remaining_size) {
   // Set common fields that are shared by all entity types
   msg.key = entity->get_object_id_hash();
-
-  // API 1.14+ clients compute object_id client-side from the entity name
-  // For older clients, we must send object_id for backward compatibility
-  // See: https://github.com/esphome/backlog/issues/76
-  // TODO: Remove this backward compat code before 2026.7.0 - all clients should support API 1.14 by then
-  // Buffer must remain in scope until encode_to_buffer is called
-  char object_id_buf[OBJECT_ID_MAX_LEN];
-  if (!conn->client_supports_api_version(1, 14)) {
-    msg.object_id = entity->get_object_id_to(object_id_buf);
-  }
 
   if (entity->has_own_name()) {
     msg.name = entity->get_name();

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -43,10 +43,7 @@ class APIServer;
 // Keepalive timeout in milliseconds
 static constexpr uint32_t KEEPALIVE_TIMEOUT_MS = 60000;
 // Maximum number of entities to process in a single batch during initial state/info sending
-// API 1.14+ clients compute object_id client-side, so messages are smaller and we can fit more per batch
-// TODO: Remove MAX_INITIAL_PER_BATCH_LEGACY before 2026.7.0 - all clients should support API 1.14 by then
-static constexpr size_t MAX_INITIAL_PER_BATCH_LEGACY = 24;  // For clients < API 1.14 (includes object_id)
-static constexpr size_t MAX_INITIAL_PER_BATCH = 34;         // For clients >= API 1.14 (no object_id)
+static constexpr size_t MAX_INITIAL_PER_BATCH = 34;
 // Verify MAX_MESSAGES_PER_BATCH (defined in api_frame_helper.h) can hold the initial batch
 static_assert(MAX_MESSAGES_PER_BATCH >= MAX_INITIAL_PER_BATCH,
               "MAX_MESSAGES_PER_BATCH must be >= MAX_INITIAL_PER_BATCH");
@@ -480,13 +477,6 @@ class APIConnection final : public APIServerConnectionBase {
   // Helper to check voice assistant validity and connection ownership
   inline bool check_voice_assistant_api_connection_() const;
 #endif
-
-  // Get the max batch size based on client API version
-  // API 1.14+ clients don't receive object_id, so messages are smaller and more fit per batch
-  // TODO: Remove this method before 2026.7.0 and use MAX_INITIAL_PER_BATCH directly
-  size_t get_max_batch_size_() const {
-    return this->client_supports_api_version(1, 14) ? MAX_INITIAL_PER_BATCH : MAX_INITIAL_PER_BATCH_LEGACY;
-  }
 
   // Send keepalive ping or disconnect unresponsive client.
   // Cold path — extracted from loop() to reduce instruction cache pressure.


### PR DESCRIPTION
# What does this implement/fix?

API 1.14 moved object_id computation to the client side, so the device no longer needs to send object_id in entity info messages; it also let us pack more entities per initial batch. Until now the device kept two code paths to stay compatible with clients older than 1.14. Those paths were scheduled for removal before 2026.7.0 (we are now in the 2026.7.0 dev cycle), so this drops them.

Removed:
- the `MAX_INITIAL_PER_BATCH_LEGACY` constant and the `get_max_batch_size_()` helper; `process_iterator_batch_()` now uses `MAX_INITIAL_PER_BATCH` directly
- the branch in `fill_and_encode_entity_info()` that sent `object_id` to pre-1.14 clients

Out of scope and intentionally kept: the protobuf `object_id` field, the `get_object_id_to()` / `OBJECT_ID_MAX_LEN` helpers (still used by mqtt, web_server, prometheus), and the outdated-client warning log whose own TODO targets 2026.8.0.

Migration: clients older than API 1.14 will no longer receive `object_id` and must derive it client-side; update any such client to 1.14 or newer. Home Assistant and current aioesphomeapi already support 1.14, so no action is needed there.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; existing api config is unaffected
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
