### PR TITLE
[ethernet] Defer clk_mode removal to 2026.9.0

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -324,7 +324,7 @@ def _validate(config):
                     "  clk:\n"
                     "    mode: %s\n"
                     "    pin: %s\n"
-                    "Removal scheduled for 2026.7.0.",
+                    "Removal scheduled for 2026.9.0.",
                     config[CONF_CLK_MODE],
                     mode,
                     pin,


### PR DESCRIPTION
# What does this implement/fix?

The `ethernet` `clk_mode` option is deprecated in favor of `clk: { mode, pin }`, and the warning currently says it will be removed in 2026.7.0. We are not ready to drop it yet; device-builder still pulls in configs that use the legacy `clk_mode`, and handling that needs an audit there first (tracked in esphome/backlog#152). To avoid expanding device-builder scope right now, this punts the removal target out two months to 2026.9.0.

Only the warning string changes; the legacy option stays supported.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/backlog#152 (device-builder needs to normalize legacy `clk_mode` before removal)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO17_OUT  # still accepted; warning now says removal in 2026.9.0
  phy_addr: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
