### PR TITLE
[opentherm] Support power scaling disabled

### DIFF
--- a/esphome/components/opentherm/output/opentherm_output.cpp
+++ b/esphome/components/opentherm/output/opentherm_output.cpp
@@ -12,9 +12,8 @@ void opentherm::OpenthermOutput::write_state(float state) {
 #else
   bool zero_means_zero = false;
 #endif
-  this->state = state < 0.003 && zero_means_zero
-                    ? 0.0
-                    : clamp(std::lerp(min_value_, max_value_, state), min_value_, max_value_);
+  this->state =
+      state < 0.003 && zero_means_zero ? 0.0 : clamp(std::lerp(min_value_, max_value_, state), min_value_, max_value_);
   this->has_state_ = true;
   ESP_LOGD(TAG, "Output %s set to %.2f", this->id_, this->state);
 }

--- a/esphome/components/opentherm/output/opentherm_output.cpp
+++ b/esphome/components/opentherm/output/opentherm_output.cpp
@@ -7,7 +7,12 @@ static const char *const TAG = "opentherm.output";
 
 void opentherm::OpenthermOutput::write_state(float state) {
   ESP_LOGD(TAG, "Received state: %.2f. Min value: %.2f, max value: %.2f", state, min_value_, max_value_);
-  this->state = state < 0.003 && this->zero_means_zero_
+#ifdef USE_OUTPUT_FLOAT_POWER_SCALING
+  bool zero_means_zero = this->zero_means_zero_;
+#else
+  bool zero_means_zero = false;
+#endif
+  this->state = state < 0.003 && zero_means_zero
                     ? 0.0
                     : clamp(std::lerp(min_value_, max_value_, state), min_value_, max_value_);
   this->has_state_ = true;


### PR DESCRIPTION
# What does this implement/fix?

Fixes a compile error in the OpenTherm output when no output uses power scaling.

`USE_OUTPUT_FLOAT_POWER_SCALING` is a compile-time gate that Python codegen enables only when some output actually uses `min_power`, `max_power`, or `zero_means_zero`. When it's off, `FloatOutput::zero_means_zero_` isn't compiled in at all (it's declared under `#ifdef USE_OUTPUT_FLOAT_POWER_SCALING`).

`OpenthermOutput::write_state()` read `this->zero_means_zero_` unconditionally, so any configuration with an OpenTherm output but no power-scaling option anywhere fails to build:

```
error: 'class esphome::opentherm::OpenthermOutput' has no member named 'zero_means_zero_'
```

The fix reads `zero_means_zero` behind the same `#ifdef`, defaulting to `false` when the gate is off — which matches the member's previous default, so behavior is unchanged when the define is on.

Also adds a regression test: the existing `tests/components/opentherm/common.yaml` sets `zero_means_zero: true`, which keeps the define **on** and masks this bug. A new no-power-scaling test exercises the off path.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

If you set an OpenTherm output component without `zero_means_zero: true` (and no other output uses `min_power`/`max_power`), the code fails to compile.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
opentherm:
  in_pin: GPIOXX
  out_pin: GPIOXX

output:
  - platform: opentherm
    t_set:
      id: t_set
      min_value: 20
      max_value: 65
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).