### PR TITLE
[wifi] Report STA IP, not SoftAP IP, in wifi_info on ESP8266

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -218,9 +218,18 @@ network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
     return {};
   network::IPAddresses addresses;
   uint8_t index = 0;
+  // addrList enumerates all lwIP netifs, including the SoftAP / fallback hotspot. Filter out
+  // the AP address so the STA address is reported as the device IP (see issue #17181).
+  struct ip_info ap_ip {};
+  wifi_get_ip_info(SOFTAP_IF, &ap_ip);
+  network::IPAddress ap_address(&ap_ip.ip);
+  bool filter_ap = ap_address.is_set();
   for (auto &addr : addrList) {
+    network::IPAddress ip(addr.ipFromNetifNum());
+    if (filter_ap && ip == ap_address)
+      continue;
     assert(index < addresses.size());
-    addresses[index++] = addr.ipFromNetifNum();
+    addresses[index++] = ip;
   }
   return addresses;
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes the `wifi_info` **IP Address** text sensor reporting the SoftAP / fallback-hotspot gateway IP (e.g. `192.168.4.1`) instead of the STA (client) IP on ESP8266.

On ESP8266, `WiFiComponent::wifi_sta_ip_addresses()` iterates `addrList`, which enumerates **all** lwIP netifs — including the SoftAP. When the fallback hotspot is active (AP+STA), the AP address can land at index 0, so the `wifi_info` IP sensor (and the device web UI) publishes the AP IP. Home Assistant and the device logs are unaffected because they use the connection / STA-specific address, which is why the values disagree.

The fix filters out the AP address before building the list, so the STA address is reported. This mirrors the existing approach already used in the `pico_w` implementation (`wifi_component_pico_w.cpp`), which solves the identical "addrList includes the AP netif" problem. An `is_set()` guard ensures nothing is filtered when the AP is inactive.

> **Depends on #17200.** The `is_set()` / `==` comparison here goes through `IPAddress(ip4_addr_t *)`, whose lwIP type tag is left uninitialized on esp8266 under `enable_ipv6` until #17200 lands. Without it, the filter (and `==`) misbehave on IPv6 builds.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17181
- depends on #17200

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Reproduces with the fallback hotspot active on an ESP8266
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  ap: {}

text_sensor:
  - platform: wifi_info
    ip_address:
      name: ip
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).