### PR TITLE
[epaper_spi] Queue display updates when sent in rapid succession

### DIFF
--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -47,6 +47,7 @@ DEPENDENCIES = ["spi"]
 
 CONF_INIT_SEQUENCE_ID = "init_sequence_id"
 CONF_MINIMUM_UPDATE_INTERVAL = "minimum_update_interval"
+CONF_COLLECT_UPDATES_FOR = "collect_updates_for"
 
 epaper_spi_ns = cg.esphome_ns.namespace("epaper_spi")
 EPaperBase = epaper_spi_ns.class_(
@@ -112,6 +113,9 @@ def model_schema(config):
                 cv.positive_time_period_milliseconds,
                 cv.Range(max=core.TimePeriod(milliseconds=500)),
             ),
+            cv.Optional(
+                CONF_COLLECT_UPDATES_FOR, default=core.TimePeriodMilliseconds(0)
+            ): cv.positive_time_period_milliseconds,
         }
     )
 
@@ -218,6 +222,7 @@ async def to_code(config):
         enable = [await cg.gpio_pin_expression(pin) for pin in enable_pin]
         cg.add(var.set_enable_pins(enable))
     cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))
+    cg.add(var.set_collect_updates_for(config[CONF_COLLECT_UPDATES_FOR]))
     if CONF_RESET_DURATION in config:
         cg.add(var.set_reset_duration(config[CONF_RESET_DURATION]))
     if transform := config.get(CONF_TRANSFORM):

