### PR TITLE
[json] Bump ArduinoJson to 7.4.3

### DIFF
--- a/esphome/components/json/__init__.py
+++ b/esphome/components/json/__init__.py
@@ -15,8 +15,8 @@ async def to_code(config):
     if CORE.is_esp32:
         from esphome.components.esp32 import add_idf_component
 
-        add_idf_component(name="bblanchon/arduinojson", ref="7.4.2")
+        add_idf_component(name="bblanchon/arduinojson", ref="7.4.3")
     else:
-        cg.add_library("bblanchon/ArduinoJson", "7.4.2")
+        cg.add_library("bblanchon/ArduinoJson", "7.4.3")
     cg.add_define("USE_JSON")
     cg.add_global(json_ns.using)

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -1,6 +1,6 @@
 dependencies:
   bblanchon/arduinojson:
-    version: "7.4.2"
+    version: "7.4.3"
   esphome/dlms_parser:
     version: 1.1.0
   esphome/esp-audio-libs:

--- a/platformio.ini
+++ b/platformio.ini
@@ -104,7 +104,7 @@ build_unflags =
 [common:idf-component-libs]
 lib_deps =
     esphome/dlms_parser@1.1.0             ; dlms_meter
-    bblanchon/ArduinoJson@7.4.2           ; json
+    bblanchon/ArduinoJson@7.4.3           ; json
     lvgl/lvgl@9.5.0                       ; lvgl
 
 ; This are common settings for the ESP8266 using Arduino.


### PR DESCRIPTION
# What does this implement/fix?

Bumps the ArduinoJson library from 7.4.2 to 7.4.3; this is a security fix release. See https://github.com/bblanchon/ArduinoJson/releases/tag/v7.4.3

This is a patch release with no API changes, so no code adjustments are needed; only the version pins are updated across `platformio.ini`, the IDF component manifest, and the json component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
