### PR TITLE
[multiple] Single-precision float math, avoid double promotion (stragglers)

### DIFF
--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -216,7 +216,7 @@ void AcDimmer::setup() {
 }
 
 void AcDimmer::write_state(float state) {
-  state = std::acos(1 - (2 * state)) / std::numbers::pi;  // RMS power compensation
+  state = std::acos(1 - (2 * state)) / std::numbers::pi_v<float>;  // RMS power compensation
   auto new_value = static_cast<uint16_t>(roundf(state * 65535));
   if (new_value != 0 && this->store_.value == 0)
     this->store_.init_cycle = this->init_with_half_cycle_;

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -42,10 +42,10 @@ void Display::line_at_angle(int x, int y, int angle, int length, Color color) {
 
 void Display::line_at_angle(int x, int y, int angle, int start_radius, int stop_radius, Color color) {
   // Calculate start and end points
-  int x1 = (start_radius * cos(angle * M_PI / 180)) + x;
-  int y1 = (start_radius * sin(angle * M_PI / 180)) + y;
-  int x2 = (stop_radius * cos(angle * M_PI / 180)) + x;
-  int y2 = (stop_radius * sin(angle * M_PI / 180)) + y;
+  int x1 = (start_radius * std::cos(angle * std::numbers::pi_v<float> / 180)) + x;
+  int y1 = (start_radius * std::sin(angle * std::numbers::pi_v<float> / 180)) + y;
+  int x2 = (stop_radius * std::cos(angle * std::numbers::pi_v<float> / 180)) + x;
+  int y2 = (stop_radius * std::sin(angle * std::numbers::pi_v<float> / 180)) + y;
 
   // Draw line
   this->line(x1, y1, x2, y2, color);

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -444,15 +444,15 @@ void HOT Display::get_regular_polygon_vertex(int vertex_id, int *vertex_x, int *
     // hence we rotate the shape by 270° to orient the polygon up.
     rotation_degrees += ROTATION_270_DEGREES;
     // Convert the rotation to radians, easier to use in trigonometrical calculations
-    float rotation_radians = rotation_degrees * std::numbers::pi / 180;
+    float rotation_radians = rotation_degrees * std::numbers::pi_v<float> / 180;
     // A pointy top variation means the first vertex of the polygon is at the top center of the shape, this requires no
     // additional rotation of the shape.
     // A flat top variation means the first point of the polygon has to be rotated so that the first edge is horizontal,
     // this requires to rotate the shape by π/edges radians counter-clockwise so that the first point is located on the
     // left side of the first horizontal edge.
-    rotation_radians -= (variation == VARIATION_FLAT_TOP) ? std::numbers::pi / edges : 0.0;
+    rotation_radians -= (variation == VARIATION_FLAT_TOP) ? std::numbers::pi_v<float> / edges : 0.0f;
 
-    float vertex_angle = ((float) vertex_id) / edges * 2 * std::numbers::pi + rotation_radians;
+    float vertex_angle = ((float) vertex_id) / edges * 2 * std::numbers::pi_v<float> + rotation_radians;
     *vertex_x = (int) std::round(std::cos(vertex_angle) * radius) + center_x;
     *vertex_y = (int) std::round(std::sin(vertex_angle) * radius) + center_y;
   }

--- a/esphome/components/hmc5883l/hmc5883l.cpp
+++ b/esphome/components/hmc5883l/hmc5883l.cpp
@@ -2,6 +2,8 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
+#include <numbers>
+
 namespace esphome::hmc5883l {
 
 static const char *const TAG = "hmc5883l";
@@ -126,7 +128,7 @@ void HMC5883LComponent::update() {
   const float y = int16_t(raw_y) * mg_per_bit * 0.1f;
   const float z = int16_t(raw_z) * mg_per_bit * 0.1f;
 
-  float heading = atan2f(0.0f - x, y) * 180.0f / M_PI;
+  float heading = atan2f(0.0f - x, y) * 180.0f / std::numbers::pi_v<float>;
   ESP_LOGD(TAG, "Got x=%0.02fµT y=%0.02fµT z=%0.02fµT heading=%0.01f°", x, y, z, heading);
 
   if (this->x_sensor_ != nullptr)

--- a/esphome/components/mmc5603/mmc5603.cpp
+++ b/esphome/components/mmc5603/mmc5603.cpp
@@ -1,6 +1,8 @@
 #include "mmc5603.h"
 #include "esphome/core/log.h"
 
+#include <numbers>
+
 namespace esphome::mmc5603 {
 
 static const char *const TAG = "mmc5603";
@@ -143,7 +145,7 @@ void MMC5603Component::update() {
 
   const float z = 0.00625 * (raw_z - 524288);
 
-  const float heading = atan2f(0.0f - x, y) * 180.0f / M_PI;
+  const float heading = atan2f(0.0f - x, y) * 180.0f / std::numbers::pi_v<float>;
   ESP_LOGD(TAG, "Got x=%0.02fµT y=%0.02fµT z=%0.02fµT heading=%0.01f°", x, y, z, heading);
 
   if (this->x_sensor_ != nullptr)

--- a/esphome/components/pid/pid_autotuner.cpp
+++ b/esphome/components/pid/pid_autotuner.cpp
@@ -1,10 +1,7 @@
 #include "pid_autotuner.h"
 #include "esphome/core/log.h"
 #include <cinttypes>
-
-#ifndef M_PI
-#define M_PI 3.1415926535897932384626433
-#endif
+#include <numbers>
 
 namespace esphome::pid {
 
@@ -126,7 +123,7 @@ PIDAutotuner::PIDAutotuneResult PIDAutotuner::update(float setpoint, float proce
   float osc_ampl = this->amplitude_detector_.get_mean_oscillation_amplitude();
   float d = (this->relay_function_.output_positive - this->relay_function_.output_negative) / 2.0f;
   ESP_LOGVV(TAG, "  Relay magnitude: %f", d);
-  this->ku_ = 4.0f * d / float(M_PI * osc_ampl);
+  this->ku_ = 4.0f * d / (std::numbers::pi_v<float> * osc_ampl);
   this->pu_ = this->frequency_detector_.get_mean_oscillation_period();
 
   this->state_ = AUTOTUNE_SUCCEEDED;

--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -3,6 +3,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 #include <cmath>
+#include <numbers>
 
 namespace esphome::qmc5883l {
 
@@ -173,7 +174,7 @@ void QMC5883LComponent::read_sensor_() {
   const float y = int16_t(raw[1]) * mg_per_bit * 0.1f;
   const float z = int16_t(raw[2]) * mg_per_bit * 0.1f;
 
-  float heading = atan2f(0.0f - x, y) * 180.0f / M_PI;
+  float heading = atan2f(0.0f - x, y) * 180.0f / std::numbers::pi_v<float>;
 
   float temp = NAN;
   if (this->temperature_sensor_ != nullptr) {

--- a/esphome/components/rd03d/rd03d.cpp
+++ b/esphome/components/rd03d/rd03d.cpp
@@ -4,6 +4,7 @@
 
 #include <cinttypes>
 #include <cmath>
+#include <numbers>
 
 namespace esphome::rd03d {
 
@@ -233,7 +234,7 @@ void RD03DComponent::publish_target_(uint8_t target_num, int16_t x, int16_t y, i
   // Angle is measured from the Y axis (radar forward direction)
   if (target.angle != nullptr) {
     if (valid) {
-      float angle = std::atan2(static_cast<float>(x), static_cast<float>(y)) * 180.0f / M_PI;
+      float angle = std::atan2(static_cast<float>(x), static_cast<float>(y)) * 180.0f / std::numbers::pi_v<float>;
       target.angle->publish_state(angle);
     } else {
       target.angle->publish_state(NAN);

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -215,7 +215,7 @@ void SX126x::configure() {
   // configure modem
   if (this->modulation_ == PACKET_TYPE_LORA) {
     // set modulation params
-    float duration = 1000.0f * std::pow(2, this->spreading_factor_) / BW_HZ[this->bandwidth_];
+    float duration = 1000.0f * (1UL << this->spreading_factor_) / BW_HZ[this->bandwidth_];
     buf[0] = this->spreading_factor_;
     buf[1] = BW_LORA[this->bandwidth_ - SX126X_BW_7810];
     buf[2] = this->coding_rate_;


### PR DESCRIPTION
## What does this implement/fix?

Follow-up to the double-promotion batch PRs (#17252–#17256). After those merged, I re-ran the `-Wdouble-promotion` clang-tidy scan across **all** CI platforms (ESP8266, Zephyr, Arduino, C6, P4, S3 + IDF), not just ESP32-IDF, to confirm nothing was missed.

Result: the platform-specific sites that only show up on non-IDF builds are all the inherent printf/log varargs class (`ESP_LOGx("%f", …)`, `stream->print(<float>)`) that we intentionally leave alone. But three genuine computation sites remained — they'd been deferred as judgment calls in the original batches:

- **sx126x**: `std::pow(2, spreading_factor_)` → `(1UL << spreading_factor_)`. Same fix already applied to its sibling `sx127x`; resolves to the double `pow()` overload otherwise. `spreading_factor_` is `uint8_t`, so `2^sf` is exactly `1UL << sf` — smaller, faster, no libm/double.
- **ac_dimmer**: `std::numbers::pi` → `std::numbers::pi_v<float>`.
- **rd03d**: `M_PI` → `std::numbers::pi_v<float>`.

Two other flagged sites (`bmp085`, `sensor/filter`) use an explicit `double` local by design (precision) and are correctly left as-is.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

## Test Environment

- [x] ESP32

## Checklist

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (n/a — no behavior change).