### PR TITLE
[multiple] Single-precision float math, avoid double promotion (batch 2/4)

### DIFF
--- a/esphome/components/a01nyub/a01nyub.cpp
+++ b/esphome/components/a01nyub/a01nyub.cpp
@@ -25,7 +25,7 @@ void A01nyubComponent::check_buffer_() {
   if (this->buffer_[3] == checksum) {
     float distance = (this->buffer_[1] << 8) + this->buffer_[2];
     if (distance > 280) {
-      float meters = distance / 1000.0;
+      float meters = distance / 1000.0f;
       ESP_LOGV(TAG, "Distance from sensor: %f mm, %f m", distance, meters);
       this->publish_state(meters);
     } else {

--- a/esphome/components/binary_sensor_map/binary_sensor_map.cpp
+++ b/esphome/components/binary_sensor_map/binary_sensor_map.cpp
@@ -112,7 +112,7 @@ float BinarySensorMap::bayesian_predicate_(bool sensor_state, float prior, float
     prob_state_source_false = 1 - prob_given_false;
   }
 
-  return prob_state_source_true / (prior * prob_state_source_true + (1.0 - prior) * prob_state_source_false);
+  return prob_state_source_true / (prior * prob_state_source_true + (1.0f - prior) * prob_state_source_false);
 }
 
 void BinarySensorMap::add_channel(binary_sensor::BinarySensor *sensor, float value) {

--- a/esphome/components/bl0942/bl0942.cpp
+++ b/esphome/components/bl0942/bl0942.cpp
@@ -124,14 +124,14 @@ void BL0942::setup() {
   // If either current or voltage references are set explicitly by the user,
   // calculate the power reference from it unless that is also explicitly set.
   if ((this->current_reference_set_ || this->voltage_reference_set_) && !this->power_reference_set_) {
-    this->power_reference_ = (this->voltage_reference_ * this->current_reference_ * 3537.0 / 305978.0) / 73989.0;
+    this->power_reference_ = (this->voltage_reference_ * this->current_reference_ * 3537.0f / 305978.0f) / 73989.0f;
     this->power_reference_set_ = true;
   }
 
   // Similarly for energy reference, if the power reference was set by the user
   // either implicitly or explicitly.
   if (this->power_reference_set_ && !this->energy_reference_set_) {
-    this->energy_reference_ = this->power_reference_ * 3600000 / 419430.4;
+    this->energy_reference_ = this->power_reference_ * 3600000 / 419430.4f;
     this->energy_reference_set_ = true;
   }
 

--- a/esphome/components/dallas_temp/dallas_temp.cpp
+++ b/esphome/components/dallas_temp/dallas_temp.cpp
@@ -138,7 +138,7 @@ float DallasTemperatureSensor::get_temp_c_() {
     if (this->scratch_pad_[7] == 0) {
       return NAN;
     }
-    return (temp >> 1) + (this->scratch_pad_[7] - this->scratch_pad_[6]) / float(this->scratch_pad_[7]) - 0.25;
+    return (temp >> 1) + (this->scratch_pad_[7] - this->scratch_pad_[6]) / float(this->scratch_pad_[7]) - 0.25f;
   }
   switch (this->resolution_) {
     case 9:

--- a/esphome/components/ds2484/ds2484.h
+++ b/esphome/components/ds2484/ds2484.h
@@ -12,7 +12,7 @@ class DS2484OneWireBus final : public one_wire::OneWireBus, public i2c::I2CDevic
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::BUS - 1.0; }
+  float get_setup_priority() const override { return setup_priority::BUS - 1.0f; }
 
   bool reset_device();
   int reset_int() override;

--- a/esphome/components/grove_tb6612fng/grove_tb6612fng.cpp
+++ b/esphome/components/grove_tb6612fng/grove_tb6612fng.cpp
@@ -122,7 +122,7 @@ void GroveMotorDriveTB6612FNG::stepper_run(StepperModeTypeT mode, int16_t steps,
 
   rpm = clamp<uint16_t>(rpm, 1, 300);
 
-  ms_per_step = (uint16_t) (3000.0 / (float) rpm);
+  ms_per_step = (uint16_t) (3000.0f / (float) rpm);
   buffer_[0] = mode;
   buffer_[1] = cw;  //(cw=1) => cw; (cw=0) => ccw
   buffer_[2] = steps;
@@ -153,7 +153,7 @@ void GroveMotorDriveTB6612FNG::stepper_keep_run(StepperModeTypeT mode, uint16_t 
   uint16_t ms_per_step = 0;
 
   rpm = clamp<uint16_t>(rpm, 1, 300);
-  ms_per_step = (uint16_t) (3000.0 / (float) rpm);
+  ms_per_step = (uint16_t) (3000.0f / (float) rpm);
 
   buffer_[0] = mode;
   buffer_[1] = cw;  //(cw=1) => cw; (cw=0) => ccw

--- a/esphome/components/honeywellabp/honeywellabp.cpp
+++ b/esphome/components/honeywellabp/honeywellabp.cpp
@@ -55,7 +55,9 @@ float HONEYWELLABPSensor::countstopressure_(const int counts, const float min_pr
 
 // Converts a digital temperature measurement in counts to temperature in C
 // This will be invalid if sensore daoes not have temperature measurement capability
-float HONEYWELLABPSensor::countstotemperatures_(const int counts) { return (((float) counts / 2047.0) * 200.0) - 50.0; }
+float HONEYWELLABPSensor::countstotemperatures_(const int counts) {
+  return (((float) counts / 2047.0f) * 200.0f) - 50.0f;
+}
 
 // Pressure value from the most recent reading in units
 float HONEYWELLABPSensor::read_pressure_() {
@@ -69,9 +71,9 @@ void HONEYWELLABPSensor::update() {
   ESP_LOGV(TAG, "Update Honeywell ABP Sensor");
   if (readsensor_() == 0) {
     if (this->pressure_sensor_ != nullptr)
-      this->pressure_sensor_->publish_state(read_pressure_() * 1.0);
+      this->pressure_sensor_->publish_state(read_pressure_() * 1.0f);
     if (this->temperature_sensor_ != nullptr)
-      this->temperature_sensor_->publish_state(read_temperature_() * 1.0);
+      this->temperature_sensor_->publish_state(read_temperature_() * 1.0f);
   }
 }
 

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -139,7 +139,7 @@ void I2SAudioSpeakerBase::set_volume(float volume) {
   this->volume_ = volume;
 #ifdef USE_AUDIO_DAC
   if (this->audio_dac_ != nullptr) {
-    if (volume > 0.0) {
+    if (volume > 0.0f) {
       this->audio_dac_->set_mute_off();
     }
     this->audio_dac_->set_volume(volume);

--- a/esphome/components/ltr390/ltr390.cpp
+++ b/esphome/components/ltr390/ltr390.cpp
@@ -75,7 +75,7 @@ void LTR390Component::read_als_() {
   uint32_t als = *val;
 
   if (this->light_sensor_ != nullptr) {
-    float lux = ((0.6 * als) / (GAINVALUES[this->gain_als_] * RESOLUTIONVALUE[this->res_als_])) * this->wfac_;
+    float lux = ((0.6f * als) / (GAINVALUES[this->gain_als_] * RESOLUTIONVALUE[this->res_als_])) * this->wfac_;
     this->light_sensor_->publish_state(lux);
   }
 

--- a/esphome/components/mcp4725/mcp4725.cpp
+++ b/esphome/components/mcp4725/mcp4725.cpp
@@ -24,7 +24,7 @@ void MCP4725::dump_config() {
 
 // https://learn.sparkfun.com/tutorials/mcp4725-digital-to-analog-converter-hookup-guide?_ga=2.176055202.1402343014.1607953301-893095255.1606753886
 void MCP4725::write_state(float state) {
-  const uint16_t value = (uint16_t) round(state * (pow(2, MCP4725_RES) - 1));
+  const uint16_t value = (uint16_t) roundf(state * (powf(2, MCP4725_RES) - 1));
 
   this->write_byte_16(64, value << 4);
 }

--- a/esphome/components/mics_4514/mics_4514.cpp
+++ b/esphome/components/mics_4514/mics_4514.cpp
@@ -71,10 +71,10 @@ void MICS4514Component::update() {
     float co = 0.0f;
     if (red_f > 3.4f) {
       co = 0.0;
-    } else if (red_f < 0.01) {
+    } else if (red_f < 0.01f) {
       co = 1000.0;
     } else {
-      co = 4.2 / pow(red_f, 1.2);
+      co = 4.2f / powf(red_f, 1.2f);
     }
     this->carbon_monoxide_sensor_->publish_state(co);
   }
@@ -84,47 +84,47 @@ void MICS4514Component::update() {
     if (ox_f < 0.3f) {
       nitrogendioxide = 0.0;
     } else {
-      nitrogendioxide = 0.164 * pow(ox_f, 0.975);
+      nitrogendioxide = 0.164f * powf(ox_f, 0.975f);
     }
     this->nitrogen_dioxide_sensor_->publish_state(nitrogendioxide);
   }
 
   if (this->methane_sensor_ != nullptr) {
     float methane = 0.0f;
-    if (red_f > 0.9f || red_f < 0.5) {  // outside the range->unlikely
+    if (red_f > 0.9f || red_f < 0.5f) {  // outside the range->unlikely
       methane = 0.0;
     } else {
-      methane = 630 / pow(red_f, 4.4);
+      methane = 630 / powf(red_f, 4.4f);
     }
     this->methane_sensor_->publish_state(methane);
   }
 
   if (this->ethanol_sensor_ != nullptr) {
     float ethanol = 0.0f;
-    if (red_f > 1.0f || red_f < 0.02) {  // outside the range->unlikely
+    if (red_f > 1.0f || red_f < 0.02f) {  // outside the range->unlikely
       ethanol = 0.0;
     } else {
-      ethanol = 1.52 / pow(red_f, 1.55);
+      ethanol = 1.52f / powf(red_f, 1.55f);
     }
     this->ethanol_sensor_->publish_state(ethanol);
   }
 
   if (this->hydrogen_sensor_ != nullptr) {
     float hydrogen = 0.0f;
-    if (red_f > 0.9f || red_f < 0.02) {  // outside the range->unlikely
+    if (red_f > 0.9f || red_f < 0.02f) {  // outside the range->unlikely
       hydrogen = 0.0;
     } else {
-      hydrogen = 0.85 / pow(red_f, 1.75);
+      hydrogen = 0.85f / powf(red_f, 1.75f);
     }
     this->hydrogen_sensor_->publish_state(hydrogen);
   }
 
   if (this->ammonia_sensor_ != nullptr) {
     float ammonia = 0.0f;
-    if (red_f > 0.98f || red_f < 0.2532) {  // outside the ammonia range->unlikely
+    if (red_f > 0.98f || red_f < 0.2532f) {  // outside the ammonia range->unlikely
       ammonia = 0.0;
     } else {
-      ammonia = 0.9 / pow(red_f, 4.6);
+      ammonia = 0.9f / powf(red_f, 4.6f);
     }
     this->ammonia_sensor_->publish_state(ammonia);
   }

--- a/esphome/components/opentherm/output/opentherm_output.cpp
+++ b/esphome/components/opentherm/output/opentherm_output.cpp
@@ -12,8 +12,9 @@ void opentherm::OpenthermOutput::write_state(float state) {
 #else
   bool zero_means_zero = false;
 #endif
-  this->state =
-      state < 0.003 && zero_means_zero ? 0.0 : clamp(std::lerp(min_value_, max_value_, state), min_value_, max_value_);
+  this->state = state < 0.003f && zero_means_zero
+                    ? 0.0f
+                    : clamp(std::lerp(min_value_, max_value_, state), min_value_, max_value_);
   this->has_state_ = true;
   ESP_LOGD(TAG, "Output %s set to %.2f", this->id_, this->state);
 }

--- a/esphome/components/runtime_stats/runtime_stats.cpp
+++ b/esphome/components/runtime_stats/runtime_stats.cpp
@@ -95,7 +95,7 @@ void RuntimeStatsCollector::log_stats_() {
       ESP_LOGI(TAG, "  %s: count=%" PRIu32 ", avg=%.3fms, max=%.2fms, total=%.1fms",
                LOG_STR_ARG(sorted[i]->get_component_log_str()), stats.total_count,
                stats.total_count > 0 ? stats.total_time_us / (float) stats.total_count / 1000.0f : 0.0f,
-               stats.total_max_time_us / 1000.0f, stats.total_time_us / 1000.0);
+               stats.total_max_time_us / 1000.0f, stats.total_time_us / 1000.0f);
     }
   }
 

--- a/esphome/components/sound_level/sound_level.cpp
+++ b/esphome/components/sound_level/sound_level.cpp
@@ -121,7 +121,7 @@ void SoundLevelComponent::loop() {
   if (this->sample_count_ == samples_in_window) {
     // Processed enough samples for the measurement window, compute and publish the sensor values
     if (this->peak_sensor_ != nullptr) {
-      const float peak_db = 10.0f * log10(static_cast<float>(this->squared_peak_) / MAX_SAMPLE_SQUARED_DENOMINATOR);
+      const float peak_db = 10.0f * log10f(static_cast<float>(this->squared_peak_) / MAX_SAMPLE_SQUARED_DENOMINATOR);
       this->peak_sensor_->publish_state(peak_db);
 
       this->squared_peak_ = 0;  // reset accumulator

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -225,7 +225,7 @@ void SX127x::configure_lora_() {
   }
 
   // optimize detection
-  float duration = 1000.0f * std::pow(2, this->spreading_factor_) / BW_HZ[this->bandwidth_];
+  float duration = 1000.0f * (1UL << this->spreading_factor_) / BW_HZ[this->bandwidth_];
   if (duration > 16) {
     this->write_register_(REG_MODEM_CONFIG3, MODEM_AGC_AUTO_ON | LOW_DATA_RATE_OPTIMIZE_ON);
   } else {

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -201,8 +201,8 @@ void SX127x::configure_fsk_ook_() {
   this->write_register_(REG_OOK_AVG, OOK_AVG_RESERVED | OOK_THRESH_DEC_1_8);
 
   // set rx floor
-  this->write_register_(REG_OOK_FIX, 256 + int(this->rx_floor_ * 2.0));
-  this->write_register_(REG_RSSI_THRESH, std::abs(int(this->rx_floor_ * 2.0)));
+  this->write_register_(REG_OOK_FIX, 256 + int(this->rx_floor_ * 2.0f));
+  this->write_register_(REG_RSSI_THRESH, std::abs(int(this->rx_floor_ * 2.0f)));
 }
 
 void SX127x::configure_lora_() {

--- a/esphome/components/thermopro_ble/thermopro_ble.cpp
+++ b/esphome/components/thermopro_ble/thermopro_ble.cpp
@@ -196,7 +196,7 @@ static optional<ParseResult> parse_tp3(const uint8_t *data, std::size_t data_siz
   result.humidity = static_cast<float>(data[3]);
 
   // battery level, 2 bits (0-2)
-  result.battery_level = static_cast<float>(data[4] & 0x3) * 50.0;
+  result.battery_level = static_cast<float>(data[4] & 0x3) * 50.0f;
 
   return result;
 }

--- a/esphome/components/x9c/x9c.cpp
+++ b/esphome/components/x9c/x9c.cpp
@@ -44,7 +44,7 @@ void X9cOutput::setup() {
   this->ud_pin_->get_pin();
   this->ud_pin_->setup();
 
-  if (this->initial_value_ <= 0.50) {
+  if (this->initial_value_ <= 0.50f) {
     this->trim_value(-101);  // Set min value (beyond 0)
     this->trim_value(lroundf(this->initial_value_ * 100));
   } else {


### PR DESCRIPTION
# What does this implement/fix?

Mechanical numeric-precision cleanup (batch 2 of 4). These spots implicitly promote a `float` to `double`, so on single-precision-FPU targets (ESP32 Xtensa, nRF52 Cortex-M4F) the surrounding arithmetic runs as **software-emulated double** instead of the hardware FPU. The fix is purely mechanical: `double` literals → `f`-suffixed, and bare double `libm` calls → their `f` variants (`fmod`→`fmodf`, `round`→`roundf`, …).

Found by a tree-wide `-Wdouble-promotion` clang-tidy scan — the warning is enabled by the nRF52/Zephyr toolchain, but the inefficiency is silent on ESP32 too (IDF doesn't enable the flag). Measured on the `hsv_to_rgb` core helper: ~8 soft-double helper calls eliminated and the function went 108→69 bytes (−36%). **No behavior change on targets with a double FPU.**

Split into 4 batches by component because the scan touched too many components for one reviewable PR. Core changes are in #17252; intentional-`double` and `printf`/`%f` sites were deliberately left out.

**Components in this batch:** a01nyub,binary_sensor_map bl0942,dallas_temp ds2484,grove_tb6612fng honeywellabp,i2s_audio ltr390,mcp4725 mics_4514,opentherm runtime_stats,sound_level sx127x,thermopro_ble x9c

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of the same cleanup as #17252

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change — internal numeric-precision cleanup.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).