### PR TITLE
[docker] Remove dead HA addon env exports (streamer_mode, relative_url)

### DIFF
--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
@@ -19,14 +19,6 @@ if bashio::config.true 'leave_front_door_open'; then
     export DISABLE_HA_AUTHENTICATION=true
 fi
 
-if bashio::config.true 'streamer_mode'; then
-    export ESPHOME_STREAMER_MODE=true
-fi
-
-if bashio::config.has_value 'relative_url'; then
-    export ESPHOME_DASHBOARD_RELATIVE_URL=$(bashio::config 'relative_url')
-fi
-
 if bashio::config.has_value 'default_compile_process_limit'; then
     export ESPHOME_DEFAULT_COMPILE_PROCESS_LIMIT=$(bashio::config 'default_compile_process_limit')
 else


### PR DESCRIPTION
# What does this implement/fix?

The `streamer_mode` and `relative_url` addon options are no longer consumed by `esphome-device-builder`, so the run script's `ESPHOME_STREAMER_MODE` and `ESPHOME_DASHBOARD_RELATIVE_URL` exports are dead code. This removes them from the HA addon run script.

This is the esphome-repo follow-up called for in esphome/home-assistant-addon#246, which removes the matching schema options (the builder now hides secrets unless `show_secrets` is passed per-request, and derives the ingress base path from Supervisor's `X-Ingress-Path` header).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).