### PR TITLE
[docker] Bump base image to 2026.07.0 for bundled ccache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,11 @@ RUN git config --system --add safe.directory "*" \
 # validate openocd-esp32 (it dynamically links libusb-1.0.so.0); without
 # it idf_tools.py rejects the openocd install with exit 127 and aborts
 # the whole framework setup.
+# ccache speeds up repeat ESP-IDF compiles (enabled via IDF_CCACHE_ENABLE);
+# ESP-IDF silently skips it when the binary isn't on PATH, so it must be
+# present in the image for the dashboard/Device Builder to benefit.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential libusb-1.0-0 \
+    && apt-get install -y --no-install-recommends build-essential libusb-1.0-0 ccache \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1


### PR DESCRIPTION
# What does this implement/fix?

Bumps `BUILD_BASE_VERSION` so the image picks up `ccache` from the base image.

ESP-IDF can use `ccache` (`IDF_CCACHE_ENABLE=1`) to speed up repeat compiles, but it silently skips it when the binary isn't on `PATH` — and the image didn't ship it. Per review feedback, ccache belongs in the shared base image rather than this app Dockerfile, so it's added there in **esphome/docker-base#79**; this PR just bumps the base version to consume it.

> **Depends on esphome/docker-base#79** being merged and released. The `2026.07.0` tag is an assumption — adjust to whatever version that base release publishes (CI here will fail to pull the base until it exists).

Supersedes the original approach in this PR (installing ccache in the app Dockerfile). Companion to #17163 (core: enable ccache by default for ESP-IDF builds).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other

**Related issue or feature (if applicable):**

- Depends on esphome/docker-base#79
- Companion to #17163

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - Docker image change
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).