### PR TITLE
[hub75] Remove deprecated scan_wiring name aliases

### DIFF
--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any
 
 from esphome import automation, pins
@@ -26,8 +25,6 @@ from esphome.helpers import add_class_to_obj
 from esphome.types import ConfigType
 
 from . import boards, hub75_ns
-
-_LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["esp32"]
 CODEOWNERS = ["@stuartparmenter"]
@@ -133,29 +130,10 @@ SCAN_WIRINGS = {
     "SCAN_1_8_64PX_HIGH": Hub75ScanWiring.SCAN_1_8_64PX_HIGH,
 }
 
-# Deprecated scan wiring names - mapped to new names
-DEPRECATED_SCAN_WIRINGS = {
-    "FOUR_SCAN_16PX_HIGH": "SCAN_1_4_16PX_HIGH",
-    "FOUR_SCAN_32PX_HIGH": "SCAN_1_8_32PX_HIGH",
-    "FOUR_SCAN_64PX_HIGH": "SCAN_1_8_64PX_HIGH",
-}
-
 
 def _validate_scan_wiring(value):
-    """Validate scan_wiring with deprecation warnings for old names."""
+    """Validate scan_wiring against the allowed names."""
     value = cv.string(value).upper().replace(" ", "_")
-
-    # Check if using deprecated name
-    # Remove deprecated names in 2026.7.0
-    if value in DEPRECATED_SCAN_WIRINGS:
-        new_name = DEPRECATED_SCAN_WIRINGS[value]
-        _LOGGER.warning(
-            "Scan wiring '%s' is deprecated and will be removed in ESPHome 2026.7.0. "
-            "Please use '%s' instead.",
-            value,
-            new_name,
-        )
-        value = new_name
 
     # Validate against allowed values
     if value not in SCAN_WIRINGS:


### PR DESCRIPTION
# What does this implement/fix?

Removes the deprecated `scan_wiring` name aliases (`FOUR_SCAN_16PX_HIGH`, `FOUR_SCAN_32PX_HIGH`, `FOUR_SCAN_64PX_HIGH`), which were marked for removal in 2026.7.0; the 6 month deprecation window has elapsed. Use the current names (`SCAN_1_4_16PX_HIGH`, `SCAN_1_8_32PX_HIGH`, `SCAN_1_8_64PX_HIGH`) instead; the old names now raise a clear validation error listing the valid options. The unused `logging` import and module logger are dropped along with the warning.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
display:
  - platform: hub75
    scan_wiring: SCAN_1_4_16PX_HIGH  # was FOUR_SCAN_16PX_HIGH
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
