### PR TITLE
[ci] Fix nRF52 zigbee/network test-grouping conflict

### DIFF
--- a/script/helpers.py
+++ b/script/helpers.py
@@ -261,14 +261,10 @@ def _get_test_config_components(component: str, platform: str) -> frozenset[str]
         return frozenset()
     try:
         config = yaml_util.load_yaml(test_file)
-    except Exception as err:  # noqa: BLE001 - never let a bad test config crash grouping
-        # The file exists but failed to parse -- surface it rather than silently
-        # degrading conflict detection (which could let conflicting components
-        # be grouped into the same build with no diagnostic).
-        print(
-            f"WARNING: could not parse {test_file} for conflict detection: {err}",
-            file=sys.stderr,
-        )
+    except Exception:  # noqa: BLE001 - never let a bad test config crash grouping
+        # Matches analyze_component_buses, which loads these same files and
+        # silently tolerates parse failures; surfacing it only here would be
+        # inconsistent and noisy.
         return frozenset()
     if not isinstance(config, dict):
         return frozenset()

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -261,7 +261,14 @@ def _get_test_config_components(component: str, platform: str) -> frozenset[str]
         return frozenset()
     try:
         config = yaml_util.load_yaml(test_file)
-    except Exception:  # noqa: BLE001 - never let a bad test config crash grouping
+    except Exception as err:  # noqa: BLE001 - never let a bad test config crash grouping
+        # The file exists but failed to parse -- surface it rather than silently
+        # degrading conflict detection (which could let conflicting components
+        # be grouped into the same build with no diagnostic).
+        print(
+            f"WARNING: could not parse {test_file} for conflict detection: {err}",
+            file=sys.stderr,
+        )
         return frozenset()
     if not isinstance(config, dict):
         return frozenset()

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -238,6 +238,69 @@ class _ConflictWalk:
     rejects: set[str]
 
 
+@cache
+def _get_test_config_components(component: str, platform: str) -> frozenset[str]:
+    """Return the components referenced by a component's test config for a platform.
+
+    Loads ``tests/components/<component>/test.<platform>.yaml`` and extracts the
+    top-level component keys (and list ``platform:`` values). This lets the
+    conflict splitter see components that are only pulled in via a test config
+    (e.g. nRF52 ``network`` tests that also enable ``openthread``), which a
+    purely static AUTO_LOAD/CONFLICTS_WITH parse cannot discover -- notably for
+    components like ``api`` whose ``AUTO_LOAD`` is a callable.
+
+    Failures (missing file, parse error) are treated as empty so the splitter
+    never crashes on a malformed or absent test config.
+    """
+    from esphome import yaml_util
+
+    test_file = (
+        Path(root_path) / "tests" / "components" / component / f"test.{platform}.yaml"
+    )
+    if not test_file.exists():
+        return frozenset()
+    try:
+        config = yaml_util.load_yaml(test_file)
+    except Exception:  # noqa: BLE001 - never let a bad test config crash grouping
+        return frozenset()
+    if not isinstance(config, dict):
+        return frozenset()
+    return frozenset(_extract_components_from_yaml(config))
+
+
+@cache
+def _conflict_walk(comp: str, platform: str) -> _ConflictWalk:
+    """Build the platform-aware conflict walk for a single component.
+
+    Seeds the walk with the component itself plus any components pulled in via
+    its ``test.<platform>.yaml`` config, then folds in each seed's static
+    AUTO_LOAD closure and CONFLICTS_WITH declarations. Cached per
+    ``(component, platform)`` since the test-config seeds are platform-specific.
+    """
+    seeds = {comp} | set(_get_test_config_components(comp, platform))
+    walk = _ConflictWalk(loaded=set(seeds), rejects=set())
+    stack = list(seeds)
+    while stack:
+        metadata = parse_component_metadata(stack.pop())
+        walk.rejects |= metadata.conflicts_with
+        new = metadata.auto_load - walk.loaded
+        walk.loaded |= new
+        stack.extend(new)
+    return walk
+
+
+def components_conflict(a: str, b: str, platform: str) -> bool:
+    """Return True if components ``a`` and ``b`` cannot share a build on ``platform``.
+
+    Uses the same platform-aware conflict walk as :func:`split_conflicting_groups`
+    so callers (e.g. the no-bus redistribution in ``test_build_components.py``)
+    agree with how groups were originally split. The conflict relation is
+    symmetric even when only one side declares CONFLICTS_WITH.
+    """
+    wa, wb = _conflict_walk(a, platform), _conflict_walk(b, platform)
+    return not wa.rejects.isdisjoint(wb.loaded) or not wb.rejects.isdisjoint(wa.loaded)
+
+
 def split_conflicting_groups(
     grouped_components: dict[tuple[str, str], list[str]],
 ) -> dict[tuple[str, str], list[str]]:
