### PR TITLE
[motion] Make motion test configs mergeable in CI

### DIFF
--- a/tests/components/bmi270/common.yaml
+++ b/tests/components/bmi270/common.yaml
@@ -3,52 +3,64 @@ sensor:
     name: "BMI270 Temperature"
 
   - platform: motion
+    motion_id: bmi270_motion
     type: acceleration_x
-    name: "Accel X"
+    name: "BMI270 Accel X"
     accuracy_decimals: 4
     filters:
       - sliding_window_moving_average:
           window_size: 4
           send_every: 1
   - platform: motion
+    motion_id: bmi270_motion
     type: acceleration_y
-    name: "Accel Y"
+    name: "BMI270 Accel Y"
     accuracy_decimals: 4
   - platform: motion
+    motion_id: bmi270_motion
     type: acceleration_z
-    name: "Accel Z"
+    name: "BMI270 Accel Z"
     accuracy_decimals: 4
 
     # Gyroscope axes (unit: °/s)
   - platform: motion
+    motion_id: bmi270_motion
     type: gyroscope_x
-    name: "Gyro X"
+    name: "BMI270 Gyro X"
   - platform: motion
+    motion_id: bmi270_motion
     type: gyroscope_y
-    name: "Gyro Y"
+    name: "BMI270 Gyro Y"
   - platform: motion
+    motion_id: bmi270_motion
     type: gyroscope_z
-    name: "Gyro Z"
+    name: "BMI270 Gyro Z"
 
   - platform: motion
+    motion_id: bmi270_motion
     type: angular_rate_x
-    name: "Angular Rate X"
+    name: "BMI270 Angular Rate X"
   - platform: motion
+    motion_id: bmi270_motion
     type: angular_rate_y
-    name: "Angular Rate Y"
+    name: "BMI270 Angular Rate Y"
   - platform: motion
+    motion_id: bmi270_motion
     type: angular_rate_z
-    name: "Angular Rate Z"
+    name: "BMI270 Angular Rate Z"
 
   - platform: motion
+    motion_id: bmi270_motion
     type: pitch
-    name: "Pitch"
+    name: "BMI270 Pitch"
   - platform: motion
+    motion_id: bmi270_motion
     type: roll
-    name: "Roll"
+    name: "BMI270 Roll"
 
 motion:
   - platform: bmi270
+    id: bmi270_motion
   # Accelerometer full-scale range: 2G | 4G | 8G | 16G
     accelerometer_range: 4G
 

--- a/tests/components/lsm6ds/common.yaml
+++ b/tests/components/lsm6ds/common.yaml
@@ -1,54 +1,66 @@
 sensor:
   - platform: lsm6ds
-    name: "lsm6ds Temperature"
+    name: "LSM6DS Temperature"
 
   - platform: motion
+    motion_id: lsm6ds_motion
     type: acceleration_x
-    name: "Accel X"
+    name: "LSM6DS Accel X"
     accuracy_decimals: 4
     filters:
       - sliding_window_moving_average:
           window_size: 4
           send_every: 1
   - platform: motion
+    motion_id: lsm6ds_motion
     type: acceleration_y
-    name: "Accel Y"
+    name: "LSM6DS Accel Y"
     accuracy_decimals: 4
   - platform: motion
+    motion_id: lsm6ds_motion
     type: acceleration_z
-    name: "Accel Z"
+    name: "LSM6DS Accel Z"
     accuracy_decimals: 4
 
     # Gyroscope axes (unit: °/s)
   - platform: motion
+    motion_id: lsm6ds_motion
     type: gyroscope_x
-    name: "Gyro X"
+    name: "LSM6DS Gyro X"
   - platform: motion
+    motion_id: lsm6ds_motion
     type: gyroscope_y
-    name: "Gyro Y"
+    name: "LSM6DS Gyro Y"
   - platform: motion
+    motion_id: lsm6ds_motion
     type: gyroscope_z
-    name: "Gyro Z"
+    name: "LSM6DS Gyro Z"
 
   - platform: motion
+    motion_id: lsm6ds_motion
     type: angular_rate_x
-    name: "Angular Rate X"
+    name: "LSM6DS Angular Rate X"
   - platform: motion
+    motion_id: lsm6ds_motion
     type: angular_rate_y
-    name: "Angular Rate Y"
+    name: "LSM6DS Angular Rate Y"
   - platform: motion
+    motion_id: lsm6ds_motion
     type: angular_rate_z
-    name: "Angular Rate Z"
+    name: "LSM6DS Angular Rate Z"
 
   - platform: motion
+    motion_id: lsm6ds_motion
     type: pitch
-    name: "Pitch"
+    name: "LSM6DS Pitch"
   - platform: motion
+    motion_id: lsm6ds_motion
     type: roll
-    name: "Roll"
+    name: "LSM6DS Roll"
 
 motion:
   - platform: lsm6ds
+    id: lsm6ds_motion
   # Accelerometer full-scale range: 2G | 4G | 8G | 16G
     accelerometer_range: 4G
 


### PR DESCRIPTION
# What does this implement/fix?

The `motion` sensor platform resolves its parent via `motion_id` (`cv.use_id(MotionComponent)`), which auto-resolves only when a single `MotionComponent` exists. When CI groups the `lsm6ds` and `bmi270` motion tests into one build (both share the I2C bus package), two `MotionComponent` instances exist and the auto-resolution fails with "Too many candidates found for 'motion_id'". The generic, identical entity names (`Accel X`, `Gyro X`, …) in both files also collide on merge, failing with "Duplicate sensor entity with name …".

This adds an explicit `id` to each `motion:` device, a matching `motion_id` to every `platform: motion` sensor, and prefixes all entity names in both test files with the component name so the configs validate both standalone and when merged together.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).