### PR TITLE
[audio] Bump microMP3 to v0.4.0

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -395,7 +395,7 @@ async def to_code(config):
         )
     if data.mp3_support:
         cg.add_define("USE_AUDIO_MP3_SUPPORT")
-        add_idf_component(name="esphome/micro-mp3", ref="0.3.0")
+        add_idf_component(name="esphome/micro-mp3", ref="0.4.0")
         _emit_memory_pair(
             data.mp3.buffer_memory,
             "CONFIG_MICRO_MP3_PREFER_PSRAM",

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -12,7 +12,7 @@ dependencies:
   esphome/micro-flac:
     version: 0.2.0
   esphome/micro-mp3:
-    version: 0.3.0
+    version: 0.4.0
   esphome/micro-opus:
     version: 0.4.1
   esphome/micro-wav:


### PR DESCRIPTION
# What does this implement/fix?

Bumps microMP3 ([GitHub](https://github.com/esphome-libs/micro-mp3) and [Espressif Registry](https://components.espressif.com/components/esphome/micro-mp3/versions/0.4.0/readme)) to v0.4.0. Full changelog: https://github.com/esphome-libs/micro-mp3/compare/v0.3.0...v0.4.0

The headline change is the proper upstream fix for mono / low-sample-rate MP3 playback (esphome-libs/micro-mp3#44). `decode()` now accepts an output buffer sized to the stream's actual per-frame output instead of demanding the 4608-byte MPEG1-stereo worst case, which was the upstream bug behind the crashes in #16829. #17106 worked around this in the `AudioDecoder` by reallocating to the worst-case size whenever a frame was reported as too small; that workaround stays correct, but with v0.4.0 the decoder no longer needs the two-step reallocation.

The release also brings quality and performance improvements that benefit every MP3 stream:

- **Slightly better output quality.** Fixed-point multiplies now round to nearest (esphome-libs/micro-mp3#42).
- **Faster decoding.** Huffman decode was optimized (esphome-libs/micro-mp3#50) and select decoder sources are now compiled at `-Os` on ESP-IDF (esphome-libs/micro-mp3#52). On an ESP32-S3, a 128 kbps clip now decodes a 30s file in ~2.3s (13.1x real-time), down from ~2.5s (12.1x real-time) at v0.3.0.
- **Lower internal RAM use.** Shrinking the OpenCore bit ring buffer (esphome-libs/micro-mp3#41) drops decoder state from ~27.3 KB to ~21.3 KB.

The remaining changes are CI hardening, added conformance tests, and dependency bumps.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- relates to #16829 (full upstream fix for the mono MP3 crash worked around in #17106)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

media_player:
  - platform: speaker
    name: None
    id: speaker_media_player
    announcement_pipeline:
      speaker: box_speaker
      format: MP3
      sample_rate: 48000
      num_channels: 2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
