### PR TITLE
[mqtt] Add LN882X (LN882H) platform support

### DIFF
--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -321,11 +321,11 @@ CONFIG_SCHEMA = cv.All(
     validate_config,
     cv.only_on(
         [
+            PLATFORM_BK72XX,
             PLATFORM_ESP32,
             PLATFORM_ESP8266,
-            PLATFORM_BK72XX,
-            PLATFORM_RTL87XX,
             PLATFORM_LN882X,
+            PLATFORM_RTL87XX,
         ]
     ),
     _consume_mqtt_sockets,

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -57,6 +57,7 @@ from esphome.const import (
     PLATFORM_BK72XX,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
+    PLATFORM_LN882X,
     PLATFORM_RTL87XX,
     PlatformFramework,
 )
@@ -318,7 +319,15 @@ CONFIG_SCHEMA = cv.All(
         }
     ),
     validate_config,
-    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_BK72XX, PLATFORM_RTL87XX]),
+    cv.only_on(
+        [
+            PLATFORM_ESP32,
+            PLATFORM_ESP8266,
+            PLATFORM_BK72XX,
+            PLATFORM_RTL87XX,
+            PLATFORM_LN882X,
+        ]
+    ),
     _consume_mqtt_sockets,
 )
 

--- a/tests/components/mqtt/test.ln882x-ard.yaml
+++ b/tests/components/mqtt/test.ln882x-ard.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml


### PR DESCRIPTION
## What does this implement/fix?

Enables the `mqtt` component on the **LN882X (LN882H)** platform.

MQTT already has full LibreTiny support: the `mqtt_backend_libretiny.h` backend and the `heman/AsyncMqttClient-esphome` library are added for every LibreTiny target (`CORE.is_libretiny`), and the sibling LibreTiny families **BK72XX** and **RTL87XX** are already in the platform allowlist. LN882X was simply never added, so `mqtt` was rejected on LN882H with:

> This feature is only available on [esp32, esp8266, bk72xx, rtl87xx].

This adds `PLATFORM_LN882X` to the `cv.only_on([...])` allowlist. No backend changes are required — LN882H uses the same `is_libretiny` code path as BK72XX/RTL87XX.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Test Environment

- [x] LN882X (LN882H)

Verified building for LN882H on an LN-CB3S (DS-101JL) device.

A platform test config is included (`tests/components/mqtt/test.ln882x-ard.yaml`), mirroring the existing `test.bk72xx-ard.yaml` / `test.rtl87xx-ard.yaml`.



**Pull request in [esphome-docs](https://github.com/esphome/esphome.io):** esphome/esphome.io#6874
