### PR TITLE
[docker] Move build deps to base image, drop app apt step

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_VERSION=dev
-ARG BUILD_BASE_VERSION=2026.06.0
+ARG BUILD_BASE_VERSION=2026.07.0
 ARG BUILD_TYPE=docker
 
 FROM ghcr.io/esphome/docker-base:debian-${BUILD_BASE_VERSION} AS base-source-docker
@@ -10,19 +10,6 @@ FROM base-source-${BUILD_TYPE} AS base
 
 RUN git config --system --add safe.directory "*" \
     && git config --system advice.detachedHead false
-
-# Install build tools for Python packages that require compilation
-# (e.g., ruamel.yaml.clib used by ESP-IDF's idf-component-manager).
-# Also install libusb-1.0 at runtime so the ESP-IDF tools installer can
-# validate openocd-esp32 (it dynamically links libusb-1.0.so.0); without
-# it idf_tools.py rejects the openocd install with exit 127 and aborts
-# the whole framework setup.
-# ccache speeds up repeat ESP-IDF compiles (enabled via IDF_CCACHE_ENABLE);
-# ESP-IDF silently skips it when the binary isn't on PATH, so it must be
-# present in the image for the dashboard/Device Builder to benefit.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential libusb-1.0-0 ccache \
-    && rm -rf /var/lib/apt/lists/*
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_VERSION=dev
-ARG BUILD_BASE_VERSION=2026.07.0
+ARG BUILD_BASE_VERSION=2026.06.1
 ARG BUILD_TYPE=docker
 
 FROM ghcr.io/esphome/docker-base:debian-${BUILD_BASE_VERSION} AS base-source-docker


### PR DESCRIPTION
# What does this implement/fix?

Removes the app Dockerfile's `RUN apt-get …` step entirely and bumps `BUILD_BASE_VERSION` to a base release that bundles those packages.

`build-essential`, `libusb-1.0-0` and `ccache` were installed in this app Dockerfile; per review feedback on #17157 they belong in the shared base image. They're added there in **esphome/docker-base#79**, so the app layer no longer needs its own apt install — this PR deletes it and bumps the base version to consume them.

- `build-essential` — compiles Python C extensions (`ruamel.yaml.clib`) during install.
- `libusb-1.0-0` — runtime dep for `idf_tools.py` validating `openocd-esp32`.
- `ccache` — speeds up repeat ESP-IDF compiles (originally added to the app image in #17157; now in base).

> **Depends on esphome/docker-base#79** being merged and released. `2026.07.0` is an assumption — set it to whatever that base release is tagged (CI here can't pull the base until it exists, and the build now relies on base for `build-essential`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other

**Related issue or feature (if applicable):**

- Depends on esphome/docker-base#79
- Follows up #17157, companion to #17163

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - Docker image change
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).