### PR TITLE
[espnow] Drop oversized received frames to prevent buffer overflow

### DIFF
--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -336,13 +336,13 @@ void ESPNowComponent::loop() {
   // Log dropped received packets periodically
   uint16_t received_dropped = this->receive_packet_queue_.get_and_reset_dropped_count();
   if (received_dropped > 0) {
-    ESP_LOGW(TAG, "Dropped %u received packets due to buffer overflow", received_dropped);
+    ESP_LOGW(TAG, "Dropped %u received packets (queue full or oversized frame)", received_dropped);
   }
 
   // Log dropped send packets periodically
   uint16_t send_dropped = this->send_packet_queue_.get_and_reset_dropped_count();
   if (send_dropped > 0) {
-    ESP_LOGW(TAG, "Dropped %u send packets due to buffer overflow", send_dropped);
+    ESP_LOGW(TAG, "Dropped %u send packets (queue full)", send_dropped);
   }
 }
 

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -94,6 +94,15 @@ void on_send_report(const uint8_t *mac_addr, esp_now_send_status_t status)
 }
 
 void on_data_received(const esp_now_recv_info_t *info, const uint8_t *data, int size) {
+  // Drop oversized frames before copying. ESP-NOW v2 peers (IDF >= 5.4 builds a
+  // v2 stack with no opt-out) can send up to ESP_NOW_MAX_DATA_LEN_V2 (1470 B),
+  // but our receive buffer is ESP_NOW_MAX_DATA_LEN (250 B); copying a larger
+  // frame would overflow packet_.receive.data.
+  if (size < 0 || size > ESP_NOW_MAX_DATA_LEN) {
+    global_esp_now->receive_packet_queue_.increment_dropped_count();
+    return;
+  }
+
   // Allocate an event from the pool
   ESPNowPacket *packet = global_esp_now->receive_packet_pool_.allocate();
   if (packet == nullptr) {


### PR DESCRIPTION
## What does this implement/fix?

`on_data_received()` copied the ESP-NOW driver's `data_len` straight into the fixed 250-byte `packet_.receive.data` buffer with **no bounds check**:

```cpp
memcpy(this->packet_.receive.data, data, size);  // data is uint8_t[ESP_NOW_MAX_DATA_LEN] = 250
```

ESP-NOW v2 (added in ESP-IDF 5.4 — esphome builds against 5.5.4) builds a v2 stack with **no opt-out**: there is no `esp_now_set_version()` and no Kconfig gate, so `esp_now_get_version()` reports v2 and the device receives frames up to `ESP_NOW_MAX_DATA_LEN_V2` (1470 B) and hands the full length to the recv callback. A peer in radio range broadcasting a frame larger than 250 B therefore overflows the receive buffer — which is a pooled object, so the copy corrupts adjacent pool state. ESP-NOW frames reach the callback from any device in range (no association, encryption optional), so this is a default-reachable remote overflow.

This drops frames larger than the receive buffer before copying — exactly what the IDF documents a v1-capable receiver doing. Carrying v2-sized frames (larger buffers, send/transport support) is intentionally left as a separate opt-in change.

Fixes #17267

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Test Environment

- [x] ESP32 IDF

## Checklist

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (n/a — requires the WiFi RX driver callback with an over-length frame; not reproducible in the test harness).