### PR TITLE
[i2c][spi] Wire ESP32-S31/H4/H21 bus capabilities

### DIFF
--- a/esphome/components/esp32/gpio_esp32_s31.py
+++ b/esphome/components/esp32/gpio_esp32_s31.py
@@ -2,13 +2,15 @@ import logging
 from typing import Any
 
 import esphome.config_validation as cv
-from esphome.const import CONF_INPUT, CONF_MODE, CONF_NUMBER
+from esphome.const import CONF_INPUT, CONF_MODE, CONF_NUMBER, CONF_SCL, CONF_SDA
 from esphome.pins import check_strapping_pin
 
 # Per the ESP32-S31 datasheet (page 96):
 # https://documentation.espressif.com/esp32-s31_datasheet_en.pdf
 _ESP32S31_SPI_FLASH_PINS: set[int] = {27, 28, 29, 31, 32, 33}
 _ESP32S31_STRAPPING_PINS: set[int] = {60, 61}
+# LP I2C is fixed to GPIO6 (SCL) / GPIO7 (SDA) per the datasheet IO MUX table.
+_ESP32S31_I2C_LP_PINS = {"SDA": 7, "SCL": 6}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,4 +37,14 @@ def esp32_s31_validate_supports(value: dict[str, Any]) -> dict[str, Any]:
         pass
 
     check_strapping_pin(value, _ESP32S31_STRAPPING_PINS, _LOGGER)
+    return value
+
+
+def esp32_s31_validate_lp_i2c(value):
+    lp_sda_pin = _ESP32S31_I2C_LP_PINS["SDA"]
+    lp_scl_pin = _ESP32S31_I2C_LP_PINS["SCL"]
+    if int(value[CONF_SDA]) != lp_sda_pin or int(value[CONF_SCL]) != lp_scl_pin:
+        raise cv.Invalid(
+            f"Low power i2c interface is only supported on GPIO{lp_sda_pin} SDA and GPIO{lp_scl_pin} SCL for ESP32-S31"
+        )
     return value

--- a/esphome/components/esp32/gpio_esp32_s31.py
+++ b/esphome/components/esp32/gpio_esp32_s31.py
@@ -8,7 +8,8 @@ from esphome.pins import check_strapping_pin
 # Per the ESP32-S31 datasheet (page 96):
 # https://documentation.espressif.com/esp32-s31_datasheet_en.pdf
 _ESP32S31_SPI_FLASH_PINS: set[int] = {27, 28, 29, 31, 32, 33}
-_ESP32S31_STRAPPING_PINS: set[int] = {60, 61}
+# GPIO60/GPIO61 set the boot mode; GPIO37 selects the JTAG signal source.
+_ESP32S31_STRAPPING_PINS: set[int] = {37, 60, 61}
 # LP I2C is fixed to GPIO6 (SCL) / GPIO7 (SDA) per the datasheet IO MUX table.
 _ESP32S31_I2C_LP_PINS = {"SDA": 7, "SCL": 6}
 

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -13,9 +13,12 @@ from esphome.components.esp32 import (
     VARIANT_ESP32C6,
     VARIANT_ESP32C61,
     VARIANT_ESP32H2,
+    VARIANT_ESP32H4,
+    VARIANT_ESP32H21,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
+    VARIANT_ESP32S31,
     get_esp32_variant,
 )
 from esphome.components.esp32.gpio_esp32_c5 import esp32_c5_validate_lp_i2c
