### PR TITLE
[modbus] Only apply turnaround delay after broadcasts

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -400,7 +400,6 @@ bool Modbus::send_frame_(const ModbusFrame &frame) {
            format_hex_pretty_to(hex_buf, frame.data.get(), frame.size), now - this->last_send_,
            now - this->last_modbus_byte_);
   this->last_send_ = now;
-  // address 0 is the Modbus broadcast address (no response expected)
   this->last_send_was_broadcast_ = frame.size > 0 && frame.data[0] == 0;
   return true;
 }

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -92,10 +92,14 @@ int32_t Modbus::tx_delay_remaining() {
 
 int32_t ModbusClientHub::tx_delay_remaining() {
   const uint32_t now = millis();
-  return std::max({(int32_t) 0,
-                   (int32_t) (this->last_send_tx_offset_ + this->frame_delay_ms_ + this->turnaround_delay_ms_ -
-                              (now - this->last_send_)),
-                   (int32_t) (this->frame_delay_ms_ + this->turnaround_delay_ms_ - (now - this->last_modbus_byte_))});
+  // Turnaround delay only applies after a broadcast: no response is expected, so we must give listening devices
+  // quiet time to process it before the next request. For normal unicast request/response the received reply already
+  // provides the inter-frame timing, so adding turnaround there just throttles throughput.
+  const uint16_t turnaround = this->last_send_was_broadcast_ ? this->turnaround_delay_ms_ : 0;
+  return std::max(
+      {(int32_t) 0,
+       (int32_t) (this->last_send_tx_offset_ + this->frame_delay_ms_ + turnaround - (now - this->last_send_)),
+       (int32_t) (this->frame_delay_ms_ + turnaround - (now - this->last_modbus_byte_))});
 }
 
 bool Modbus::tx_blocked() {
@@ -396,6 +400,8 @@ bool Modbus::send_frame_(const ModbusFrame &frame) {
            format_hex_pretty_to(hex_buf, frame.data.get(), frame.size), now - this->last_send_,
            now - this->last_modbus_byte_);
   this->last_send_ = now;
+  // address 0 is the Modbus broadcast address (no response expected)
+  this->last_send_was_broadcast_ = frame.size > 0 && frame.data[0] == 0;
   return true;
 }
 

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -416,7 +416,9 @@ void ModbusClientHub::send_next_frame_() {
   ModbusDeviceCommand &command = this->tx_buffer_.front();
 
   if (this->send_frame_(command.frame)) {
-    this->waiting_for_response_ = std::move(command);
+    // Broadcasts (address 0) get no response, so don't wait for one
+    if (!this->last_send_was_broadcast_)
+      this->waiting_for_response_ = std::move(command);
   } else {
     if (command.device)
       command.device->on_modbus_not_sent();

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -416,7 +416,6 @@ void ModbusClientHub::send_next_frame_() {
   ModbusDeviceCommand &command = this->tx_buffer_.front();
 
   if (this->send_frame_(command.frame)) {
-    // Broadcasts (address 0) get no response, so don't wait for one
     if (!this->last_send_was_broadcast_)
       this->waiting_for_response_ = std::move(command);
   } else {

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -63,6 +63,9 @@ class Modbus : public uart::UARTDevice, public Component {
   uint32_t last_receive_check_{0};
   uint32_t last_send_{0};
   uint32_t last_send_tx_offset_{0};
+  // Whether the last frame we sent was a broadcast (address 0). Broadcasts get
+  // no response, so the turnaround delay only applies after one of them.
+  bool last_send_was_broadcast_{false};
   uint16_t frame_delay_ms_{5};
   uint16_t long_rx_buffer_delay_ms_{0};
 

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -63,8 +63,6 @@ class Modbus : public uart::UARTDevice, public Component {
   uint32_t last_receive_check_{0};
   uint32_t last_send_{0};
   uint32_t last_send_tx_offset_{0};
-  // Whether the last frame we sent was a broadcast (address 0). Broadcasts get
-  // no response, so the turnaround delay only applies after one of them.
   bool last_send_was_broadcast_{false};
   uint16_t frame_delay_ms_{5};
   uint16_t long_rx_buffer_delay_ms_{0};

--- a/tests/integration/fixtures/uart_mock_modbus_broadcast.yaml
+++ b/tests/integration/fixtures/uart_mock_modbus_broadcast.yaml
@@ -1,0 +1,56 @@
+esphome:
+  name: uart-mock-modbus-bcast
+
+host:
+api:
+logger:
+  level: VERBOSE
+
+external_components:
+  - source:
+      type: local
+      path: EXTERNAL_COMPONENT_PATH
+
+# Dummy uart entry to satisfy modbus's DEPENDENCIES = ["uart"]
+# The actual UART bus used is the uart_mock component below
+uart:
+  baud_rate: 115200
+  port: /dev/null
+
+# No on_tx injection: a broadcast (address 0) gets no reply on a real bus.
+uart_mock:
+  - id: virtual_uart
+    baud_rate: 9600
+    auto_start: true
+    debug:
+
+modbus:
+  - uart_id: virtual_uart
+    id: virtual_modbus
+    role: client
+    send_wait_time: 200ms
+    turnaround_time: 10ms
+
+modbus_controller:
+  - address: 0
+    modbus_id: virtual_modbus
+    update_interval: 60s
+    id: modbus_controller_bcast
+
+number:
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller_bcast
+    id: bcast_write
+    name: "bcast_write"
+    address: 0x01
+    register_type: holding
+    value_type: U_WORD
+    min_value: 0
+    max_value: 65535
+
+interval:
+  - interval: 400ms
+    then:
+      - number.set:
+          id: bcast_write
+          value: 42

--- a/tests/integration/test_uart_mock_modbus.py
+++ b/tests/integration/test_uart_mock_modbus.py
@@ -330,3 +330,28 @@ async def test_uart_mock_modbus_server_controller_multiple(
         await tracker.setup_and_start_scenario(client)
         await tracker.await_all(futures)
         _assert_no_modbus_errors(error_log_lines, warning_log_lines)
+
+
+@pytest.mark.asyncio
+async def test_uart_mock_modbus_broadcast(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that broadcast writes (address 0) don't wait for a response.
+
+    A controller at address 0 sends broadcast writes that get no reply. The
+    client must not arm the response timeout for them: otherwise every write
+    blocks for send_wait_time and logs a spurious "no response from 0" warning.
+    """
+
+    line_callback, error_log_lines, warning_log_lines = _make_modbus_line_callback()
+
+    async with (
+        run_compiled(yaml_config, line_callback=line_callback),
+        api_client_connected(),
+    ):
+        # Several broadcast writes fire on the 400ms interval; send_wait_time is
+        # 200ms, so the old behaviour would have warned on each one by now.
+        await asyncio.sleep(3.0)
+        _assert_no_modbus_errors(error_log_lines, warning_log_lines)


### PR DESCRIPTION
# What does this implement/fix?

Fixes the `modbus_controller` throughput collapse in 2026.6.x (#16996).

The Modbus RTU **turnaround delay** is, per spec, the quiet time a master waits after sending a **broadcast** request (address 0, no response expected) before the next request — so listening devices can finish processing it. But the code applied `turnaround_delay_ms_` before **every** send (`ModbusClientHub::tx_delay_remaining`), including normal unicast request/response, where the received reply already provides the inter-frame timing.

The default turnaround was also raised from 100ms (#8032) to **600ms** (#11969), so post-2026.6.0 every unicast poll pays a full 600ms of dead time. A controller polling N register ranges loses `N×~605ms` per cycle — exactly the "identical YAML, ~6× slower than 2024.x" the reporter saw, with all-default timing.

This change tracks whether the last sent frame was a broadcast (`frame.data[0] == 0`) and only charges turnaround in that case. Unicast polling goes back to `frame_delay` (T3.5) pacing — full throughput — while genuine broadcast writes still get the spec-correct turnaround.

## Broadcasts don't wait for a response

Follow-up from review: broadcasts never get a reply, but `send_next_frame_` still armed `waiting_for_response_` for them. So every broadcast write blocked for `send_wait_time` (2000ms default) and logged a spurious `no response from 0` warning — which also subsumed the turnaround delay above. The fix skips `waiting_for_response_` when the last send was a broadcast.

`send_wait_time` is intentionally left at 2000ms: it only affects the *no-response* timeout (not steady-state throughput), and lowering it risks false timeouts on slow devices.

## Tests

Added `test_uart_mock_modbus_broadcast`: a controller at `address: 0` fires broadcast writes on a virtual UART that never replies and asserts no `[W]/[E][modbus:` output. Verified it fails on the old code (12 `no response from 0` warnings) and passes with the fix.

### Draft — needs

- Real-device verification (I don't have a modbus_controller + RS-485 server handy). Logic-reviewed, integration-tested and config-validates, but timing changes warrant a hardware check.
- Decide whether the 600ms default should also be lowered (this PR makes it moot for unicast, so probably leave it).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #16996

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
modbus:
  - uart_id: uart_modbus
    flow_control_pin: GPIO21
modbus_controller:
  - modbus_id: modbus_item
    address: 0x04
    update_interval: 5s
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).