### PR TITLE
[bluetooth_proxy] Fix -Wtype-limits warning with active: false

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -68,7 +68,8 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
   void loop() override;
   esp32_ble_tracker::AdvertisementParserType get_advertisement_parser_type() override;
 
-  void register_connection(BluetoothConnection *connection) {
+  // maybe_unused: in a passive proxy (active: false) MAX is 0, the body below is removed, and connection is unused.
+  void register_connection([[maybe_unused]] BluetoothConnection *connection) {
     // Guard the always-false comparison (-Wtype-limits) in a passive proxy (active: false), where MAX is 0.
 #if BLUETOOTH_PROXY_MAX_CONNECTIONS > 0
     if (this->connection_count_ < BLUETOOTH_PROXY_MAX_CONNECTIONS) {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -69,10 +69,13 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
   esp32_ble_tracker::AdvertisementParserType get_advertisement_parser_type() override;
 
   void register_connection(BluetoothConnection *connection) {
+    // Guard the always-false comparison (-Wtype-limits) in a passive proxy (active: false), where MAX is 0.
+#if BLUETOOTH_PROXY_MAX_CONNECTIONS > 0
     if (this->connection_count_ < BLUETOOTH_PROXY_MAX_CONNECTIONS) {
       this->connections_[this->connection_count_++] = connection;
       connection->proxy_ = this;
     }
+#endif
   }
 
   void bluetooth_device_request(const api::BluetoothDeviceRequest &msg);


### PR DESCRIPTION
## What does this implement/fix?

With `bluetooth_proxy: { active: false }` (a passive proxy — advertisements only, no GATT connections), no connections are configured, so `BLUETOOTH_PROXY_MAX_CONNECTIONS` is defined as `0`. The comparison in `register_connection()` then becomes `uint8_t connection_count_ < 0`, which is always false and emits:

```
bluetooth_proxy.h:72:33: warning: comparison is always false due to limited range of data type [-Wtype-limits]
   72 |     if (this->connection_count_ < BLUETOOTH_PROXY_MAX_CONNECTIONS) {
```

`register_connection()` is only emitted by codegen per configured connection, so in a passive build it's never called — the body is dead code. Guard it with `#if BLUETOOTH_PROXY_MAX_CONNECTIONS > 0` so the always-false comparison isn't compiled when there are no connection slots. No behavior change for `active: true`.

(`if constexpr` doesn't help here — `register_connection()` isn't a template, so the discarded branch is still compiled and would still warn.)

Verified by compiling an `active: false` config on esp32-idf: the warning is gone and the build succeeds.

Fixes #17269

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Test Environment

- [x] ESP32 IDF

## Checklist

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (n/a — compile-warning fix; existing bluetooth_proxy tests cover the build).