### PR TITLE
[config_validation] Fix multicast typo in error message

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1494,9 +1494,7 @@ def ipv6address(value):
 def ipv4address_multi_broadcast(value):
     address = ipv4address(value)
     if not (address.is_multicast or (address == IPv4Address("255.255.255.255"))):
-        raise Invalid(
-            f"{value} is not a multicasst address nor local broadcast address"
-        )
+        raise Invalid(f"{value} is not a multicast address nor local broadcast address")
     return address
 
 

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -1926,7 +1926,7 @@ def test_ipv4address_multi_broadcast_broadcast() -> None:
 
 
 def test_ipv4address_multi_broadcast_invalid() -> None:
-    with pytest.raises(Invalid, match="not a multicasst"):
+    with pytest.raises(Invalid, match="not a multicast"):
         cv.ipv4address_multi_broadcast("192.168.0.1")
 
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a typo in the validation error message raised by `ipv4address_multi_broadcast`: "multicasst" → "multicast". The matching assertion in `tests/unit_tests/test_config_validation.py` is updated accordingly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).