### PR TITLE
[multiple] Single-precision float math, avoid double promotion (batch 1/4)

### DIFF
--- a/esphome/components/daikin_brc/daikin_brc.cpp
+++ b/esphome/components/daikin_brc/daikin_brc.cpp
@@ -151,7 +151,7 @@ uint8_t DaikinBrcClimate::temperature_() {
       // Temperature in remote is in F
       if (this->fahrenheit_) {
         temperature = (uint8_t) roundf(
-            clamp<float>(((this->target_temperature * 1.8) + 32), DAIKIN_BRC_TEMP_MIN_F, DAIKIN_BRC_TEMP_MAX_F));
+            clamp<float>(((this->target_temperature * 1.8f) + 32), DAIKIN_BRC_TEMP_MIN_F, DAIKIN_BRC_TEMP_MAX_F));
       } else {
         temperature = ((uint8_t) roundf(this->target_temperature) - 9) << 1;
       }

--- a/esphome/components/dfrobot_sen0395/commands.cpp
+++ b/esphome/components/dfrobot_sen0395/commands.cpp
@@ -127,7 +127,7 @@ DetRangeCfgCommand::DetRangeCfgCommand(float min1, float max1, float min2, float
         this->max4_ = max4 = -1;
 
     char buf[72];  // max 72: "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
-    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f", min1 / 0.15, max1 / 0.15);
+    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f", min1 / 0.15f, max1 / 0.15f);
     this->cmd_ = buf;
   } else if (min3 < 0 || max3 < 0) {
     this->min1_ = min1 = roundf(min1 / 0.15f) * 0.15f;
@@ -137,7 +137,7 @@ DetRangeCfgCommand::DetRangeCfgCommand(float min1, float max1, float min2, float
     this->min3_ = min3 = this->max3_ = max3 = this->min4_ = min4 = this->max4_ = max4 = -1;
 
     char buf[72];  // max 72: "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
-    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f", min1 / 0.15, max1 / 0.15, min2 / 0.15,
+    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f", min1 / 0.15f, max1 / 0.15f, min2 / 0.15f,
              max2 / 0.15f);
     this->cmd_ = buf;
   } else if (min4 < 0 || max4 < 0) {
@@ -150,7 +150,7 @@ DetRangeCfgCommand::DetRangeCfgCommand(float min1, float max1, float min2, float
     this->min4_ = min4 = this->max4_ = max4 = -1;
 
     char buf[72];  // max 72: "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
-    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f %.0f %.0f", min1 / 0.15, max1 / 0.15, min2 / 0.15,
+    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f %.0f %.0f", min1 / 0.15f, max1 / 0.15f, min2 / 0.15f,
              max2 / 0.15f, min3 / 0.15f, max3 / 0.15f);
     this->cmd_ = buf;
   } else {
@@ -164,7 +164,7 @@ DetRangeCfgCommand::DetRangeCfgCommand(float min1, float max1, float min2, float
     this->max4_ = max4 = roundf(max4 / 0.15f) * 0.15f;
 
     char buf[72];  // max 72: "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
-    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f %.0f %.0f %.0f %.0f", min1 / 0.15, max1 / 0.15,
+    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f %.0f %.0f %.0f %.0f", min1 / 0.15f, max1 / 0.15f,
              min2 / 0.15f, max2 / 0.15f, min3 / 0.15f, max3 / 0.15f, min4 / 0.15f, max4 / 0.15f);
     this->cmd_ = buf;
   }

