### PR TITLE
[ld2420] Mark configurable classes as final

### DIFF
--- a/esphome/components/ld2420/binary_sensor/ld2420_binary_sensor.h
+++ b/esphome/components/ld2420/binary_sensor/ld2420_binary_sensor.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2420 {
 
-class LD2420BinarySensor : public LD2420Listener, public Component, binary_sensor::BinarySensor {
+class LD2420BinarySensor final : public LD2420Listener, public Component, public binary_sensor::BinarySensor {
  public:
   void dump_config() override;
   void set_presence_sensor(binary_sensor::BinarySensor *bsensor) { this->presence_bsensor_ = bsensor; };

--- a/esphome/components/ld2420/button/reconfig_buttons.h
+++ b/esphome/components/ld2420/button/reconfig_buttons.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2420 {
 
-class LD2420ApplyConfigButton : public button::Button, public Parented<LD2420Component> {
+class LD2420ApplyConfigButton final : public button::Button, public Parented<LD2420Component> {
  public:
   LD2420ApplyConfigButton() = default;
 
@@ -13,7 +13,7 @@ class LD2420ApplyConfigButton : public button::Button, public Parented<LD2420Com
   void press_action() override;
 };
 
-class LD2420RevertConfigButton : public button::Button, public Parented<LD2420Component> {
+class LD2420RevertConfigButton final : public button::Button, public Parented<LD2420Component> {
  public:
   LD2420RevertConfigButton() = default;
 
@@ -21,7 +21,7 @@ class LD2420RevertConfigButton : public button::Button, public Parented<LD2420Co
   void press_action() override;
 };
 
-class LD2420RestartModuleButton : public button::Button, public Parented<LD2420Component> {
+class LD2420RestartModuleButton final : public button::Button, public Parented<LD2420Component> {
  public:
   LD2420RestartModuleButton() = default;
 
@@ -29,7 +29,7 @@ class LD2420RestartModuleButton : public button::Button, public Parented<LD2420C
   void press_action() override;
 };
 
-class LD2420FactoryResetButton : public button::Button, public Parented<LD2420Component> {
+class LD2420FactoryResetButton final : public button::Button, public Parented<LD2420Component> {
  public:
   LD2420FactoryResetButton() = default;
 

--- a/esphome/components/ld2420/ld2420.h
+++ b/esphome/components/ld2420/ld2420.h
@@ -40,7 +40,7 @@ class LD2420Listener {
   virtual void on_fw_version(std::string &fw){};
 };
 
-class LD2420Component : public Component, public uart::UARTDevice {
+class LD2420Component final : public Component, public uart::UARTDevice {
  public:
   struct CmdFrameT {
     uint32_t header{0};

--- a/esphome/components/ld2420/number/gate_config_number.h
+++ b/esphome/components/ld2420/number/gate_config_number.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2420 {
 
-class LD2420TimeoutNumber : public number::Number, public Parented<LD2420Component> {
+class LD2420TimeoutNumber final : public number::Number, public Parented<LD2420Component> {
  public:
   LD2420TimeoutNumber() = default;
 
@@ -13,7 +13,7 @@ class LD2420TimeoutNumber : public number::Number, public Parented<LD2420Compone
   void control(float timeout) override;
 };
 
-class LD2420MinDistanceNumber : public number::Number, public Parented<LD2420Component> {
+class LD2420MinDistanceNumber final : public number::Number, public Parented<LD2420Component> {
  public:
   LD2420MinDistanceNumber() = default;
 
@@ -21,7 +21,7 @@ class LD2420MinDistanceNumber : public number::Number, public Parented<LD2420Com
   void control(float min_gate) override;
 };
 
-class LD2420MaxDistanceNumber : public number::Number, public Parented<LD2420Component> {
+class LD2420MaxDistanceNumber final : public number::Number, public Parented<LD2420Component> {
  public:
   LD2420MaxDistanceNumber() = default;
 
@@ -29,7 +29,7 @@ class LD2420MaxDistanceNumber : public number::Number, public Parented<LD2420Com
   void control(float max_gate) override;
 };
 
-class LD2420GateSelectNumber : public number::Number, public Parented<LD2420Component> {
+class LD2420GateSelectNumber final : public number::Number, public Parented<LD2420Component> {
  public:
   LD2420GateSelectNumber() = default;
 
@@ -37,7 +37,7 @@ class LD2420GateSelectNumber : public number::Number, public Parented<LD2420Comp
   void control(float gate_select) override;
 };
 
-class LD2420MoveSensFactorNumber : public number::Number, public Parented<LD2420Component> {
+class LD2420MoveSensFactorNumber final : public number::Number, public Parented<LD2420Component> {
  public:
   LD2420MoveSensFactorNumber() = default;
 
@@ -45,7 +45,7 @@ class LD2420MoveSensFactorNumber : public number::Number, public Parented<LD2420
   void control(float move_factor) override;
 };
 
-class LD2420StillSensFactorNumber : public number::Number, public Parented<LD2420Component> {
+class LD2420StillSensFactorNumber final : public number::Number, public Parented<LD2420Component> {
  public:
   LD2420StillSensFactorNumber() = default;
 
@@ -53,7 +53,7 @@ class LD2420StillSensFactorNumber : public number::Number, public Parented<LD242
   void control(float still_factor) override;
 };
 
-class LD2420StillThresholdNumbers : public number::Number, public Parented<LD2420Component> {
+class LD2420StillThresholdNumbers final : public number::Number, public Parented<LD2420Component> {
  public:
   LD2420StillThresholdNumbers() = default;
   LD2420StillThresholdNumbers(uint8_t gate);
@@ -63,7 +63,7 @@ class LD2420StillThresholdNumbers : public number::Number, public Parented<LD242
   void control(float still_threshold) override;
 };
 
-class LD2420MoveThresholdNumbers : public number::Number, public Parented<LD2420Component> {
+class LD2420MoveThresholdNumbers final : public number::Number, public Parented<LD2420Component> {
  public:
   LD2420MoveThresholdNumbers() = default;
   LD2420MoveThresholdNumbers(uint8_t gate);

--- a/esphome/components/ld2420/select/operating_mode_select.h
+++ b/esphome/components/ld2420/select/operating_mode_select.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2420 {
 
-class LD2420Select : public Component, public select::Select, public Parented<LD2420Component> {
+class LD2420Select final : public Component, public select::Select, public Parented<LD2420Component> {
  public:
   LD2420Select() = default;
 

--- a/esphome/components/ld2420/sensor/ld2420_sensor.h
+++ b/esphome/components/ld2420/sensor/ld2420_sensor.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2420 {
 
-class LD2420Sensor : public LD2420Listener, public Component, sensor::Sensor {
+class LD2420Sensor final : public LD2420Listener, public Component, public sensor::Sensor {
  public:
   void dump_config() override;
   void set_distance_sensor(sensor::Sensor *sensor) { this->distance_sensor_ = sensor; }

--- a/esphome/components/ld2420/text_sensor/ld2420_text_sensor.h
+++ b/esphome/components/ld2420/text_sensor/ld2420_text_sensor.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2420 {
 
-class LD2420TextSensor : public LD2420Listener, public Component, text_sensor::TextSensor {
+class LD2420TextSensor final : public LD2420Listener, public Component, public text_sensor::TextSensor {
  public:
   void dump_config() override;
   void set_fw_version_text_sensor(text_sensor::TextSensor *tsensor) { this->fw_version_text_sensor_ = tsensor; };


### PR DESCRIPTION
# What does this implement/fix?

Marks the configurable LD2420 classes (component, numbers, buttons, select, and the sensor/binary_sensor/text_sensor entities) as `final`, continuing the codebase-wide effort to mark configurable classes as final. The `LD2420Listener` base interface is intentionally left non-final since the three entity classes derive from it.

While in here, also fixes the sensor, binary_sensor, and text_sensor classes that were inheriting their entity base (`sensor::Sensor`, `binary_sensor::BinarySensor`, `text_sensor::TextSensor`) privately instead of publicly — the `public` keyword was missing on the trailing base.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).