### PR TITLE
[ci] Widen import-time margin for CI runner variance

### DIFF
--- a/script/import_time_budget.json
+++ b/script/import_time_budget.json
@@ -1,5 +1,5 @@
 {
   "target_module": "esphome.__main__",
-  "margin_pct": 15,
-  "cumulative_us": 102000
+  "margin_pct": 30,
+  "cumulative_us": 91000
 }

--- a/script/import_time_budget.json
+++ b/script/import_time_budget.json
@@ -1,5 +1,5 @@
 {
   "target_module": "esphome.__main__",
-  "margin_pct": 30,
+  "margin_pct": 20,
   "cumulative_us": 91000
 }

--- a/script/import_time_budget.json
+++ b/script/import_time_budget.json
@@ -1,5 +1,5 @@
 {
   "target_module": "esphome.__main__",
   "margin_pct": 15,
-  "cumulative_us": 91000
+  "cumulative_us": 102000
 }


### PR DESCRIPTION
# What does this implement/fix?

Widens the `esphome.__main__` import-time check margin from 15% to 20% (baseline unchanged at 91 ms) so normal CI runner-to-runner variance stops flaky-failing unrelated PRs.

The check measures `import esphome.__main__` against `91 ms + margin`. The 91 ms baseline was calibrated on one ubuntu-24.04 runner, but these runners vary enough that the same code measures anywhere from ~92 ms to ~108 ms depending on which runner/load it lands on. With the old 15% margin (104.6 ms ceiling) that variance tips no-op PRs over the limit:

- a no-op dependency bump (#17284, esptool — which is lazy-imported and can't affect startup) measured 104.8 ms then 108 ms — failed twice
- #17280 measured 101.5 ms — passed, but with only ~3 ms of headroom
- this PR's branch (same code) measured 92.7 ms and 104.5 ms on two different runners

20% margin → 109.2 ms ceiling, which clears the observed ~92–108 ms spread while keeping the check tight enough to catch a genuine eager-import regression.

### Why a margin bump and not a baseline bump

I checked whether the baseline actually rose, and it didn't:

- **Python 3.12 is not slower.** Measuring `import esphome.__main__` with the same tool on the same machine, 3.12 is ~10% *faster* than 3.11 (43.8 ms vs 48.6 ms). The 3.12 default switch (#17280) is not the cause.
- **Nothing snuck into dev.** Comparing dev from ~5 days ago to now on the same 3.12 interpreter: the exact same 206 modules are imported (no new module-scope imports), and total import time is flat within noise (~49 ms then, ~50 ms now). Recent dep bumps (esptool, puremagic) are lazy-imported and don't touch startup.

So the baseline is genuinely ~91 ms; the failures are pure runner variance. Widening the margin models that correctly, rather than inflating the baseline (which would also dull the check's sensitivity to real regressions).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Unblocks flaky import-time failures such as #17284

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
n/a
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).