### PR TITLE
[esp32] Only warn about S3 PSRAM pins (GPIO33-37) in octal mode

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1100,7 +1100,10 @@ def _detect_variant(value):
 
 def final_validate(config):
     # Imported locally to avoid circular import issues
-    from esphome.components.psram import DOMAIN as PSRAM_DOMAIN
+    from esphome.components.psram import DOMAIN as PSRAM_DOMAIN, TYPE_OCTAL
+    from esphome.const import CONF_MODE
+
+    from .gpio_esp32_s3 import KEY_ESP32S3R8_PSRAM_PINS_USED
 
     errs = []
     conf_fw = config[CONF_FRAMEWORK]
@@ -1183,6 +1186,18 @@ def final_validate(config):
                     f"'{CONF_EXECUTE_FROM_PSRAM}' requires PSRAM to be configured",
                     path=[CONF_FRAMEWORK, CONF_ADVANCED, CONF_EXECUTE_FROM_PSRAM],
                 )
+            )
+
+    # GPIO33-37 are only used by the PSRAM interface in octal mode (ESP32-S3R8 /
+    # S3R8V). Warn about pins recorded during validation only when octal PSRAM is
+    # actually configured, otherwise (quad PSRAM or none) the pins are free.
+    if (
+        psram_pins := CORE.data.pop(KEY_ESP32S3R8_PSRAM_PINS_USED, None)
+    ) and full_config.get(PSRAM_DOMAIN, {}).get(CONF_MODE) == TYPE_OCTAL:
+        for pin in sorted(psram_pins):
+            _LOGGER.warning(
+                "GPIO%d is used by the PSRAM interface in octal mode and should be avoided",
+                pin,
             )
 
     if (

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1100,10 +1100,9 @@ def _detect_variant(value):
 
 def final_validate(config):
     # Imported locally to avoid circular import issues
-    from esphome.components.psram import DOMAIN as PSRAM_DOMAIN, TYPE_OCTAL
-    from esphome.const import CONF_MODE
+    from esphome.components.psram import DOMAIN as PSRAM_DOMAIN
 
-    from .gpio_esp32_s3 import KEY_ESP32S3R8_PSRAM_PINS_USED
+    from .gpio import final_validate_pins
 
     errs = []
     conf_fw = config[CONF_FRAMEWORK]
@@ -1188,17 +1187,7 @@ def final_validate(config):
                 )
             )
 
