### PR TITLE
[ms8607] Mark configurable classes as final

### DIFF
--- a/esphome/components/ms8607/ms8607.h
+++ b/esphome/components/ms8607/ms8607.h
@@ -10,7 +10,7 @@ namespace esphome::ms8607 {
  Class for I2CDevice used to communicate with the Humidity sensor
  on the chip. See MS8607Component instead
  */
-class MS8607HumidityDevice : public i2c::I2CDevice {
+class MS8607HumidityDevice final : public i2c::I2CDevice {
  public:
   uint8_t get_address() { return address_; }
 };
@@ -30,9 +30,9 @@ class MS8607HumidityDevice : public i2c::I2CDevice {
  - https://github.com/adafruit/Adafruit_MS8607
  - https://github.com/sparkfun/SparkFun_PHT_MS8607_Arduino_Library
  */
-class MS8607Component : public PollingComponent, public i2c::I2CDevice {
+class MS8607Component final : public PollingComponent, public i2c::I2CDevice {
  public:
-  virtual ~MS8607Component() = default;
+  ~MS8607Component() = default;
   void setup() override;
   void update() override;
   void dump_config() override;


### PR DESCRIPTION
# What does this implement/fix?

Adds the C++ `final` specifier to the leaf, user-configurable `ms8607` classes (`MS8607HumidityDevice` and `MS8607Component`), so they can no longer be subclassed by external components.

`ms8607` was pulled out of the mechanical "mark configurable classes as final" series PR #16962 (part 11/21) because it can't be handled by a pure `final`-keyword addition: `MS8607Component` declares an explicit `virtual ~MS8607Component()` destructor, and marking the class `final` makes that `virtual` redundant, tripping `clang-diagnostic-unnecessary-virtual-specifier`. This PR therefore both adds `final` and drops the now-unnecessary `virtual` from the destructor. Tracked as an exception in #17143.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/developers.esphome.io#157

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
