### PR TITLE
[multiple] Single-precision float math, avoid double promotion (batch 4/4)

### DIFF
--- a/esphome/components/am43/cover/am43_cover.cpp
+++ b/esphome/components/am43/cover/am43_cover.cpp
@@ -118,9 +118,9 @@ void Am43Component::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         if (!this->invert_position_)
           this->position = 1 - this->position;
         if (this->position > 0.97f)
-          this->position = 1.0;
+          this->position = 1.0f;
         if (this->position < 0.02f)
-          this->position = 0.0;
+          this->position = 0.0f;
         this->publish_state();
       }
 

--- a/esphome/components/am43/cover/am43_cover.cpp
+++ b/esphome/components/am43/cover/am43_cover.cpp
@@ -114,12 +114,12 @@ void Am43Component::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       this->decoder_->decode(param->notify.value, param->notify.value_len);
 
       if (this->decoder_->has_position()) {
-        this->position = ((float) this->decoder_->position_ / 100.0);
+        this->position = ((float) this->decoder_->position_ / 100.0f);
         if (!this->invert_position_)
           this->position = 1 - this->position;
-        if (this->position > 0.97)
+        if (this->position > 0.97f)
           this->position = 1.0;
-        if (this->position < 0.02)
+        if (this->position < 0.02f)
           this->position = 0.0;
         this->publish_state();
       }

