### PR TITLE
[api] Add nRF52 support

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -305,6 +305,7 @@ CONFIG_SCHEMA = cv.All(
                 rtl87xx=4,  # Moderate RAM, BSD-style sockets
                 host=4,  # Abundant resources
                 ln882x=4,  # Moderate RAM
+                nrf52=4,  # ~256KB RAM, BSD sockets
             ): cv.int_range(min=1, max=10),
             cv.SplitDefault(
                 CONF_MAX_CONNECTIONS,
@@ -315,6 +316,7 @@ CONFIG_SCHEMA = cv.All(
                 rtl87xx=5,  # Moderate RAM
                 host=8,  # Abundant resources
                 ln882x=5,  # Moderate RAM
+                nrf52=4,  # ~256KB RAM, BSD sockets, Thread (single HA controller)
             ): cv.int_range(min=1, max=20),
             # Maximum queued send buffers per connection before dropping connection
             # Each buffer uses ~8-12 bytes overhead plus actual message size

--- a/esphome/components/api/api_pb2_includes.h
+++ b/esphome/components/api/api_pb2_includes.h
@@ -31,8 +31,10 @@
 #include <vector>
 #include <string>
 
-#ifdef LOG_LEVEL_NONE
-#pragma push_macro("LOG_LEVEL_NONE")
+#if defined(LOG_LEVEL_NONE)
+// Zephyr defines LOG_LEVEL_NONE as a logging macro that collides with the LogLevel enum value of
+// the same name in the generated api_pb2.h. Undefine it for the rest of this translation unit so
+// the enum parses; nothing below needs Zephyr's logging macro.
 #undef LOG_LEVEL_NONE
 #endif
 
@@ -41,11 +43,3 @@ namespace esphome::api {
 // This file only provides includes, no actual code
 
 }  // namespace esphome::api
-
-// NOTE: intentionally do NOT pop_macro LOG_LEVEL_NONE here. On Zephyr it is defined as a logging
-// macro that collides with the LogLevel enum value of the same name in api_pb2.h; it must stay
-// undefined so the enum parses. The guard below is false after the #undef above (the macro is no
-// longer defined), so the pop never fires -- leaving the macro suppressed for this translation unit.
-#ifdef LOG_LEVEL_NONE
-#pragma pop_macro("LOG_LEVEL_NONE")
-#endif

--- a/esphome/components/api/api_pb2_includes.h
+++ b/esphome/components/api/api_pb2_includes.h
@@ -31,8 +31,21 @@
 #include <vector>
 #include <string>
 
+#ifdef LOG_LEVEL_NONE
+#pragma push_macro("LOG_LEVEL_NONE")
+#undef LOG_LEVEL_NONE
+#endif
+
 namespace esphome::api {
 
 // This file only provides includes, no actual code
 
 }  // namespace esphome::api
+
+// NOTE: intentionally do NOT pop_macro LOG_LEVEL_NONE here. On Zephyr it is defined as a logging
+// macro that collides with the LogLevel enum value of the same name in api_pb2.h; it must stay
+// undefined so the enum parses. The guard below is false after the #undef above (the macro is no
+// longer defined), so the pop never fires -- leaving the macro suppressed for this translation unit.
+#ifdef LOG_LEVEL_NONE
+#pragma pop_macro("LOG_LEVEL_NONE")
+#endif

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -221,6 +221,11 @@ async def to_code(config):
         zephyr_add_prj_conf("NET_IPV6", True)
         zephyr_add_prj_conf("NET_TCP", True)
         zephyr_add_prj_conf("NET_UDP", True)
+        # The nRF Connect SDK replaces mbedTLS with PSA/Oberon crypto, which does not provide the
+        # legacy mbedtls_md5() symbol that Zephyr's RFC 6528 TCP ISN generator links against
+        # (selecting MBEDTLS_MAC_MD5_ENABLED does not bring in the legacy C API here). Fall back to
+        # the non-cryptographic sys_rand ISN — acceptable on an isolated IPv6/OpenThread mesh device.
+        zephyr_add_prj_conf("NET_TCP_ISN_RFC6528", False)
 
     if (enable_ipv6 := config.get(CONF_ENABLE_IPV6, None)) is not None:
         cg.add_define("USE_NETWORK_IPV6", enable_ipv6)

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -221,10 +221,11 @@ async def to_code(config):
         zephyr_add_prj_conf("NET_IPV6", True)
         zephyr_add_prj_conf("NET_TCP", True)
         zephyr_add_prj_conf("NET_UDP", True)
-        # The nRF Connect SDK replaces mbedTLS with PSA/Oberon crypto, which does not provide the
+        # The nRF Connect SDK replaces mbedTLS with PSA/Oberon crypto and does not provide the
         # legacy mbedtls_md5() symbol that Zephyr's RFC 6528 TCP ISN generator links against
-        # (selecting MBEDTLS_MAC_MD5_ENABLED does not bring in the legacy C API here). Fall back to
-        # the non-cryptographic sys_rand ISN — acceptable on an isolated IPv6/OpenThread mesh device.
+        # (selecting MBEDTLS_MAC_MD5_ENABLED does not bring in the legacy C API here). Disable it so
+        # TCP links; Zephyr falls back to sys_rand32_get() for the ISN (randomized, but not the
+        # RFC 6528 keyed hash).
         zephyr_add_prj_conf("NET_TCP_ISN_RFC6528", False)
 
     if (enable_ipv6 := config.get(CONF_ENABLE_IPV6, None)) is not None:

--- a/tests/components/api/test.nrf52-adafruit.yaml
+++ b/tests/components/api/test.nrf52-adafruit.yaml
@@ -1,0 +1,4 @@
+network:
+  enable_ipv6: true
+
+api:


### PR DESCRIPTION
# What does this implement/fix?

Enables the ESPHome native API on the nRF52/Zephyr platform.
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [X] Other



## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [X] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
nrf52:
  board: adafruit_feather_nrf52840

network:
  enable_ipv6: true

api:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
