### PR TITLE
[graphical_display_menu] Mark configurable classes as final

### DIFF
--- a/esphome/components/graphical_display_menu/graphical_display_menu.cpp
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.cpp
@@ -118,7 +118,7 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
   for (size_t i = 0; max_item_index >= 0 && i <= static_cast<size_t>(max_item_index); i++) {
     const auto *item = this->displayed_item_->get_item(i);
     const bool selected = i == this->cursor_index_;
-    const display::Rect item_dimensions = this->measure_item(display, item, bounds, selected);
+    const display::Rect item_dimensions = this->measure_item_(display, item, bounds, selected);
 
     menu_dimensions.push_back(item_dimensions);
     total_height += item_dimensions.h + (i == 0 ? 0 : y_padding);
@@ -181,7 +181,7 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
 
     dimensions.y = y_offset;
     dimensions.x = bounds->x;
-    this->draw_item(display, item, &dimensions, selected);
+    this->draw_item_(display, item, &dimensions, selected);
 
     y_offset += dimensions.h + y_padding;
   }
@@ -189,8 +189,8 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
   display->end_clipping();
 }
 
-display::Rect GraphicalDisplayMenu::measure_item(display::Display *display, const display_menu_base::MenuItem *item,
-                                                 const display::Rect *bounds, const bool selected) {
+display::Rect GraphicalDisplayMenu::measure_item_(display::Display *display, const display_menu_base::MenuItem *item,
+                                                  const display::Rect *bounds, const bool selected) {
   display::Rect dimensions(0, 0, 0, 0);
 
   if (selected) {
@@ -218,8 +218,8 @@ display::Rect GraphicalDisplayMenu::measure_item(display::Display *display, cons
   return dimensions;
 }
 
-inline void GraphicalDisplayMenu::draw_item(display::Display *display, const display_menu_base::MenuItem *item,
-                                            const display::Rect *bounds, const bool selected) {
+inline void GraphicalDisplayMenu::draw_item_(display::Display *display, const display_menu_base::MenuItem *item,
+                                             const display::Rect *bounds, const bool selected) {
   const auto background_color = selected ? this->foreground_color_ : this->background_color_;
   const auto foreground_color = selected ? this->background_color_ : this->foreground_color_;
 

--- a/esphome/components/graphical_display_menu/graphical_display_menu.h
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.h
@@ -53,10 +53,10 @@ class GraphicalDisplayMenu final : public display_menu_base::DisplayMenuComponen
   void draw_menu() override;
   void draw_menu_internal_(display::Display *display, const display::Rect *bounds);
   void draw_item(const display_menu_base::MenuItem *item, uint8_t row, bool selected) override;
-  display::Rect measure_item(display::Display *display, const display_menu_base::MenuItem *item,
-                             const display::Rect *bounds, bool selected);
-  void draw_item(display::Display *display, const display_menu_base::MenuItem *item, const display::Rect *bounds,
-                 bool selected);
+  display::Rect measure_item_(display::Display *display, const display_menu_base::MenuItem *item,
+                              const display::Rect *bounds, bool selected);
+  void draw_item_(display::Display *display, const display_menu_base::MenuItem *item, const display::Rect *bounds,
+                  bool selected);
   void update() override;
 
   void on_before_show() override;

--- a/esphome/components/graphical_display_menu/graphical_display_menu.h
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.h
@@ -33,7 +33,7 @@ struct MenuItemValueArguments {
   bool is_menu_editing;
 };
 
-class GraphicalDisplayMenu : public display_menu_base::DisplayMenuComponent {
+class GraphicalDisplayMenu final : public display_menu_base::DisplayMenuComponent {
  public:
   void setup() override;
   void dump_config() override;
@@ -53,10 +53,10 @@ class GraphicalDisplayMenu : public display_menu_base::DisplayMenuComponent {
   void draw_menu() override;
   void draw_menu_internal_(display::Display *display, const display::Rect *bounds);
   void draw_item(const display_menu_base::MenuItem *item, uint8_t row, bool selected) override;
-  virtual display::Rect measure_item(display::Display *display, const display_menu_base::MenuItem *item,
-                                     const display::Rect *bounds, bool selected);
-  virtual void draw_item(display::Display *display, const display_menu_base::MenuItem *item,
-                         const display::Rect *bounds, bool selected);
+  display::Rect measure_item(display::Display *display, const display_menu_base::MenuItem *item,
+                             const display::Rect *bounds, bool selected);
+  void draw_item(display::Display *display, const display_menu_base::MenuItem *item, const display::Rect *bounds,
+                 bool selected);
   void update() override;
 
   void on_before_show() override;
@@ -73,7 +73,7 @@ class GraphicalDisplayMenu : public display_menu_base::DisplayMenuComponent {
   CallbackManager<void()> on_redraw_callbacks_{};
 };
 
-class GraphicalDisplayMenuOnRedrawTrigger : public Trigger<const GraphicalDisplayMenu *> {
+class GraphicalDisplayMenuOnRedrawTrigger final : public Trigger<const GraphicalDisplayMenu *> {
  public:
   explicit GraphicalDisplayMenuOnRedrawTrigger(GraphicalDisplayMenu *parent) : parent_(parent) {
     parent->add_on_redraw_callback([this]() { this->trigger(this->parent_); });


### PR DESCRIPTION
# What does this implement/fix?

Adds the C++ `final` specifier to `GraphicalDisplayMenu` and `GraphicalDisplayMenuOnRedrawTrigger` — leaf, user-configurable classes that are never used as a base anywhere in the ESPHome tree.

This was split out of the mechanical "mark configurable classes as final" series (parts 1–21) because it needs one extra, non-mechanical change: once `GraphicalDisplayMenu` is `final`, its protected `measure_item()` and `draw_item(Display*, …)` methods can no longer be overridden, so their `virtual` specifiers become unnecessary and trip clang-tidy's `unnecessary-virtual-specifier` check. Both are only ever called internally via `this->`, so dropping `virtual` keeps behavior identical.

- **Change:** add `final` to two classes and remove the two now-unnecessary `virtual` specifiers; no behavior, config, or API surface changes
- **Why separate:** the rest of the series is a pure `final`-only mechanical edit; this component additionally required the `virtual` removal

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
