### PR TITLE
[uart] Validate fixed UART settings at config time for fixed-baud components

### DIFF
--- a/esphome/components/bl0940/sensor.py
+++ b/esphome/components/bl0940/sensor.py
@@ -211,6 +211,10 @@ CONFIG_SCHEMA = (
     .add_extra(set_reference_values)
 )
 
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "bl0940", baud_rate=4800, stop_bits=1, require_rx=True, require_tx=True
+)
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/esphome/components/bl0940/sensor.py
+++ b/esphome/components/bl0940/sensor.py
@@ -211,8 +211,15 @@ CONFIG_SCHEMA = (
     .add_extra(set_reference_values)
 )
 
+# BL0940 datasheet: 4800 baud, 8 data bits, no parity (stop bits are 1.5 -- not
+# representable in the uart schema, so it isn't asserted).
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
-    "bl0940", baud_rate=4800, stop_bits=1, require_rx=True, require_tx=True
+    "bl0940",
+    baud_rate=4800,
+    data_bits=8,
+    parity="NONE",
+    require_rx=True,
+    require_tx=True,
 )
 
 

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -260,6 +260,11 @@ async def power_inv_to_code(var, config, args):
     pass
 
 
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "midea", baud_rate=9600, require_rx=True, require_tx=True
+)
+
+
 async def to_code(config):
     var = await climate.new_climate(config)
     await cg.register_component(var, config)

--- a/esphome/components/pzem004t/sensor.py
+++ b/esphome/components/pzem004t/sensor.py
@@ -58,6 +58,10 @@ CONFIG_SCHEMA = (
     .extend(uart.UART_DEVICE_SCHEMA)
 )
 
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "pzem004t", baud_rate=9600, require_rx=True, require_tx=True
+)
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/esphome/components/rdm6300/__init__.py
+++ b/esphome/components/rdm6300/__init__.py
@@ -29,6 +29,10 @@ CONFIG_SCHEMA = (
     .extend(uart.UART_DEVICE_SCHEMA)
 )
 
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "rdm6300", baud_rate=9600, require_rx=True
+)
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/esphome/components/rf_bridge/__init__.py
+++ b/esphome/components/rf_bridge/__init__.py
@@ -80,6 +80,10 @@ _CALLBACK_AUTOMATIONS = (
     ),
 )
 
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "rf_bridge", baud_rate=19200, require_rx=True, require_tx=True
+)
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/esphome/components/rf_bridge/__init__.py
+++ b/esphome/components/rf_bridge/__init__.py
@@ -81,7 +81,13 @@ _CALLBACK_AUTOMATIONS = (
 )
 
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
-    "rf_bridge", baud_rate=19200, require_rx=True, require_tx=True
+    "rf_bridge",
+    baud_rate=19200,
+    require_rx=True,
+    require_tx=True,
+    data_bits=8,
+    parity="NONE",
+    stop_bits=1,
 )
 
 

--- a/esphome/components/rf_bridge/rf_bridge.cpp
+++ b/esphome/components/rf_bridge/rf_bridge.cpp
@@ -195,10 +195,7 @@ void RFBridgeComponent::learn() {
   this->flush();
 }
 
-void RFBridgeComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "RF_Bridge:");
-  this->check_uart_settings(19200);
-}
+void RFBridgeComponent::dump_config() { ESP_LOGCONFIG(TAG, "RF_Bridge:"); }
 
 void RFBridgeComponent::start_advanced_sniffing() {
   ESP_LOGI(TAG, "Advanced Sniffing on");

--- a/esphome/components/sds011/sds011.cpp
+++ b/esphome/components/sds011/sds011.cpp
@@ -73,7 +73,6 @@ void SDS011Component::dump_config() {
                 this->update_interval_min_, ONOFF(this->rx_mode_only_));
   LOG_SENSOR("  ", "PM2.5", this->pm_2_5_sensor_);
   LOG_SENSOR("  ", "PM10.0", this->pm_10_0_sensor_);
-  this->check_uart_settings(9600);
 }
 
 void SDS011Component::loop() {

--- a/esphome/components/sds011/sensor.py
+++ b/esphome/components/sds011/sensor.py
@@ -62,9 +62,23 @@ CONFIG_SCHEMA = cv.All(
     validate_sds011_rx_mode,
 )
 
-FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
-    "sds011", baud_rate=9600, require_rx=True, data_bits=8, parity="NONE", stop_bits=1
-)
+
+def _final_validate(config):
+    # In the default mode setup() writes config commands, so tx is required;
+    # rx_only mode never writes, so tx is optional.
+    uart.final_validate_device_schema(
+        "sds011",
+        baud_rate=9600,
+        require_rx=True,
+        require_tx=not config.get(CONF_RX_ONLY, False),
+        data_bits=8,
+        parity="NONE",
+        stop_bits=1,
+    )(config)
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 
 async def to_code(config):

