### PR TITLE
[network] Set IPv4 type tag on all lwIP platforms, not just esp32

### DIFF
--- a/esphome/components/network/ip_address.h
+++ b/esphome/components/network/ip_address.h
@@ -119,7 +119,7 @@ struct IPAddress {
   IPAddress(const std::string &in_address) { ipaddr_aton(in_address.c_str(), &ip_addr_); }
   IPAddress(ip4_addr_t *other_ip) {
     memcpy((void *) &ip_addr_, (void *) other_ip, sizeof(ip4_addr_t));
-#if USE_ESP32 && LWIP_IPV6
+#if LWIP_IPV6
     ip_addr_.type = IPADDR_TYPE_V4;
 #endif
   }


### PR DESCRIPTION
# What does this implement/fix?

The `IPAddress(ip4_addr_t *)` constructor only set the lwIP `type` tag under `USE_ESP32`, so on the other lwIP platforms (esp8266 / rp2040 / libretiny) with `enable_ipv6`, the tagged `ip_addr_t` was left with an **uninitialized type byte**. `ip_addr_cmp` / `operator+=` / `str()` all read that byte, so they misbehave on those platforms under IPv6 — e.g. the esp8266 AP DHCP lease math (`start_address += 99` in `wifi_component_esp8266.cpp`) silently no-ops, and SoftAP-IP filtering compares unequal even for identical addresses.

The `type` field exists whenever `LWIP_IPV6` is set, so gate the assignment on that (matching the `esp_ip4_addr_t` sibling constructor a few lines down). On IPv4-only builds the field doesn't exist and the block compiles out — unchanged. On esp32 nothing changes.

Preexisting since #5595: the `USE_ESP32` was vestigial scope from #5583 (which fixed the same `operator+=` symptom on esp32 only), and #5595 only added the orthogonal `LWIP_IPV6` compile-guard without revisiting it. Surfaced while reviewing #17185.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced by #17185

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# ESP8266 with IPv6 enabled exercises the affected lwIP type tag
esp8266:
  board: nodemcuv2
network:
  enable_ipv6: true
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  ap:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).