### PR TITLE
[network] Enlarge Zephyr net buffer pool and TCP windows on nRF52/Zephyr plataform

### DIFF
--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -227,6 +227,21 @@ async def to_code(config):
         # TCP links; Zephyr falls back to sys_rand32_get() for the ISN (randomized, but not the
         # RFC 6528 keyed hash).
         zephyr_add_prj_conf("NET_TCP_ISN_RFC6528", False)
+        # Enlarge the Zephyr network buffer pool and TCP windows for the Thread path.
+        # Zephyr's defaults are tiny: NET_BUF_TX_COUNT=16 * NET_BUF_DATA_SIZE=128 is only
+        # ~2 KB of TX data -- barely one 1280-byte IPv6 packet once 6LoWPAN fragments it.
+        # The ESPHome API entity-sync burst overruns that instantly, so socket writes fail
+        # with ENOBUFS ("Buffer full") and the connection is dropped. ESP32 sidesteps this
+        # by enlarging the lwIP TCP window (CONFIG_LWIP_TCP_* above); give Zephyr the
+        # equivalent headroom, sized to RAM and the Thread 1280-byte MTU (not ESP32's 64 KB).
+        # The bounded send window also provides flow control so TCP stops queueing past
+        # what the buffer pool can hold instead of erroring.
+        zephyr_add_prj_conf("NET_PKT_RX_COUNT", 24)
+        zephyr_add_prj_conf("NET_PKT_TX_COUNT", 24)
+        zephyr_add_prj_conf("NET_BUF_RX_COUNT", 48)
+        zephyr_add_prj_conf("NET_BUF_TX_COUNT", 48)
+        zephyr_add_prj_conf("NET_TCP_MAX_RECV_WINDOW_SIZE", 2280)
+        zephyr_add_prj_conf("NET_TCP_MAX_SEND_WINDOW_SIZE", 2280)
 
     if (enable_ipv6 := config.get(CONF_ENABLE_IPV6, None)) is not None:
         cg.add_define("USE_NETWORK_IPV6", enable_ipv6)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
The nRF52840 would not have an stable connection to the ESPHome TCP API. Turns out that the default network buffer pool was only ~2 KB (NET_BUF_TX_COUNT=16 × 128 B), too small for the API over Thread, so writes failed with ENOBUFS and the connection dropped.
This PR raises the pool to ~6 KB and adds bounded TCP send/recv windows for the nRF52 Zephyr build.
## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [X] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
