### PR TITLE
[esp32_ble_server] Fix set_value action with by-reference triggers

### DIFF
--- a/esphome/components/esp32_ble_server/ble_server_automations.h
+++ b/esphome/components/esp32_ble_server/ble_server_automations.h
@@ -77,13 +77,15 @@ template<typename... Ts> class BLECharacteristicSetValueAction final : public Ac
     // Set initial value
     this->parent_->set_value(this->buffer_.value(x...));
     // Set the listener for read events
-    this->parent_->on_read([this, x...](uint16_t id) {
+    // ``mutable`` keeps by-copy captures non-const for triggers passing args by reference
+    // (e.g. climate on_control's ClimateCall&). See #17142.
+    this->parent_->on_read([this, x...](uint16_t id) mutable {
       // Set the value of the characteristic every time it is read
       this->parent_->set_value(this->buffer_.value(x...));
     });
     // Set the listener in the global manager so only one BLECharacteristicSetValueAction is set for each characteristic
     BLECharacteristicSetValueActionManager::get_instance()->set_listener(
-        this->parent_, [this, x...]() { this->parent_->set_value(this->buffer_.value(x...)); });
+        this->parent_, [this, x...]() mutable { this->parent_->set_value(this->buffer_.value(x...)); });
   }
 
  protected:

--- a/tests/components/esp32_ble_server/common.yaml
+++ b/tests/components/esp32_ble_server/common.yaml
@@ -77,3 +77,34 @@ esp32_ble_server:
                   id: test_change_descriptor
                   value:
                     data: [0x01, 0x02, 0x03]
+
+# Regression test for #17142: the set_value action used from a trigger that passes
+# its argument by reference (climate on_control supplies ClimateCall&) previously
+# failed to compile.
+sensor:
+  - platform: template
+    id: ble_test_temp
+    lambda: "return 20.0;"
+
+output:
+  - platform: template
+    id: ble_test_output
+    type: float
+    write_action:
+      - logger.log: "out"
+
+climate:
+  - platform: pid
+    name: "BLE Test Climate"
+    id: ble_test_climate
+    sensor: ble_test_temp
+    default_target_temperature: 20
+    heat_output: ble_test_output
+    control_parameters:
+      kp: 0.1
+      ki: 0.001
+      kd: 0.1
+    on_control:
+      - ble_server.characteristic.set_value:
+          id: test_notify_characteristic
+          value: !lambda "return std::vector<uint8_t>{0, 1, 2};"


### PR DESCRIPTION
# What does this implement/fix?

`ble_server.characteristic.set_value` fails to compile when attached to a trigger that passes its argument **by reference** — e.g. climate `on_control`, which supplies `ClimateCall&`:

```
error: binding reference of type 'esphome::climate::ClimateCall&' to 'const esphome::climate::ClimateCall' discards qualifiers
```

`BLECharacteristicSetValueAction::play` captures the trigger args by copy into two persisted lambdas (the `on_read` handler and the manager listener). In a non-`mutable` lambda those captured copies are **const**, so for a by-reference `Ts` the copy can't bind to `TemplatableValue::value()`'s non-const reference parameter. The direct call in `play` works because there the arg is still the non-const reference from `play(const Ts &...)`; only the captured-lambda copies break. Most triggers pass by value, so this only surfaces with the few by-reference triggers (climate `on_control`/`on_state`, opentherm).

Marking the two lambdas `mutable` makes the captures non-const, which binds correctly for both reference and value template args.

Verified by compiling the reporter's config (climate `on_control` → `set_value` lambda) on `esp32-c3-idf` — previously a hard compile error, now builds clean. A regression test wiring the action to a climate `on_control` is added to the component test.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17142

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: pid
    # ...
    on_control:
      - ble_server.characteristic.set_value:
          id: some_characteristic
          value: !lambda 'return std::vector<uint8_t>{0, 1, 2};'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).