### PR TITLE
[tinyusb][usb_cdc_acm][usb_host][usb_uart] Support ESP32-S31/H4

### DIFF
--- a/esphome/components/tinyusb/__init__.py
+++ b/esphome/components/tinyusb/__init__.py
@@ -72,7 +72,8 @@ def _final_validate(config):
             "'tinyusb' cannot be used with 'logger.hardware_uart: USB_CDC' "
             "because both share the USB OTG peripheral. Set "
             "'logger.hardware_uart' to a hardware UART (e.g. UART0), or to "
-            "USB_SERIAL_JTAG on variants that support it (ESP32-S3, ESP32-P4)"
+            "USB_SERIAL_JTAG on variants that support it "
+            "(ESP32-S3, ESP32-S31, ESP32-P4, ESP32-H4)"
         )
     return config
 

--- a/esphome/components/tinyusb/__init__.py
+++ b/esphome/components/tinyusb/__init__.py
@@ -94,7 +94,7 @@ async def to_code(config):
     if config[CONF_USB_SERIAL_STR]:
         cg.add(var.set_usb_desc_serial(config[CONF_USB_SERIAL_STR]))
 
-    add_idf_component(name="espressif/esp_tinyusb", ref="2.1.1")
+    add_idf_component(name="espressif/esp_tinyusb", ref="2.2.1")
 
     add_idf_sdkconfig_option("CONFIG_TINYUSB_DESC_USE_ESPRESSIF_VID", False)
     add_idf_sdkconfig_option("CONFIG_TINYUSB_DESC_USE_DEFAULT_PID", False)

--- a/esphome/components/tinyusb/__init__.py
+++ b/esphome/components/tinyusb/__init__.py
@@ -2,9 +2,11 @@ from esphome import final_validate as fv
 import esphome.codegen as cg
 from esphome.components import esp32
 from esphome.components.esp32 import (
+    VARIANT_ESP32H4,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
+    VARIANT_ESP32S31,
     add_idf_component,
     add_idf_sdkconfig_option,
 )
@@ -44,7 +46,13 @@ CONFIG_SCHEMA = cv.All(
         }
     ).extend(cv.COMPONENT_SCHEMA),
     esp32.only_on_variant(
-        supported=[VARIANT_ESP32P4, VARIANT_ESP32S2, VARIANT_ESP32S3],
+        supported=[
+            VARIANT_ESP32H4,
+            VARIANT_ESP32P4,
+            VARIANT_ESP32S2,
+            VARIANT_ESP32S3,
+            VARIANT_ESP32S31,
+        ],
     ),
 )
 

--- a/esphome/components/tinyusb/tinyusb_component.cpp
+++ b/esphome/components/tinyusb/tinyusb_component.cpp
@@ -1,4 +1,5 @@
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "tinyusb_component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -61,4 +62,5 @@ void TinyUSB::dump_config() {
 }
 
 }  // namespace esphome::tinyusb
-#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3
+#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 ||
+        // USE_ESP32_VARIANT_ESP32S31 || USE_ESP32_VARIANT_ESP32H4

--- a/esphome/components/tinyusb/tinyusb_component.h
+++ b/esphome/components/tinyusb/tinyusb_component.h
@@ -1,5 +1,6 @@
 #pragma once
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "esphome/core/component.h"
 
 #include "tinyusb.h"
@@ -69,4 +70,5 @@ class TinyUSB : public Component {
 };
 
 }  // namespace esphome::tinyusb
-#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3
+#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 ||
+        // USE_ESP32_VARIANT_ESP32S31 || USE_ESP32_VARIANT_ESP32H4

--- a/esphome/components/usb_cdc_acm/__init__.py
+++ b/esphome/components/usb_cdc_acm/__init__.py
@@ -1,9 +1,11 @@
 import esphome.codegen as cg
 from esphome.components import esp32, uart
 from esphome.components.esp32 import (
+    VARIANT_ESP32H4,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
+    VARIANT_ESP32S31,
     add_idf_sdkconfig_option,
 )
 import esphome.config_validation as cv
@@ -48,7 +50,13 @@ CONFIG_SCHEMA = cv.All(
         }
     ).extend(cv.COMPONENT_SCHEMA),
     esp32.only_on_variant(
-        supported=[VARIANT_ESP32P4, VARIANT_ESP32S2, VARIANT_ESP32S3],
+        supported=[
+            VARIANT_ESP32H4,
+            VARIANT_ESP32P4,
+            VARIANT_ESP32S2,
+            VARIANT_ESP32S3,
+            VARIANT_ESP32S31,
+        ],
     ),
 )
 

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm.cpp
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm.cpp
@@ -1,4 +1,5 @@
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "usb_cdc_acm.h"
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm.h
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm.h
@@ -1,5 +1,6 @@
 #pragma once
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 
 #include "esphome/core/component.h"
 #include "esphome/core/event_pool.h"

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
@@ -1,4 +1,5 @@
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "usb_cdc_acm.h"
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"

