### PR TITLE
[web_server] Include assumed_state in cover detail=all JSON

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1079,6 +1079,7 @@ json::SerializationBuffer<> WebServer::cover_json_(cover::Cover *obj, JsonDetail
   if (obj->get_traits().get_supports_tilt())
     root[ESPHOME_F("tilt")] = obj->tilt;
   if (start_config == DETAIL_ALL) {
+    root[ESPHOME_F("assumed_state")] = obj->get_traits().get_is_assumed_state();
     this->add_sorting_info_(root, obj);
   }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

`WebServer::cover_json_()` did not serialize the `assumed_state` flag in the `DETAIL_ALL` JSON, unlike `WebServer::switch_json_()` which already emits it.

As a result, consumers of the web server JSON/SSE API could not tell whether a cover's state is assumed. The native API (aioesphomeapi) exposes this flag, so Home Assistant behaves correctly, but the web server did not, a web vs native-API inconsistency. The visible symptom is in the v3 web UI, where a cover with `assumed_state: true` has the open/close button matching the current state disabled.

This emits `assumed_state` from the cover's traits under `detail=all`, matching the switch behavior.

fixes https://github.com/esphome/esphome/issues/16799

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16799

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
web_server:

cover:
  - platform: template
    name: "Gate"
    assumed_state: true
    open_action:
      - logger.log: open
    close_action:
      - logger.log: close
    stop_action:
      - logger.log: stop
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
