### PR TITLE
[qmi8658] Pin i2c_id in test config to fix grouped component test conflict

### DIFF
--- a/tests/components/qmi8658/common.yaml
+++ b/tests/components/qmi8658/common.yaml
@@ -49,6 +49,7 @@ sensor:
 
 motion:
   - platform: qmi8658
+    i2c_id: i2c_bus
     # Accelerometer full-scale range: 2G | 4G | 8G | 16G
     accelerometer_range: 4G
 


### PR DESCRIPTION
# What does this implement/fix?

The `qmi8658` test config (`tests/components/qmi8658/common.yaml`) declares its `motion` platform without an explicit `i2c_id`. On its own this is fine — there is only one I2C bus, so it auto-resolves.

But when the CI component grouping merges `qmi8658` into the same build as `tca9548a` (an I2C multiplexer that creates additional buses such as `multiplex0_chan0`), there are now multiple `i2c::I2CBus` candidates and validation fails:

```
motion.qmi8658: Too many candidates found for 'i2c_id' type 'i2c::I2CBus'
  Some are 'i2c_bus', 'multiplex0_chan0'.
```

This surfaced in #17145 (rp2040 → rp2 rename), which touches platform-level files and therefore triggers a broad i2c component grouping that co-locates `qmi8658` with `tca9548a` for the first time. It is a pre-existing gap in the qmi8658 test fixture, not a regression from that PR. Note `tca9548a`'s own test already pins `i2c_id: i2c_bus`; `qmi8658` simply never did.

Pinning `i2c_id: i2c_bus` on the `motion` platform makes the bus unambiguous regardless of grouping. The `sensor` (temperature) entry needs no change since it references the motion hub by id rather than being an I2C device itself.

Verified locally: with the multiplexer present, the merged config fails with the exact error above before this change and validates successfully after.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Test infrastructure only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).