--- a/esphome/components/usb_host/__init__.py
+++ b/esphome/components/usb_host/__init__.py
@@ -94,7 +94,7 @@ async def register_usb_client(config):
 async def to_code(config: ConfigType) -> None:
     # IDF 6.0 moved USB host to an external component
     if idf_version() >= cv.Version(6, 0, 0):
-        add_idf_component(name="espressif/usb", ref="1.3.0")
+        add_idf_component(name="espressif/usb", ref="1.4.1")
     add_idf_sdkconfig_option("CONFIG_USB_HOST_CONTROL_TRANSFER_MAX_SIZE", 1024)
     if config.get(CONF_ENABLE_HUBS):
         add_idf_sdkconfig_option("CONFIG_USB_HOST_HUBS_SUPPORTED", True)

--- a/esphome/components/usb_host/__init__.py
+++ b/esphome/components/usb_host/__init__.py
@@ -1,8 +1,10 @@
 import esphome.codegen as cg
 from esphome.components.esp32 import (
+    VARIANT_ESP32H4,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
+    VARIANT_ESP32S31,
     add_idf_component,
     add_idf_sdkconfig_option,
     idf_version,
@@ -70,7 +72,15 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DEVICES): cv.ensure_list(usb_device_schema()),
         }
     ),
-    only_on_variant(supported=[VARIANT_ESP32P4, VARIANT_ESP32S2, VARIANT_ESP32S3]),
+    only_on_variant(
+        supported=[
+            VARIANT_ESP32H4,
+            VARIANT_ESP32P4,
+            VARIANT_ESP32S2,
+            VARIANT_ESP32S3,
+            VARIANT_ESP32S31,
+        ]
+    ),
     _set_max_packet_size,
 )
 

--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -1,7 +1,8 @@
 #pragma once
 
 // Should not be needed, but it's required to pass CI clang-tidy checks
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "esphome/core/defines.h"
 #include "esphome/core/component.h"
 #include <vector>
@@ -195,4 +196,5 @@ class USBHost : public Component {
 
 }  // namespace esphome::usb_host
 
-#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3
+#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 ||
+        // USE_ESP32_VARIANT_ESP32S31 || USE_ESP32_VARIANT_ESP32H4

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -1,5 +1,6 @@
 // Should not be needed, but it's required to pass CI clang-tidy checks
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "usb_host.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
@@ -581,4 +582,5 @@ void USBClient::release_trq(TransferRequest *trq) {
 }
 
 }  // namespace esphome::usb_host
-#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3
+#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 ||
+        // USE_ESP32_VARIANT_ESP32S31 || USE_ESP32_VARIANT_ESP32H4

--- a/esphome/components/usb_host/usb_host_component.cpp
+++ b/esphome/components/usb_host/usb_host_component.cpp
@@ -1,5 +1,6 @@
 // Should not be needed, but it's required to pass CI clang-tidy checks
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "usb_host.h"
 #include <cinttypes>
 #include "esphome/core/log.h"
@@ -29,4 +30,5 @@ void USBHost::loop() {
 
 }  // namespace esphome::usb_host
 
-#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3
+#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 ||
+        // USE_ESP32_VARIANT_ESP32S31 || USE_ESP32_VARIANT_ESP32H4

--- a/esphome/components/usb_uart/ch34x.cpp
+++ b/esphome/components/usb_uart/ch34x.cpp
@@ -1,4 +1,5 @@
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "usb_uart.h"
 #include "usb/usb_host.h"
 #include "esphome/core/log.h"
@@ -170,4 +171,5 @@ std::vector<CdcEps> USBUartTypeCH34X::parse_descriptors(usb_device_handle_t dev_
 }
 }  // namespace esphome::usb_uart
 
-#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3
+#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 ||
+        // USE_ESP32_VARIANT_ESP32S31 || USE_ESP32_VARIANT_ESP32H4

--- a/esphome/components/usb_uart/cp210x.cpp
+++ b/esphome/components/usb_uart/cp210x.cpp
@@ -1,4 +1,5 @@
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "usb_uart.h"
 #include "usb/usb_host.h"
 #include "esphome/core/log.h"
@@ -122,4 +123,5 @@ void USBUartTypeCP210X::enable_channels() {
 }
 }  // namespace esphome::usb_uart
 
-#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3
+#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 ||
+        // USE_ESP32_VARIANT_ESP32S31 || USE_ESP32_VARIANT_ESP32H4

--- a/esphome/components/usb_uart/ft23xx.cpp
+++ b/esphome/components/usb_uart/ft23xx.cpp
@@ -1,4 +1,5 @@
-#if defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32P4)
+#if defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32P4) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "usb_uart.h"
 #include "usb/usb_host.h"
 #include "esphome/core/log.h"
