### PR TITLE
[dashboard_import] Store package_import_url in flash on ESP8266

### DIFF
--- a/esphome/components/dashboard_import/__init__.py
+++ b/esphome/components/dashboard_import/__init__.py
@@ -77,7 +77,7 @@ async def to_code(config):
     url = config[CONF_PACKAGE_IMPORT_URL]
     if config[CONF_IMPORT_FULL_CONFIG]:
         url += "?full_config"
-    cg.add(dashboard_import_ns.set_package_import_url(url))
+    cg.add(dashboard_import_ns.set_package_import_url(cg.FlashStringLiteral(url)))
 
 
 def import_config(

--- a/esphome/components/dashboard_import/dashboard_import.cpp
+++ b/esphome/components/dashboard_import/dashboard_import.cpp
@@ -2,9 +2,10 @@
 
 namespace esphome::dashboard_import {
 
-static const char *g_package_import_url = "";  // NOLINT
+static const char EMPTY_URL[] PROGMEM = "";                                        // NOLINT
+static ProgmemStr g_package_import_url = reinterpret_cast<ProgmemStr>(EMPTY_URL);  // NOLINT
 
-const char *get_package_import_url() { return g_package_import_url; }
-void set_package_import_url(const char *url) { g_package_import_url = url; }
+ProgmemStr get_package_import_url() { return g_package_import_url; }
+void set_package_import_url(ProgmemStr url) { g_package_import_url = url; }
 
 }  // namespace esphome::dashboard_import

--- a/esphome/components/dashboard_import/dashboard_import.h
+++ b/esphome/components/dashboard_import/dashboard_import.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "esphome/core/progmem.h"
+
 namespace esphome::dashboard_import {
 
-const char *get_package_import_url();
-void set_package_import_url(const char *url);
+ProgmemStr get_package_import_url();
+void set_package_import_url(ProgmemStr url);
 
 }  // namespace esphome::dashboard_import


### PR DESCRIPTION
# What does this implement/fix?

On ESP8266 the `package_import_url` was emitted as a plain string literal, so it landed in `.rodata` which the Arduino core copies into DRAM at boot. It is the only mDNS TXT value still pinned in RAM; every sibling value (project name, version, platform, board) is already in flash.

This emits the URL as a PROGMEM flash literal (`ESPHOME_F`) and carries it through `dashboard_import` as `ProgmemStr`. Both consumers already read it as a flash pointer; mDNS via `MDNS_STR_ARG`, MQTT via ArduinoJson's `__FlashStringHelper` overload, so nothing else changes. It is a no-op on other platforms where `ProgmemStr` is `const char *`.

Verified on an ESP8266 build: before the change the URL sat at `0x3ffe8e40` (DRAM `.rodata`), after it sits at `0x40266690` (flash `.irom0.text`), freeing the string from RAM.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
dashboard_import:
  package_import_url: github://esphome/example-configs/example.yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
