### PR TITLE
[core] Suppress unactionable legacy-redaction warning for substitutions

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1488,12 +1488,29 @@ _LEGACY_REDACTION_REMOVAL = "2026.12.0"
 
 def _redact_with_legacy_fallback(output: str) -> str:
     unmarked: set[str] = set()
+    # Track the top-level ``substitutions:`` block. Its keys are arbitrary
+    # user-chosen names with no schema validator, so the ``cv.sensitive(...)``
+    # migration named in the warning can't be applied to them. Their values are
+    # still redacted, but emitting the (unactionable) deprecation warning would
+    # only confuse users.
+    in_substitutions = False
 
-    def _replace(m: re.Match[str]) -> str:
-        unmarked.add(m.group("key"))
-        return f"{m.group('key')}: \\033[8m{m.group('val')}\\033[28m"
-
-    output = _LEGACY_REDACTION_RE.sub(_replace, output)
+    lines = output.split("\n")
+    for i, line in enumerate(lines):
+        # A non-indented, non-blank line is a top-level key that opens or
+        # closes the substitutions block.
+        if line and not line[0].isspace():
+            in_substitutions = line.startswith(f"{CONF_SUBSTITUTIONS}:")
+        m = _LEGACY_REDACTION_RE.search(line)
+        if m is None:
+            continue
+        if not in_substitutions:
+            unmarked.add(m.group("key"))
+        lines[i] = (
+            f"{line[: m.start()]}{m.group('key')}: "
+            f"\\033[8m{m.group('val')}\\033[28m{line[m.end() :]}"
+        )
+    output = "\n".join(lines)
     for key in sorted(unmarked):
         _LOGGER.warning(
             "Field '%s' is being redacted by a legacy substring heuristic. "

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -442,6 +442,36 @@ def test_redact_with_legacy_fallback__does_not_match_fragment_as_suffix(
     assert not any("legacy substring" in rec.message for rec in caplog.records)
 
 
+def test_redact_with_legacy_fallback__substitutions_redacted_without_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Substitution keys have no schema validator, so their values are still
+    redacted but the unactionable cv.sensitive migration warning is suppressed
+    (see issue #17225)."""
+    text = "substitutions:\n  ota_password: apolloautomation\nesphome:\n  name: x\n"
+    with caplog.at_level(logging.WARNING, logger="esphome.__main__"):
+        out = _redact_with_legacy_fallback(text)
+    assert "ota_password: \\033[8mapolloautomation\\033[28m" in out
+    assert not any("legacy substring" in rec.message for rec in caplog.records)
+
+
+def test_redact_with_legacy_fallback__warns_after_substitutions_block(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The suppression ends at the next top-level key; a sensitive-shaped field
+    in a later block (a real schema field) still warns, while the substitution
+    above it does not."""
+    text = (
+        "substitutions:\n  ota_password: apolloautomation\nwifi:\n  password: hunter2\n"
+    )
+    with caplog.at_level(logging.WARNING, logger="esphome.__main__"):
+        out = _redact_with_legacy_fallback(text)
+    assert "ota_password: \\033[8mapolloautomation\\033[28m" in out
+    assert "password: \\033[8mhunter2\\033[28m" in out
+    assert any("'password'" in rec.message for rec in caplog.records)
+    assert not any("ota_password" in rec.message for rec in caplog.records)
+
+
 def test_command_config__invokes_legacy_fallback_when_redacting(
     tmp_path: Path, capfd: CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

`esphome config` dumps the `substitutions:` block, and the legacy substring redaction (`_redact_with_legacy_fallback`, removal scheduled 2026.12.0) runs over that text. Any substitution whose key ends in `password`/`key`/`psk`/`ssid` (e.g. `ota_password`) matches the heuristic, so its value is redacted **and** a deprecation warning is emitted telling the user to mark the field with `cv.sensitive(...)`. A substitution is not a schema field and has no validator to mark, so the warning is completely unactionable.

This PR makes `_redact_with_legacy_fallback` track the top-level `substitutions:` block. Inside that block, values are **still redacted** (the secret stays concealed) but the unactionable deprecation warning is suppressed. Everything outside the block is unchanged — real schema fields still warn until migrated.

Before:
```
WARNING Field 'ota_password' is being redacted by a legacy substring heuristic. Mark this field's schema validator with cv.sensitive(...) for deterministic redaction; the heuristic will be removed in 2026.12.0.
substitutions:
  ota_password: <redacted>
```

After:
```
substitutions:
  ota_password: <redacted>
```

Note for later: when the legacy heuristic is removed in 2026.12.0, substitution values would otherwise stop being redacted entirely (they have no `cv.sensitive` migration path). A code comment near the block-tracking flags that a dedicated redaction pass for the substitutions block should be preserved at that point.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17225

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
substitutions:
  ota_password: "apolloautomation"

esphome:
  name: redact-test

esp32:
  board: esp32dev
  framework:
    type: esp-idf

wifi:
  ssid: "MyNetwork"
  password: "MyPassword"

ota:
  - platform: esphome
    password: ${ota_password}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).