### PR TITLE
[core] Use single-precision float math to avoid double promotion

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -669,11 +669,11 @@ void rgb_to_hsv(float red, float green, float blue, int &hue, float &saturation,
   if (delta == 0) {
     hue = 0;
   } else if (max_color_value == red) {
-    hue = int(fmod(((60 * ((green - blue) / delta)) + 360), 360));
+    hue = int(fmodf((60.0f * ((green - blue) / delta)) + 360.0f, 360.0f));
   } else if (max_color_value == green) {
-    hue = int(fmod(((60 * ((blue - red) / delta)) + 120), 360));
+    hue = int(fmodf((60.0f * ((blue - red) / delta)) + 120.0f, 360.0f));
   } else if (max_color_value == blue) {
-    hue = int(fmod(((60 * ((red - green) / delta)) + 240), 360));
+    hue = int(fmodf((60.0f * ((red - green) / delta)) + 240.0f, 360.0f));
   }
 
   if (max_color_value == 0) {
@@ -686,8 +686,8 @@ void rgb_to_hsv(float red, float green, float blue, int &hue, float &saturation,
 }
 void hsv_to_rgb(int hue, float saturation, float value, float &red, float &green, float &blue) {
   float chroma = value * saturation;
-  float hue_prime = fmod(hue / 60.0, 6);
-  float intermediate = chroma * (1 - fabs(fmod(hue_prime, 2) - 1));
+  float hue_prime = fmodf(hue / 60.0f, 6.0f);
+  float intermediate = chroma * (1.0f - fabsf(fmodf(hue_prime, 2.0f) - 1.0f));
   float delta = value - chroma;
 
   if (0 <= hue_prime && hue_prime < 1) {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -356,7 +356,7 @@ void HOT Scheduler::set_retry_common_(Component *component, NameType name_type, 
   }
 #endif
 
-  if (backoff_increase_factor < 0.0001) {
+  if (backoff_increase_factor < 0.0001f) {
     ESP_LOGE(TAG, "set_retry: backoff_factor %0.1f too small, using 1.0: %s", backoff_increase_factor,
              (name_type == NameType::STATIC_STRING && static_name) ? static_name : "");
     backoff_increase_factor = 1;


### PR DESCRIPTION
# What does this implement/fix?

A few spots in `esphome/core/` force `float`→`double` promotion, so on single-precision-FPU targets (ESP32 Xtensa, nRF52 Cortex-M4F) the surrounding arithmetic runs in **software-emulated double** instead of the hardware FPU:

- `hsv_to_rgb` / `rgb_to_hsv`: `fmod`/`fabs` → `fmodf`/`fabsf` with float literals
- `Scheduler` backoff guard: `0.0001` → `0.0001f`

These were found by a tree-wide `-Wdouble-promotion` clang-tidy scan (the warning is enabled by the nRF52/Zephyr toolchain, but the inefficiency is silent on ESP32 too since IDF doesn't enable the flag).

Verified the impact by compiling the affected function for a single-precision target before/after: the old `hsv_to_rgb` emitted ~8 soft-double helper calls (`__muldf3`, `__divdf3`, `__subdf3`, `__extendsfdf2`, `__truncdfsf2`, double `fmod`) and was **108 bytes**; the new version is hardware single-precision FPU + `fmodf` only, **69 bytes** (−36%). No behavior change on targets with a double FPU.

This is the `esphome/core/` slice; the same scan found ~170 more genuine sites across components, which can follow as separate per-component PRs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change — internal numeric-precision cleanup.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).