### PR TITLE
[web_server] Deprecate version 1

### DIFF
--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import logging
 
 import esphome.codegen as cg
 from esphome.components import web_server_base
@@ -38,6 +39,8 @@ from esphome.core import CORE, CoroPriority, coroutine_with_priority
 import esphome.final_validate as fv
 from esphome.types import ConfigType
 
+_LOGGER = logging.getLogger(__name__)
+
 AUTO_LOAD = ["json", "web_server_base"]
 
 CONF_SORTING_GROUP_ID = "sorting_group_id"
@@ -68,6 +71,15 @@ def default_url(config: ConfigType) -> ConfigType:
             config[CONF_CSS_URL] = ""
         if CONF_JS_URL not in config:
             config[CONF_JS_URL] = "https://oi.esphome.io/v3/www.js"
+    return config
+
+
+def validate_version_deprecated(config: ConfigType) -> ConfigType:
+    if config[CONF_VERSION] == 1:
+        _LOGGER.warning(
+            "Version 1 of 'web_server' is deprecated and will be removed in "
+            "2027.1.0. Please migrate to version 2 (the default) or version 3."
+        )
     return config
 
 
@@ -220,6 +232,7 @@ CONFIG_SCHEMA = cv.All(
         ]
     ),
     default_url,
+    validate_version_deprecated,
     validate_local,
     validate_sorting_groups,
     validate_ota,


### PR DESCRIPTION
# What does this implement/fix?

Starts the 6 month deprecation period for `web_server` version 1; v1 is unmaintained and superseded by v2 (the default) and v3, so rather than pretending it is supported we are starting the clock to drop it.

This only adds a config validation warning when `version: 1` is set, pointing users to v2 or v3; v1 still validates and compiles for now. Removal is targeted for 2027.1.0.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6826

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
web_server:
  port: 8080
  version: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

