### PR TITLE
[docs] Remove leftover dashboard references after dashboard removal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This document provides essential context for AI models interacting with this pro
 *   **Build Systems:** PlatformIO is the primary build system. CMake is used as an alternative.
 *   **Configuration:** YAML.
 *   **Key Libraries/Dependencies:**
-    *   **Python:** `voluptuous` (for configuration validation), `PyYAML` (for parsing configuration files), `paho-mqtt` (for MQTT communication), `tornado` (for the web server), `aioesphomeapi` (for the native API).
+    *   **Python:** `voluptuous` (for configuration validation), `PyYAML` (for parsing configuration files), `paho-mqtt` (for MQTT communication), `aioesphomeapi` (for the native API).
     *   **C++:** `ArduinoJson` (for JSON serialization/deserialization), `AsyncMqttClient-esphome` (for MQTT), `ESPAsyncWebServer` (for the web server).
 *   **Package Manager(s):** `pip` (for Python dependencies), `platformio` (for C++/PlatformIO dependencies).
 *   **Communication Protocols:** Protobuf (for native API), MQTT, HTTP.

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -88,8 +88,6 @@ These *are* security bugs in this repo, and we want to hear about them privately
   holds the API key / OTA / web credentials).
 - Anything in the dashboard / device-builder — report that in its own repository
   (linked at the top).
-- The legacy bundled dashboard in this repo (`esphome/dashboard/`) — it is
-  deprecated and being replaced by Device Builder; report dashboard issues there.
 - Deployments where the operator removed protections or exposed credentials. See
   the security best practices guide:
   https://esphome.io/guides/security_best_practices/


### PR DESCRIPTION
# What does this implement/fix?

Followup cleanup after #17124, which removed the legacy bundled web dashboard; a couple of references to it were left behind.

THREAT_MODEL.md: drops the "out of scope" bullet about the legacy `esphome/dashboard/` package, since it no longer exists; the existing device-builder bullet already covers that case. AGENTS.md: removes `tornado` from the Python dependencies list, since it was a dashboard-only dependency that #17124 dropped from requirements.

Docs only, no code changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
