### PR TITLE
[ld2450] Mark configurable classes as final

### DIFF
--- a/esphome/components/ld2450/button/factory_reset_button.h
+++ b/esphome/components/ld2450/button/factory_reset_button.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2450 {
 
-class FactoryResetButton : public button::Button, public Parented<LD2450Component> {
+class FactoryResetButton final : public button::Button, public Parented<LD2450Component> {
  public:
   FactoryResetButton() = default;
 

--- a/esphome/components/ld2450/button/restart_button.h
+++ b/esphome/components/ld2450/button/restart_button.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2450 {
 
-class RestartButton : public button::Button, public Parented<LD2450Component> {
+class RestartButton final : public button::Button, public Parented<LD2450Component> {
  public:
   RestartButton() = default;
 

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -75,7 +75,7 @@ struct ZoneOfNumbers {
 };
 #endif
 
-class LD2450Component : public Component, public uart::UARTDevice {
+class LD2450Component final : public Component, public uart::UARTDevice {
 #ifdef USE_BINARY_SENSOR
   SUB_BINARY_SENSOR(moving_target)
   SUB_BINARY_SENSOR(still_target)

--- a/esphome/components/ld2450/number/presence_timeout_number.h
+++ b/esphome/components/ld2450/number/presence_timeout_number.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2450 {
 
-class PresenceTimeoutNumber : public number::Number, public Parented<LD2450Component> {
+class PresenceTimeoutNumber final : public number::Number, public Parented<LD2450Component> {
  public:
   PresenceTimeoutNumber() = default;
 

--- a/esphome/components/ld2450/number/zone_coordinate_number.h
+++ b/esphome/components/ld2450/number/zone_coordinate_number.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2450 {
 
-class ZoneCoordinateNumber : public number::Number, public Parented<LD2450Component> {
+class ZoneCoordinateNumber final : public number::Number, public Parented<LD2450Component> {
  public:
   ZoneCoordinateNumber(uint8_t zone);
 

--- a/esphome/components/ld2450/select/baud_rate_select.h
+++ b/esphome/components/ld2450/select/baud_rate_select.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2450 {
 
-class BaudRateSelect : public select::Select, public Parented<LD2450Component> {
+class BaudRateSelect final : public select::Select, public Parented<LD2450Component> {
  public:
   BaudRateSelect() = default;
 

--- a/esphome/components/ld2450/select/zone_type_select.h
+++ b/esphome/components/ld2450/select/zone_type_select.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2450 {
 
-class ZoneTypeSelect : public select::Select, public Parented<LD2450Component> {
+class ZoneTypeSelect final : public select::Select, public Parented<LD2450Component> {
  public:
   ZoneTypeSelect() = default;
 

--- a/esphome/components/ld2450/switch/bluetooth_switch.h
+++ b/esphome/components/ld2450/switch/bluetooth_switch.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2450 {
 
-class BluetoothSwitch : public switch_::Switch, public Parented<LD2450Component> {
+class BluetoothSwitch final : public switch_::Switch, public Parented<LD2450Component> {
  public:
   BluetoothSwitch() = default;
 

--- a/esphome/components/ld2450/switch/multi_target_switch.h
+++ b/esphome/components/ld2450/switch/multi_target_switch.h
@@ -5,7 +5,7 @@
 
 namespace esphome::ld2450 {
 
-class MultiTargetSwitch : public switch_::Switch, public Parented<LD2450Component> {
+class MultiTargetSwitch final : public switch_::Switch, public Parented<LD2450Component> {
  public:
   MultiTargetSwitch() = default;
 


### PR DESCRIPTION
# What does this implement/fix?

Adds the C++ `final` specifier to `LD2450Component` and its leaf entity classes (`FactoryResetButton`, `RestartButton`, `PresenceTimeoutNumber`, `ZoneCoordinateNumber`, `BaudRateSelect`, `ZoneTypeSelect`, `BluetoothSwitch`, `MultiTargetSwitch`).

**Opened as a draft for discussion.** This was split out of the mechanical "mark configurable classes as final" series (parts 1–21) because marking `LD2450Component` `final` breaks an existing C++ unit test: `tests/components/ld2450/common.h` defines `class TestableLD2450 : public LD2450Component` to expose the protected `buffer_data_`, `buffer_pos_`, and `readline_` members for the readline tests in `tests/components/ld2450/ld2450_readline.cpp`. A `final` base class cannot be subclassed, so the test would no longer compile.

Options to decide between:

- **Keep `LD2450Component` non-final** and only mark the leaf entity classes final (drop the `ld2450.h` change from this PR).
- **Refactor the test** so it no longer subclasses the component — e.g. make the test a `friend`, or test `readline_` via a small free function / public test hook instead of `using`-exposing protected members.

The leaf entity class changes are uncontroversial; the open question is purely `LD2450Component` itself.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
