### PR TITLE
[esp32] Fix Windows OTA signing: emit signing key path as posix

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2370,10 +2370,8 @@ async def to_code(config):
             add_idf_sdkconfig_option("CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES", True)
             add_idf_sdkconfig_option(
                 "CONFIG_SECURE_BOOT_SIGNING_KEY",
-                # as_posix() so kconfiglib doesn't consume Windows backslashes
-                # as escape sequences (C:\Work\key.pem -> C:Workkey.pem) when it
-                # generates the final sdkconfig; espsecure accepts forward
-                # slashes. No-op on POSIX.
+                # as_posix() so kconfiglib doesn't eat Windows backslashes as
+                # escapes (C:\Work\key.pem -> C:Workkey.pem). No-op on POSIX.
                 signed_ota[CONF_SIGNING_KEY].resolve().as_posix(),
             )
         else:

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2370,14 +2370,19 @@ async def to_code(config):
             add_idf_sdkconfig_option("CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES", True)
             add_idf_sdkconfig_option(
                 "CONFIG_SECURE_BOOT_SIGNING_KEY",
-                str(signed_ota[CONF_SIGNING_KEY].resolve()),
+                # as_posix() so kconfiglib doesn't consume Windows backslashes
+                # as escape sequences (C:\Work\key.pem -> C:Workkey.pem) when it
+                # generates the final sdkconfig; espsecure accepts forward
+                # slashes. No-op on POSIX.
+                signed_ota[CONF_SIGNING_KEY].resolve().as_posix(),
             )
         else:
             # Public key mode — verification only, external signing required
             add_idf_sdkconfig_option("CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES", False)
             add_idf_sdkconfig_option(
                 "CONFIG_SECURE_BOOT_VERIFICATION_KEY",
-                str(signed_ota[CONF_VERIFICATION_KEY].resolve()),
+                # as_posix() to avoid Windows backslash mangling (see above).
+                signed_ota[CONF_VERIFICATION_KEY].resolve().as_posix(),
             )
 
         cg.add_define("USE_OTA_SIGNED_VERIFICATION")


### PR DESCRIPTION
# What does this implement/fix?

Fixes `signed_ota_verification` failing on native Windows because the signing-key path loses its backslashes.

`esphome/components/esp32/__init__.py` wrote the resolved key path with `str(Path.resolve())`, which is backslash-separated on Windows. That value lands correctly in the `*.esphomeinternal` sdkconfig, but kconfiglib then consumes the backslashes as escape sequences when generating the final `sdkconfig` (`\W` -> `W`, `\M` -> `M`, …), turning `C:\Work\MyProj\key.pem` into `C:WorkMyProjkey.pem`. The build then fails at the signing step:

```
Error: Signing key not found: C:WorkMyProjkey.pem
```

Emitting the path with `Path.as_posix()` (`C:/Work/MyProj/key.pem`) avoids the mangling — kconfiglib leaves forward slashes intact and `espsecure`/`pathlib` accept them on Windows. No-op on POSIX, where `as_posix() == str()`. Applied to both `CONFIG_SECURE_BOOT_SIGNING_KEY` and `CONFIG_SECURE_BOOT_VERIFICATION_KEY` (same code path).

Reported with root-cause analysis and a verified fix by @mnewton25 in #17164 (confirmed on Windows: "Successfully signed firmware").

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17164

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Existing signed_ota_verification config; no schema change.
esp32:
  variant: esp32s3
  framework:
    advanced:
      signed_ota_verification:
        signing_scheme: ecdsa_p256
        signing_key: key.pem
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).