@@ -250,33 +313,24 @@ def split_conflicting_groups(
     conflict relation is treated as symmetric even when only one side
     declares it (e.g. ethernet rejects wifi but wifi does not declare the
     reverse).
+
+    The walk is platform-aware: in addition to the static AUTO_LOAD closure,
+    each ``(component, platform)`` walk is seeded with the components found in
+    that component's ``test.<platform>.yaml`` config. This catches conflicts
+    that only exist on a given platform and are expressed through the test
+    config rather than static metadata -- e.g. on nRF52 the ``network``/``api``
+    test configs also enable ``openthread``, which ``zigbee`` declares a
+    conflict with, so ``api`` and ``zigbee`` end up split there. On ESP32 those
+    test configs have no ``openthread``, so the components still group together.
     """
-    batch = {c for comps in grouped_components.values() for c in comps}
-
-    walks: dict[str, _ConflictWalk] = {}
-    for comp in batch:
-        walk = _ConflictWalk(loaded={comp}, rejects=set())
-        stack = [comp]
-        while stack:
-            metadata = parse_component_metadata(stack.pop())
-            walk.rejects |= metadata.conflicts_with
-            new = metadata.auto_load - walk.loaded
-            walk.loaded |= new
-            stack.extend(new)
-        walks[comp] = walk
-
-    def conflicts(a: str, b: str) -> bool:
-        wa, wb = walks[a], walks[b]
-        return not wa.rejects.isdisjoint(wb.loaded) or not wb.rejects.isdisjoint(
-            wa.loaded
-        )
-
     result: dict[tuple[str, str], list[str]] = {}
     for (platform, signature), components in grouped_components.items():
         buckets: list[list[str]] = []
         for comp in components:
             for bucket in buckets:
-                if not any(conflicts(comp, other) for other in bucket):
+                if not any(
+                    components_conflict(comp, other, platform) for other in bucket
+                ):
                     bucket.append(comp)
                     break
             else:

--- a/script/test_build_components.py
+++ b/script/test_build_components.py
@@ -40,6 +40,7 @@ from script.analyze_component_buses import (
     uses_local_file_references,
 )
 from script.helpers import (
+    components_conflict,
     get_component_test_files,
     is_validate_only_file,
     parse_test_filename,
@@ -788,14 +789,35 @@ def run_grouped_component_tests(
             if plat == platform and sig != NO_BUSES_SIGNATURE
         ]
 
-        if platform_groups:
-            # Distribute no_buses components round-robin across existing groups
-            for i, comp in enumerate(no_buses_comps):
-                sig, _ = platform_groups[i % len(platform_groups)]
-                grouped_components[(platform, sig)].append(comp)
-        else:
-            # No other groups for this platform - keep no_buses components together
-            grouped_components[(platform, NO_BUSES_SIGNATURE)] = no_buses_comps
+        # Distribute no_buses components round-robin across existing groups,
+        # but never place a component into a group it conflicts with. Conflict
+        # splitting (split_conflicting_groups) may have created sibling groups
+        # like "no_buses__conflict1" precisely to keep incompatible components
+        # apart (e.g. on nRF52, network pulls in openthread which zigbee
+        # conflicts with); redistribution must not silently undo that split.
+        leftover: list[str] = []
+        for i, comp in enumerate(no_buses_comps):
+            placed = False
+            # Try groups starting at the round-robin offset to keep the spread.
+            for offset in range(len(platform_groups)):
+                sig, comps = platform_groups[(i + offset) % len(platform_groups)]
+                if any(components_conflict(comp, other, platform) for other in comps):
+                    continue
+                # comps is the same list object stored in grouped_components, so
+                # this also extends the group in grouped_components.
+                comps.append(comp)
+                placed = True
+                break
+            if not placed:
+                leftover.append(comp)
+
+        if leftover:
+            # Components that conflict with every existing group stay together in
+            # their own no_buses group (they were grouped before, so they don't
+            # conflict with each other).
+            grouped_components.setdefault((platform, NO_BUSES_SIGNATURE), []).extend(
+                leftover
+            )
 
     groups_to_test = []
     individual_tests = set()  # Use set to avoid duplicates

--- a/tests/components/api/test.nrf52-adafruit.yaml
+++ b/tests/components/api/test.nrf52-adafruit.yaml
@@ -1,4 +1,7 @@
 network:
   enable_ipv6: true
 
+openthread:
+  tlv: 0E080000000000010000
+
 api:

--- a/tests/components/mdns/test.nrf52-adafruit.yaml
+++ b/tests/components/mdns/test.nrf52-adafruit.yaml
@@ -1,4 +1,7 @@
 network:
   enable_ipv6: true
 
+openthread:
+  tlv: 0E080000000000010000
+
 mdns:

--- a/tests/components/network/test.nrf52-adafruit.yaml
+++ b/tests/components/network/test.nrf52-adafruit.yaml
@@ -1,1 +1,5 @@
 network:
+  enable_ipv6: true
+
+openthread:
+  tlv: 0E080000000000010000

--- a/tests/components/network/test.nrf52-mcumgr.yaml
+++ b/tests/components/network/test.nrf52-mcumgr.yaml
@@ -1,1 +1,5 @@
 network:
+  enable_ipv6: true
+
+openthread:
+  tlv: 0E080000000000010000

--- a/tests/components/network/test.nrf52-xiao-ble.yaml
+++ b/tests/components/network/test.nrf52-xiao-ble.yaml
@@ -1,1 +1,5 @@
 network:
+  enable_ipv6: true
+
+openthread:
+  tlv: 0E080000000000010000

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1504,6 +1504,8 @@ def fake_components(tmp_path: Path) -> Path:
     write("callable_auto", "def AUTO_LOAD():\n    return ['beta']\n")
     write("broken", "this is not valid python !!!")
     helpers.parse_component_metadata.cache_clear()
+    helpers._get_test_config_components.cache_clear()
+    helpers._conflict_walk.cache_clear()
     return tmp_path
 
 
@@ -1622,6 +1624,47 @@ def test_split_conflicting_groups_preserves_original_signature_for_first_bucket(
     platform, signature = next(iter(extra))
     assert platform == "esp32"
     assert signature.startswith("i2c__conflict")
+
+
+def test_split_conflicting_groups_seeds_from_test_config(
+    fake_components: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A conflict reachable only via a component's test config splits the group.
+
+    ``host_user`` declares no static conflict with ``beta``, but its
+    ``test.<platform>.yaml`` pulls in ``beta_variant`` (which AUTO_LOADs
+    ``beta``). On that platform the group must split; on another platform
+    (no such test config) it must stay together.
+    """
+    monkeypatch.setattr(helpers, "root_path", str(fake_components))
+
+    # host_user has no static metadata, but its esp32 test config references
+    # beta_variant -> AUTO_LOAD beta, which conflicts with alpha.
+    tests_dir = fake_components / "tests" / "components" / "host_user"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "test.esp32.yaml").write_text("beta_variant:\n")
+    (fake_components / "esphome" / "components" / "host_user").mkdir()
+    (
+        fake_components / "esphome" / "components" / "host_user" / "__init__.py"
+    ).write_text("")
+
+    helpers.parse_component_metadata.cache_clear()
+    helpers._get_test_config_components.cache_clear()
+    helpers._conflict_walk.cache_clear()
+
+    # On esp32, host_user pulls in beta (via its test config) -> conflicts with alpha.
+    result = helpers.split_conflicting_groups(
+        {("esp32", "no_buses"): ["alpha", "host_user"]}
+    )
+    buckets = list(result.values())
+    for bucket in buckets:
+        assert not ({"alpha", "host_user"} <= set(bucket))
+
+    # On a platform without that test config, they stay grouped together.
+    result_other = helpers.split_conflicting_groups(
+        {("rp2040", "no_buses"): ["alpha", "host_user"]}
+    )
+    assert result_other == {("rp2040", "no_buses"): ["alpha", "host_user"]}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -35,6 +35,8 @@ def clear_helpers_cache() -> None:
     helpers._get_github_event_data.cache_clear()
     helpers._get_changed_files_github_actions.cache_clear()
     helpers.get_components_per_integration_fixture.cache_clear()
