### PR TITLE
[wifi][openthread] Wire ESP32-S31/H4/H21 radio support

### DIFF
--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -3,6 +3,9 @@ from esphome.components.esp32 import (
     VARIANT_ESP32C5,
     VARIANT_ESP32C6,
     VARIANT_ESP32H2,
+    VARIANT_ESP32H4,
+    VARIANT_ESP32H21,
+    VARIANT_ESP32S31,
     add_idf_sdkconfig_option,
     get_esp32_variant,
     include_builtin_idf_component,
@@ -187,7 +190,14 @@ def _validate_platform(config):
     if CORE.using_zephyr:
         return config
     return only_on_variant(
-        supported=[VARIANT_ESP32C5, VARIANT_ESP32C6, VARIANT_ESP32H2]
+        supported=[
+            VARIANT_ESP32C5,
+            VARIANT_ESP32C6,
+            VARIANT_ESP32H2,
+            VARIANT_ESP32H4,
+            VARIANT_ESP32H21,
+            VARIANT_ESP32S31,
+        ]
     )(config)
 
 

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -87,8 +87,9 @@ NO_WIFI_VARIANTS = [
 def variant_has_wifi(variant: str) -> bool:
     """Return True if *variant* has a native WiFi PHY.
 
-    Variants without a native PHY (ESP32-H2, ESP32-P4) need the
-    ``esp32_hosted`` co-processor to use ``wifi:``.
+    Variants without a native PHY (see ``NO_WIFI_VARIANTS`` — currently
+    ESP32-H2, ESP32-H4, ESP32-H21, ESP32-P4) need the ``esp32_hosted``
+    co-processor to use ``wifi:``.
 
     Case-insensitive on *variant* so external callers can pass either
     the upstream uppercase form (e.g. ``"ESP32H2"`` from

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -76,7 +76,12 @@ _LOGGER = logging.getLogger(__name__)
 
 AUTO_LOAD = ["network"]
 
-NO_WIFI_VARIANTS = [const.VARIANT_ESP32H2, const.VARIANT_ESP32P4]
+NO_WIFI_VARIANTS = [
+    const.VARIANT_ESP32H2,
+    const.VARIANT_ESP32H4,
+    const.VARIANT_ESP32H21,
+    const.VARIANT_ESP32P4,
+]
 
 
 def variant_has_wifi(variant: str) -> bool:

--- a/esphome/components/zigbee/__init__.py
+++ b/esphome/components/zigbee/__init__.py
@@ -8,6 +8,9 @@ from esphome.components.esp32.const import (
     VARIANT_ESP32C5,
     VARIANT_ESP32C6,
     VARIANT_ESP32H2,
+    VARIANT_ESP32H4,
+    VARIANT_ESP32H21,
+    VARIANT_ESP32S31,
 )
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_INTERNAL, CONF_MODEL, CONF_NAME
@@ -112,6 +115,9 @@ CONFIG_SCHEMA = cv.All(
             only_on_variant(
                 supported=[
                     VARIANT_ESP32H2,
+                    VARIANT_ESP32H4,
+                    VARIANT_ESP32H21,
+                    VARIANT_ESP32S31,
                     VARIANT_ESP32C5,
                     VARIANT_ESP32C6,
                 ]

--- a/esphome/components/zigbee/__init__.py
+++ b/esphome/components/zigbee/__init__.py
@@ -8,9 +8,6 @@ from esphome.components.esp32.const import (
     VARIANT_ESP32C5,
     VARIANT_ESP32C6,
     VARIANT_ESP32H2,
-    VARIANT_ESP32H4,
-    VARIANT_ESP32H21,
-    VARIANT_ESP32S31,
 )
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_INTERNAL, CONF_MODEL, CONF_NAME
@@ -115,9 +112,6 @@ CONFIG_SCHEMA = cv.All(
             only_on_variant(
                 supported=[
                     VARIANT_ESP32H2,
-                    VARIANT_ESP32H4,
-                    VARIANT_ESP32H21,
-                    VARIANT_ESP32S31,
                     VARIANT_ESP32C5,
                     VARIANT_ESP32C6,
                 ]


### PR DESCRIPTION
# What does this implement/fix?

Wires the new ESP32-S31 / ESP32-H4 / ESP32-H21 variants into the radio capability gates:

- **wifi** — add ESP32-H4 and ESP32-H21 to `NO_WIFI_VARIANTS` (no native Wi-Fi PHY; they need `esp32_hosted`). ESP32-S31 has Wi-Fi and stays enabled.
- **openthread** — allow ESP32-H4 / ESP32-H21 / ESP32-S31 (all have an 802.15.4 radio).

**Zigbee was dropped from this PR.** `esp-zigbee-lib` / `esp-zboss-lib` ship no prebuilt library for esp32s31/h4/h21 — the lib's CMakeLists errors `target ... is not supported`, even with the SDK 2.0.1 bump (#16869, verified by compiling against ESP-IDF `release/v6.1`). Zigbee for these variants can be added once upstream publishes the libraries.

Follow-up to #16700.

## Verification

Compiled against ESP-IDF `release/v6.1` (`toolchain: esp-idf`): wifi on S31 and openthread on H4 both build.

## Types of changes

- [x] Other

**Related issue or feature (if applicable):**

- follow-up to #16700

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6846

## Test Environment

- [x] ESP32 IDF

## Checklist:
  - [x] The code change is tested and works locally (compiled on S31 + H4 against IDF 6.1).
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