--- a/esphome/components/epaper_spi/epaper_spi.cpp
+++ b/esphome/components/epaper_spi/epaper_spi.cpp
@@ -142,12 +142,6 @@ void EPaperBase::update() {
 
 void EPaperBase::start_update_() {
   this->debounce_timer_active_ = false;
-  if (this->state_ != EPaperState::IDLE) {
-    // Should not normally happen, but if the display started updating for another
-    // reason, queue this update for after that refresh.
-    this->pending_update_ = true;
-    return;
-  }
   ESP_LOGD(TAG, "Update starting");
   this->set_state_(EPaperState::UPDATE);
   this->enable_loop();
@@ -201,8 +195,7 @@ void EPaperBase::loop() {
  * DEEP_SLEEP -> IDLE
  *
  * When a pending update is queued, REFRESH_SCREEN skips POWER_OFF/DEEP_SLEEP and loops
- * directly back to UPDATE (after waiting for the physical refresh to complete), keeping
- * the display powered on between consecutive refreshes.
+ * directly back to UPDATE, keeping the display awake between consecutive refreshes.
  *
  * Should a subclassed class need to override this, the method will need to be made virtual.
  */
@@ -225,6 +218,7 @@ void EPaperBase::process_state_() {
       }
       break;
     case EPaperState::UPDATE:
+      this->pending_update_ = false;
       this->do_update_();  // Calls ESPHome (current page) lambda
       // Snapshot the live dirty bounds for this transfer, then reset the live
       // bounds so that draws during the refresh are tracked for the next cycle.
@@ -237,7 +231,6 @@ void EPaperBase::process_state_() {
       this->live_y_low_ = this->height_;
       this->live_y_high_ = 0;
       if (this->x_high_ < this->x_low_ || this->y_high_ < this->y_low_) {
-        this->pending_update_ = false;
         this->set_state_(EPaperState::IDLE);
         return;
       }

--- a/esphome/components/epaper_spi/epaper_spi.cpp
+++ b/esphome/components/epaper_spi/epaper_spi.cpp
@@ -120,9 +120,35 @@ void EPaperBase::update_effective_transform_() {
 
 void EPaperBase::update() {
   if (this->state_ != EPaperState::IDLE) {
-    ESP_LOGE(TAG, "Display already in state %s", epaper_state_to_string_());
+    // Display is busy; queue the update to run after the current refresh completes.
+    // Multiple queued updates are naturally combined because the live dirty bounds
+    // keep expanding as pixels are drawn.
+    ESP_LOGD(TAG, "Update queued (display busy, state %s)", this->epaper_state_to_string_());
+    this->pending_update_ = true;
     return;
   }
+  if (this->collect_updates_for_ms_ == 0) {
+    this->start_update_();
+    return;
+  }
+  if (this->debounce_timer_active_) {
+    ESP_LOGD(TAG, "Update debounced (collecting rapid updates)");
+    return;
+  }
+  ESP_LOGD(TAG, "Update debouncing for %lums", this->collect_updates_for_ms_);
+  this->debounce_timer_active_ = true;
+  this->set_timeout(this->collect_updates_for_ms_, [this] { this->start_update_(); });
+}
+
+void EPaperBase::start_update_() {
+  this->debounce_timer_active_ = false;
+  if (this->state_ != EPaperState::IDLE) {
+    // Should not normally happen, but if the display started updating for another
+    // reason, queue this update for after that refresh.
+    this->pending_update_ = true;
+    return;
+  }
+  ESP_LOGD(TAG, "Update starting");
   this->set_state_(EPaperState::UPDATE);
   this->enable_loop();
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
@@ -174,6 +200,10 @@ void EPaperBase::loop() {
  * IDLE -> RESET -> RESET_END -> UPDATE -> INITIALISE -> TRANSFER_DATA -> POWER_ON -> REFRESH_SCREEN -> POWER_OFF ->
  * DEEP_SLEEP -> IDLE
  *
+ * When a pending update is queued, REFRESH_SCREEN skips POWER_OFF/DEEP_SLEEP and loops
+ * directly back to UPDATE (after waiting for the physical refresh to complete), keeping
+ * the display powered on between consecutive refreshes.
+ *
  * Should a subclassed class need to override this, the method will need to be made virtual.
  */
 void EPaperBase::process_state_() {
@@ -196,7 +226,18 @@ void EPaperBase::process_state_() {
       break;
     case EPaperState::UPDATE:
       this->do_update_();  // Calls ESPHome (current page) lambda
+      // Snapshot the live dirty bounds for this transfer, then reset the live
+      // bounds so that draws during the refresh are tracked for the next cycle.
+      this->x_low_ = this->live_x_low_;
+      this->y_low_ = this->live_y_low_;
+      this->x_high_ = this->live_x_high_;
+      this->y_high_ = this->live_y_high_;
+      this->live_x_low_ = this->width_;
+      this->live_x_high_ = 0;
+      this->live_y_low_ = this->height_;
+      this->live_y_high_ = 0;
       if (this->x_high_ < this->x_low_ || this->y_high_ < this->y_low_) {
+        this->pending_update_ = false;
         this->set_state_(EPaperState::IDLE);
         return;
       }
@@ -212,10 +253,6 @@ void EPaperBase::process_state_() {
       if (!this->transfer_data()) {
         return;  // Not done yet, come back next loop
       }
-      this->x_low_ = this->width_;
-      this->x_high_ = 0;
-      this->y_low_ = this->height_;
-      this->y_high_ = 0;
       this->set_state_(EPaperState::POWER_ON);
       break;
     case EPaperState::POWER_ON:
@@ -225,7 +262,15 @@ void EPaperBase::process_state_() {
     case EPaperState::REFRESH_SCREEN:
       this->refresh_screen(this->update_count_ != 0);
       this->update_count_ = (this->update_count_ + 1) % this->full_update_every_;
-      this->set_state_(EPaperState::POWER_OFF);
+      if (this->pending_update_) {
+        this->pending_update_ = false;
+        // Skip power-off/deep-sleep; the display stays powered on. Wait for the
+        // physical refresh to complete, then immediately start the next update.
+        this->set_state_(EPaperState::UPDATE);
+        this->wait_for_idle_(true);
+      } else {
+        this->set_state_(EPaperState::POWER_OFF);
+      }
       break;
     case EPaperState::POWER_OFF:
       this->power_off();
@@ -309,10 +354,10 @@ bool EPaperBase::rotate_coordinates_(int &x, int &y) {
     y = this->height_ - y - 1;
   if (x >= this->width_ || y >= this->height_ || x < 0 || y < 0)
     return false;
-  this->x_low_ = clamp_at_most(this->x_low_, x);
-  this->x_high_ = clamp_at_least(this->x_high_, x + 1);
-  this->y_low_ = clamp_at_most(this->y_low_, y);
-  this->y_high_ = clamp_at_least(this->y_high_, y + 1);
+  this->live_x_low_ = clamp_at_most(this->live_x_low_, x);
+  this->live_x_high_ = clamp_at_least(this->live_x_high_, x + 1);
+  this->live_y_low_ = clamp_at_most(this->live_y_low_, y);
+  this->live_y_high_ = clamp_at_least(this->live_y_high_, y + 1);
   return true;
 }
 

--- a/esphome/components/epaper_spi/epaper_spi.cpp
+++ b/esphome/components/epaper_spi/epaper_spi.cpp
@@ -389,10 +389,11 @@ void EPaperBase::dump_config() {
                 "  Full update every: %d\n"
                 "  Swap X/Y: %s\n"
                 "  Mirror X: %s\n"
-                "  Mirror Y: %s",
+                "  Mirror Y: %s\n"
+                "  Collect updates for: %lums",
                 this->name_, (unsigned) (this->data_rate_ / 1000000), this->full_update_every_,
                 YESNO(this->transform_ & SWAP_XY), YESNO(this->transform_ & MIRROR_X),
-                YESNO(this->transform_ & MIRROR_Y));
+                YESNO(this->transform_ & MIRROR_Y), this->collect_updates_for_ms_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);

--- a/esphome/components/epaper_spi/epaper_spi.cpp
+++ b/esphome/components/epaper_spi/epaper_spi.cpp
@@ -267,7 +267,6 @@ void EPaperBase::process_state_() {
         // Skip power-off/deep-sleep; the display stays powered on. Wait for the
         // physical refresh to complete, then immediately start the next update.
         this->set_state_(EPaperState::UPDATE);
-        this->wait_for_idle_(true);
       } else {
         this->set_state_(EPaperState::POWER_OFF);
       }

--- a/esphome/components/epaper_spi/epaper_spi.cpp
+++ b/esphome/components/epaper_spi/epaper_spi.cpp
@@ -135,7 +135,7 @@ void EPaperBase::update() {
     ESP_LOGD(TAG, "Update debounced (collecting rapid updates)");
     return;
   }
-  ESP_LOGD(TAG, "Update debouncing for %lums", this->collect_updates_for_ms_);
+  ESP_LOGD(TAG, "Update debouncing for %" PRIu32 "ms", this->collect_updates_for_ms_);
   this->debounce_timer_active_ = true;
   this->set_timeout(this->collect_updates_for_ms_, [this] { this->start_update_(); });
 }
@@ -390,7 +390,7 @@ void EPaperBase::dump_config() {
                 "  Swap X/Y: %s\n"
                 "  Mirror X: %s\n"
                 "  Mirror Y: %s\n"
-                "  Collect updates for: %lums",
+                "  Collect updates for: %" PRIu32 "ms",
                 this->name_, (unsigned) (this->data_rate_ / 1000000), this->full_update_every_,
                 YESNO(this->transform_ & SWAP_XY), YESNO(this->transform_ & MIRROR_X),
                 YESNO(this->transform_ & MIRROR_Y), this->collect_updates_for_ms_);

--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -61,6 +61,7 @@ class EPaperBase : public Display,
     this->update_effective_transform_();
   }
   void set_full_update_every(uint8_t full_update_every) { this->full_update_every_ = full_update_every; }
+  void set_collect_updates_for(uint32_t ms) { this->collect_updates_for_ms_ = ms; }
   void dump_config() override;
 
   void command(uint8_t value);
@@ -100,10 +101,10 @@ class EPaperBase : public Display,
 
     // We store 8 pixels per byte
     this->buffer_.fill(pixel_color);
-    this->x_high_ = this->width_;
-    this->y_high_ = this->height_;
-    this->x_low_ = 0;
-    this->y_low_ = 0;
+    this->live_x_high_ = this->width_;
+    this->live_y_high_ = this->height_;
+    this->live_x_low_ = 0;
+    this->live_y_low_ = 0;
   }
 
   void clear() override {
@@ -120,6 +121,7 @@ class EPaperBase : public Display,
   int get_width_internal() override { return this->width_; };
   bool is_using_partial_update_() const { return this->full_update_every_ > 1; }
   void process_state_();
+  void start_update_();
 
   const char *epaper_state_to_string_();
   bool is_idle_() const;
@@ -185,9 +187,23 @@ class EPaperBase : public Display,
   uint8_t transform_{};
   uint8_t effective_transform_{};
   uint8_t update_count_{};
-  // these values represent the bounds of the updated buffer. Note that x_high and y_high
-  // point to the pixel past the last one updated, i.e. may range up to width/height.
+  // The x_/y_ bounds are the transfer snapshot: copied from the live_ bounds when the
+  // UPDATE state begins, then used by set_window()/transfer_data() to know which region
+  // to send to the display. The live_ bounds track every pixel drawn since the last
+  // snapshot; they are copied to x_/y_ at the start of each update cycle and then reset
+  // so that draws during the refresh are captured for the next cycle.
   uint16_t x_low_{}, y_low_{}, x_high_{}, y_high_{};
+  uint16_t live_x_low_{}, live_y_low_{}, live_x_high_{}, live_y_high_{};
+
+  // When true, an update() call was received while the display was busy; the update
+  // will be started immediately after the current refresh returns to IDLE.
+  bool pending_update_{};
+  // When true, the debounce timer is active (waiting before starting an update).
+  bool debounce_timer_active_{};
+  // How long to wait (in ms) after an update() call while idle before starting the
+  // refresh, to collect multiple rapid updates into a single screen refresh. A value
+  // of 0 starts the refresh immediately.
+  uint32_t collect_updates_for_ms_{};
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   uint32_t waiting_for_idle_last_print_{};

--- a/esphome/components/epaper_spi/epaper_spi_inkplate2.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_inkplate2.cpp
@@ -71,10 +71,10 @@ void EPaperInkplate2::fill(Color color) {
   for (size_t i = half_buffer; i < this->buffer_length_; i++)
     this->buffer_[i] = red_byte;
 
-  this->x_low_ = 0;
-  this->y_low_ = 0;
-  this->x_high_ = this->width_;
-  this->y_high_ = this->height_;
+  this->live_x_low_ = 0;
+  this->live_y_low_ = 0;
+  this->live_x_high_ = this->width_;
+  this->live_y_high_ = this->height_;
 }
 
 void EPaperInkplate2::clear() { this->fill(COLOR_ON); }

--- a/tests/component_tests/epaper_spi/config/collect_updates_for_test.yaml
+++ b/tests/component_tests/epaper_spi/config/collect_updates_for_test.yaml
@@ -1,0 +1,19 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+
+spi:
+  clk_pin: GPIO18
+  mosi_pin: GPIO19
+
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: goodisplay-gdey042t81-4.2
+    dc_pin: GPIO21
+    busy_pin: GPIO22
+    reset_pin: GPIO23
+    cs_pin: GPIO5
+    collect_updates_for: 100ms

--- a/tests/component_tests/epaper_spi/test_init.py
+++ b/tests/component_tests/epaper_spi/test_init.py
@@ -454,3 +454,71 @@ def test_enable_pin_code_generation(
     # Both pin objects must be passed to the display via set_enable_pins() as a
     # std::vector initializer list, in the configured order.
     assert f"set_enable_pins({{{pin_25}, {pin_26}}});" in main_cpp
+
+
+def test_collect_updates_for_config_validation(
+    set_core_config: SetCoreConfigCallable,
+    set_component_config: Callable[[str, Any], None],
+) -> None:
+    """Test that collect_updates_for accepts a time period and validates correctly."""
+    set_core_config(
+        PlatformFramework.ESP32_IDF,
+        platform_data={KEY_BOARD: "esp32dev", KEY_VARIANT: VARIANT_ESP32},
+    )
+
+    set_component_config("spi", {"id": "spi_bus", "clk_pin": 18, "mosi_pin": 19})
+
+    result = run_schema_validation(
+        {
+            "id": "test_display",
+            "model": "goodisplay-gdey042t81-4.2",
+            "dc_pin": 21,
+            "busy_pin": 22,
+            "reset_pin": 23,
+            "cs_pin": 5,
+            "collect_updates_for": "100ms",
+        }
+    )
+
+    from esphome.core import TimePeriodMilliseconds
+
+    assert "collect_updates_for" in result
+    assert result["collect_updates_for"] == TimePeriodMilliseconds(milliseconds=100)
+
+
+def test_collect_updates_for_default_is_zero(
+    set_core_config: SetCoreConfigCallable,
+    set_component_config: Callable[[str, Any], None],
+) -> None:
+    """Test that collect_updates_for defaults to 0ms when not specified."""
+    set_core_config(
+        PlatformFramework.ESP32_IDF,
+        platform_data={KEY_BOARD: "esp32dev", KEY_VARIANT: VARIANT_ESP32},
+    )
+
+    set_component_config("spi", {"id": "spi_bus", "clk_pin": 18, "mosi_pin": 19})
+
+    result = run_schema_validation(
+        {
+            "id": "test_display",
+            "model": "goodisplay-gdey042t81-4.2",
+            "dc_pin": 21,
+            "busy_pin": 22,
+            "reset_pin": 23,
+            "cs_pin": 5,
+        }
+    )
+
+    from esphome.core import TimePeriodMilliseconds
+
+    assert result["collect_updates_for"] == TimePeriodMilliseconds(milliseconds=0)
+
+
+def test_collect_updates_for_code_generation(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Test that collect_updates_for is wired up in the generated C++ code."""
+    main_cpp = generate_main(component_config_path("collect_updates_for_test.yaml"))
+
+    assert "set_collect_updates_for(100);" in main_cpp


### PR DESCRIPTION
# What does this implement/fix?

Adds two new features to help with e-ink displays that are expected to update rapidly, responding to user inputs. Currently updating the contents of the display multiple times in rapid succession can either end up with the display showing stale data, or worse, corrupted graphics due to the buffer being written to while the display is refreshing.

### `collect_updates_for`
Specify a duration of time that the display waits when idle after the first update for more updates to arrive before actually starting to update. Defaults to `0ms` so as not to be a breaking change. When set to a small value like 100ms, it allows for many smaller display updates to be collected and displayed at once, rather than having to refresh multiple times. This comes at the cost of some added latency before the refresh, so it is user-configurable.

This is especially important for LVGL. As each element tends to update independently, you can end up with a series of small updates. LVGL's `update_when_display_idle` helps here by pausing between updates, but this ends up with many refreshes, one for each element. This streamlines it, while not blocking LVGL.

### Queue refreshes
When the display is currently busy and a new update comes in, instead of either dropping it (like in LVGL's `update_when_display_idle`) or writing to the buffer while the refresh is in progress, queue the refresh to happen immediately after the current refresh has completed.

If multiple updates come in during the refresh, the last update is used and the refresh window expanded to encompass all changes. The state machine has been modified to skip the power off and deep sleep stages when a refresh is queued, moving straight back to `REFRESH_SCREEN`.

I physically tested these changes on the `goodisplay-gdey042t81-4.2` so the unit tests were written also using this display. I do have a concern that shortcutting the poweroff/sleep stages could cause issues on displays I haven't tested - I have found in the past that resetting a display after every refresh was "fixing" some bugs in the display's implementation.

This PR is part of a series of changes I am submitting to improve epaper refresh performance. #14047 allows more direct control of the refresh type and has been sitting since February.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6869

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
lvgl:
  [...]
  on_draw_end:
    - component.update: goodisplay

display:
  - platform: epaper_spi
    id: goodisplay
    model: goodisplay-gdey042t81-4.2
    cs_pin: GPIO20
    dc_pin: GPIO21
    busy_pin: GPIO23
    reset_pin: GPIO22
    update_interval: never
    full_update_every: 5
    auto_clear_enabled: false
    collect_updates_for: 100ms

touchscreen:
  - platform: ft63x6
    interrupt_pin: GPIO4
    reset_pin: GPIO5
    on_touch:
      - script.execute:
          id: touch_backlight
      - lambda: |-
          ESP_LOGI("cal", "x=%d, y=%d, x_raw=%d, y_raw=%0d",
              touch.x, touch.y, touch.x_raw, touch.y_raw);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