+    helpers._get_test_config_components.cache_clear()
+    helpers._conflict_walk.cache_clear()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

Fixes a CI failure where the component-test grouper merges `network` and `zigbee` into a single nRF52 build, which then aborts in codegen with:

```
ValueError: CONFIG_NET_IPV6 already set with value 'True', cannot set again to 'False'
```

On nRF52 there is a single radio, so IP networking over Thread and Zigbee are mutually exclusive. They genuinely cannot share a build: `network` (in its `CORE.is_nrf52` block) enables the Zephyr IP stack (`NET_IPV6=True`, `NET_UDP=True`, …), while `zigbee` tears it down to save flash/RAM (`NET_IPV6=False`, `NET_UDP=False`, …). `zephyr_add_prj_conf`'s conflict guard correctly refuses the contradiction. The grouper was merging them anyway because it couldn't see the incompatibility.

## How it works

**1. Make the nRF52 network tests realistic.** The nRF52 `network`/`api`/`mdns` test configs declared `network:` without `openthread:`, but you can't do IP networking on nRF52 without the Thread radio/L2. Added `openthread:` to the 5 affected files (`network` ×3 targets, `api`, `mdns`). This lets the **existing** `zigbee` declaration `CONFLICTS_WITH = ["openthread"]` express the incompatibility — no new static conflict needed, so ESP32 (C6/H2) `zigbee` + `wifi`/`network` coexistence is preserved.

