### PR TITLE
[core] Remove deprecated value_accuracy_to_string()

### DIFF
--- a/esphome/core/alloc_helpers.cpp
+++ b/esphome/core/alloc_helpers.cpp
@@ -86,14 +86,6 @@ std::string str_sprintf(const char *fmt, ...) {
   return str;
 }
 
-// --- Value formatting helpers ---
-
-std::string value_accuracy_to_string(float value, int8_t accuracy_decimals) {
-  char buf[VALUE_ACCURACY_MAX_LEN];
-  value_accuracy_to_buf(buf, value, accuracy_decimals);
-  return std::string(buf);
-}
-
 // --- Base64 helpers ---
 
 static constexpr const char *BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/esphome/core/alloc_helpers.h
+++ b/esphome/core/alloc_helpers.h
@@ -94,14 +94,6 @@ std::string format_hex_pretty(const std::string &data, char separator = '.', boo
 /// @warning Allocates heap memory. Use format_bin_to() with a stack buffer instead.
 std::string format_bin(const uint8_t *data, size_t length);
 
-// --- Value formatting helpers (allocating) ---
-
-/// Format a float value with accuracy decimals to a string.
-/// @deprecated Allocates heap memory. Use value_accuracy_to_buf() instead. Removed in 2026.7.0.
-__attribute__((deprecated("Allocates heap memory. Use value_accuracy_to_buf() instead. Removed in 2026.7.0.")))
-std::string
-value_accuracy_to_string(float value, int8_t accuracy_decimals);
-
 // --- Base64 helpers (allocating) ---
 
 /// Encode a byte buffer to base64 string.


### PR DESCRIPTION
# What does this implement/fix?

Removes the deprecated `value_accuracy_to_string()` helper, which was marked for removal in 2026.7.0; the 6 month deprecation window has elapsed. It allocated a `std::string`; callers should use `value_accuracy_to_buf()` which writes into a caller-provided buffer. There are no remaining callers in the codebase.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; this is an internal C++ API cleanup
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
