### PR TITLE
[adc] Only call cyw43_thread_enter/exit for VSYS when WiFi is active on RP2040

### DIFF
--- a/esphome/components/adc/adc_sensor_rp2040.cpp
+++ b/esphome/components/adc/adc_sensor_rp2040.cpp
@@ -66,15 +66,18 @@ float ADCSensor::sample() {
   }
 
   uint8_t pin = this->pin_->get_pin();
-#ifdef CYW43_USES_VSYS_PIN
+#if defined(CYW43_USES_VSYS_PIN) && defined(USE_WIFI)
   if (pin == PICO_VSYS_PIN) {
     // Measuring VSYS on Raspberry Pico W needs to be wrapped with
     // `cyw43_thread_enter()`/`cyw43_thread_exit()` as discussed in
     // https://github.com/raspberrypi/pico-sdk/issues/1222, since Wifi chip and
-    // VSYS ADC both share GPIO29
+    // VSYS ADC both share GPIO29.
+    // The USE_WIFI guard is required because CYW43_USES_VSYS_PIN can be defined
+    // transitively (e.g. via lwip_wrap.h) even on non-WiFi boards where the CYW43
+    // driver is never initialized; calling cyw43_thread_enter() there hard-faults.
     cyw43_thread_enter();
   }
-#endif  // CYW43_USES_VSYS_PIN
+#endif  // defined(CYW43_USES_VSYS_PIN) && defined(USE_WIFI)
 
   adc_gpio_init(pin);
   adc_select_input(pin - 26);
@@ -84,11 +87,11 @@ float ADCSensor::sample() {
     aggr.add_sample(raw);
   }
 
-#ifdef CYW43_USES_VSYS_PIN
+#if defined(CYW43_USES_VSYS_PIN) && defined(USE_WIFI)
   if (pin == PICO_VSYS_PIN) {
     cyw43_thread_exit();
   }
-#endif  // CYW43_USES_VSYS_PIN
+#endif  // defined(CYW43_USES_VSYS_PIN) && defined(USE_WIFI)
 
   if (this->output_raw_) {
     return aggr.aggregate();


### PR DESCRIPTION
# What does this implement/fix?

On RP2040, `ADCSensor::sample()` guards its `cyw43_thread_enter()` /
`cyw43_thread_exit()` calls (needed for the GPIO29/VSYS vs WiFi-SPI race on the
Pico W, see raspberrypi/pico-sdk#1222) only with `#ifdef CYW43_USES_VSYS_PIN`.

That macro can be defined **transitively** on non-WiFi boards — e.g. via
`lwip_wrap.h`, pulled into `rp2040/helpers.cpp` by #15624. On a board with no
CYW43 chip (WIZnet W5100S/W5500-EVB-Pico), the CYW43 driver is never
initialized, so calling `cyw43_thread_enter()` while sampling GPIO29 spins on an
uninitialized mutex and hard-faults — the device boot-loops before USB
enumerates.

This gates those calls behind `USE_WIFI` as well, so they only run when the
`wifi:` component is actually active (i.e. a Pico W), while still protecting
Pico W users. Non-WiFi Ethernet boards can now read VSYS on GPIO29 safely.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- #17202

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: wiznet-pico

rp2040:
  board: wiznet_5100s_evb_pico

ethernet:
  type: W5100
  clk_pin: 18
  mosi_pin: 19
  miso_pin: 16
  cs_pin: 17
  interrupt_pin: 21
  reset_pin: 20

sensor:
  - platform: adc
    pin: GPIO29
    name: "VSYS Voltage"
    update_interval: 60s

logger:
  hardware_uart: UART0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