**2. Make the conflict split platform-aware.** `split_conflicting_groups` (`script/helpers.py`) only walked static `AUTO_LOAD`/`CONFLICTS_WITH`, so it couldn't see `network`/`api` pulling in `openthread` (it's declared in the test config, and `api`'s `AUTO_LOAD` is a callable that parses as empty). The conflict walk is now seeded per `(component, platform)` with the components found in that component's `test.<platform>.yaml` (via the existing `_extract_components_from_yaml`), then folds in each seed's `AUTO_LOAD` closure and `CONFLICTS_WITH` as before. Net effect: on nRF52, `network`/`api`/`mdns` conflict with `zigbee` via `openthread` and get split into separate builds; on ESP32 those configs have no `openthread`, so they still group (no grouping regression).

**3. Fix no-bus redistribution silently undoing the split.** The post-split step that round-robins no-bus components into existing groups could place a component right back into a group it conflicts with. It is now conflict-aware (skips conflicting target groups; leftovers form their own group).

Scope verified: across all components and platforms, the only new groupable conflict edges are on nRF52 (`network`/`api`/`mdns`/`deep_sleep` ↔ `zigbee` — `deep_sleep`'s nRF52 test uses `zigbee`). ESP32 is unaffected because `ethernet`/`openthread` are already `ISOLATED_COMPONENTS` (never grouped), so their edges are moot.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Unblocks the nRF52 component-test failures seen on unrelated PRs (e.g. #17288); those need no changes, just a rebase once this lands.

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
n/a (CI test-grouping fix)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).