### PR TITLE
[esp32] Accept '#' as ESP-IDF source ref separator

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -337,16 +337,19 @@ print(".".join([str(x) for x in sys.version_info]))
 
 
 _GITHUB_SHORTHAND_RE = re.compile(
-    r"^github://([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\._]+?)(?:@([a-zA-Z0-9\-_.\./]+))?$"
+    r"^github://([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\._]+?)(?:[@#]([a-zA-Z0-9\-_.\./]+))?$"
 )
 _GITHUB_HTTPS_RE = re.compile(
-    r"^(https://github\.com/[a-zA-Z0-9\-]+/[a-zA-Z0-9\-\._]+?\.git)(?:@([a-zA-Z0-9\-_.\./]+))?$"
+    r"^(https://github\.com/[a-zA-Z0-9\-]+/[a-zA-Z0-9\-\._]+?\.git)(?:[@#]([a-zA-Z0-9\-_.\./]+))?$"
 )
 
 
 def _parse_git_source(source_url: str) -> tuple[str, str | None] | None:
     """Return ``(url, ref)`` for ``github://owner/repo[@ref]`` or
-    ``https://github.com/owner/repo.git[@ref]``, else ``None``."""
+    ``https://github.com/owner/repo.git[@ref]``, else ``None``.
+
+    The ref may be separated with ``@`` or ``#``; ``#`` matches the PlatformIO
+    convention used for ``platform_version`` URLs."""
     if m := _GITHUB_SHORTHAND_RE.match(source_url):
         owner, repo, ref = m.group(1), m.group(2), m.group(3)
         # Tolerate a trailing ".git" on the shorthand repo so the

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -65,6 +65,19 @@ from esphome.framework_helpers import _tar_extract_all, get_python_env_executabl
             "https://github.com/espressif/esp-idf.git@v6.0.1",
             ("https://github.com/espressif/esp-idf.git", "v6.0.1"),
         ),
+        # '#' ref separator (PlatformIO/git-web convention) works on both forms
+        (
+            "https://github.com/espressif/esp-idf.git#release/v6.1",
+            ("https://github.com/espressif/esp-idf.git", "release/v6.1"),
+        ),
+        (
+            "github://espressif/esp-idf#release/v6.1",
+            ("https://github.com/espressif/esp-idf.git", "release/v6.1"),
+        ),
+        (
+            "github://espressif/esp-idf.git#master",
+            ("https://github.com/espressif/esp-idf.git", "master"),
+        ),
         # Tolerate a trailing ".git" on the shorthand so the user doesn't
         # silently end up with a doubled "...esp-idf.git.git" URL.
         (


### PR DESCRIPTION
# What does this implement/fix?

The native ESP-IDF builder (`toolchain: esp-idf`) parses a custom framework `source:` for a git ref, but only accepted the `@ref` separator:

```yaml
# worked
source: https://github.com/espressif/esp-idf.git@release/v6.1
# failed cryptically
source: https://github.com/espressif/esp-idf.git#release/v6.1
```

A `#ref` URL doesn't match `_parse_git_source`, so it falls through to the archive-download path and fails with the unhelpful `ValueError: Unsupported archive format` — with no hint that the separator is the problem.

`#` is the PlatformIO / git-web ref convention, and esphome already uses it elsewhere (the `platform_version` URLs are literally `platform-espressif32.git#prep_IDF6` / `#develop`), so users naturally reach for it. This accepts both `@` and `#` as the ref separator on the `github://owner/repo` shorthand and the `https://github.com/owner/repo.git` URL forms. There's no ambiguity — a git ref or URL never contains `@`/`#`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
esp32:
  variant: esp32s31
  toolchain: esp-idf
  framework:
    type: esp-idf
    version: 6.1.0
    source: https://github.com/espressif/esp-idf.git#release/v6.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
