### PR TITLE
[mcp4725] Use constexpr bit shift instead of powf for full-scale value

### DIFF
--- a/esphome/components/mcp4725/mcp4725.cpp
+++ b/esphome/components/mcp4725/mcp4725.cpp
@@ -24,7 +24,8 @@ void MCP4725::dump_config() {
 
 // https://learn.sparkfun.com/tutorials/mcp4725-digital-to-analog-converter-hookup-guide?_ga=2.176055202.1402343014.1607953301-893095255.1606753886
 void MCP4725::write_state(float state) {
-  const uint16_t value = (uint16_t) roundf(state * (powf(2, MCP4725_RES) - 1));
+  constexpr uint16_t max_value = (1U << MCP4725_RES) - 1;
+  const uint16_t value = (uint16_t) roundf(state * max_value);
 
   this->write_byte_16(64, value << 4);
 }

--- a/esphome/components/mcp4725/mcp4725.h
+++ b/esphome/components/mcp4725/mcp4725.h
@@ -4,10 +4,11 @@
 #include "esphome/core/component.h"
 #include "esphome/components/i2c/i2c.h"
 
-static const uint8_t MCP4725_ADDR = 0x60;
-static const uint8_t MCP4725_RES = 12;
-
 namespace esphome::mcp4725 {
+
+static constexpr uint8_t MCP4725_ADDR = 0x60;
+static constexpr uint8_t MCP4725_RES = 12;
+
 class MCP4725 final : public Component, public output::FloatOutput, public i2c::I2CDevice {
  public:
   void setup() override;


### PR DESCRIPTION
# What does this implement/fix?

`write_state` computed the DAC full-scale value with `powf(2, MCP4725_RES) - 1`. `MCP4725_RES` is a compile-time constant (12), so this pulled in floating-point `powf` to produce a fixed value of 4095. Replaced it with a `constexpr` left shift so the value is computed at compile time with no floating-point math; output behavior is unchanged.

While here, made `MCP4725_ADDR` and `MCP4725_RES` `constexpr` and moved them inside the `esphome::mcp4725` namespace instead of sitting at global scope.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
mcp4725:
  id: mcp4725_dac

output:
  - platform: mcp4725
    id: dac_output
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
