### PR TITLE
[mipi_spi] fix invert_colors YAML setting being ignored at runtime

### DIFF
--- a/esphome/components/mipi_spi/display.py
+++ b/esphome/components/mipi_spi/display.py
@@ -413,6 +413,7 @@ async def to_code(config):
     var = cg.new_Pvariable(var_id, TemplateArguments(*templateargs))
     cg.add(var.set_init_sequence(init_sequence))
     cg.add(var.set_model(config[CONF_MODEL]))
+    cg.add(var.set_invert_colors(config[CONF_INVERT_COLORS]))
     if enable_pin := config.get(CONF_ENABLE_PIN):
         enable = [await cg.gpio_pin_expression(pin) for pin in enable_pin]
         cg.add(var.set_enable_pins(enable))


### PR DESCRIPTION
# mipi_spi: fix `invert_colors` YAML setting being ignored at runtime

## What does this implement/fix?

The `invert_colors` configuration option for the `mipi_spi` display platform
was parsed correctly but never passed to the C++ object via `set_invert_colors()`.
At runtime, `reset_params_()` sends `INVOFF` because `invert_colors_` defaults
to `false`, overriding whatever the model init sequence had set.

This is a regression in 2026.6.x — previously the init sequence result was not
overridden at runtime, so models with `invert_colors=True` in their definition
(e.g. `wt32-sc01-plus`) worked correctly.

**Fix:** Call `set_invert_colors()` during code generation so the runtime value
matches the YAML configuration.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
display:
  - platform: mipi_spi
    model: wt32-sc01-plus
    invert_colors: true