### PR TITLE
[ci] Exclude test changes from small-pr/medium-pr size labels

### DIFF
--- a/.github/scripts/auto-label-pr/detectors.js
+++ b/.github/scripts/auto-label-pr/detectors.js
@@ -147,18 +147,8 @@ async function detectCoreChanges(changedFiles) {
 }
 
 // Strategy: PR size detection
-async function detectPRSize(prFiles, totalAdditions, totalDeletions, totalChanges, isMegaPR, SMALL_PR_THRESHOLD, MEDIUM_PR_THRESHOLD, TOO_BIG_THRESHOLD) {
+async function detectPRSize(prFiles, totalAdditions, totalDeletions, isMegaPR, SMALL_PR_THRESHOLD, MEDIUM_PR_THRESHOLD, TOO_BIG_THRESHOLD) {
   const labels = new Set();
-
-  if (totalChanges <= SMALL_PR_THRESHOLD) {
-    labels.add('small-pr');
-    return labels;
-  }
-
-  if (totalChanges <= MEDIUM_PR_THRESHOLD) {
-    labels.add('medium-pr');
-    return labels;
-  }
 
   const testAdditions = prFiles
     .filter(file => file.filename.startsWith('tests/'))
@@ -167,7 +157,24 @@ async function detectPRSize(prFiles, totalAdditions, totalDeletions, totalChange
     .filter(file => file.filename.startsWith('tests/'))
     .reduce((sum, file) => sum + (file.deletions || 0), 0);
 
-  const nonTestChanges = (totalAdditions - testAdditions) - (totalDeletions - testDeletions);
+  const nonTestAdditions = totalAdditions - testAdditions;
+  const nonTestDeletions = totalDeletions - testDeletions;
+
+  // small/medium count churn (additions + deletions) so a balanced refactor isn't undersized.
+  const nonTestChurn = nonTestAdditions + nonTestDeletions;
+
+  if (nonTestChurn <= SMALL_PR_THRESHOLD) {
+    labels.add('small-pr');
+    return labels;
+  }
+
+  if (nonTestChurn <= MEDIUM_PR_THRESHOLD) {
+    labels.add('medium-pr');
+    return labels;
+  }
+
+  // too-big uses net line delta (additions - deletions), matching the review message in reviews.js.
+  const nonTestChanges = nonTestAdditions - nonTestDeletions;
 
   // Don't add too-big if mega-pr label is already present
   if (nonTestChanges > TOO_BIG_THRESHOLD && !isMegaPR) {

--- a/.github/scripts/auto-label-pr/index.js
+++ b/.github/scripts/auto-label-pr/index.js
@@ -123,7 +123,7 @@ module.exports = async ({ github, context }) => {
     detectNewComponents(github, context, prFiles),
     detectNewPlatforms(github, context, prFiles, apiData),
     detectCoreChanges(changedFiles),
-    detectPRSize(prFiles, totalAdditions, totalDeletions, totalChanges, isMegaPR, SMALL_PR_THRESHOLD, MEDIUM_PR_THRESHOLD, TOO_BIG_THRESHOLD),
+    detectPRSize(prFiles, totalAdditions, totalDeletions, isMegaPR, SMALL_PR_THRESHOLD, MEDIUM_PR_THRESHOLD, TOO_BIG_THRESHOLD),
     detectDashboardChanges(changedFiles),
     detectGitHubActionsChanges(changedFiles),
     detectCodeOwner(github, context, changedFiles),

--- a/.github/scripts/auto-label-pr/tests/detectors.test.js
+++ b/.github/scripts/auto-label-pr/tests/detectors.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { detectNewPlatforms, detectNewComponents } = require('../detectors');
+const { detectNewPlatforms, detectNewComponents, detectPRSize } = require('../detectors');
 
 // Minimal GitHub API mock — only repos.getContent is called by detectNewPlatforms/detectNewComponents
 // to check for CONFIG_SCHEMA in newly added files.
@@ -143,5 +143,81 @@ describe('detectNewComponents', () => {
     ];
     const result = await detectNewComponents(makeGithub(WITH_SCHEMA), CONTEXT, prFiles);
     assert.equal(result.labels.size, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectPRSize
+// ---------------------------------------------------------------------------
+
+describe('detectPRSize', () => {
+  const SMALL = 30;
+  const MEDIUM = 100;
+  const TOO_BIG = 1000;
+
+  function size(prFiles, isMegaPR = false) {
+    const totalAdditions = prFiles.reduce((sum, file) => sum + (file.additions || 0), 0);
+    const totalDeletions = prFiles.reduce((sum, file) => sum + (file.deletions || 0), 0);
+    return detectPRSize(prFiles, totalAdditions, totalDeletions, isMegaPR, SMALL, MEDIUM, TOO_BIG);
+  }
+
+  it('counts only non-test changes toward small-pr', async () => {
+    // 10 source + 5000 test lines -> non-test churn of 10 is still small.
+    const labels = await size([
+      { filename: 'esphome/components/foo/foo.cpp', additions: 10, deletions: 0 },
+      { filename: 'tests/components/foo/test.esp32-idf.yaml', additions: 5000, deletions: 0 },
+    ]);
+    assert.ok(labels.has('small-pr'));
+    assert.equal(labels.size, 1);
+  });
+
+  it('counts additions and deletions as churn (not net delta)', async () => {
+    // A balanced refactor (40 added, 40 removed) is 80 lines of churn -> medium, not small.
+    const labels = await size([
+      { filename: 'esphome/components/foo/foo.cpp', additions: 40, deletions: 40 },
+    ]);
+    assert.ok(labels.has('medium-pr'));
+    assert.equal(labels.size, 1);
+  });
+
+  it('labels medium-pr when non-test changes exceed small threshold', async () => {
+    const labels = await size([
+      { filename: 'esphome/components/foo/foo.cpp', additions: 60, deletions: 0 },
+      { filename: 'tests/components/foo/test.esp32-idf.yaml', additions: 5000, deletions: 0 },
+    ]);
+    assert.ok(labels.has('medium-pr'));
+    assert.equal(labels.size, 1);
+  });
+
+  it('uses net delta (not churn) for too-big', async () => {
+    // 600 added + 600 removed: 1200 churn (above too-big) but 0 net delta -> not too-big.
+    const labels = await size([
+      { filename: 'esphome/components/foo/foo.cpp', additions: 600, deletions: 600 },
+    ]);
+    assert.equal(labels.size, 0);
+  });
+
+  it('labels too-big when non-test changes exceed the big threshold', async () => {
+    const labels = await size([
+      { filename: 'esphome/components/foo/foo.cpp', additions: 2000, deletions: 0 },
+      { filename: 'tests/components/foo/test.esp32-idf.yaml', additions: 5000, deletions: 0 },
+    ]);
+    assert.ok(labels.has('too-big'));
+    assert.equal(labels.size, 1);
+  });
+
+  it('does not label too-big when mega-pr is set', async () => {
+    const labels = await size([
+      { filename: 'esphome/components/foo/foo.cpp', additions: 2000, deletions: 0 },
+    ], true);
+    assert.equal(labels.size, 0);
+  });
+
+  it('produces no size label for a large mega-pr in the gap above medium', async () => {
+    // Non-test changes land between MEDIUM and TOO_BIG: not small/medium, and mega-pr suppresses too-big.
+    const labels = await size([
+      { filename: 'esphome/components/foo/foo.cpp', additions: 500, deletions: 0 },
+    ], true);
+    assert.equal(labels.size, 0);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The auto-label PR size detection previously counted total line changes (including `tests/`) toward the `small-pr` and `medium-pr` labels, so a small code change with large test fixtures could be labeled as larger than it really is. This moves both labels onto non-test churn (`additions + deletions` outside `tests/`), matching the test-exclusion that `too-big` already applied. `too-big` is unchanged — it keeps its existing net-delta metric (`additions - deletions`) and stays in sync with the review message in `reviews.js`. Adds unit tests for `detectPRSize` covering the churn-vs-net-delta distinction and mega-pr suppression.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).