### PR TITLE
[waveshare_io_ch32v003] Pin i2c_id in test to avoid grouping conflict

### DIFF
--- a/tests/components/waveshare_io_ch32v003/common.yaml
+++ b/tests/components/waveshare_io_ch32v003/common.yaml
@@ -1,5 +1,6 @@
 waveshare_io_ch32v003:
   - id: wave_io
+    i2c_id: i2c_bus
     address: 0x24
 
 binary_sensor:


### PR DESCRIPTION
# What does this implement/fix?

The `waveshare_io_ch32v003` test config does not set `i2c_id`, relying on automatic I2C bus resolution. That works when the component is tested in isolation, but when CI groups it together with `tca9548a` (which registers multiplexer channel buses as additional `i2c::I2CBus` instances), auto-resolution finds more than one candidate and config fails:

```
waveshare_io_ch32v003:
  Too many candidates found for 'i2c_id' type 'i2c::I2CBus' Some are 'i2c_bus', 'multiplex0_chan0'.
```

This is a latent bug in the test that surfaces on any PR that changes a base I2C component (which causes CI to regroup all I2C components together). The fix is to pin `i2c_id: i2c_bus`, matching what every other I2C component test does.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# test-only change; see tests/components/waveshare_io_ch32v003/common.yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).