--- a/esphome/components/bl0940/bl0940.cpp
+++ b/esphome/components/bl0940/bl0940.cpp
@@ -120,7 +120,7 @@ float BL0940::calculate_power_reference_() {
 float BL0940::calculate_energy_reference_() {
   // formula: 3600000 * 4046 * RL * R1 * 1000 / (1638.4 * 256) / Vref² / (R1 + R2)
   // or:  power_reference_ * 3600000 / (1638.4 * 256)
-  return this->power_reference_cal_ * 3600000 / (1638.4 * 256);
+  return this->power_reference_cal_ * 3600000 / (1638.4f * 256);
 }
 
 float BL0940::calculate_calibration_value_(float state) { return (100 + state) / 100; }

--- a/esphome/components/current_based/current_based_cover.cpp
+++ b/esphome/components/current_based/current_based_cover.cpp
@@ -39,7 +39,7 @@ void CurrentBasedCover::control(const CoverCall &call) {
   auto opt_pos = call.get_position();
   if (opt_pos.has_value()) {
     auto pos = *opt_pos;
-    if (fabsf(this->position - pos) < 0.01) {
+    if (fabsf(this->position - pos) < 0.01f) {
       // already at target
     } else {
       auto op = pos < this->position ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;

--- a/esphome/components/demo/demo_switch.h
+++ b/esphome/components/demo/demo_switch.h
@@ -9,7 +9,7 @@ namespace esphome::demo {
 class DemoSwitch final : public switch_::Switch, public Component {
  public:
   void setup() override {
-    bool initial = random_float() < 0.5;
+    bool initial = random_float() < 0.5f;
     this->publish_state(initial);
   }
 

--- a/esphome/components/es7210/es7210.cpp
+++ b/esphome/components/es7210/es7210.cpp
@@ -169,7 +169,7 @@ bool ES7210::configure_mic_gain_() {
 
 uint8_t ES7210::es7210_gain_reg_value_(float mic_gain) {
   // reg: 12 - 34.5dB, 13 - 36dB, 14 - 37.5dB
-  mic_gain += 0.5;
+  mic_gain += 0.5f;
   if (mic_gain <= 33.0f) {
     return (uint8_t) (mic_gain / 3);
   }

--- a/esphome/components/es7210/es7210.cpp
+++ b/esphome/components/es7210/es7210.cpp
@@ -170,13 +170,13 @@ bool ES7210::configure_mic_gain_() {
 uint8_t ES7210::es7210_gain_reg_value_(float mic_gain) {
   // reg: 12 - 34.5dB, 13 - 36dB, 14 - 37.5dB
   mic_gain += 0.5;
-  if (mic_gain <= 33.0) {
+  if (mic_gain <= 33.0f) {
     return (uint8_t) (mic_gain / 3);
   }
-  if (mic_gain < 36.0) {
+  if (mic_gain < 36.0f) {
     return 12;
   }
-  if (mic_gain < 37.0) {
+  if (mic_gain < 37.0f) {
     return 13;
   }
   return 14;

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -139,7 +139,7 @@ void Graph::draw(Display *buff, uint16_t x_offset, uint16_t y_offset, Color colo
   /// Draw grid
   if (!std::isnan(this->gridspacing_y_)) {
     for (int y = yn; y <= ym; y++) {
-      int16_t py = (int16_t) roundf((this->height_ - 1) * (1.0 - (float) (y - yn) / (ym - yn)));
+      int16_t py = (int16_t) roundf((this->height_ - 1) * (1.0f - (float) (y - yn) / (ym - yn)));
       for (uint32_t x = 0; x < this->width_; x += 2) {
         buff->draw_pixel_at(x_offset + x, y_offset + py, color);
       }
@@ -177,7 +177,7 @@ void Graph::draw(Display *buff, uint16_t x_offset, uint16_t y_offset, Color colo
         uint8_t bit = 1 << ((i % (thick * LineType::PATTERN_LENGTH)) / thick);
         bool b = (trace->get_line_type() & bit) == bit;
         if (b) {
-          int16_t y = (int16_t) roundf((this->height_ - 1) * (1.0 - v)) - thick / 2 + y_offset;
+          int16_t y = (int16_t) roundf((this->height_ - 1) * (1.0f - v)) - thick / 2 + y_offset;
           auto draw_pixel_at = [&buff, c, y_offset, this](int16_t x, int16_t y) {
             if (y >= y_offset && static_cast<uint32_t>(y) < y_offset + this->height_)
               buff->draw_pixel_at(x, y, c);

--- a/esphome/components/haier/smartair2_climate.cpp
+++ b/esphome/components/haier/smartair2_climate.cpp
@@ -341,7 +341,7 @@ haier_protocol::HaierMessage Smartair2Climate::get_control_message() {
     if (climate_control.target_temperature.has_value()) {
       float target_temp = climate_control.target_temperature.value();
       out_data->set_point = ((int) target_temp) - 16;  // set the temperature with offset 16
-      out_data->half_degree = (target_temp - ((int) target_temp) >= 0.49) ? 1 : 0;
+      out_data->half_degree = (target_temp - ((int) target_temp) >= 0.49f) ? 1 : 0;
     }
     if (out_data->ac_power == 0) {
       // If AC is off - no presets allowed

--- a/esphome/components/ina226/ina226.cpp
+++ b/esphome/components/ina226/ina226.cpp
@@ -70,7 +70,7 @@ void INA226Component::setup() {
 
   this->calibration_lsb_ = lsb;
 
-  auto calibration = uint32_t(0.00512 / (lsb * this->shunt_resistance_ohm_ / 1000000.0f));
+  auto calibration = uint32_t(0.00512f / (lsb * this->shunt_resistance_ohm_ / 1000000.0f));
 
   ESP_LOGV(TAG, "    Using LSB=%" PRIu32 " calibration=%" PRIu32, lsb, calibration);
 

--- a/esphome/components/ltr_als_ps/ltr_als_ps.cpp
+++ b/esphome/components/ltr_als_ps/ltr_als_ps.cpp
@@ -480,12 +480,12 @@ void LTRAlsPsComponent::apply_lux_calculation_(AlsReadings &data) {
   float inv_pfactor = this->glass_attenuation_factor_;
   float lux = 0.0f;
 
-  if (ratio < 0.45) {
-    lux = (1.7743 * ch0 + 1.1059 * ch1);
-  } else if (ratio < 0.64 && ratio >= 0.45) {
-    lux = (4.2785 * ch0 - 1.9548 * ch1);
-  } else if (ratio < 0.85 && ratio >= 0.64) {
-    lux = (0.5926 * ch0 + 0.1185 * ch1);
+  if (ratio < 0.45f) {
+    lux = (1.7743f * ch0 + 1.1059f * ch1);
+  } else if (ratio < 0.64f && ratio >= 0.45f) {
+    lux = (4.2785f * ch0 - 1.9548f * ch1);
+  } else if (ratio < 0.85f && ratio >= 0.64f) {
+    lux = (0.5926f * ch0 + 0.1185f * ch1);
   } else {
     ESP_LOGW(TAG, "Impossible ch1/(ch0 + ch1) ratio");
     lux = 0.0f;

--- a/esphome/components/mcp3204/mcp3204.cpp
+++ b/esphome/components/mcp3204/mcp3204.cpp
@@ -31,7 +31,7 @@ float MCP3204::read_data(uint8_t pin, bool differential) {
   this->disable();
 
   uint16_t digital_value = encode_uint16(b0, b1) >> 4;
-  return float(digital_value) / 4096.000 * this->reference_voltage_;  // in V
+  return float(digital_value) / 4096.000f * this->reference_voltage_;  // in V
 }
 
 }  // namespace esphome::mcp3204

--- a/esphome/components/mpl3115a2/mpl3115a2.cpp
+++ b/esphome/components/mpl3115a2/mpl3115a2.cpp
@@ -75,16 +75,16 @@ void MPL3115A2Component::update() {
   float altitude = 0, pressure = 0;
   if (this->altitude_ != nullptr) {
     int32_t alt = encode_uint32(buffer[0], buffer[1], buffer[2], 0);
-    altitude = float(alt) / 65536.0;
+    altitude = float(alt) / 65536.0f;
     this->altitude_->publish_state(altitude);
   } else {
     uint32_t p = encode_uint32(0, buffer[0], buffer[1], buffer[2]);
-    pressure = float(p) / 6400.0;
+    pressure = float(p) / 6400.0f;
     if (this->pressure_ != nullptr)
       this->pressure_->publish_state(pressure);
   }
   int16_t t = encode_uint16(buffer[3], buffer[4]);
-  float temperature = float(t) / 256.0;
+  float temperature = float(t) / 256.0f;
   if (this->temperature_ != nullptr)
     this->temperature_->publish_state(temperature);
 

--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -115,9 +115,9 @@ void MQTTClimateComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryCo
   // max_temp
   root[MQTT_MAX_TEMP] = traits.get_visual_max_temperature();
   // target_temp_step
-  root[MQTT_TARGET_TEMPERATURE_STEP] = roundf(traits.get_visual_target_temperature_step() * 10) * 0.1;
+  root[MQTT_TARGET_TEMPERATURE_STEP] = roundf(traits.get_visual_target_temperature_step() * 10) * 0.1f;
   // current_temp_step
-  root[MQTT_CURRENT_TEMPERATURE_STEP] = roundf(traits.get_visual_current_temperature_step() * 10) * 0.1;
+  root[MQTT_CURRENT_TEMPERATURE_STEP] = roundf(traits.get_visual_current_temperature_step() * 10) * 0.1f;
   // temperature units are always coerced to Celsius internally
   root[MQTT_TEMPERATURE_UNIT] = "C";
 

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -176,7 +176,7 @@ void Nextion::goto_page(const char *page) { this->add_no_result_to_queue_with_pr
 void Nextion::goto_page(uint8_t page) { this->add_no_result_to_queue_with_printf_("page", "page %i", page); }
 
 void Nextion::set_backlight_brightness(float brightness) {
-  if (brightness < 0 || brightness > 1.0) {
+  if (brightness < 0 || brightness > 1.0f) {
     ESP_LOGD(TAG, "Brightness out of bounds (0-1.0)");
     return;
   }

--- a/esphome/components/pid/pid_autotuner.cpp
+++ b/esphome/components/pid/pid_autotuner.cpp
@@ -300,7 +300,7 @@ bool PIDAutotuner::OscillationFrequencyDetector::is_increase_decrease_symmetrica
     min_interval = std::min(min_interval, interval);
   }
   float ratio = min_interval / float(max_interval);
-  return ratio >= 0.66;
+  return ratio >= 0.66f;
 }
 
 // ================== OscillationAmplitudeDetector ==================

--- a/esphome/components/servo/servo.cpp
+++ b/esphome/components/servo/servo.cpp
@@ -86,7 +86,7 @@ void Servo::write(float value) {
 void Servo::internal_write(float value) {
   value = clamp(value, -1.0f, 1.0f);
   float level;
-  if (value < 0.0) {
+  if (value < 0.0f) {
     level = std::lerp(this->idle_level_, this->min_level_, -value);
   } else {
     level = std::lerp(this->idle_level_, this->max_level_, value);

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -612,7 +612,7 @@ void SpeakerMediaPlayer::set_volume_(float volume, bool publish) {
   }
 
   // Turn on the mute state if the volume is effectively zero, off otherwise
-  if (volume < 0.001) {
+  if (volume < 0.001f) {
     this->set_mute_state_(true);
   } else {
     this->set_mute_state_(false);

--- a/esphome/components/veml3235/veml3235.cpp
+++ b/esphome/components/veml3235/veml3235.cpp
@@ -215,7 +215,7 @@ void VEML3235Sensor::dump_config() {
                   "  Auto-gain upper threshold: %f%%\n"
                   "  Auto-gain lower threshold: %f%%\n"
                   "  Values below will be used as initial values only",
-                  this->auto_gain_threshold_high_ * 100.0, this->auto_gain_threshold_low_ * 100.0);
+                  this->auto_gain_threshold_high_ * 100.0f, this->auto_gain_threshold_low_ * 100.0f);
   }
   ESP_LOGCONFIG(TAG,
                 "  Digital gain: %uX\n"

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
@@ -49,7 +49,7 @@ bool XiaomiMHOC401::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
     }
     if (res->humidity.has_value() && this->humidity_ != nullptr) {
       // see https://github.com/custom-components/sensor.mitemp_bt/issues/7#issuecomment-595948254
-      *res->humidity = trunc(*res->humidity);
+      *res->humidity = truncf(*res->humidity);
     }
     if (!(xiaomi_ble::report_xiaomi_results(res, addr_str))) {
       continue;


### PR DESCRIPTION
# What does this implement/fix?

Mechanical numeric-precision cleanup (batch 4 of 4). These spots implicitly promote a `float` to `double`, so on single-precision-FPU targets (ESP32 Xtensa, nRF52 Cortex-M4F) the surrounding arithmetic runs as **software-emulated double** instead of the hardware FPU. The fix is purely mechanical: `double` literals → `f`-suffixed, and bare double `libm` calls → their `f` variants (`fmod`→`fmodf`, `round`→`roundf`, …).

Found by a tree-wide `-Wdouble-promotion` clang-tidy scan — the warning is enabled by the nRF52/Zephyr toolchain, but the inefficiency is silent on ESP32 too (IDF doesn't enable the flag). Measured on the `hsv_to_rgb` core helper: ~8 soft-double helper calls eliminated and the function went 108→69 bytes (−36%). **No behavior change on targets with a double FPU.**

Split into 4 batches by component because the scan touched too many components for one reviewable PR. Core changes are in #17252; intentional-`double` and `printf`/`%f` sites were deliberately left out.

**Components in this batch:** am43,bl0940 current_based,demo es7210,graph haier,ina226 ltr_als_ps,mcp3204 mpl3115a2,mqtt nextion,pid servo,speaker veml3235,xiaomi_mhoc401

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of the same cleanup as #17252

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change — internal numeric-precision cleanup.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).