### PR TITLE
[cli] Deprecate the dashboard command

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1692,6 +1692,11 @@ def command_bundle(args: ArgsProtocol, config: ConfigType) -> int | None:
 
 
 def command_dashboard(args: ArgsProtocol) -> int | None:
+    _LOGGER.warning(
+        "The 'dashboard' command is deprecated and will be removed in ESPHome "
+        "2027.1.0. Install the 'esphome-device-builder' package and run "
+        "'esphome-device-builder' instead."
+    )
     from esphome.dashboard import dashboard
 
     return dashboard.start_dashboard(args)
@@ -2356,9 +2361,9 @@ def parse_args(argv):
         "configuration", help="Your YAML file or configuration directory.", nargs="*"
     )
 
-    parser_dashboard = subparsers.add_parser(
-        "dashboard", help="Create a simple web server for a dashboard."
-    )
+    # Deprecated, will be removed in 2027.1.0. Omitting help= hides it from the
+    # main parser's command listing while keeping the subcommand functional.
+    parser_dashboard = subparsers.add_parser("dashboard")
     parser_dashboard.add_argument(
         "configuration", help="Your YAML configuration file directory."
     )

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -32,6 +32,7 @@ from esphome.__main__ import (
     command_clean_all,
     command_config,
     command_config_hash,
+    command_dashboard,
     command_idedata,
     command_rename,
     command_run,
@@ -6283,3 +6284,25 @@ def test_command_idedata_esp_idf_no_build_errors() -> None:
         result = command_idedata(MagicMock(), CORE.config)
 
     assert result == 1
+
+
+def test_command_dashboard_warns_deprecated(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The dashboard command logs a deprecation warning and still starts."""
+    args = MockArgs()
+
+    with (
+        patch(
+            "esphome.dashboard.dashboard.start_dashboard", return_value=0
+        ) as mock_start,
+        caplog.at_level(logging.WARNING, logger="esphome.__main__"),
+    ):
+        result = command_dashboard(args)
+
+    assert result == 0
+    mock_start.assert_called_once_with(args)
+    assert any(
+        "deprecated" in rec.message and "2027.1.0" in rec.message
+        for rec in caplog.records
+    )


### PR DESCRIPTION
# What does this implement/fix?

Marks the `esphome dashboard` CLI command as deprecated, slated for removal in 2027.1.0. Invoking it now logs a deprecation warning, and since the Home Assistant add-on and the container images already use the standalone Device Builder, the warning points the remaining standalone pip-install users at the `esphome-device-builder` package. The subcommand is also hidden from the main parser's command listing (by omitting `help=`) while remaining fully functional.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).