### PR TITLE
[core] Remove deprecated std::string GPIOPin::dump_summary()

### DIFF
--- a/esphome/core/gpio.h
+++ b/esphome/core/gpio.h
@@ -1,8 +1,6 @@
 #pragma once
 #include <algorithm>
 #include <cstdint>
-#include <cstring>
-#include <string>
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -80,11 +78,6 @@ class GPIOPin {
   ///         which may exceed len-1 if truncation occurred (snprintf semantics)
   virtual size_t dump_summary(char *buffer, size_t len) const;
 
-  /// Get a summary of this pin as a string.
-  /// @deprecated Use dump_summary(char*, size_t) instead. Will be removed in 2026.7.0.
-  ESPDEPRECATED("Override dump_summary(char*, size_t) instead. Will be removed in 2026.7.0.", "2026.1.0")
-  virtual std::string dump_summary() const;
-
   virtual bool is_internal() { return false; }
 };
 
@@ -122,27 +115,13 @@ class InternalGPIOPin : public GPIOPin {
   virtual void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const = 0;
 };
 
-// Inline default implementations for GPIOPin virtual methods.
-// These provide bridge functionality for backwards compatibility with external components.
-
-// Default implementation bridges to old std::string method for backwards compatibility.
+// Inline default implementation for GPIOPin::dump_summary.
+// Writes an empty summary; subclasses override to provide pin details.
 inline size_t GPIOPin::dump_summary(char *buffer, size_t len) const {
-  if (len == 0)
-    return 0;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  std::string s = this->dump_summary();
-#pragma GCC diagnostic pop
-  size_t copy_len = std::min(s.size(), len - 1);
-  memcpy(buffer, s.c_str(), copy_len);
-  buffer[copy_len] = '\0';
-  return s.size();  // Return would-be length (snprintf semantics)
+  if (len > 0)
+    buffer[0] = '\0';
+  return 0;
 }
-
-// Default implementation returns empty string.
-// External components should override this if they haven't migrated to buffer-based version.
-// Remove before 2026.7.0
-inline std::string GPIOPin::dump_summary() const { return {}; }
 
 // Inline helper for log_pin - allows compiler to inline into log_pin in gpio.cpp
 inline void log_pin_with_prefix(const char *tag, const char *prefix, GPIOPin *pin) {


### PR DESCRIPTION
# What does this implement/fix?

Removes the deprecated `std::string GPIOPin::dump_summary()` overload from `esphome/core/gpio.h`; it was marked `ESPDEPRECATED` for removal in 2026.7.0 and we are now on 2026.7.0-dev. The buffer based `dump_summary(char *, size_t)` replaces it, so the bridging default implementation and the now unused `<string>` and `<cstring>` includes are dropped as well.

All in-tree GPIOPin subclasses already override the buffer version, so nothing internal changes; external components that still implement or call the old string method must switch to `dump_summary(char *, size_t)`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
binary_sensor:
  - platform: gpio
    name: Btn
    pin: GPIO0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