--- a/esphome/components/sds011/sensor.py
+++ b/esphome/components/sds011/sensor.py
@@ -63,7 +63,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
-    "sds011", baud_rate=9600, require_rx=True
+    "sds011", baud_rate=9600, require_rx=True, data_bits=8, parity="NONE", stop_bits=1
 )
 
 

--- a/esphome/components/sds011/sensor.py
+++ b/esphome/components/sds011/sensor.py
@@ -62,6 +62,10 @@ CONFIG_SCHEMA = cv.All(
     validate_sds011_rx_mode,
 )
 
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "sds011", baud_rate=9600, require_rx=True
+)
+
 
 async def to_code(config):
     # Pop update_interval before register_component so it doesn't generate

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -146,7 +146,6 @@ bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t 
 void SenseAirComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "SenseAir:");
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);
-  this->check_uart_settings(9600);
 }
 
 }  // namespace esphome::senseair

--- a/esphome/components/senseair/sensor.py
+++ b/esphome/components/senseair/sensor.py
@@ -51,6 +51,10 @@ CONFIG_SCHEMA = (
     .extend(uart.UART_DEVICE_SCHEMA)
 )
 
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "senseair", baud_rate=9600, require_rx=True, require_tx=True
+)
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/esphome/components/senseair/sensor.py
+++ b/esphome/components/senseair/sensor.py
@@ -52,7 +52,13 @@ CONFIG_SCHEMA = (
 )
 
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
-    "senseair", baud_rate=9600, require_rx=True, require_tx=True
+    "senseair",
+    baud_rate=9600,
+    require_rx=True,
+    require_tx=True,
+    data_bits=8,
+    parity="NONE",
+    stop_bits=1,
 )
 
 

--- a/esphome/components/shelly_dimmer/light.py
+++ b/esphome/components/shelly_dimmer/light.py
@@ -186,6 +186,10 @@ CONFIG_SCHEMA = (
     .extend(uart.UART_DEVICE_SCHEMA)
 )
 
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "shelly_dimmer", baud_rate=115200, require_rx=True, require_tx=True
+)
+
 
 async def to_code(config):
     fw_hex = get_firmware(config[CONF_FIRMWARE])

--- a/esphome/components/sm300d2/sensor.py
+++ b/esphome/components/sm300d2/sensor.py
@@ -89,7 +89,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
-    "sm300d2", baud_rate=9600, require_rx=True
+    "sm300d2", baud_rate=9600, require_rx=True, data_bits=8, parity="NONE", stop_bits=1
 )
 
 

--- a/esphome/components/sm300d2/sensor.py
+++ b/esphome/components/sm300d2/sensor.py
@@ -88,6 +88,10 @@ CONFIG_SCHEMA = cv.All(
     .extend(uart.UART_DEVICE_SCHEMA)
 )
 
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "sm300d2", baud_rate=9600, require_rx=True
+)
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -100,7 +100,6 @@ void SM300D2Sensor::dump_config() {
   LOG_SENSOR("  ", "PM10", this->pm_10_0_sensor_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
-  this->check_uart_settings(9600);
 }
 
 }  // namespace esphome::sm300d2

--- a/tests/components/bl0940/test.esp32-idf.yaml
+++ b/tests/components/bl0940/test.esp32-idf.yaml
@@ -3,6 +3,6 @@ substitutions:
   rx_pin: GPIO14
 
 packages:
-  uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
+  uart_4800: !include ../../test_build_components/common/uart_4800/esp32-idf.yaml
 
 <<: !include common.yaml

--- a/tests/components/bl0940/test.esp8266-ard.yaml
+++ b/tests/components/bl0940/test.esp8266-ard.yaml
@@ -3,6 +3,6 @@ substitutions:
   rx_pin: GPIO3
 
 packages:
-  uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
+  uart_4800: !include ../../test_build_components/common/uart_4800/esp8266-ard.yaml
 
 <<: !include common.yaml

--- a/tests/components/bl0940/test.rp2040-ard.yaml
+++ b/tests/components/bl0940/test.rp2040-ard.yaml
@@ -3,6 +3,6 @@ substitutions:
   rx_pin: GPIO5
 
 packages:
-  uart: !include ../../test_build_components/common/uart/rp2040-ard.yaml
+  uart_4800: !include ../../test_build_components/common/uart_4800/rp2040-ard.yaml
 
 <<: !include common.yaml

--- a/tests/components/rf_bridge/test.esp32-idf.yaml
+++ b/tests/components/rf_bridge/test.esp32-idf.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
+  uart_19200: !include ../../test_build_components/common/uart_19200/esp32-idf.yaml
 
 <<: !include common.yaml

--- a/tests/components/rf_bridge/test.esp8266-ard.yaml
+++ b/tests/components/rf_bridge/test.esp8266-ard.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
+  uart_19200: !include ../../test_build_components/common/uart_19200/esp8266-ard.yaml
 
 <<: !include common.yaml

--- a/tests/components/rf_bridge/test.rp2040-ard.yaml
+++ b/tests/components/rf_bridge/test.rp2040-ard.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart/rp2040-ard.yaml
+  uart_19200: !include ../../test_build_components/common/uart_19200/rp2040-ard.yaml
 
 <<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Nine UART components communicate at a **fixed baud rate** but declared no `baud_rate` constraint, so a wrong `baud_rate` on the referenced `uart:` bus was only discovered at runtime (the device silently doesn't work). This adds `uart.final_validate_device_schema(...)` to each — mirroring `cse7766` — so the misconfiguration is caught at `esphome config` time and the required baud is surfaced to schema-driven tooling.

| component | baud | direction |
|---|---|---|
| `midea` | 9600 | rx + tx |
| `rdm6300` | 9600 | rx |
| `sm300d2` | 9600 | rx |
| `sds011` | 9600 | rx |
| `senseair` | 9600 | rx + tx |
| `pzem004t` | 9600 | rx + tx |
| `bl0940` | 4800, 8 data bits, no parity | rx + tx |
| `rf_bridge` | 19200 | rx + tx |
| `shelly_dimmer` | 115200 | rx + tx |

`require_rx`/`require_tx` verified against the drivers: `sds011` is rx-only (it has a passive `rx_mode_only` mode, so tx is optional); `midea` writes through a `UARTStream` wrapper so it needs tx; the rest with `require_tx` actively write to the bus.

`bl0940`'s framing comes from its [datasheet](https://www.belling.com.cn/media/file_object/bel_product/BL0940/datasheet/BL0940_V1.1_en.pdf) (4800 baud, 8 data bits, no parity, **1.5** stop bits); the 1.5 stop bits aren't representable in the uart schema, so only baud/data_bits/parity are asserted (the originally-reported `stop_bits=1` was incorrect).

### Also: move existing runtime checks to config time

Four of these (`sm300d2`, `sds011`, `senseair`, `rf_bridge`) already had a runtime `check_uart_settings(BAUD)` in `dump_config()`, which only **warns** after the device is flashed. Since the new `FINAL_VALIDATE_SCHEMA` now validates at config time (and *fails*), this expands those four schemas to also assert the 8N1 settings the runtime check enforced (`data_bits=8`, `parity="NONE"`, `stop_bits=1`) and drops the now-redundant `check_uart_settings` calls. (Their baud values matched the schema, which also confirms those four are genuinely fixed-baud.)

### Tests

The six 9600-baud components already use the shared 9600 `uart/` package, so no test change was needed. `bl0940` switches to `uart_4800` and `rf_bridge` to `uart_19200` (`shelly_dimmer` already used `uart_115200`). Verified all nine pass `esphome config` on their platforms, and that the check fires on a baud mismatch.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Fixes #16936
- Fixes #16934
- Fixes #16933
- Fixes #16932
- Fixes #16931
- Fixes #16930
- Fixes #16929
- Fixes #16938
- Fixes #16937

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Wrong baud is now rejected at config time
uart:
  id: uart_bus
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 115200   # ERROR: Component pzem004t requires baud rate 9600

sensor:
  - platform: pzem004t
    uart_id: uart_bus
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).