### PR TITLE
[packages] Remove deprecated single-package include syntax

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -1,7 +1,6 @@
 from collections import UserDict
 from collections.abc import Callable
 from functools import reduce
-import logging
 from pathlib import Path
 from typing import Any
 
@@ -35,8 +34,6 @@ from esphome.const import (
     __version__ as ESPHOME_VERSION,
 )
 from esphome.core import EsphomeError
-
-_LOGGER = logging.getLogger(__name__)
 
 DOMAIN = CONF_PACKAGES
 # Guard against infinite include chains (e.g. A includes B includes A).
@@ -134,22 +131,6 @@ def validate_source_shorthand(value):
     return REMOTE_PACKAGE_SCHEMA(conf)
 
 
-def deprecate_single_package(config: dict) -> dict:
-    _LOGGER.warning(
-        """
-        Including a single package under `packages:`, i.e., `packages: !include mypackage.yaml` is deprecated.
-        This method for including packages will go away in 2026.7.0
-        Please use a list instead:
-
-        packages:
-          - !include mypackage.yaml
-
-        See https://github.com/esphome/esphome/pull/12116
-        """
-    )
-    return config
-
-
 REMOTE_PACKAGE_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -198,10 +179,7 @@ CONFIG_SCHEMA = cv.Any(  # under `packages:` we can have either:
             str: PACKAGE_SCHEMA,  # a named dict of package definitions, or
         }
     ),
-    [PACKAGE_SCHEMA],  # a list of package definitions, or
-    cv.All(  # a single package definition (deprecated)
-        cv.ensure_list(PACKAGE_SCHEMA), deprecate_single_package
-    ),
+    [PACKAGE_SCHEMA],  # a list of package definitions
 )
 
 
@@ -348,7 +326,6 @@ def _walk_packages(
     config: dict,
     callback: PackageCallback,
     context: ContextVars | None = None,
-    validate_deprecated: bool = True,
     path: yaml_util.DocumentPath | None = None,
 ) -> dict:
     """Walks the packages structure in priority order, invoking ``callback`` on each package definition found.
@@ -378,17 +355,7 @@ def _walk_packages(
         elif (
             result := _walk_package_dict(packages, callback, context, packages_path)
         ) is not None:
-            if not validate_deprecated or any(
-                is_package_definition(v) for v in packages.values()
-            ):
-                raise result
-            # Fallback: treat the dict as a single deprecated package.
-            # This block can be removed once the single-package
-            # deprecation period (2026.7.0) is over.
-            config[CONF_PACKAGES] = [packages]
-            return _walk_packages(
-                deprecate_single_package(config), callback, context, path=path
-            )
+            raise result
 
     config[CONF_PACKAGES] = packages
     return config
@@ -588,9 +555,6 @@ class _PackageProcessor:
         path: yaml_util.DocumentPath,
     ) -> dict:
         """Resolve a single package and recurse into any nested packages."""
-        from_remote = isinstance(package_config, dict) and is_remote_package(
-            package_config
-        )
         package_config = self.resolve_package(package_config, context_vars, path)
         context_vars = self.collect_substitutions(package_config, context_vars)
 
@@ -600,17 +564,10 @@ class _PackageProcessor:
         # Push context from !include vars on the packages key (the package root
         # was already pushed in collect_substitutions above).
         context_vars = push_context(package_config[CONF_PACKAGES], context_vars)
-        # Disable the deprecated single-package fallback for remote
-        # packages.  _process_remote_package returns dicts with
-        # already-resolved values that is_package_definition cannot
-        # distinguish from config fragments, so the fallback would
-        # always fire and mask real errors with wrong paths
-        # (packages->0 instead of packages-><name>).
         return _walk_packages(
             package_config,
             self.process_package,
             context_vars,
-            validate_deprecated=not from_remote,
             path=path,
         )
 
@@ -673,7 +630,7 @@ def merge_packages(config: dict) -> dict:
         merge_list.append(package_config)
         return _walk_packages(package_config, process_package_callback, path=path)
 
-    _walk_packages(config, process_package_callback, validate_deprecated=False)
+    _walk_packages(config, process_package_callback)
     # Merge all packages into the main config:
     config = reduce(lambda new, old: merge_config(old, new), merge_list, config)
     del config[CONF_PACKAGES]

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -50,18 +50,6 @@ def is_remote_package(package_config: dict) -> bool:
     return CONF_URL in package_config
 
 
-def is_package_definition(value: object) -> bool:
-    """Returns True if the value looks like a package definition rather than a config fragment.
-
-    Package definitions are IncludeFile objects, git URL shorthand strings, or
-    remote package dicts (containing a ``url:`` key).  Config fragments are
-    plain dicts that represent component configuration.
-    """
-    return isinstance(value, (yaml_util.IncludeFile, str)) or (
-        isinstance(value, dict) and is_remote_package(value)
-    )
-
-
 def valid_package_contents(package_config: dict) -> dict:
     """Validate that a package looks like a plausible ESPHome config fragment.
 

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -1108,6 +1108,20 @@ def test_invalid_package_contents_rejected(invalid_package: object) -> None:
         do_packages_pass(config)
 
 
