### PR TITLE
Revert "Bump awalsh128/cache-apt-pkgs-action from 1.6.0 to 1.6.2 (#17286)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,7 +820,7 @@ jobs:
         run: echo ${{ matrix.components }}
 
       - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.5.3
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libsdl2-dev ccache
           version: 1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,7 +820,7 @@ jobs:
         run: echo ${{ matrix.components }}
 
       - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@5513791f75b039e2a79653b1a92238d3fb8d99b4 # v1.6.2
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.5.3
         with:
           packages: libsdl2-dev ccache
           version: 1.1


### PR DESCRIPTION
# What does this implement/fix?

Reverts #17286, which bumped `awalsh128/cache-apt-pkgs-action` to `5513791f… # v1.6.2`. That version is broken — it aborts the apt cache step with:

```
Validating action arguments (version='1.1', packages='')...
Packages argument is empty.
aborted
exit status 100
```

even though the step passes a non-empty package list (`libsdl2-dev ccache`). This fails **every** CI job that installs apt packages — all `Test components batch (...)` jobs and the pytest jobs go red in a few seconds at the cache step (the actual compiles that don't use it still pass). dev was green immediately before #17286 with the prior pin (`acb598e5… # v1.5.3`), which this restores.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- reverts #17286

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally. *(workflow-only revert; restores the last green action SHA)*
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