@@ -455,4 +456,5 @@ void USBUartTypeFT23XX::enable_channels() {
 }
 
 }  // namespace esphome::usb_uart
-#endif  // USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 || USE_ESP32_VARIANT_ESP32P4
+#endif  // USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 || USE_ESP32_VARIANT_ESP32P4 ||
+        // USE_ESP32_VARIANT_ESP32S31 || USE_ESP32_VARIANT_ESP32H4

--- a/esphome/components/usb_uart/pl2303.cpp
+++ b/esphome/components/usb_uart/pl2303.cpp
@@ -1,4 +1,5 @@
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "usb_uart.h"
 #include "usb/usb_host.h"
 #include "esphome/core/log.h"
@@ -295,4 +296,5 @@ void USBUartTypePL2303::enable_channels() {
 }
 
 }  // namespace esphome::usb_uart
-#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3
+#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 ||
+        // USE_ESP32_VARIANT_ESP32S31 || USE_ESP32_VARIANT_ESP32H4

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -1,5 +1,6 @@
 // Should not be needed, but it's required to pass CI clang-tidy checks
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "usb_uart.h"
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
@@ -541,4 +542,5 @@ void USBUartTypeCdcAcm::start_channels_() {
 
 }  // namespace esphome::usb_uart
 
-#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3
+#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 ||
+        // USE_ESP32_VARIANT_ESP32S31 || USE_ESP32_VARIANT_ESP32H4

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32S31) || defined(USE_ESP32_VARIANT_ESP32H4)
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/string_ref.h"
@@ -286,4 +287,5 @@ class USBUartTypePL2303 : public USBUartTypeCdcAcm {
 
 }  // namespace esphome::usb_uart
 
-#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3
+#endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3 ||
+        // USE_ESP32_VARIANT_ESP32S31 || USE_ESP32_VARIANT_ESP32H4

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -84,9 +84,9 @@ dependencies:
     rules:
       - if: "idf_version >=6.0.0"
   espressif/esp_tinyusb:
-    version: "2.1.1"
+    version: "2.2.1"
     rules:
-      - if: "target in [esp32s2, esp32s3, esp32p4]"
+      - if: "target in [esp32s2, esp32s3, esp32s31, esp32p4, esp32h4]"
   esphome/esp-hub75:
     version: 0.3.5
     rules:
@@ -96,9 +96,9 @@ dependencies:
     rules:
       - if: "idf_version >=6.0.0"
   espressif/usb:
-    version: "1.3.0"
+    version: "1.4.1"
     rules:
-      - if: "idf_version >=6.0.0 && target in [esp32s2, esp32s3, esp32p4]"
+      - if: "idf_version >=6.0.0 && target in [esp32s2, esp32s3, esp32s31, esp32p4, esp32h4]"
   esp32async/asynctcp:
     version: 3.4.91
   sendspin/sendspin-cpp:


### PR DESCRIPTION
# What does this implement/fix?

Wires the new ESP32-S31 and ESP32-H4 variants into the USB device/host components. Both have USB-OTG (`SOC_USB_OTG_SUPPORTED`, matching S2/S3/P4). ESP32-H21 has only USB-Serial-JTAG (no OTG) and stays excluded.

This required three coordinated changes (the first two were missing in the initial revision and only surfaced via a real ESP-IDF 6.1 compile — config validation passed but the build failed):

1. **Python `only_on_variant`** — add S31/H4 to `tinyusb`, `usb_cdc_acm`, `usb_host`.
2. **C++ variant guards** — every USB component's source is wrapped in `#if defined(USE_ESP32_VARIANT_ESP32P4) || ...S2 || ...S3`; without S31/H4 the code compiled out (`'usb_host' has not been declared`). Extended across `usb_host`, `tinyusb`, `usb_cdc_acm`, `usb_uart`.
3. **IDF managed components** — bumped so the new targets resolve, plus the static `idf_component.yml` (clang-tidy) target rules:
   - `espressif/usb` 1.3.0 → 1.4.1 (adds esp32s31; h4 already supported)
   - `espressif/esp_tinyusb` 2.1.1 → 2.2.1 (adds esp32s31)
   - `idf_component.yml` rules also gained the previously-missing `esp32h4`.

`usb_uart` follows `usb_host` automatically.

## Verification

Compiled against ESP-IDF `release/v6.1` (`toolchain: esp-idf`):
- S31: `usb_host`+`usb_uart` ✅, `tinyusb`+`usb_cdc_acm` ✅
- H4: `usb_host`+`usb_uart` ✅

## Types of changes

- [x] Other

**Related issue or feature (if applicable):**

- follow-up to #16700

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6849

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
esp32:
  variant: esp32s31
  framework:
    type: esp-idf

usb_host:
  id: usb_host_id
```

## Checklist:
  - [x] The code change is tested and works locally (compiled on S31 + H4 against IDF 6.1).
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
