### PR TITLE
[espnow] Don't throttle ESP-NOW RX when deep_sleep is present

### DIFF
--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -28,9 +28,6 @@ namespace esphome::espnow {
 
 static constexpr const char *TAG = "espnow";
 
-static const esp_err_t CONFIG_ESPNOW_WAKE_WINDOW = 50;
-static const esp_err_t CONFIG_ESPNOW_WAKE_INTERVAL = 100;
-
 ESPNowComponent *global_esp_now = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 static const LogString *espnow_error_to_str(esp_err_t error) {
@@ -203,11 +200,6 @@ void ESPNowComponent::enable_() {
   }
 
   esp_wifi_get_mac(WIFI_IF_STA, this->own_address_);
-
-#ifdef USE_DEEP_SLEEP
-  esp_now_set_wake_window(CONFIG_ESPNOW_WAKE_WINDOW);
-  esp_wifi_connectionless_module_set_wake_interval(CONFIG_ESPNOW_WAKE_INTERVAL);
-#endif
 
   this->state_ = ESPNOW_STATE_ENABLED;
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes #17238: ESP-NOW reception is silently degraded to a ~50% duty cycle whenever a `deep_sleep:` block is present.

`ESPNowComponent::enable_()` unconditionally configured a 50ms-wake / 100ms-interval connectionless wake window whenever `USE_DEEP_SLEEP` was defined:
```cpp
#ifdef USE_DEEP_SLEEP
  esp_now_set_wake_window(CONFIG_ESPNOW_WAKE_WINDOW);                       // 50
  esp_wifi_connectionless_module_set_wake_interval(CONFIG_ESPNOW_WAKE_INTERVAL);  // 100
#endif
```
That puts the ESP-NOW radio on a ~50% RX duty cycle **while the device is fully awake**, dropping roughly half of received frames — with nothing to do with actually deep sleeping. It is:

- **Wrongly triggered** — keyed on the *presence* of a `deep_sleep` component (`USE_DEEP_SLEEP` is defined merely by declaring `deep_sleep:`, even one that never sleeps), not on any sleep state. ESP-NOW RX duty cycle and deep-sleep are unrelated concerns.
- **Conceptually misplaced** — the connectionless wake window is for keeping ESP-NOW RX alive during **modem/light sleep**; it has no role in **deep** sleep (the radio is off there), so it never served its apparent purpose.
- **Silent and unconfigurable** — no YAML option to disable or tune it, and undocumented in either the `espnow` or `deep_sleep` docs.
- **Misnamed/mistyped** — `CONFIG_ESPNOW_WAKE_WINDOW` / `CONFIG_ESPNOW_WAKE_INTERVAL` are `CONFIG_`-prefixed (look like ESP-IDF Kconfig symbols, but aren't and can't be overridden via `sdkconfig_options`) and typed `esp_err_t` (these are window/interval values, not error codes).

This has been present since the espnow component was first added (`c42c5dd946`, #9582) — the lines were never touched after introduction — so it has affected every `espnow` + `deep_sleep` user the whole time.

## What this changes

Removes the wake-window calls and the two unused constants. With those APIs simply never called, the radio stays at full RX duty (subject to normal WiFi power-save) — which is exactly the reporter's confirmed workaround (`esp_now_set_wake_window(65535)` = always awake). So reception is reliable by default and there is no new config surface.

A genuine ESP-NOW power-save feature (low-duty RX during light sleep for battery receivers) is worth supporting later as a **proper, opt-in, documented** option (`espnow:` `power_save:` with `wake_window`/`wake_interval`, default off) — deliberately, not as a hardcoded default coupled to `deep_sleep`. Out of scope here.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17238

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
espnow:
  auto_add_peer: true
  channel: 1

deep_sleep:
  id: ds
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).