@@ -72,9 +75,14 @@ ESP32_I2C_CAPABILITIES = {
     VARIANT_ESP32C6: {"NUM": 2, "HP": 1, "LP": 1},
     VARIANT_ESP32C61: {"NUM": 1, "HP": 1},
     VARIANT_ESP32H2: {"NUM": 2, "HP": 2},
+    VARIANT_ESP32H4: {"NUM": 2, "HP": 2},
+    VARIANT_ESP32H21: {"NUM": 2, "HP": 2},
     VARIANT_ESP32P4: {"NUM": 3, "HP": 2, "LP": 1},
     VARIANT_ESP32S2: {"NUM": 2, "HP": 2},
     VARIANT_ESP32S3: {"NUM": 2, "HP": 2},
+    # S31 has 3 HP + 1 LP I2C; LP I2C is deferred until its LP pin validator lands,
+    # so only the 3 HP interfaces are exposed here.
+    VARIANT_ESP32S31: {"NUM": 3, "HP": 3},
 }
 VALIDATE_LP_I2C = {
     VARIANT_ESP32C5: esp32_c5_validate_lp_i2c,

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -81,7 +81,7 @@ ESP32_I2C_CAPABILITIES = {
     VARIANT_ESP32P4: {"NUM": 3, "HP": 2, "LP": 1},
     VARIANT_ESP32S2: {"NUM": 2, "HP": 2},
     VARIANT_ESP32S3: {"NUM": 2, "HP": 2},
-    VARIANT_ESP32S31: {"NUM": 4, "HP": 3, "LP": 1},
+    VARIANT_ESP32S31: {"NUM": 3, "HP": 2, "LP": 1},
 }
 VALIDATE_LP_I2C = {
     VARIANT_ESP32C5: esp32_c5_validate_lp_i2c,

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -80,8 +80,10 @@ ESP32_I2C_CAPABILITIES = {
     VARIANT_ESP32P4: {"NUM": 3, "HP": 2, "LP": 1},
     VARIANT_ESP32S2: {"NUM": 2, "HP": 2},
     VARIANT_ESP32S3: {"NUM": 2, "HP": 2},
-    # S31 has 3 HP + 1 LP I2C; LP I2C is deferred until its LP pin validator lands,
-    # so only the 3 HP interfaces are exposed here.
+    # S31 has 3 HP + 1 LP I2C, but only the 3 HP interfaces are exposed for now: LP I2C
+    # needs an exact SDA/SCL pin validator like C5/C6/P4 (see VALIDATE_LP_I2C), and the fixed
+    # LP I2C pin assignment for S31 isn't published yet -- it's a datasheet value (e.g. C6 is
+    # GPIO6/7), not present in ESP-IDF soc_caps. Add LP I2C once that pin pair is known.
     VARIANT_ESP32S31: {"NUM": 3, "HP": 3},
 }
 VALIDATE_LP_I2C = {

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -24,6 +24,7 @@ from esphome.components.esp32 import (
 from esphome.components.esp32.gpio_esp32_c5 import esp32_c5_validate_lp_i2c
 from esphome.components.esp32.gpio_esp32_c6 import esp32_c6_validate_lp_i2c
 from esphome.components.esp32.gpio_esp32_p4 import esp32_p4_validate_lp_i2c
+from esphome.components.esp32.gpio_esp32_s31 import esp32_s31_validate_lp_i2c
 from esphome.components.zephyr import (
     zephyr_add_overlay,
     zephyr_add_prj_conf,
@@ -80,16 +81,13 @@ ESP32_I2C_CAPABILITIES = {
     VARIANT_ESP32P4: {"NUM": 3, "HP": 2, "LP": 1},
     VARIANT_ESP32S2: {"NUM": 2, "HP": 2},
     VARIANT_ESP32S3: {"NUM": 2, "HP": 2},
-    # S31 has 3 HP + 1 LP I2C, but only the 3 HP interfaces are exposed for now: LP I2C
-    # needs an exact SDA/SCL pin validator like C5/C6/P4 (see VALIDATE_LP_I2C), and the fixed
-    # LP I2C pin assignment for S31 isn't published yet -- it's a datasheet value (e.g. C6 is
-    # GPIO6/7), not present in ESP-IDF soc_caps. Add LP I2C once that pin pair is known.
-    VARIANT_ESP32S31: {"NUM": 3, "HP": 3},
+    VARIANT_ESP32S31: {"NUM": 4, "HP": 3, "LP": 1},
 }
 VALIDATE_LP_I2C = {
     VARIANT_ESP32C5: esp32_c5_validate_lp_i2c,
     VARIANT_ESP32C6: esp32_c6_validate_lp_i2c,
     VARIANT_ESP32P4: esp32_p4_validate_lp_i2c,
+    VARIANT_ESP32S31: esp32_s31_validate_lp_i2c,
 }
 LP_I2C_VARIANT = list(VALIDATE_LP_I2C.keys())
 

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -11,6 +11,7 @@ from esphome.components.esp32 import (
     VARIANT_ESP32C6,
     VARIANT_ESP32C61,
     VARIANT_ESP32H2,
+    VARIANT_ESP32H21,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
@@ -174,6 +175,7 @@ def get_hw_interface_list():
             VARIANT_ESP32C6,
             VARIANT_ESP32C61,
             VARIANT_ESP32H2,
+            VARIANT_ESP32H21,
         ]:
             return [["spi", "spi2"]]
         return [["spi", "spi2"], ["spi3"]]


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #16700. Wires the new ESP32-S31 / H4 / H21 variants into the i2c and spi capability tables, per ESP-IDF `soc_caps.h` and the ESP32-S31 datasheet.

- **i2c** (`ESP32_I2C_CAPABILITIES`):
  - ESP32-H4 / H21: 2 HP I2C (`SOC_HP_I2C_NUM = 2`, no LP).
  - ESP32-S31: 2 HP + 1 LP I2C (`SOC_I2C_NUM = 3`, `SOC_HP_I2C_NUM = 2`, `SOC_LP_I2C_NUM = 1`). LP I2C is fixed to **GPIO6 (SCL) / GPIO7 (SDA)** per the S31 datasheet IO MUX table (note: SDA/SCL are swapped vs ESP32-C6); added `esp32_s31_validate_lp_i2c` to enforce those pins. Also adds GPIO37 (JTAG source) to the S31 strapping-pin set alongside GPIO60/61.
- **spi** (`get_hw_interface_list`):
  - ESP32-H21: 2 SPI peripherals (`SOC_SPI_PERIPH_NUM = 2`) → one usable bus (`spi2`), added to the 2-SPI list.
  - ESP32-S31 / H4: 3 SPI (`SOC_SPI_PERIPH_NUM = 3`) → fall through to the default `spi2` + `spi3`, no change needed.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Developer breaking change
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Follow-up to #16700

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- Variant I2C/SPI counts are documented in esphome/esphome.io#6847

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  variant: esp32s31
  framework:
    type: esp-idf
    version: 6.1.0
    source: https://github.com/espressif/esp-idf.git@release/v6.1

i2c:
  - sda: 7      # LP I2C
    scl: 6
    low_power_mode: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
