### PR TITLE
[multiple] Single-precision float math, avoid double promotion (batch 3/4)

### DIFF
--- a/esphome/components/anova/anova_base.cpp
+++ b/esphome/components/anova/anova_base.cpp
@@ -6,9 +6,9 @@
 
 namespace esphome::anova {
 
-float ftoc(float f) { return (f - 32.0) * (5.0f / 9.0f); }
+float ftoc(float f) { return (f - 32.0f) * (5.0f / 9.0f); }
 
-float ctof(float c) { return (c * 9.0f / 5.0f) + 32.0; }
+float ctof(float c) { return (c * 9.0f / 5.0f) + 32.0f; }
 
 AnovaPacket *AnovaCodec::clean_packet_() {
   this->packet_.length = strlen((char *) this->packet_.data);

--- a/esphome/components/bl0906/bl0906.cpp
+++ b/esphome/components/bl0906/bl0906.cpp
@@ -205,7 +205,7 @@ void BL0906::read_data_(const uint8_t address, const float reference, sensor::Se
   // Chip temperature
   if (reference == BL0906_TREF) {
     value = (float) to_int32_t(data_s24);
-    value = (value - 64) * 12.5 / 59 - 40;
+    value = (value - 64) * 12.5f / 59 - 40;
   }
   sensor->publish_state(value);
 }

--- a/esphome/components/combination/combination.cpp
+++ b/esphome/components/combination/combination.cpp
@@ -204,7 +204,7 @@ void MedianCombinationComponent::handle_new_value(float value) {
       median = sensor_states[sensor_states_size / 2];
     } else {
       // Even number of measurements, use the average of the two middle measurements
-      median = (sensor_states[sensor_states_size / 2] + sensor_states[sensor_states_size / 2 - 1]) / 2.0;
+      median = (sensor_states[sensor_states_size / 2] + sensor_states[sensor_states_size / 2 - 1]) / 2.0f;
     }
   }
 

--- a/esphome/components/demo/demo_sensor.h
+++ b/esphome/components/demo/demo_sensor.h
@@ -15,7 +15,7 @@ class DemoSensor final : public sensor::Sensor, public PollingComponent {
       float base = std::isnan(this->state) ? 0.0f : this->state;
       this->publish_state(base + val * 10);
     } else {
-      if (val < 0.1) {
+      if (val < 0.1f) {
         this->publish_state(NAN);
       } else {
         this->publish_state(val * 100);

--- a/esphome/components/demo/demo_text_sensor.h
+++ b/esphome/components/demo/demo_text_sensor.h
@@ -10,9 +10,9 @@ class DemoTextSensor final : public text_sensor::TextSensor, public PollingCompo
  public:
   void update() override {
     float val = random_float();
-    if (val < 0.33) {
+    if (val < 0.33f) {
       this->publish_state("foo");
-    } else if (val < 0.66) {
+    } else if (val < 0.66f) {
       this->publish_state("bar");
     } else {
       this->publish_state("foobar");

--- a/esphome/components/es7243e/es7243e.cpp
+++ b/esphome/components/es7243e/es7243e.cpp
@@ -105,7 +105,7 @@ bool ES7243E::configure_mic_gain_() {
 
 uint8_t ES7243E::es7243e_gain_reg_value_(float mic_gain) {
   // reg: 12 - 34.5dB, 13 - 36dB, 14 - 37.5dB
-  mic_gain += 0.5;
+  mic_gain += 0.5f;
   if (mic_gain <= 33.0f) {
     return (uint8_t) mic_gain / 3;
   }

--- a/esphome/components/es7243e/es7243e.cpp
+++ b/esphome/components/es7243e/es7243e.cpp
@@ -106,13 +106,13 @@ bool ES7243E::configure_mic_gain_() {
 uint8_t ES7243E::es7243e_gain_reg_value_(float mic_gain) {
   // reg: 12 - 34.5dB, 13 - 36dB, 14 - 37.5dB
   mic_gain += 0.5;
-  if (mic_gain <= 33.0) {
+  if (mic_gain <= 33.0f) {
     return (uint8_t) mic_gain / 3;
   }
-  if (mic_gain < 36.0) {
+  if (mic_gain < 36.0f) {
     return 12;
   }
-  if (mic_gain < 37.0) {
+  if (mic_gain < 37.0f) {
     return 13;
   }
   return 14;

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -607,7 +607,7 @@ haier_protocol::HaierMessage HonClimate::get_control_message() {
     if (climate_control.target_temperature.has_value()) {
       float target_temp = climate_control.target_temperature.value();
       out_data->set_point = ((int) target_temp) - 16;  // set the temperature with offset 16
-      out_data->half_degree = (target_temp - ((int) target_temp) >= 0.49) ? 1 : 0;
+      out_data->half_degree = (target_temp - ((int) target_temp) >= 0.49f) ? 1 : 0;
     }
     if (out_data->ac_power == 0) {
       // If AC is off - no presets allowed

--- a/esphome/components/ina219/ina219.cpp
+++ b/esphome/components/ina219/ina219.cpp
@@ -119,7 +119,7 @@ void INA219Component::setup() {
   }
 
   this->calibration_lsb_ = lsb;
-  auto calibration = uint32_t(0.04096f / (0.000001 * lsb * this->shunt_resistance_ohm_));
+  auto calibration = uint32_t(0.04096f / (0.000001f * lsb * this->shunt_resistance_ohm_));
   ESP_LOGV(TAG, "    Using LSB=%" PRIu32 " calibration=%" PRIu32, lsb, calibration);
   if (!this->write_byte_16(INA219_REGISTER_CALIBRATION, calibration)) {
     this->mark_failed();

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -315,14 +315,14 @@ class LightColorValues {
     if (this->color_temperature_ <= 0) {
       return this->color_temperature_;
     }
-    return 1000000.0 / this->color_temperature_;
+    return 1000000.0f / this->color_temperature_;
   }
   /// Set the color temperature property of these light color values in kelvin.
   void set_color_temperature_kelvin(float color_temperature) {
     if (color_temperature <= 0) {
       return;
     }
-    this->color_temperature_ = 1000000.0 / color_temperature;
+    this->color_temperature_ = 1000000.0f / color_temperature;
   }
 
   /// Get the cold white property of these light color values. In range 0.0 to 1.0.

--- a/esphome/components/ltr501/ltr501.cpp
+++ b/esphome/components/ltr501/ltr501.cpp
@@ -500,12 +500,12 @@ void LTRAlsPs501Component::apply_lux_calculation_(AlsReadings &data) {
   // method from
   // https://github.com/fards/Ainol_fire_kernel/blob/83832cf8a3082fd8e963230f4b1984479d1f1a84/customer/drivers/lightsensor/ltr501als.c#L295
 
-  if (ratio < 0.45) {
-    lux = 1.7743 * ch0 + 1.1059 * ch1;
-  } else if (ratio < 0.64) {
-    lux = 3.7725 * ch0 - 1.3363 * ch1;
-  } else if (ratio < 0.85) {
-    lux = 1.6903 * ch0 - 0.1693 * ch1;
+  if (ratio < 0.45f) {
+    lux = 1.7743f * ch0 + 1.1059f * ch1;
+  } else if (ratio < 0.64f) {
+    lux = 3.7725f * ch0 - 1.3363f * ch1;
+  } else if (ratio < 0.85f) {
+    lux = 1.6903f * ch0 - 0.1693f * ch1;
   } else {
     ESP_LOGW(TAG, "Impossible ch1/(ch0 + ch1) ratio");
     lux = 0.0f;

--- a/esphome/components/max17043/max17043.cpp
+++ b/esphome/components/max17043/max17043.cpp
@@ -23,7 +23,7 @@ void MAX17043Component::update() {
     if (!this->read_byte_16(MAX17043_VCELL, &raw_voltage)) {
       this->status_set_warning(LOG_STR("Unable to read MAX17043_VCELL"));
     } else {
-      float voltage = (1.25 * (float) (raw_voltage >> 4)) / 1000.0;
+      float voltage = (1.25f * (float) (raw_voltage >> 4)) / 1000.0f;
       this->voltage_sensor_->publish_state(voltage);
       this->status_clear_warning();
     }

--- a/esphome/components/msa3xx/msa3xx.cpp
+++ b/esphome/components/msa3xx/msa3xx.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "msa3xx";
 const uint8_t MSA_3XX_PART_ID = 0x13;
 
 const float GRAVITY_EARTH = 9.80665f;
-const float LSB_COEFF = 1000.0f / (GRAVITY_EARTH * 3.9);  // LSB to 1 LSB = 3.9mg = 0.0039g
+const float LSB_COEFF = 1000.0f / (GRAVITY_EARTH * 3.9f);  // LSB to 1 LSB = 3.9mg = 0.0039g
 const float G_OFFSET_MIN = -4.5f;  // -127...127 LSB = +- 0.4953g = +- 4.857 m/s^2 => +- 4.5 for the safe
 const float G_OFFSET_MAX = 4.5f;   // -127...127 LSB = +- 0.4953g = +- 4.857 m/s^2 => +- 4.5 for the safe
 

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -85,7 +85,7 @@ class OpenThreadSrpComponent final : public Component {
  public:
   void set_mdns(esphome::mdns::MDNSComponent *mdns);
   // This has to run after the mdns component or else no services are available to advertise
-  float get_setup_priority() const override { return this->mdns_->get_setup_priority() - 1.0; }
+  float get_setup_priority() const override { return this->mdns_->get_setup_priority() - 1.0f; }
   void setup() override;
   static void srp_callback(otError err, const otSrpClientHostInfo *host_info, const otSrpClientService *services,
                            const otSrpClientService *removed_services, void *context);

--- a/esphome/components/spa06_base/spa06_base.cpp
+++ b/esphome/components/spa06_base/spa06_base.cpp
@@ -224,7 +224,7 @@ bool SPA06Component::soft_reset_() {
 }
 
 // Temperature conversion formula. See datasheet pg. 14
-float SPA06Component::convert_temperature_(const float &t_raw_sc) { return this->c0_ * 0.5 + this->c1_ * t_raw_sc; }
+float SPA06Component::convert_temperature_(const float &t_raw_sc) { return this->c0_ * 0.5f + this->c1_ * t_raw_sc; }
 // Pressure conversion formula. See datasheet pg. 14
 float SPA06Component::convert_pressure_(const float &p_raw_sc, const float &t_raw_sc) {
   float p2_raw_sc = p_raw_sc * p_raw_sc;

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -256,7 +256,7 @@ void TCS34725Component::update() {
     // increase only if not already maximum
     // do not use max gain, as ist will not get better
     if (this->gain_reg_ < 3) {
-      if (((float) raw_c / 655.35 < 20.f) && (this->integration_time_ > 600.f)) {
+      if (((float) raw_c / 655.35f < 20.f) && (this->integration_time_ > 600.f)) {
         gain_reg_val_new = this->gain_reg_ + 1;
         // update integration time to new situation
         integration_time_ideal = integration_time_ideal / 4;
@@ -265,7 +265,7 @@ void TCS34725Component::update() {
 
     // decrease gain, if very high clear values and integration times alreadey low
     if (this->gain_reg_ > 0) {
-      if (70 < ((float) raw_c / 655.35) && (this->integration_time_ < 200)) {
+      if (70 < ((float) raw_c / 655.35f) && (this->integration_time_ < 200)) {
         gain_reg_val_new = this->gain_reg_ - 1;
         // update integration time to new situation
         integration_time_ideal = integration_time_ideal * 4;

--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -593,7 +593,7 @@ void ToshibaClimate::transmit_rac_pt1411hwru_() {
   message[3] = ~message[2];
   // Byte 4u: Temp
   if (this->model_ == MODEL_RAC_PT1411HWRU_F) {
-    temperature = (temperature * 1.8) + 32;
+    temperature = (temperature * 1.8f) + 32;
     temp_adjd = temperature - TOSHIBA_RAC_PT1411HWRU_TEMP_F_MIN;
   }
 

--- a/esphome/components/ufire_ise/ufire_ise.cpp
+++ b/esphome/components/ufire_ise/ufire_ise.cpp
@@ -70,19 +70,19 @@ float UFireISEComponent::measure_ph_(float temperature) {
   if (mv == -1)
     return -1;
 
-  ph = fabs(7.0 - (mv / PROBE_MV_TO_PH));
+  ph = fabsf(7.0f - (mv / PROBE_MV_TO_PH));
 
   // Determine the temperature correction
   float distance_from_7 = std::abs(7 - roundf(ph));
   float distance_from_25 = std::floor(std::abs(25 - roundf(temperature)) / 10);
   float temp_multiplier = (distance_from_25 * distance_from_7) * PROBE_TMP_CORRECTION;
-  if ((ph >= 8.0) && (temperature >= 35))
+  if ((ph >= 8.0f) && (temperature >= 35))
     temp_multiplier *= -1;
-  if ((ph <= 6.0) && (temperature <= 15))
+  if ((ph <= 6.0f) && (temperature <= 15))
     temp_multiplier *= -1;
 
   ph += temp_multiplier;
-  if ((ph <= 0.0) || (ph > 14.0))
+  if ((ph <= 0.0f) || (ph > 14.0f))
     ph = -1;
   if (std::isinf(ph))
     ph = -1;

--- a/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
+++ b/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
@@ -49,7 +49,7 @@ bool XiaomiLYWSD03MMC::parse_device(const esp32_ble_tracker::ESPBTDevice &device
     }
     if (res->humidity.has_value() && this->humidity_ != nullptr) {
       // see https://github.com/custom-components/sensor.mitemp_bt/issues/7#issuecomment-595948254
-      *res->humidity = trunc(*res->humidity);
+      *res->humidity = truncf(*res->humidity);
     }
     if (!(xiaomi_ble::report_xiaomi_results(res, addr_str))) {
       continue;


### PR DESCRIPTION
# What does this implement/fix?

Mechanical numeric-precision cleanup (batch 3 of 4). These spots implicitly promote a `float` to `double`, so on single-precision-FPU targets (ESP32 Xtensa, nRF52 Cortex-M4F) the surrounding arithmetic runs as **software-emulated double** instead of the hardware FPU. The fix is purely mechanical: `double` literals → `f`-suffixed, and bare double `libm` calls → their `f` variants (`fmod`→`fmodf`, `round`→`roundf`, …).

Found by a tree-wide `-Wdouble-promotion` clang-tidy scan — the warning is enabled by the nRF52/Zephyr toolchain, but the inefficiency is silent on ESP32 too (IDF doesn't enable the flag). Measured on the `hsv_to_rgb` core helper: ~8 soft-double helper calls eliminated and the function went 108→69 bytes (−36%). **No behavior change on targets with a double FPU.**

Split into 4 batches by component because the scan touched too many components for one reviewable PR. Core changes are in #17252; intentional-`double` and `printf`/`%f` sites were deliberately left out.

**Components in this batch:** anova,bl0906 combination,demo es7243e,haier ina219,light ltr501,max17043 msa3xx,openthread spa06_base,tcs34725 toshiba,ufire_ise xiaomi_lywsd03mmc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of the same cleanup as #17252

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change — internal numeric-precision cleanup.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).