### PR TITLE
[es8388] Fix DAC unable to unmute once muted

### DIFF
--- a/esphome/components/es8388/es8388.cpp
+++ b/esphome/components/es8388/es8388.cpp
@@ -173,8 +173,14 @@ bool ES8388::set_mute_state_(bool mute_state) {
   ES8388_ERROR_CHECK(this->read_byte(ES8388_DACCONTROL3, &value));
   ESP_LOGV(TAG, "Read ES8388_DACCONTROL3: 0x%02X", value);
 
+  // Only toggle the DACMute bit; the other bits of this register hold unrelated
+  // DAC settings that must be preserved. Previously muting overwrote the whole
+  // register with 0x3C and unmuting never cleared the bit, so once muted the DAC
+  // could not be unmuted again.
   if (mute_state) {
-    value = 0x3C;
+    value |= ES8388_DACCONTROL3_DAC_MUTE;
+  } else {
+    value &= ~ES8388_DACCONTROL3_DAC_MUTE;
   }
 
   ESP_LOGV(TAG, "Setting ES8388_DACCONTROL3 to 0x%02X (muted: %s)", value, YESNO(mute_state));

--- a/esphome/components/es8388/es8388_const.h
+++ b/esphome/components/es8388/es8388_const.h
@@ -38,8 +38,7 @@ static const uint8_t ES8388_ADCCONTROL14 = 0x16;
 static const uint8_t ES8388_DACCONTROL1 = 0x17;
 static const uint8_t ES8388_DACCONTROL2 = 0x18;
 static const uint8_t ES8388_DACCONTROL3 = 0x19;
-// DACMute is bit 2 of DAC Control 3; the other bits hold unrelated DAC settings.
-static const uint8_t ES8388_DACCONTROL3_DAC_MUTE = 0x04;
+static const uint8_t ES8388_DACCONTROL3_DAC_MUTE = 0x04;  // DACMute, bit 2 of DACCONTROL3
 static const uint8_t ES8388_DACCONTROL4 = 0x1a;
 static const uint8_t ES8388_DACCONTROL5 = 0x1b;
 static const uint8_t ES8388_DACCONTROL6 = 0x1c;

--- a/esphome/components/es8388/es8388_const.h
+++ b/esphome/components/es8388/es8388_const.h
@@ -38,6 +38,8 @@ static const uint8_t ES8388_ADCCONTROL14 = 0x16;
 static const uint8_t ES8388_DACCONTROL1 = 0x17;
 static const uint8_t ES8388_DACCONTROL2 = 0x18;
 static const uint8_t ES8388_DACCONTROL3 = 0x19;
+// DACMute is bit 2 of DAC Control 3; the other bits hold unrelated DAC settings.
+static const uint8_t ES8388_DACCONTROL3_DAC_MUTE = 0x04;
 static const uint8_t ES8388_DACCONTROL4 = 0x1a;
 static const uint8_t ES8388_DACCONTROL5 = 0x1b;
 static const uint8_t ES8388_DACCONTROL6 = 0x1c;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fixes the ES8388 DAC being unable to unmute once muted.

`set_mute_state_()` mishandled DAC Control 3 (register 0x19) in two ways:

- **Unmuting was a no-op.** It read the register into `value` but never cleared the DACMute bit before writing it back, so once something muted the DAC (for example a media player), it stayed muted until the device was power-cycled.
- **Muting clobbered other settings.** It overwrote the whole register with `0x3C`, discarding the unrelated DAC settings stored in the same register.

The fix does a read-modify-write of only the DACMute bit (bit 2), so mute/unmute toggles just that flag and preserves the rest of the register.

fixes https://github.com/esphome/esphome/issues/16890

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16890

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
es8388:

# Mute, then unmute again (previously the DAC stayed muted):
# - audio_dac.mute_on:
# - audio_dac.mute_off:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
