### PR TITLE
[core] Remove deprecated get_object_id() and get_compilation_time()

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -194,15 +194,6 @@ class Application {
   /// Buffer must be BUILD_TIME_STR_SIZE bytes (compile-time enforced)
   void get_build_time_string(std::span<char, BUILD_TIME_STR_SIZE> buffer);
 
-  /// Get the build time as a string (deprecated, use get_build_time_string() instead)
-  // Remove before 2026.7.0
-  ESPDEPRECATED("Use get_build_time_string() instead. Removed in 2026.7.0", "2026.1.0")
-  std::string get_compilation_time() {
-    char buf[BUILD_TIME_STR_SIZE];
-    this->get_build_time_string(buf);
-    return std::string(buf);
-  }
-
   /// Get the cached time in milliseconds from when the current component started its loop execution
   inline uint32_t IRAM_ATTR HOT get_loop_component_start_time() const { return this->loop_component_start_time_; }
 

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -147,13 +147,6 @@ std::string EntityBase::get_icon() const {
 }
 #endif  // !USE_ESP8266
 
-// Entity Object ID - computed on-demand from name
-std::string EntityBase::get_object_id() const {
-  char buf[OBJECT_ID_MAX_LEN];
-  size_t len = this->write_object_id_to(buf, sizeof(buf));
-  return std::string(buf, len);
-}
-
 // Calculate Object ID Hash directly from name using snake_case + sanitize
 void EntityBase::calc_object_id_() {
   this->object_id_hash_ = fnv1_hash_object_id(this->name_.c_str(), this->name_.size());

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -73,18 +73,6 @@ class EntityBase {
   // Get whether this Entity has its own name or it should use the device friendly_name.
   bool has_own_name() const { return this->flags_.has_own_name; }
 
-  // Get the sanitized name of this Entity as an ID.
-  // Deprecated: object_id mangles names and all object_id methods are planned for removal.
-  // See https://github.com/esphome/backlog/issues/76
-  // Now is the time to stop using object_id entirely. If you still need it temporarily,
-  // use get_object_id_to() which will remain available longer but will also eventually be removed.
-  ESPDEPRECATED("object_id mangles names and all object_id methods are planned for removal "
-                "(see https://github.com/esphome/backlog/issues/76). "
-                "Now is the time to stop using object_id. If still needed, use get_object_id_to() "
-                "which will remain available longer. get_object_id() will be removed in 2026.7.0",
-                "2025.12.0")
-  std::string get_object_id() const;
-
   // Get the unique Object ID of this Entity
   uint32_t get_object_id_hash() const { return this->object_id_hash_; }
 

--- a/esphome/core/entity_helpers.py
+++ b/esphome/core/entity_helpers.py
@@ -337,7 +337,7 @@ def get_base_entity_object_id(
 
     This function calculates what object_id_c_str_ should be set to in C++.
 
-    The C++ EntityBase::get_object_id() (entity_base.cpp lines 38-49) works as:
+    The C++ EntityBase::write_object_id_to() (entity_base.cpp) works as:
     - If !has_own_name && is_name_add_mac_suffix_enabled():
         return str_sanitize(str_snake_case(App.get_friendly_name()))  // Dynamic
     - Else:

--- a/tests/unit_tests/core/test_entity_helpers.py
+++ b/tests/unit_tests/core/test_entity_helpers.py
@@ -174,10 +174,11 @@ def test_empty_name_fallback() -> None:
 def test_name_add_mac_suffix_behavior() -> None:
     """Test behavior related to name_add_mac_suffix.
 
-    In C++, when name_add_mac_suffix is enabled and entity has no name,
-    write_object_id_to() returns str_sanitize(str_snake_case(App.get_friendly_name()))
-    dynamically. Our function always returns the same result since we're
-    calculating the base for duplicate tracking.
+    In C++, an entity's object_id is computed from its name_ via
+    write_object_id_to() (sanitized snake_case). When an entity has no name,
+    configure_entity_() sets name_ from the friendly name, with the MAC suffix
+    appended when name_add_mac_suffix is enabled. Our function always returns
+    the same result since we're calculating the base for duplicate tracking.
     """
     # The function should always return the same result regardless of
     # name_add_mac_suffix setting, as we're calculating the base object_id

--- a/tests/unit_tests/core/test_entity_helpers.py
+++ b/tests/unit_tests/core/test_entity_helpers.py
@@ -175,7 +175,7 @@ def test_name_add_mac_suffix_behavior() -> None:
     """Test behavior related to name_add_mac_suffix.
 
     In C++, when name_add_mac_suffix is enabled and entity has no name,
-    get_object_id() returns str_sanitize(str_snake_case(App.get_friendly_name()))
+    write_object_id_to() returns str_sanitize(str_snake_case(App.get_friendly_name()))
     dynamically. Our function always returns the same result since we're
     calculating the base for duplicate tracking.
     """


### PR DESCRIPTION
# What does this implement/fix?

Removes two deprecated string-returning methods that were marked for removal in 2026.7.0; the 6 month deprecation window has elapsed. Both had no internal callers.

- `Application::get_compilation_time()`; use `get_build_time_string(buffer)` which writes into a caller-provided buffer (no heap allocation).
- `EntityBase::get_object_id()`; use `get_object_id_to(buffer)` or `write_object_id_to(buffer, size)` instead. The hash accessor `get_object_id_hash()` and the buffer based helpers stay.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; this is an internal C++ API cleanup
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
