### PR TITLE
[psram] Support ESP32-S31/H4

### DIFF
--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -10,9 +10,11 @@ from esphome.components.esp32 import (
     VARIANT_ESP32,
     VARIANT_ESP32C5,
     VARIANT_ESP32C61,
+    VARIANT_ESP32H4,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
+    VARIANT_ESP32S31,
     add_idf_sdkconfig_option,
     get_esp32_variant,
     idf_version,
@@ -57,8 +59,10 @@ SPIRAM_MODES = {
     VARIANT_ESP32: (TYPE_QUAD,),
     VARIANT_ESP32C5: (TYPE_QUAD,),
     VARIANT_ESP32C61: (TYPE_QUAD,),
+    VARIANT_ESP32H4: (TYPE_QUAD,),
     VARIANT_ESP32S2: (TYPE_QUAD,),
     VARIANT_ESP32S3: (TYPE_QUAD, TYPE_OCTAL),
+    VARIANT_ESP32S31: (TYPE_OCTAL,),
     VARIANT_ESP32P4: (TYPE_HEX,),
 }
 
@@ -67,8 +71,10 @@ SPIRAM_SPEEDS = {
     VARIANT_ESP32: (40, 80, 120),
     VARIANT_ESP32C5: (40, 80, 120),
     VARIANT_ESP32C61: (40, 80),
+    VARIANT_ESP32H4: (32, 64),
     VARIANT_ESP32S2: (40, 80, 120),
     VARIANT_ESP32S3: (40, 80, 120),
+    VARIANT_ESP32S31: (40, 100, 200, 250),
     VARIANT_ESP32P4: (20, 100, 200),
 }
 
@@ -145,10 +151,8 @@ def validate_psram_mode(config):
         raise cv.Invalid("ECC is only available in octal mode.")
     if config[CONF_MODE] == TYPE_OCTAL:
         variant = get_esp32_variant()
-        if variant != VARIANT_ESP32S3:
-            raise cv.Invalid(
-                f"Octal PSRAM is only supported on ESP32-S3, not {variant}"
-            )
+        if TYPE_OCTAL not in SPIRAM_MODES.get(variant, ()):
+            raise cv.Invalid(f"Octal PSRAM is not supported on {variant}")
     return config
 
 

--- a/tests/component_tests/psram/test_psram.py
+++ b/tests/component_tests/psram/test_psram.py
@@ -12,9 +12,12 @@ from esphome.components.esp32 import (
     VARIANT_ESP32C5,
     VARIANT_ESP32C6,
     VARIANT_ESP32H2,
+    VARIANT_ESP32H4,
+    VARIANT_ESP32H21,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
+    VARIANT_ESP32S31,
 )
 import esphome.config_validation as cv
 from esphome.const import CONF_ESPHOME, PlatformFramework
@@ -25,21 +28,26 @@ UNSUPPORTED_PSRAM_VARIANTS = [
     VARIANT_ESP32C3,
     VARIANT_ESP32C6,
     VARIANT_ESP32H2,
+    VARIANT_ESP32H21,
 ]
 
 SUPPORTED_PSRAM_VARIANTS = [
     VARIANT_ESP32,
     VARIANT_ESP32C5,
+    VARIANT_ESP32H4,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
+    VARIANT_ESP32S31,
 ]
 SUPPORTED_PSRAM_MODES = {
     VARIANT_ESP32: ["quad"],
     VARIANT_ESP32C5: ["quad"],
+    VARIANT_ESP32H4: ["quad"],
     VARIANT_ESP32P4: ["hex"],
     VARIANT_ESP32S2: ["quad"],
     VARIANT_ESP32S3: ["quad", "octal"],
+    VARIANT_ESP32S31: ["octal"],
 }
 
 
@@ -187,7 +195,7 @@ def _setup_psram_final_validation_test(
             {"mode": "octal"},
             {"variant": "ESP32"},
             True,
-            r"Octal PSRAM is only supported on ESP32-S3",
+            r"Octal PSRAM is not supported on ESP32",
             id="octal_mode_only_esp32s3",
         ),
         pytest.param(


### PR DESCRIPTION
# What does this implement/fix?

Wires PSRAM support for two of the new ESP32 variants:

- **ESP32-S31** — octal mode, speeds 40 / 100 / 200 / 250 MHz
- **ESP32-H4** — quad mode, speeds 32 / 64 MHz

Values come from the `esp_psram` Kconfig on ESP-IDF `release/v6.1`. **ESP32-H21** has no PSRAM (`SOC_SPIRAM_SUPPORTED` is not set) and stays unsupported.

The octal-mode validation previously hardcoded `ESP32-S3`; this generalizes it to a data-driven check against `SPIRAM_MODES`, so ESP32-S31 (octal) is accepted and the check stays correct as more variants are added (verified ESP32-S3 octal still validates).

Follow-up to #16700.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- follow-up to #16700

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6850

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
esp32:
  variant: esp32s31
  framework:
    type: esp-idf

psram:
  mode: octal
  speed: 200MHz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