+def test_single_package_fragment_form_rejected() -> None:
+    """The deprecated single-package form is removed and now raises.
+
+    Previously ``packages: !include some_package.yaml`` resolving to a bare config
+    fragment dict was silently wrapped and merged via the single-package fallback.
+    That form must now raise instead of being accepted.
+    """
+    config = {
+        CONF_PACKAGES: {CONF_WIFI: {CONF_SSID: "test", CONF_PASSWORD: "secret"}},
+    }
+    with pytest.raises(cv.Invalid):
+        do_packages_pass(config)
+
+
 def test_named_dict_with_include_files_no_false_deprecation_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -210,30 +210,6 @@ def test_package_include(basic_wifi, basic_esphome) -> None:
     assert actual == expected
 
 
-def test_single_package(
-    basic_esphome,
-    basic_wifi,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """
-    Tests the simple case where a single package is added to the top-level config as is.
-    In this test, the CONF_WIFI config is expected to be simply added to the top-level config.
-    This tests the case where the user just put packages: !include package.yaml, not
-    part of a list or mapping of packages.
-    This behavior is deprecated, the test also checks if a warning is issued.
-    """
-    config = {CONF_ESPHOME: basic_esphome, CONF_PACKAGES: {CONF_WIFI: basic_wifi}}
-
-    expected = {CONF_ESPHOME: basic_esphome, CONF_WIFI: basic_wifi}
-
-    with caplog.at_level("WARNING"):
-        actual = packages_pass(config)
-
-    assert actual == expected
-
-    assert "This method for including packages will go away in 2026.7.0" in caplog.text
-
-
 def test_package_append(basic_wifi, basic_esphome) -> None:
     """
     Tests the case where a key is present in both a package and top-level config.
@@ -1154,37 +1130,14 @@ def test_packages_include_file_resolves_to_invalid_type_raises(
         6,
         "some string",
         True,
-    ],
-)
-def test_invalid_package_contents_rejected(invalid_package: object) -> None:
-    """Invalid package contents are rejected by PACKAGE_SCHEMA during do_packages_pass."""
-    config = {
-        CONF_PACKAGES: {
-            "some_package": invalid_package,
-        },
-    }
-    with pytest.raises(cv.Invalid):
-        do_packages_pass(config)
-
-
-@pytest.mark.xfail(
-    reason="Deprecated single-package fallback swallows these errors. "
-    "Remove xfail when single-package deprecation is removed (2026.7.0).",
-    strict=True,
-)
-@pytest.mark.parametrize(
-    "invalid_package",
-    [
         None,
         ["some string"],
         {"some_component": 8},
         {3: 2},
     ],
 )
-def test_invalid_package_contents_masked_by_deprecation(
-    invalid_package: object,
-) -> None:
-    """These invalid packages are swallowed by the deprecated single-package fallback."""
+def test_invalid_package_contents_rejected(invalid_package: object) -> None:
+    """Invalid package contents are rejected by PACKAGE_SCHEMA during do_packages_pass."""
     config = {
         CONF_PACKAGES: {
             "some_package": invalid_package,
@@ -1231,14 +1184,10 @@ def test_named_dict_with_include_files_no_false_deprecation_warning(
     assert "deprecated" not in caplog.text.lower()
 
 
-def test_validate_deprecated_false_raises_directly(
+def test_named_package_errors_raise_directly(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """With validate_deprecated=False, errors raise directly without fallback.
-
-    This is the codepath used for remote packages where _process_remote_package
-    returns already-resolved dicts that is_package_definition cannot detect.
-    """
+    """Errors processing a named-dict package raise directly, with no deprecation warning."""
     config = {
         CONF_PACKAGES: {
             "pkg_a": {CONF_WIFI: {CONF_SSID: "test"}},
@@ -1261,7 +1210,7 @@ def test_validate_deprecated_false_raises_directly(
         caplog.at_level(logging.WARNING),
         pytest.raises(cv.Invalid, match="nested error"),
     ):
-        _walk_packages(config, failing_callback, validate_deprecated=False)
+        _walk_packages(config, failing_callback)
 
     assert "deprecated" not in caplog.text.lower()
 
@@ -1294,40 +1243,6 @@ def test_error_on_first_declared_package_still_detected() -> None:
 
     with pytest.raises(cv.Invalid, match="error in first_pkg"):
         _walk_packages(config, fail_on_last)
-
-
-def test_deprecated_single_package_fallback_still_works(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """The deprecated single-package form still falls back at the top level.
-
-    When a dict's values are plain config fragments (not package definitions)
-    and the callback fails, the deprecated fallback wraps the dict in a list
-    and retries with a deprecation warning.
-    """
-    config = {
-        CONF_PACKAGES: {
-            CONF_WIFI: {CONF_SSID: "test", CONF_PASSWORD: "secret"},
-        },
-    }
-
-    attempt = 0
-
-    def fail_then_succeed(
-        package_config: dict, context: object, path: DocumentPath | None = None
-    ) -> dict:
-        nonlocal attempt
-        attempt += 1
-        if attempt == 1:
-            # First attempt: treating as named dict fails
-            raise cv.Invalid("not a valid package")
-        # Second attempt: after fallback wraps as list, succeeds
-        return package_config
-
-    with caplog.at_level(logging.WARNING):
-        _walk_packages(config, fail_then_succeed)
-
-    assert "deprecated" in caplog.text.lower()
 
 
 def test_merge_packages_invalid_nested_type_raises() -> None:

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -12,7 +12,6 @@ from esphome.components.packages import (
     _substitute_package_definition,
     _walk_packages,
     do_packages_pass,
-    is_package_definition,
     merge_packages,
     resolve_packages,
 )
@@ -87,44 +86,6 @@ def packages_pass(config):
     config = merge_packages(config)
     resolve_extend_remove(config)
     return config
-
-
-_INCLUDE_FILE = "INCLUDE_FILE"
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        # IncludeFile objects are package definitions
-        (_INCLUDE_FILE, True),
-        # Git URL shorthand strings are package definitions
-        ("github://esphome/firmware/base.yaml@main", True),
-        # Remote package dicts (with url key) are package definitions
-        ({"url": "https://github.com/esphome/firmware", "file": "base.yaml"}, True),
-        # Plain config dicts are NOT package definitions (they are config fragments)
-        ({"wifi": {"ssid": "test"}}, False),
-        # None is not a package definition
-        (None, False),
-        # Lists are not package definitions
-        ([{"wifi": {"ssid": "test"}}], False),
-        # Empty dicts are not package definitions
-        ({}, False),
-    ],
-    ids=[
-        "include_file",
-        "git_shorthand",
-        "remote_package",
-        "config_fragment",
-        "none",
-        "list",
-        "empty_dict",
-    ],
-)
-def test_is_package_definition(value: object, expected: bool) -> None:
-    """Test that is_package_definition correctly identifies package definitions."""
-    if value is _INCLUDE_FILE:
-        value = MagicMock(spec=IncludeFile)
-    assert is_package_definition(value) is expected
 
 
 def test_package_unused(basic_esphome, basic_wifi) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Removes the deprecated single-package form under `packages:`, i.e. `packages: !include mypackage.yaml` pointing at one package; it was marked to go away in 2026.7.0 and the 6 month deprecation window has elapsed. Use a list (or a named mapping) instead:

```yaml
packages:
  - !include mypackage.yaml
```

The single-package code paths are gone: the `deprecate_single_package` warning, the `cv.All(cv.ensure_list(...))` schema branch, and the `_walk_packages` fallback that wrapped a non package-definition dict into a list and retried. With the fallback removed, invalid package contents now raise a proper validation error instead of being silently swallowed; the unused `validate_deprecated` parameter and module logger are dropped. Tests are updated accordingly (the previously xfailed invalid-content cases now pass, and the fallback-specific tests are removed).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
packages:
  - !include mypackage.yaml  # single include must now be a list item
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