--- a/esphome/components/dfrobot_sen0395/commands.cpp
+++ b/esphome/components/dfrobot_sen0395/commands.cpp
@@ -121,8 +121,8 @@ DetRangeCfgCommand::DetRangeCfgCommand(float min1, float max1, float min2, float
 
     this->cmd_ = "detRangeCfg -1 0 0";
   } else if (min2 < 0 || max2 < 0) {
-    this->min1_ = min1 = round(min1 / 0.15) * 0.15;
-    this->max1_ = max1 = round(max1 / 0.15) * 0.15;
+    this->min1_ = min1 = roundf(min1 / 0.15f) * 0.15f;
+    this->max1_ = max1 = roundf(max1 / 0.15f) * 0.15f;
     this->min2_ = min2 = this->max2_ = max2 = this->min3_ = min3 = this->max3_ = max3 = this->min4_ = min4 =
         this->max4_ = max4 = -1;
 
@@ -130,42 +130,42 @@ DetRangeCfgCommand::DetRangeCfgCommand(float min1, float max1, float min2, float
     snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f", min1 / 0.15, max1 / 0.15);
     this->cmd_ = buf;
   } else if (min3 < 0 || max3 < 0) {
-    this->min1_ = min1 = round(min1 / 0.15) * 0.15;
-    this->max1_ = max1 = round(max1 / 0.15) * 0.15;
-    this->min2_ = min2 = round(min2 / 0.15) * 0.15;
-    this->max2_ = max2 = round(max2 / 0.15) * 0.15;
+    this->min1_ = min1 = roundf(min1 / 0.15f) * 0.15f;
+    this->max1_ = max1 = roundf(max1 / 0.15f) * 0.15f;
+    this->min2_ = min2 = roundf(min2 / 0.15f) * 0.15f;
+    this->max2_ = max2 = roundf(max2 / 0.15f) * 0.15f;
     this->min3_ = min3 = this->max3_ = max3 = this->min4_ = min4 = this->max4_ = max4 = -1;
 
     char buf[72];  // max 72: "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
     snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f", min1 / 0.15, max1 / 0.15, min2 / 0.15,
-             max2 / 0.15);
+             max2 / 0.15f);
     this->cmd_ = buf;
   } else if (min4 < 0 || max4 < 0) {
-    this->min1_ = min1 = round(min1 / 0.15) * 0.15;
-    this->max1_ = max1 = round(max1 / 0.15) * 0.15;
-    this->min2_ = min2 = round(min2 / 0.15) * 0.15;
-    this->max2_ = max2 = round(max2 / 0.15) * 0.15;
-    this->min3_ = min3 = round(min3 / 0.15) * 0.15;
-    this->max3_ = max3 = round(max3 / 0.15) * 0.15;
+    this->min1_ = min1 = roundf(min1 / 0.15f) * 0.15f;
+    this->max1_ = max1 = roundf(max1 / 0.15f) * 0.15f;
+    this->min2_ = min2 = roundf(min2 / 0.15f) * 0.15f;
+    this->max2_ = max2 = roundf(max2 / 0.15f) * 0.15f;
+    this->min3_ = min3 = roundf(min3 / 0.15f) * 0.15f;
+    this->max3_ = max3 = roundf(max3 / 0.15f) * 0.15f;
     this->min4_ = min4 = this->max4_ = max4 = -1;
 
     char buf[72];  // max 72: "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
     snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f %.0f %.0f", min1 / 0.15, max1 / 0.15, min2 / 0.15,
-             max2 / 0.15, min3 / 0.15, max3 / 0.15);
+             max2 / 0.15f, min3 / 0.15f, max3 / 0.15f);
     this->cmd_ = buf;
   } else {
-    this->min1_ = min1 = round(min1 / 0.15) * 0.15;
-    this->max1_ = max1 = round(max1 / 0.15) * 0.15;
-    this->min2_ = min2 = round(min2 / 0.15) * 0.15;
-    this->max2_ = max2 = round(max2 / 0.15) * 0.15;
-    this->min3_ = min3 = round(min3 / 0.15) * 0.15;
-    this->max3_ = max3 = round(max3 / 0.15) * 0.15;
-    this->min4_ = min4 = round(min4 / 0.15) * 0.15;
-    this->max4_ = max4 = round(max4 / 0.15) * 0.15;
+    this->min1_ = min1 = roundf(min1 / 0.15f) * 0.15f;
+    this->max1_ = max1 = roundf(max1 / 0.15f) * 0.15f;
+    this->min2_ = min2 = roundf(min2 / 0.15f) * 0.15f;
+    this->max2_ = max2 = roundf(max2 / 0.15f) * 0.15f;
+    this->min3_ = min3 = roundf(min3 / 0.15f) * 0.15f;
+    this->max3_ = max3 = roundf(max3 / 0.15f) * 0.15f;
+    this->min4_ = min4 = roundf(min4 / 0.15f) * 0.15f;
+    this->max4_ = max4 = roundf(max4 / 0.15f) * 0.15f;
 
     char buf[72];  // max 72: "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
     snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f %.0f %.0f %.0f %.0f", min1 / 0.15, max1 / 0.15,
-             min2 / 0.15, max2 / 0.15, min3 / 0.15, max3 / 0.15, min4 / 0.15, max4 / 0.15);
+             min2 / 0.15f, max2 / 0.15f, min3 / 0.15f, max3 / 0.15f, min4 / 0.15f, max4 / 0.15f);
     this->cmd_ = buf;
   }
 

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -228,7 +228,7 @@ void Display::filled_gauge(int center_x, int center_y, int radius1, int radius2,
   int e2max, e2min;
   progress = std::max(0, std::min(progress, 100));  // 0..100
   int draw_progress = progress > 50 ? (100 - progress) : progress;
-  float tan_a = (progress == 50) ? 65535 : tanf(float(draw_progress) * M_PI / 100);  // slope
+  float tan_a = (progress == 50) ? 65535 : tanf(float(draw_progress) * float(M_PI) / 100);  // slope
 
   do {
     // outer dots

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -228,7 +228,7 @@ void Display::filled_gauge(int center_x, int center_y, int radius1, int radius2,
   int e2max, e2min;
   progress = std::max(0, std::min(progress, 100));  // 0..100
   int draw_progress = progress > 50 ? (100 - progress) : progress;
-  float tan_a = (progress == 50) ? 65535 : tanf(float(draw_progress) * float(M_PI) / 100);  // slope
+  float tan_a = (progress == 50) ? 65535 : tanf(float(draw_progress) * std::numbers::pi_v<float> / 100);  // slope
 
   do {
     // outer dots

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -228,7 +228,7 @@ void Display::filled_gauge(int center_x, int center_y, int radius1, int radius2,
   int e2max, e2min;
   progress = std::max(0, std::min(progress, 100));  // 0..100
   int draw_progress = progress > 50 ? (100 - progress) : progress;
-  float tan_a = (progress == 50) ? 65535 : tan(float(draw_progress) * M_PI / 100);  // slope
+  float tan_a = (progress == 50) ? 65535 : tanf(float(draw_progress) * M_PI / 100);  // slope
 
   do {
     // outer dots

--- a/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
+++ b/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
@@ -55,7 +55,7 @@ void HrxlMaxsonarWrComponent::check_buffer_() {
         millimeters = millimeters * 10;
       }
 
-      float meters = float(millimeters) / 1000.0;
+      float meters = float(millimeters) / 1000.0f;
       ESP_LOGV(TAG, "Distance from sensor: %d mm, %f m", millimeters, meters);
       this->publish_state(meters);
     } else {

--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -47,7 +47,7 @@ class LightTransitionTransformer : public LightTransformer {
     LightColorValues &start = this->changing_color_mode_ && p > 0.5f ? this->intermediate_values_ : this->start_values_;
     LightColorValues &end = this->changing_color_mode_ && p < 0.5f ? this->intermediate_values_ : this->end_values_;
     if (this->changing_color_mode_)
-      p = p < 0.5f ? p * 2 : (p - 0.5) * 2;
+      p = p < 0.5f ? p * 2 : (p - 0.5f) * 2;
 
     float v = LightTransformer::smoothed_progress(p);
     return LightColorValues::lerp(start, end, v);

--- a/esphome/components/mcp4461/output/mcp4461_output.cpp
+++ b/esphome/components/mcp4461/output/mcp4461_output.cpp
@@ -29,7 +29,9 @@ void Mcp4461Wiper::write_state(float state) {
   }
 }
 
-float Mcp4461Wiper::read_state() { return (static_cast<float>(this->parent_->get_wiper_level_(this->wiper_)) / 256.0); }
+float Mcp4461Wiper::read_state() {
+  return (static_cast<float>(this->parent_->get_wiper_level_(this->wiper_)) / 256.0f);
+}
 
 float Mcp4461Wiper::update_state() {
   this->state_ = this->read_state();

--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -541,7 +541,7 @@ void OpenTherm::debug_error(OpenThermError &error) const {
            error.capture, error.bit_pos);
 }
 
-float OpenthermData::f88() { return ((float) this->s16()) / 256.0; }
+float OpenthermData::f88() { return ((float) this->s16()) / 256.0f; }
 
 void OpenthermData::f88(float value) { this->s16((int16_t) (value * 256)); }
 

--- a/esphome/components/qmp6988/qmp6988.cpp
+++ b/esphome/components/qmp6988/qmp6988.cpp
@@ -276,7 +276,7 @@ void QMP6988Component::write_oversampling_temperature_(QMP6988Oversampling overs
 
 void QMP6988Component::calculate_altitude_(float pressure, float temp) {
   float altitude;
-  altitude = (pow((101325 / pressure), 1 / 5.257) - 1) * (temp + 273.15) / 0.0065;
+  altitude = (powf((101325 / pressure), 1 / 5.257f) - 1) * (temp + 273.15f) / 0.0065f;
   this->qmp6988_data_.altitude = altitude;
 }
 

--- a/esphome/components/shelly_dimmer/shelly_dimmer.cpp
+++ b/esphome/components/shelly_dimmer/shelly_dimmer.cpp
@@ -207,7 +207,7 @@ bool ShellyDimmer::upgrade_firmware_() {
 
 uint16_t ShellyDimmer::convert_brightness_(float brightness) {
   // Special case for zero as only zero means turn off completely.
-  if (brightness == 0.0) {
+  if (brightness == 0.0f) {
     return 0;
   }
 

--- a/esphome/components/speaker_source/speaker_source_media_player.cpp
+++ b/esphome/components/speaker_source/speaker_source_media_player.cpp
@@ -831,7 +831,7 @@ void SpeakerSourceMediaPlayer::set_volume_(float volume, bool publish) {
 
   // Turn on the mute state if the volume is effectively zero, off otherwise.
   // Pass publish=false to avoid saving twice.
-  if (volume < 0.001) {
+  if (volume < 0.001f) {
     this->set_mute_state_(true, false);
   } else {
     this->set_mute_state_(false, false);

--- a/esphome/components/veml7700/veml7700.cpp
+++ b/esphome/components/veml7700/veml7700.cpp
@@ -380,7 +380,7 @@ void VEML7700Component::apply_lux_compensation_(Readings &data) {
   // if this light level is exceeded"
   auto compensate = [&local_data](float &lux) {
     auto calculate_high_lux_compensation = [](float lux_veml) -> float {
-      return (((6.0135e-13 * lux_veml - 9.3924e-9) * lux_veml + 8.1488e-5) * lux_veml + 1.0023) * lux_veml;
+      return (((6.0135e-13f * lux_veml - 9.3924e-9f) * lux_veml + 8.1488e-5f) * lux_veml + 1.0023f) * lux_veml;
     };
 
     if (lux > 1000.0f || local_data.actual_gain == Gain::X_1_8 || local_data.actual_gain == Gain::X_1_4) {

--- a/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.cpp
+++ b/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.cpp
@@ -49,7 +49,7 @@ bool XiaomiXMWSDJ04MMC::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
     }
     if (res->humidity.has_value() && this->humidity_ != nullptr) {
       // see https://github.com/custom-components/sensor.mitemp_bt/issues/7#issuecomment-595948254
-      *res->humidity = trunc(*res->humidity);
+      *res->humidity = truncf(*res->humidity);
     }
     if (!(xiaomi_ble::report_xiaomi_results(res, addr_str))) {
       continue;


### PR DESCRIPTION
# What does this implement/fix?

Mechanical numeric-precision cleanup (batch 1 of 4). These spots implicitly promote a `float` to `double`, so on single-precision-FPU targets (ESP32 Xtensa, nRF52 Cortex-M4F) the surrounding arithmetic runs as **software-emulated double** instead of the hardware FPU. The fix is purely mechanical: `double` literals → `f`-suffixed, and bare double `libm` calls → their `f` variants (`fmod`→`fmodf`, `round`→`roundf`, …).

Found by a tree-wide `-Wdouble-promotion` clang-tidy scan — the warning is enabled by the nRF52/Zephyr toolchain, but the inefficiency is silent on ESP32 too (IDF doesn't enable the flag). Measured on the `hsv_to_rgb` core helper: ~8 soft-double helper calls eliminated and the function went 108→69 bytes (−36%). **No behavior change on targets with a double FPU.**

Split into 4 batches by component because the scan touched too many components for one reviewable PR. Core changes are in #17252; intentional-`double` and `printf`/`%f` sites were deliberately left out.

**Components in this batch:** daikin_brc,dfrobot_sen0395 display,hrxl_maxsonar_wr light,mcp4461 opentherm,qmp6988 shelly_dimmer,speaker_source veml7700,xiaomi_xmwsdj04mmc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of the same cleanup as #17252

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change — internal numeric-precision cleanup.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).