-    # GPIO33-37 are only used by the PSRAM interface in octal mode (ESP32-S3R8 /
-    # S3R8V). Warn about pins recorded during validation only when octal PSRAM is
-    # actually configured, otherwise (quad PSRAM or none) the pins are free.
-    if (
-        psram_pins := CORE.data.pop(KEY_ESP32S3R8_PSRAM_PINS_USED, None)
-    ) and full_config.get(PSRAM_DOMAIN, {}).get(CONF_MODE) == TYPE_OCTAL:
-        for pin in sorted(psram_pins):
-            _LOGGER.warning(
-                "GPIO%d is used by the PSRAM interface in octal mode and should be avoided",
-                pin,
-            )
+    final_validate_pins(full_config)
 
     if (
         config[CONF_FLASH_SIZE] == "32MB"

--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -18,6 +18,7 @@ from esphome.const import (
     PLATFORM_ESP32,
 )
 from esphome.core import CORE
+from esphome.types import ConfigType
 
 from . import boards
 from .const import (
@@ -50,7 +51,11 @@ from .gpio_esp32_h4 import esp32_h4_validate_gpio_pin, esp32_h4_validate_support
 from .gpio_esp32_h21 import esp32_h21_validate_gpio_pin, esp32_h21_validate_supports
 from .gpio_esp32_p4 import esp32_p4_validate_gpio_pin, esp32_p4_validate_supports
 from .gpio_esp32_s2 import esp32_s2_validate_gpio_pin, esp32_s2_validate_supports
-from .gpio_esp32_s3 import esp32_s3_validate_gpio_pin, esp32_s3_validate_supports
+from .gpio_esp32_s3 import (
+    esp32_s3_final_validate_pins,
+    esp32_s3_validate_gpio_pin,
+    esp32_s3_validate_supports,
+)
 from .gpio_esp32_s31 import esp32_s31_validate_gpio_pin, esp32_s31_validate_supports
 
 ESP32InternalGPIOPin = esp32_ns.class_("ESP32InternalGPIOPin", cg.InternalGPIOPin)
@@ -96,6 +101,7 @@ def _translate_pin(value):
 class ESP32ValidationFunctions:
     pin_validation: Callable[[int], int]
     usage_validation: Callable[[dict[str, Any]], dict[str, Any]]
+    final_validate: Callable[[ConfigType], None] | None = None
 
 
 _esp32_validations = {
@@ -145,6 +151,7 @@ _esp32_validations = {
     VARIANT_ESP32S3: ESP32ValidationFunctions(
         pin_validation=esp32_s3_validate_gpio_pin,
         usage_validation=esp32_s3_validate_supports,
+        final_validate=esp32_s3_final_validate_pins,
     ),
     VARIANT_ESP32S31: ESP32ValidationFunctions(
         pin_validation=esp32_s31_validate_gpio_pin,
@@ -261,3 +268,10 @@ async def esp32_pin_to_code(config):
         cg.add(var.set_drive_strength(config[CONF_DRIVE_STRENGTH]))
     cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))
     return var
+
+
+def final_validate_pins(full_config: ConfigType) -> None:
+    """Run the active variant's pin final-validation, if it defines one."""
+    funcs = _esp32_validations.get(CORE.data[KEY_ESP32][KEY_VARIANT])
+    if funcs is not None and funcs.final_validate is not None:
+        funcs.final_validate(full_config)

--- a/esphome/components/esp32/gpio_esp32_s3.py
+++ b/esphome/components/esp32/gpio_esp32_s3.py
@@ -3,7 +3,14 @@ from typing import Any
 
 import esphome.config_validation as cv
 from esphome.const import CONF_INPUT, CONF_MODE, CONF_NUMBER
+from esphome.core import CORE
 from esphome.pins import check_strapping_pin
+
+# CORE.data key recording any GPIO33-37 usage. Kept outside CORE.data[KEY_ESP32]
+# (which set_core_data resets) so the esp32 final_validate can decide whether to
+# warn: these pins are only taken by the PSRAM interface in octal mode, which is
+# not known yet when an individual pin is validated.
+KEY_ESP32S3R8_PSRAM_PINS_USED = "esp32_s3_r8_psram_pins_used"
 
 _ESP32S3_SPI_PSRAM_PINS = {
     26: "SPICS1",
@@ -39,10 +46,10 @@ def esp32_s3_validate_gpio_pin(value: int) -> int:
             f"This pin cannot be used on ESP32-S3s and is already used by the SPI/PSRAM interface(function: {_ESP32S3_SPI_PSRAM_PINS[value]})"
         )
     if value in _ESP32S3R8_PSRAM_PINS:
-        _LOGGER.warning(
-            "GPIO%d is used by the PSRAM interface on ESP32-S3R8 / ESP32-S3R8V and should be avoided on these models",
-            value,
-        )
+        # Record usage; the esp32 final_validate warns only if octal PSRAM (which
+        # actually uses these pins) is configured. On quad-PSRAM S3 variants these
+        # pins are free, so warning unconditionally here is a false positive.
+        CORE.data.setdefault(KEY_ESP32S3R8_PSRAM_PINS_USED, set()).add(value)
 
     if value in (22, 23, 24, 25):
         # These pins are not exposed in GPIO mux (reason unknown)

--- a/esphome/components/esp32/gpio_esp32_s3.py
+++ b/esphome/components/esp32/gpio_esp32_s3.py
@@ -2,15 +2,9 @@ import logging
 from typing import Any
 
 import esphome.config_validation as cv
-from esphome.const import CONF_INPUT, CONF_MODE, CONF_NUMBER
-from esphome.core import CORE
-from esphome.pins import check_strapping_pin
-
-# CORE.data key recording any GPIO33-37 usage. Kept outside CORE.data[KEY_ESP32]
-# (which set_core_data resets) so the esp32 final_validate can decide whether to
-# warn: these pins are only taken by the PSRAM interface in octal mode, which is
-# not known yet when an individual pin is validated.
-KEY_ESP32S3R8_PSRAM_PINS_USED = "esp32_s3_r8_psram_pins_used"
+from esphome.const import CONF_INPUT, CONF_MODE, CONF_NUMBER, PLATFORM_ESP32
+from esphome.pins import PIN_SCHEMA_REGISTRY, check_strapping_pin
+from esphome.types import ConfigType
 
 _ESP32S3_SPI_PSRAM_PINS = {
     26: "SPICS1",
@@ -45,11 +39,9 @@ def esp32_s3_validate_gpio_pin(value: int) -> int:
         raise cv.Invalid(
             f"This pin cannot be used on ESP32-S3s and is already used by the SPI/PSRAM interface(function: {_ESP32S3_SPI_PSRAM_PINS[value]})"
         )
-    if value in _ESP32S3R8_PSRAM_PINS:
-        # Record usage; the esp32 final_validate warns only if octal PSRAM (which
-        # actually uses these pins) is configured. On quad-PSRAM S3 variants these
-        # pins are free, so warning unconditionally here is a false positive.
-        CORE.data.setdefault(KEY_ESP32S3R8_PSRAM_PINS_USED, set()).add(value)
+    # GPIO33-37 (_ESP32S3R8_PSRAM_PINS) are only taken by the PSRAM interface in
+    # octal mode -- whether that applies isn't known here, so the warning is
+    # deferred to final_validate_pins() in gpio.py once the PSRAM mode is resolved.
 
     if value in (22, 23, 24, 25):
         # These pins are not exposed in GPIO mux (reason unknown)
@@ -78,3 +70,27 @@ def esp32_s3_validate_supports(value: dict[str, Any]) -> dict[str, Any]:
 
     check_strapping_pin(value, _ESP32S3_STRAPPING_PINS, _LOGGER)
     return value
+
+
+def esp32_s3_final_validate_pins(full_config: ConfigType) -> None:
+    """Warn about GPIO33-37 usage, but only when octal PSRAM (which uses them) is set.
+
+    These pins are only taken by the PSRAM interface in octal mode (ESP32-S3R8 /
+    S3R8V); on quad-PSRAM variants they are free. The per-pin validator can't know
+    the PSRAM mode, so the check is deferred here, where PIN_SCHEMA_REGISTRY.pins_used
+    already lists every used pin.
+    """
+    # Imported locally to avoid circular import issues
+    from esphome.components.psram import DOMAIN as PSRAM_DOMAIN, TYPE_OCTAL
+
+    if full_config.get(PSRAM_DOMAIN, {}).get(CONF_MODE) != TYPE_OCTAL:
+        return
+    for number in sorted(
+        number
+        for key, _client_id, number in PIN_SCHEMA_REGISTRY.pins_used
+        if key == PLATFORM_ESP32 and number in _ESP32S3R8_PSRAM_PINS
+    ):
+        _LOGGER.warning(
+            "GPIO%d is used by the PSRAM interface in octal mode and should be avoided",
+            number,
+        )

--- a/esphome/components/esp32/gpio_esp32_s3.py
+++ b/esphome/components/esp32/gpio_esp32_s3.py
@@ -2,7 +2,13 @@ import logging
 from typing import Any
 
 import esphome.config_validation as cv
-from esphome.const import CONF_INPUT, CONF_MODE, CONF_NUMBER, PLATFORM_ESP32
+from esphome.const import (
+    CONF_DISABLED,
+    CONF_INPUT,
+    CONF_MODE,
+    CONF_NUMBER,
+    PLATFORM_ESP32,
+)
 from esphome.pins import PIN_SCHEMA_REGISTRY, check_strapping_pin
 from esphome.types import ConfigType
 
@@ -76,14 +82,16 @@ def esp32_s3_final_validate_pins(full_config: ConfigType) -> None:
     """Warn about GPIO33-37 usage, but only when octal PSRAM (which uses them) is set.
 
     These pins are only taken by the PSRAM interface in octal mode (ESP32-S3R8 /
-    S3R8V); on quad-PSRAM variants they are free. The per-pin validator can't know
-    the PSRAM mode, so the check is deferred here, where PIN_SCHEMA_REGISTRY.pins_used
-    already lists every used pin.
+    S3R8V); on quad-PSRAM variants -- or when the psram block is disabled, so the
+    octal interface is never configured -- they are free. The per-pin validator
+    can't know the PSRAM mode, so the check is deferred here, where
+    PIN_SCHEMA_REGISTRY.pins_used already lists every used pin.
     """
     # Imported locally to avoid circular import issues
     from esphome.components.psram import DOMAIN as PSRAM_DOMAIN, TYPE_OCTAL
 
-    if full_config.get(PSRAM_DOMAIN, {}).get(CONF_MODE) != TYPE_OCTAL:
+    psram_config = full_config.get(PSRAM_DOMAIN, {})
+    if psram_config.get(CONF_DISABLED) or psram_config.get(CONF_MODE) != TYPE_OCTAL:
         return
     for number in sorted(
         number

--- a/tests/component_tests/esp32/config/psram_octal_disabled_gpio34.yaml
+++ b/tests/component_tests/esp32/config/psram_octal_disabled_gpio34.yaml
@@ -1,0 +1,16 @@
+esphome:
+  name: test
+
+esp32:
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+  disabled: true
+
+binary_sensor:
+  - platform: gpio
+    pin: GPIO34
+    name: test

--- a/tests/component_tests/esp32/config/psram_octal_gpio34.yaml
+++ b/tests/component_tests/esp32/config/psram_octal_gpio34.yaml
@@ -1,0 +1,15 @@
+esphome:
+  name: test
+
+esp32:
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+
+binary_sensor:
+  - platform: gpio
+    pin: GPIO34
+    name: test

--- a/tests/component_tests/esp32/config/psram_quad_gpio34.yaml
+++ b/tests/component_tests/esp32/config/psram_quad_gpio34.yaml
@@ -1,0 +1,15 @@
+esphome:
+  name: test
+
+esp32:
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: quad
+
+binary_sensor:
+  - platform: gpio
+    pin: GPIO34
+    name: test

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -218,6 +218,7 @@ def test_execute_from_psram_p4_sdkconfig(
     [
         ("psram_quad_gpio34.yaml", False),
         ("psram_octal_gpio34.yaml", True),
+        ("psram_octal_disabled_gpio34.yaml", False),
     ],
 )
 def test_s3_psram_pin_warning_only_for_octal(

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -232,7 +232,8 @@ def test_s3_psram_pin_warning_only_for_octal(
     Using such a pin must only warn when octal PSRAM is configured; on quad
     PSRAM the pins are free and warning would be a false positive (#16857).
     """
-    generate_main(component_config_path(fixture))
+    with caplog.at_level("WARNING"):
+        generate_main(component_config_path(fixture))
     warned = "GPIO34 is used by the PSRAM interface in octal mode" in caplog.text
     assert warned == expect_warning
 

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -213,6 +213,30 @@ def test_execute_from_psram_p4_sdkconfig(
     assert "CONFIG_SPIRAM_RODATA" not in sdkconfig
 
 
+@pytest.mark.parametrize(
+    ("fixture", "expect_warning"),
+    [
+        ("psram_quad_gpio34.yaml", False),
+        ("psram_octal_gpio34.yaml", True),
+    ],
+)
+def test_s3_psram_pin_warning_only_for_octal(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+    caplog: pytest.LogCaptureFixture,
+    fixture: str,
+    expect_warning: bool,
+) -> None:
+    """GPIO33-37 are only used by the PSRAM interface in octal mode.
+
+    Using such a pin must only warn when octal PSRAM is configured; on quad
+    PSRAM the pins are free and warning would be a false positive (#16857).
+    """
+    generate_main(component_config_path(fixture))
+    warned = "GPIO34 is used by the PSRAM interface in octal mode" in caplog.text
+    assert warned == expect_warning
+
+
 def test_ignore_pin_validation_error_on_clean_pin_warns(
     set_core_config: SetCoreConfigCallable,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fixes a false-positive warning on ESP32-S3 boards with quad PSRAM.

The ESP32-S3 GPIO validator (`gpio_esp32_s3.py`) warned that GPIO33-37 are used by the PSRAM interface for *every* ESP32-S3 board whenever one of those pins was used:

```
WARNING GPIO35 is used by the PSRAM interface on ESP32-S3R8 / ESP32-S3R8V and should be avoided on these models
```

But those pins are only used by **octal** PSRAM (ESP32-S3R8 / S3R8V). On quad-PSRAM variants (e.g. S3R2) they are free, so the warning was a false positive with no way to suppress it.

The validator can't know the PSRAM mode when an individual pin is validated (cross-component ordering isn't guaranteed), so the warning is deferred to final validation. The check is hung off the existing per-variant pin dispatch: `ESP32ValidationFunctions` gains an optional `final_validate`, and the S3 entry points at `gpio_esp32_s3.esp32_s3_final_validate_pins`, which reads the used pins from esphome's existing `PIN_SCHEMA_REGISTRY.pins_used` and warns only when octal PSRAM is actually configured. The esp32 component's `final_validate` -- the one place with cross-component PSRAM-mode visibility -- dispatches to it via `gpio.final_validate_pins()`. No custom pin-tracking state is needed, and any other variant can opt in by setting its own `final_validate`.

Verified with `esphome config`: an S3 + quad PSRAM config using GPIO34 is now silent, while S3 + octal PSRAM using GPIO34 still warns.

fixes https://github.com/esphome/esphome/issues/16857

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16857

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml — quad PSRAM, no longer warns about GPIO34
esp32:
  variant: esp32s3
  framework:
    type: esp-idf

psram:
  mode: quad

binary_sensor:
  - platform: gpio
    pin: GPIO34
    name: test
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

