### PR TITLE
[tests] Disable Hypothesis deadline on IP validation property tests

### DIFF
--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -1,6 +1,6 @@
 import string
 
-from hypothesis import example, given
+from hypothesis import example, given, settings
 from hypothesis.strategies import builds, integers, ip_addresses, one_of, text
 import pytest
 import voluptuous as vol
@@ -276,6 +276,10 @@ def test_boolean__invalid(value):
         config_validation.boolean(value)
 
 
+# deadline disabled: the validator is trivially fast, but Hypothesis's per-example
+# deadline can spuriously trip on slow/loaded CI runners (e.g. one example hitting
+# a GC pause), making this a flaky failure. Matches test_helpers.py.
+@settings(deadline=None)
 @given(value=ip_addresses(v=4).map(str))
 def test_ipv4__valid(value):
     config_validation.ipv4address(value)
@@ -287,6 +291,7 @@ def test_ipv4__invalid(value):
         config_validation.ipv4address(value)
 
 
+@settings(deadline=None)
 @given(value=ip_addresses(v=6).map(str))
 def test_ipv6__valid(value):
     config_validation.ipaddress(value)


### PR DESCRIPTION
# What does this implement/fix?

`test_ipv4__valid` and `test_ipv6__valid` in `tests/unit_tests/test_config_validation.py` are Hypothesis property tests. Hypothesis enforces a per-example deadline (~200ms by default) and fails with `DeadlineExceeded` if any single generated example takes longer — which can happen purely from CI environment jitter (a GC pause, a loaded runner) rather than the code under test.

This was observed as a flaky failure on the `pytest (3.14, macOS-latest)` matrix cell, in `test_ipv6__valid`, while every other matrix cell passed:

```
hypothesis.errors.DeadlineExceeded
  tests/unit_tests/test_config_validation.py::test_ipv6__valid
```

The validators (`config_validation.ipv4address` / `ipaddress`) just call stdlib `ipaddress.ip_address()` — microsecond-fast and correct — so the deadline is catching runner noise, not a real performance issue.

Disable the deadline on both IP-validation tests with `@settings(deadline=None)`, matching the existing guard already applied to the analogous `tests/unit_tests/test_helpers.py::test_is_ip_address__valid`. `test_ipv4__valid` is guarded too since it's the same flake class (the helpers test guards its v4 equivalent for the same reason).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (CI flake)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - test-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Test-only change; `test_ipv4__valid` / `test_ipv6__valid` pass locally with the deadline disabled.