### PR TITLE
[api] Send object_id in API message

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -10,6 +10,7 @@
 #ifdef USE_API_USER_DEFINED_ACTIONS
 #include "user_services.h"
 #endif
+#include <array>
 #include <cerrno>
 #include <cinttypes>
 #include <functional>
@@ -417,6 +418,8 @@ uint16_t APIConnection::fill_and_encode_entity_info(EntityBase *entity, InfoResp
                                                     APIConnection *conn, uint32_t remaining_size) {
   // Set common fields that are shared by all entity types
   msg.key = entity->get_object_id_hash();
+  std::array<char, OBJECT_ID_MAX_LEN> object_id_buf;
+  msg.object_id = entity->get_object_id_to(object_id_buf);
 
   if (entity->has_own_name()) {
     msg.name = entity->get_name();


### PR DESCRIPTION
# What does this implement/fix?

Fix ESPHome native API entity discovery by including the entity `object_id` in `ListEntities*Response` messages again.

Without `object_id`, Home Assistant builds duplicate unique IDs such as `MAC-sensor-` for every sensor on a device. It accepts the first entity and rejects the rest as duplicates.

Example HA log:

    Platform esphome does not generate unique IDs. ID <mac>-sensor- already exists

This restores `msg.object_id` in the shared entity-info serialization path.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [[policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [[policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [[policy](https://developers.esphome.io/contributing/code/#c-user-expectations)](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [[esphome.io](https://github.com/esphome/esphome.io)](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

    # Any ESPHome device with multiple API-exposed entities can reproduce this.
    # Example: a device with multiple sensors.
    api:

    sensor:
      - platform: uptime
        name: "Uptime"
      - platform: wifi_signal
        name: "WiFi Signal"

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [[esphome.io](https://github.com/esphome/esphome.io)](https://github.com/esphome/esphome.io).