### PR TITLE
[sha256] Add nRF52/Zephyr TinyCrypt backend

### DIFF
--- a/esphome/components/sha256/__init__.py
+++ b/esphome/components/sha256/__init__.py
@@ -14,6 +14,15 @@ CONFIG_SCHEMA = cv.Schema({})
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_SHA256")
 
+    # Zephyr/nRF52 has no mbedTLS/PSA in the default build; the SHA256 backend uses
+    # the bundled TinyCrypt, which must be enabled in the Zephyr config.
+    if CORE.using_zephyr:
+        from esphome.components.zephyr import zephyr_add_prj_conf
+
+        zephyr_add_prj_conf("TINYCRYPT", True)
+        zephyr_add_prj_conf("TINYCRYPT_SHA256", True)
+        return
+
     # Add OpenSSL library for host platform
     if not CORE.is_host:
         return

--- a/esphome/components/sha256/sha256.cpp
+++ b/esphome/components/sha256/sha256.cpp
@@ -1,7 +1,8 @@
 #include "sha256.h"
 
 // Only compile SHA256 implementation on platforms that support it
-#if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || defined(USE_HOST)
+#if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || \
+    defined(USE_HOST) || defined(USE_ZEPHYR)
 
 #include "esphome/core/helpers.h"
 #include <cstring>
@@ -125,6 +126,27 @@ void SHA256::calculate() {
   if (!this->calculated_) {
     unsigned int len = 32;
     EVP_DigestFinal_ex(this->ctx_, this->digest_, &len);
+    this->calculated_ = true;
+  }
+}
+
+#elif defined(USE_SHA256_TINYCRYPT)
+
+// Zephyr/nRF52: bundled TinyCrypt (software SHA256). tc_sha256_final consumes the
+// state, so guard repeated calculate() calls like the BearSSL/OpenSSL backends.
+
+SHA256::~SHA256() = default;
+
+void SHA256::init() {
+  tc_sha256_init(&this->ctx_);
+  this->calculated_ = false;
+}
+
+void SHA256::add(const uint8_t *data, size_t len) { tc_sha256_update(&this->ctx_, data, len); }
+
+void SHA256::calculate() {
+  if (!this->calculated_) {
+    tc_sha256_final(this->digest_, &this->ctx_);
     this->calculated_ = true;
   }
 }

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -3,7 +3,8 @@
 #include "esphome/core/defines.h"
 
 // Only define SHA256 on platforms that support it
-#if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || defined(USE_HOST)
+#if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || \
+    defined(USE_HOST) || defined(USE_ZEPHYR)
 
 #include <cstdint>
 #include <string>
@@ -29,6 +30,11 @@
 #include <bearssl/bearssl_hash.h>
 #elif defined(USE_HOST)
 #include <openssl/evp.h>
+#elif defined(USE_ZEPHYR)
+// Zephyr/nRF52 has no mbedTLS/PSA in the default build; use the bundled TinyCrypt
+// SHA256 (enabled via CONFIG_TINYCRYPT_SHA256 from the component's to_code).
+#define USE_SHA256_TINYCRYPT
+#include <tinycrypt/sha256.h>
 #else
 #error "SHA256 not supported on this platform"
 #endif
@@ -75,6 +81,9 @@ class SHA256 final : public esphome::HashBase {
   bool calculated_{false};
 #elif defined(USE_HOST)
   EVP_MD_CTX *ctx_{nullptr};
+  bool calculated_{false};
+#elif defined(USE_SHA256_TINYCRYPT)
+  tc_sha256_state_struct ctx_{};
   bool calculated_{false};
 #else
 #error "SHA256 not supported on this platform"

--- a/tests/components/sha256/test.nrf52-xiao-ble.yaml
+++ b/tests/components/sha256/test.nrf52-xiao-ble.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a SHA256 backend for the Zephyr / nRF52 platform (`USE_ZEPHYR`).

Until now the `sha256` component only defined `esphome::sha256::SHA256` on ESP32,
ESP8266, RP2040, LibreTiny and host, so any code that uses it (e.g. a
PBKDF2 / HMAC-SHA256 helper) failed to compile on nRF52 with
`'esphome::sha256' has not been declared`.

The default nRF Connect SDK / Zephyr build ships no mbedTLS or PSA crypto, but it
does bundle TinyCrypt. This adds a TinyCrypt-backed `SHA256` implementation
(`tc_sha256_init` / `tc_sha256_update` / `tc_sha256_final`) following the existing
backend pattern, and enables `CONFIG_TINYCRYPT_SHA256` from the component's
`to_code()` on Zephyr. No behavior change on any existing platform.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (no user-facing config: the `sha256` component has no new options; this only adds a platform backend)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# SHA256 has no user-facing options; it is pulled in by components that use it
# (or can be requested explicitly). On nRF52 it now resolves via TinyCrypt.
sha256:
```

## Checklist:
  - [x] The code change is tested and works locally. (Built and linked on nRF52840 / Seeed XIAO BLE; `esphome::sha256::SHA256` is exercised by a PBKDF2-HMAC-SHA256 helper.)
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). (`tests/components/sha256/test.nrf52-xiao-ble.yaml`)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io). (N/A — no user-facing config change)
