### PR TITLE
[remote_base] Remove deprecated MideaData::to_string()

### DIFF
--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -28,9 +28,6 @@ class MideaData {
   bool is_valid() const { return this->data_[OFFSET_CS] == this->calc_cs_(); }
   void finalize() { this->data_[OFFSET_CS] = this->calc_cs_(); }
   bool is_compliment(const MideaData &rhs) const;
-  /// @deprecated Allocates heap memory. Use to_str() instead. Removed in 2026.7.0.
-  ESPDEPRECATED("Allocates heap memory. Use to_str() instead. Removed in 2026.7.0.", "2026.1.0")
-  std::string to_string() const { return format_hex_pretty(this->data_.data(), this->data_.size()); }  // NOLINT
   /// Buffer size for to_str(): 6 bytes = "AA.BB.CC.DD.EE.FF\0"
   static constexpr size_t TO_STR_BUFFER_SIZE = format_hex_pretty_size(6);
   /// Format to buffer, returns pointer to buffer


### PR DESCRIPTION
# What does this implement/fix?

Removes the deprecated `MideaData::to_string()` method, which was marked for removal in 2026.7.0; the 6 month deprecation window has elapsed. It allocated a `std::string`; callers should use `to_str(buffer)` which formats into a caller-provided buffer. There are no remaining callers in the codebase.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; this is an internal C++ API cleanup
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
