### PR TITLE
[deep_sleep] Add ESP32-C5 support

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -96,7 +96,8 @@ class DeepSleepComponent final : public Component {
 #endif
 
 #if !defined(USE_ESP32_VARIANT_ESP32C2) && !defined(USE_ESP32_VARIANT_ESP32C3) && \
-    !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32H2)
+    !defined(USE_ESP32_VARIANT_ESP32C5) && !defined(USE_ESP32_VARIANT_ESP32C6) && \
+    !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32H2)
   void set_touch_wakeup(bool touch_wakeup);
 #endif
 

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -124,7 +124,7 @@ void DeepSleepComponent::deep_sleep_() {
   }
 #endif
 
-  // GPIO wakeup - C2, C3, C6, C61 only
+  // GPIO wakeup - C2, C3, C5, C6, C61 only
 #if defined(USE_ESP32_VARIANT_ESP32C2) || defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C5) || \
     defined(USE_ESP32_VARIANT_ESP32C6) || defined(USE_ESP32_VARIANT_ESP32C61)
   if (this->wakeup_pin_ != nullptr) {

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -16,7 +16,7 @@ namespace esphome::deep_sleep {
 // | ESP32-S3  | ✓    | ✓    | ✓     |             |
 // | ESP32-C2  |      |      |       | ✓           |
 // | ESP32-C3  |      |      |       | ✓           |
-// | ESP32-C5  |      | (✓)  |       | (✓)         |
+// | ESP32-C5  |      | ✓    |       | ✓           |
 // | ESP32-C6  |      | ✓    |       | ✓           |
 // | ESP32-C61 |      | ✓    |       | ✓           |
 // | ESP32-H2  |      | ✓    |       |             |
@@ -56,7 +56,8 @@ void DeepSleepComponent::set_ext1_wakeup(Ext1Wakeup ext1_wakeup) { this->ext1_wa
 #endif
 
 #if !defined(USE_ESP32_VARIANT_ESP32C2) && !defined(USE_ESP32_VARIANT_ESP32C3) && \
-    !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32H2)
+    !defined(USE_ESP32_VARIANT_ESP32C5) && !defined(USE_ESP32_VARIANT_ESP32C6) && \
+    !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32H2)
 void DeepSleepComponent::set_touch_wakeup(bool touch_wakeup) { this->touch_wakeup_ = touch_wakeup; }
 #endif
 
@@ -99,7 +100,8 @@ void DeepSleepComponent::deep_sleep_() {
 
     // Single pin wakeup (ext0) - ESP32, S2, S3 only
 #if !defined(USE_ESP32_VARIANT_ESP32C2) && !defined(USE_ESP32_VARIANT_ESP32C3) && \
-    !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32H2)
+    !defined(USE_ESP32_VARIANT_ESP32C5) && !defined(USE_ESP32_VARIANT_ESP32C6) && \
+    !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32H2)
   if (this->wakeup_pin_ != nullptr) {
     const auto gpio_pin = gpio_num_t(this->wakeup_pin_->get_pin());
     if (this->wakeup_pin_->get_flags() & gpio::FLAG_PULLUP) {
@@ -123,8 +125,8 @@ void DeepSleepComponent::deep_sleep_() {
 #endif
 
   // GPIO wakeup - C2, C3, C6, C61 only
-#if defined(USE_ESP32_VARIANT_ESP32C2) || defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C6) || \
-    defined(USE_ESP32_VARIANT_ESP32C61)
+#if defined(USE_ESP32_VARIANT_ESP32C2) || defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C5) || \
+    defined(USE_ESP32_VARIANT_ESP32C6) || defined(USE_ESP32_VARIANT_ESP32C61)
   if (this->wakeup_pin_ != nullptr) {
     const auto gpio_pin = gpio_num_t(this->wakeup_pin_->get_pin());
     // Make sure GPIO is in input mode, not all RTC GPIO pins are input by default
@@ -154,7 +156,8 @@ void DeepSleepComponent::deep_sleep_() {
 
   // Touch wakeup - ESP32, S2, S3 only
 #if !defined(USE_ESP32_VARIANT_ESP32C2) && !defined(USE_ESP32_VARIANT_ESP32C3) && \
-    !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32H2)
+    !defined(USE_ESP32_VARIANT_ESP32C5) && !defined(USE_ESP32_VARIANT_ESP32C6) && \
+    !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32H2)
   if (this->touch_wakeup_.has_value() && *(this->touch_wakeup_)) {
     esp_sleep_enable_touchpad_wakeup();
     esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);

--- a/tests/components/deep_sleep/test.esp32-c5-idf.yaml
+++ b/tests/components/deep_sleep/test.esp32-c5-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  wakeup_pin: GPIO4
+
+<<: !include common.yaml
+<<: !include common-esp32-ext1.yaml

--- a/tests/components/deep_sleep/test.esp32-c61-idf.yaml
+++ b/tests/components/deep_sleep/test.esp32-c61-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  wakeup_pin: GPIO4
+
+<<: !include common.yaml
+<<: !include common-esp32-ext1.yaml


### PR DESCRIPTION
# What does this implement/fix?

Fixes deep sleep failing to compile on the ESP32-C5 (#17235). A bare `deep_sleep:` config errors out:

```
deep_sleep_esp32.cpp:121: error: 'esp_sleep_enable_ext0_wakeup' was not declared in this scope
deep_sleep_esp32.cpp:159: error: 'esp_sleep_enable_touchpad_wakeup' was not declared in this scope
```

The wakeup paths in `deep_sleep_()` are gated by hardcoded per-variant deny/allow lists, and the ESP32-C5 was never added to them — so the compiler emits calls to `esp_sleep_enable_ext0_wakeup` and `esp_sleep_enable_touchpad_wakeup`, which don't exist on the C5. Per `esp32c5/soc_caps.h` the C5 has **EXT1 but no EXT0 and no Touch** — i.e. the same capability set as the ESP32-C6.

This change treats the C5 like the C6:
- exclude it from the **ext0** and **touch** blocks (it has neither),
- include it in the **GPIO single-pin wakeup** path (so `wakeup_pin` works),
- keep **ext1** (already not excluded, which is correct).

It also adds the **ESP32-C61** to the ext0 exclusion — it has the same `soc_caps` (no EXT0) and the same latent gap, so it would hit the identical error.

The comment support-matrix is updated to mark the C5 ext1/GPIO columns as implemented.

> Note: these guards are deny/allow lists that break every time a new variant is added (this is the second variant to slip through). A follow-up could replace them with the `soc_caps` macros (`SOC_PM_SUPPORT_EXT0_WAKEUP` / `SOC_PM_SUPPORT_EXT1_WAKEUP` / `SOC_TOUCH_SENSOR_SUPPORTED`) so it's self-maintaining. Kept out of scope here to unblock the reporter with a minimal, low-risk fix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17235

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: seeed_xiao_esp32c5
  framework:
    type: esp-idf

deep_sleep:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).