### PR TITLE
[espidf] Install native ESP-IDF into a machine-global cache dir

### DIFF
--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -21,6 +21,12 @@ export PLATFORMIO_PLATFORMS_DIR="${pio_cache_base}/platforms"
 export PLATFORMIO_PACKAGES_DIR="${pio_cache_base}/packages"
 export PLATFORMIO_CACHE_DIR="${pio_cache_base}/cache"
 
+# Keep the native ESP-IDF toolchain install (multi-GB framework + tools) on the
+# same persistent cache root as the PlatformIO packages. Without this it would
+# default to the OS user cache dir inside the container and be re-downloaded on
+# every container restart.
+export ESPHOME_ESP_IDF_PREFIX="$(dirname "${pio_cache_base}")/idf"
+
 # If /build is mounted, use that as the build path
 # otherwise use path in /config (so that builds aren't lost on container restart)
 if [[ -d /build ]]; then

--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -21,10 +21,8 @@ export PLATFORMIO_PLATFORMS_DIR="${pio_cache_base}/platforms"
 export PLATFORMIO_PACKAGES_DIR="${pio_cache_base}/packages"
 export PLATFORMIO_CACHE_DIR="${pio_cache_base}/cache"
 
-# Keep the native ESP-IDF toolchain install (multi-GB framework + tools) on the
-# same persistent cache root as the PlatformIO packages. Without this it would
-# default to the OS user cache dir inside the container and be re-downloaded on
-# every container restart.
+# Keep the native ESP-IDF install on the persistent cache root, not the
+# container's ephemeral user cache dir (re-downloaded on every restart).
 export ESPHOME_ESP_IDF_PREFIX="$(dirname "${pio_cache_base}")/idf"
 
 # If /build is mounted, use that as the build path

--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
@@ -15,6 +15,12 @@ export PLATFORMIO_PLATFORMS_DIR="${pio_cache_base}/platforms"
 export PLATFORMIO_PACKAGES_DIR="${pio_cache_base}/packages"
 export PLATFORMIO_CACHE_DIR="${pio_cache_base}/cache"
 
+# Keep the native ESP-IDF toolchain install (multi-GB framework + tools) on the
+# persistent /data volume. Without this it would default to the OS user cache
+# dir inside the container, which is wiped on every add-on update/restart and
+# re-downloaded from scratch.
+export ESPHOME_ESP_IDF_PREFIX=/data/cache/idf
+
 if bashio::config.true 'leave_front_door_open'; then
     export DISABLE_HA_AUTHENTICATION=true
 fi

--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
@@ -15,10 +15,8 @@ export PLATFORMIO_PLATFORMS_DIR="${pio_cache_base}/platforms"
 export PLATFORMIO_PACKAGES_DIR="${pio_cache_base}/packages"
 export PLATFORMIO_CACHE_DIR="${pio_cache_base}/cache"
 
-# Keep the native ESP-IDF toolchain install (multi-GB framework + tools) on the
-# persistent /data volume. Without this it would default to the OS user cache
-# dir inside the container, which is wiped on every add-on update/restart and
-# re-downloaded from scratch.
+# Keep the native ESP-IDF install on the persistent /data volume, not the
+# container's ephemeral user cache dir (wiped on every add-on update/restart).
 export ESPHOME_ESP_IDF_PREFIX=/data/cache/idf
 
 if bashio::config.true 'leave_front_door_open'; then

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2386,7 +2386,11 @@ def parse_args(argv):
     )
 
     parser_clean_all = subparsers.add_parser(
-        "clean-all", help="Clean all build and platform files."
+        "clean-all",
+        help="Clean all build and platform files, including machine-global "
+        "toolchain caches (PlatformIO packages/platforms and the native "
+        "ESP-IDF install) shared by all configurations, so other projects will "
+        "re-download them on next build.",
     )
     parser_clean_all.add_argument(
         "configuration", help="Your YAML file or configuration directory.", nargs="*"

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2388,8 +2388,7 @@ def parse_args(argv):
     parser_clean_all = subparsers.add_parser(
         "clean-all",
         help="Clean all build and platform files, including machine-global "
-        "toolchain caches (PlatformIO packages/platforms and the native "
-        "ESP-IDF install) shared by all configurations, so other projects will "
+        "toolchain caches shared by all configurations, so other projects will "
         "re-download them on next build.",
     )
     parser_clean_all.add_argument(

--- a/esphome/espidf/clang_tidy.py
+++ b/esphome/espidf/clang_tidy.py
@@ -148,9 +148,8 @@ def _setup_core(work_dir: Path, settings: _Settings) -> None:
 
     CORE.name = TIDY_PROJECT_NAME
     # config_path's parent is the data dir root for per-run artifacts (idedata,
-    # converted pio_components). The IDF install itself lives in the machine-
-    # global cache dir (or ESPHOME_ESP_IDF_PREFIX), independent of this path, so
-    # clearing the project never forces an IDF re-download.
+    # converted pio_components). The IDF install is in the global cache dir,
+    # independent of this path.
     CORE.config_path = work_dir.parent / "tidy.yaml"
     CORE.build_path = work_dir
     esp32 = CORE.data.setdefault(KEY_ESP32, {})

--- a/esphome/espidf/clang_tidy.py
+++ b/esphome/espidf/clang_tidy.py
@@ -147,9 +147,10 @@ def _setup_core(work_dir: Path, settings: _Settings) -> None:
     from esphome.core import CORE
 
     CORE.name = TIDY_PROJECT_NAME
-    # config_path's parent is the data dir root: the IDF install lives at
-    # ``<parent>/.esphome/idf`` -- keep it beside (not inside) the per-run
-    # project dir so clearing the project doesn't force an IDF re-download.
+    # config_path's parent is the data dir root for per-run artifacts (idedata,
+    # converted pio_components). The IDF install itself lives in the machine-
+    # global cache dir (or ESPHOME_ESP_IDF_PREFIX), independent of this path, so
+    # clearing the project never forces an IDF re-download.
     CORE.config_path = work_dir.parent / "tidy.yaml"
     CORE.build_path = work_dir
     esp32 = CORE.data.setdefault(KEY_ESP32, {})

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -82,8 +82,11 @@ def _get_idf_tools_path() -> Path:
     Returns:
         Path object pointing to the ESP-IDF tools directory
     """
-    if "ESPHOME_ESP_IDF_PREFIX" in os.environ:
-        path = Path(get_str_env("ESPHOME_ESP_IDF_PREFIX", None)).expanduser()
+    # Treat an empty/whitespace ESPHOME_ESP_IDF_PREFIX as unset: Path("")
+    # resolves to the CWD, which would install into (and let clean-all delete)
+    # the working directory by accident.
+    if prefix := get_str_env("ESPHOME_ESP_IDF_PREFIX", "").strip():
+        path = Path(prefix).expanduser()
     else:
         # Machine-global so all projects share the multi-GB install instead of
         # a per-config-directory copy. The user cache dir (not ~/.esphome)

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -159,7 +159,7 @@ def _check_windows_path_length() -> None:
         "    PowerShell run:\n"
         "      Set-ItemProperty 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\FileSystem' LongPathsEnabled 1\n"
         "    Details: https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation\n"
-        "  - Or set ESPHOME_ESP_IDF_PREFIX to a shorter path (e.g. C:\\esphome-idf)\n"
+        "  - Or set ESPHOME_ESP_IDF_PREFIX to a shorter path (e.g. C:\\ESPHome\\idf)\n"
         "Then delete the ESP-IDF tools directory above so the toolchain "
         "reinstalls cleanly.",
         tools_path,

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -9,6 +9,8 @@ import re
 import shutil
 import tempfile
 
+import platformdirs
+
 from esphome.config_validation import Version
 from esphome.core import CORE
 from esphome.framework_helpers import (
@@ -83,11 +85,28 @@ def _get_idf_tools_path() -> Path:
     if "ESPHOME_ESP_IDF_PREFIX" in os.environ:
         path = Path(get_str_env("ESPHOME_ESP_IDF_PREFIX", None)).expanduser()
     else:
-        path = CORE.data_dir / "idf"
+        # Machine-global cache shared across all projects rather than the
+        # per-config-directory ``<data_dir>/idf``. ESP-IDF plus its toolchains
+        # are multi-GB, so a per-project copy wastes disk and forces a fresh
+        # download for every config directory. The OS user *cache* dir (not
+        # ``~/.esphome``) is used deliberately: ``data_dir`` defaults to
+        # ``<config_dir>/.esphome``, so a user keeping configs in their home
+        # directory would otherwise collide the global install with a config's
+        # own data dir.
+        path = Path(platformdirs.user_cache_dir("esphome")) / "idf"
     # Resolve so an unnormalized config path (e.g. compiling ``../config/x.yaml``)
     # doesn't leave ``..`` segments in the IDF_TOOLS_PATH handed to idf.py, which
     # otherwise warns that the venv interpreter path doesn't match the install.
     return path.resolve()
+
+
+def get_idf_install_path() -> Path:
+    """Return the ESP-IDF install root (frameworks, penvs, tools, ccache).
+
+    Public accessor for the machine-global install location so callers such as
+    ``esphome clean-all`` can remove it. Honors ``ESPHOME_ESP_IDF_PREFIX``.
+    """
+    return _get_idf_tools_path()
 
 
 # Windows' default MAX_PATH is 260 characters. ESP-IDF toolchains nest deeply
@@ -553,7 +572,7 @@ def _check_esphome_idf_framework_install(
     # Logged every invocation (not just on install) so the user can verify the
     # override. A changed URL needs ``esphome clean-all`` to force a re-download
     # (``esphome clean`` only wipes the build dir, not the extracted framework
-    # under <data_dir>/idf/frameworks/<version>).
+    # under the global install dir's ``frameworks/<version>``).
     if source_url:
         _LOGGER.info("Using framework source override: %s", source_url)
 
@@ -822,11 +841,10 @@ def _ccache_env() -> dict[str, str]:
 
     Enabled by default whenever the ``ccache`` binary is on PATH; set
     ``IDF_CCACHE_ENABLE=0`` in the environment to opt out. The cache lives under
-    the IDF tools path. How widely it is shared depends on where that resolves:
-    across projects (and surviving ``clean-all``) when it is a common location
-    (``ESPHOME_ESP_IDF_PREFIX`` or the add-on ``/data``), but per-project under
-    ``.esphome/idf`` for a default pip install, where ``clean-all`` clears it
-    along with the framework.
+    the IDF tools path, which defaults to the machine-global OS user cache dir
+    (or ``ESPHOME_ESP_IDF_PREFIX`` / the add-on ``/data``), so it is shared
+    across all projects. ``esphome clean-all`` removes it along with the
+    framework.
 
     Depend mode keeps cache-miss overhead low (hashes the compiler's depfiles
     instead of preprocessing). ``CCACHE_BASEDIR`` rewrites the per-build

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -100,15 +100,6 @@ def _get_idf_tools_path() -> Path:
     return path.resolve()
 
 
-def get_idf_install_path() -> Path:
-    """Return the ESP-IDF install root (frameworks, penvs, tools, ccache).
-
-    Public accessor for the machine-global install location so callers such as
-    ``esphome clean-all`` can remove it. Honors ``ESPHOME_ESP_IDF_PREFIX``.
-    """
-    return _get_idf_tools_path()
-
-
 # Windows' default MAX_PATH is 260 characters. ESP-IDF toolchains nest deeply
 # below the IDF tools directory: the longest file on disk (picolibc C++
 # headers) sits ~209 characters down, but the operative number is worse -- gcc

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -88,7 +88,9 @@ def _get_idf_tools_path() -> Path:
         # Machine-global so all projects share the multi-GB install instead of
         # a per-config-directory copy. The user cache dir (not ~/.esphome)
         # avoids colliding with data_dir when configs live in the home dir.
-        path = Path(platformdirs.user_cache_dir("esphome")) / "idf"
+        # appauthor=False drops the redundant <author>\ segment on Windows
+        # (which otherwise repeats "esphome\esphome\") to keep the path short.
+        path = Path(platformdirs.user_cache_dir("esphome", appauthor=False)) / "idf"
     # Resolve so an unnormalized config path (e.g. compiling ``../config/x.yaml``)
     # doesn't leave ``..`` segments in the IDF_TOOLS_PATH handed to idf.py, which
     # otherwise warns that the venv interpreter path doesn't match the install.

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -153,7 +153,7 @@ def _check_windows_path_length() -> None:
         "  - Enable Windows long path support: set\n"
         "    HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem\\LongPathsEnabled\n"
         "    to 1 and reboot, or\n"
-        "  - Move your ESPHome project to a shorter path\n"
+        "  - Set ESPHOME_ESP_IDF_PREFIX to a shorter path (e.g. C:\\esphome-idf)\n"
         "Then delete the ESP-IDF tools directory above so the toolchain "
         "reinstalls cleanly.",
         tools_path,

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -150,10 +150,11 @@ def _check_windows_path_length() -> None:
         "  fatal error: bits/c++config.h: No such file or directory\n"
         "  cannot execute 'as': CreateProcess: No such file or directory\n"
         "To fix, either:\n"
-        "  - Enable Windows long path support: set\n"
-        "    HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem\\LongPathsEnabled\n"
-        "    to 1 and reboot, or\n"
-        "  - Set ESPHOME_ESP_IDF_PREFIX to a shorter path (e.g. C:\\esphome-idf)\n"
+        "  - Enable Windows long path support, then reboot. In an elevated\n"
+        "    PowerShell run:\n"
+        "      Set-ItemProperty 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\FileSystem' LongPathsEnabled 1\n"
+        "    Details: https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation\n"
+        "  - Or set ESPHOME_ESP_IDF_PREFIX to a shorter path (e.g. C:\\esphome-idf)\n"
         "Then delete the ESP-IDF tools directory above so the toolchain "
         "reinstalls cleanly.",
         tools_path,

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -85,14 +85,9 @@ def _get_idf_tools_path() -> Path:
     if "ESPHOME_ESP_IDF_PREFIX" in os.environ:
         path = Path(get_str_env("ESPHOME_ESP_IDF_PREFIX", None)).expanduser()
     else:
-        # Machine-global cache shared across all projects rather than the
-        # per-config-directory ``<data_dir>/idf``. ESP-IDF plus its toolchains
-        # are multi-GB, so a per-project copy wastes disk and forces a fresh
-        # download for every config directory. The OS user *cache* dir (not
-        # ``~/.esphome``) is used deliberately: ``data_dir`` defaults to
-        # ``<config_dir>/.esphome``, so a user keeping configs in their home
-        # directory would otherwise collide the global install with a config's
-        # own data dir.
+        # Machine-global so all projects share the multi-GB install instead of
+        # a per-config-directory copy. The user cache dir (not ~/.esphome)
+        # avoids colliding with data_dir when configs live in the home dir.
         path = Path(platformdirs.user_cache_dir("esphome")) / "idf"
     # Resolve so an unnormalized config path (e.g. compiling ``../config/x.yaml``)
     # doesn't leave ``..`` segments in the IDF_TOOLS_PATH handed to idf.py, which
@@ -832,10 +827,9 @@ def _ccache_env() -> dict[str, str]:
 
     Enabled by default whenever the ``ccache`` binary is on PATH; set
     ``IDF_CCACHE_ENABLE=0`` in the environment to opt out. The cache lives under
-    the IDF tools path, which defaults to the machine-global OS user cache dir
-    (or ``ESPHOME_ESP_IDF_PREFIX`` / the add-on ``/data``), so it is shared
-    across all projects. ``esphome clean-all`` removes it along with the
-    framework.
+    the IDF tools path (the machine-global cache dir, or
+    ``ESPHOME_ESP_IDF_PREFIX``), so it is shared across all projects and removed
+    by ``esphome clean-all`` along with the framework.
 
     Depend mode keeps cache-miss overhead low (hashes the compiler's depfiles
     instead of preprocessing). ``CCACHE_BASEDIR`` rewrites the per-build

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -657,9 +657,9 @@ def clean_all(configuration: list[str]):
     # tools + ccache). It now lives in a machine-global cache dir (or
     # ESPHOME_ESP_IDF_PREFIX), outside any .esphome data dir, so the per-config
     # loop above no longer reaches it and it must be removed explicitly.
-    from esphome.espidf.framework import get_idf_install_path
+    from esphome.espidf.framework import _get_idf_tools_path
 
-    idf_install_path = get_idf_install_path()
+    idf_install_path = _get_idf_tools_path()
     if idf_install_path.is_dir():
         _LOGGER.info("Deleting %s", idf_install_path)
         rmtree(idf_install_path)

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -653,10 +653,8 @@ def clean_all(configuration: list[str]):
                 elif item.is_dir() and item.name != "storage":
                     rmtree(item)
 
-    # Clean the native ESP-IDF toolchain install (framework + Python envs +
-    # tools + ccache). It now lives in a machine-global cache dir (or
-    # ESPHOME_ESP_IDF_PREFIX), outside any .esphome data dir, so the per-config
-    # loop above no longer reaches it and it must be removed explicitly.
+    # The native ESP-IDF install lives in a machine-global cache dir, outside
+    # any .esphome data dir, so the per-config loop above won't reach it.
     from esphome.espidf.framework import _get_idf_tools_path
 
     idf_install_path = _get_idf_tools_path()

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -653,6 +653,17 @@ def clean_all(configuration: list[str]):
                 elif item.is_dir() and item.name != "storage":
                     rmtree(item)
 
+    # Clean the native ESP-IDF toolchain install (framework + Python envs +
+    # tools + ccache). It now lives in a machine-global cache dir (or
+    # ESPHOME_ESP_IDF_PREFIX), outside any .esphome data dir, so the per-config
+    # loop above no longer reaches it and it must be removed explicitly.
+    from esphome.espidf.framework import get_idf_install_path
+
+    idf_install_path = get_idf_install_path()
+    if idf_install_path.is_dir():
+        _LOGGER.info("Deleting %s", idf_install_path)
+        rmtree(idf_install_path)
+
     # Clean PlatformIO project files
     try:
         from platformio.project.config import ProjectConfig

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ bleak==2.1.1
 smpclient==6.0.0
 requests==2.34.2
 py7zr==1.1.3
+platformdirs==4.9.4  # native esp-idf toolchain global cache dir
 
 # esp-idf >= 5.0 requires this
 pyparsing >= 3.3.2

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -812,7 +812,9 @@ def test_get_idf_tools_path_default_uses_user_cache(
     import platformdirs
 
     monkeypatch.delenv("ESPHOME_ESP_IDF_PREFIX", raising=False)
-    expected = (Path(platformdirs.user_cache_dir("esphome")) / "idf").resolve()
+    expected = (
+        Path(platformdirs.user_cache_dir("esphome", appauthor=False)) / "idf"
+    ).resolve()
     assert _get_idf_tools_path() == expected
 
 

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -804,6 +804,24 @@ def test_get_idf_tools_path_env_override(tmp_path: Path) -> None:
         assert _get_idf_tools_path() == Path(override)
 
 
+@pytest.mark.parametrize("value", ["", "   "])
+def test_get_idf_tools_path_blank_env_falls_back_to_default(
+    value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A blank ESPHOME_ESP_IDF_PREFIX is treated as unset, not as CWD.
+
+    Path("") would resolve to the working directory, which clean-all could then
+    delete by accident.
+    """
+    import platformdirs
+
+    monkeypatch.setenv("ESPHOME_ESP_IDF_PREFIX", value)
+    expected = (
+        Path(platformdirs.user_cache_dir("esphome", appauthor=False)) / "idf"
+    ).resolve()
+    assert _get_idf_tools_path() == expected
+
+
 def test_get_idf_tools_path_default_uses_user_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -933,3 +933,5 @@ def test_check_windows_path_length_long_path_warns(
     message = caplog.records[0].getMessage()
     assert _LONG_IDF_PATH in message
     assert "long path support" in message
+    # The install is global now; the remedy is the prefix env, not moving the project.
+    assert "ESPHOME_ESP_IDF_PREFIX" in message

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -36,6 +36,19 @@ from esphome.espidf.framework import (
 from esphome.framework_helpers import _tar_extract_all, get_python_env_executable_path
 
 
+@pytest.fixture(autouse=True)
+def _isolate_idf_install_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the ESP-IDF install root to a tmp dir for every test.
+
+    The default location is the OS user cache dir, so without this any test
+    that builds framework paths or pre-creates the framework dir would touch
+    the real ``~/.cache/esphome`` on the developer's machine. Tests that need
+    to exercise the override or default-resolution logic clear/override the env
+    themselves.
+    """
+    monkeypatch.setenv("ESPHOME_ESP_IDF_PREFIX", str(tmp_path / "idf_install"))
+
+
 @pytest.mark.parametrize(
     ("source", "expected"),
     [
@@ -789,6 +802,18 @@ def test_get_idf_tools_path_env_override(tmp_path: Path) -> None:
     override = str(tmp_path / "custom-idf")
     with patch.dict("os.environ", {"ESPHOME_ESP_IDF_PREFIX": override}):
         assert _get_idf_tools_path() == Path(override)
+
+
+def test_get_idf_tools_path_default_uses_user_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the env override the install root is the machine-global OS user
+    cache dir, not the per-config ``<data_dir>/idf``."""
+    import platformdirs
+
+    monkeypatch.delenv("ESPHOME_ESP_IDF_PREFIX", raising=False)
+    expected = (Path(platformdirs.user_cache_dir("esphome")) / "idf").resolve()
+    assert _get_idf_tools_path() == expected
 
 
 def test_write_idf_version_txt_warns_on_write_error(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -67,15 +67,23 @@ def _isolate_platformio_paths(tmp_path_factory: pytest.TempPathFactory) -> Any:
     want to verify the PIO-cleanup branch (e.g. test_clean_all,
     test_clean_all_partial_exists) install their own inner patch which
     stacks on top of this one and wins for the duration of their block.
+
+    Also pin ``ESPHOME_ESP_IDF_PREFIX`` to a nonexistent tmp dir for the
+    same reason: ``clean_all`` removes the now machine-global ESP-IDF
+    install, which otherwise defaults to the real ``~/.cache/esphome``.
     """
     pio_root = tmp_path_factory.mktemp("isolated_pio") / "nonexistent"
+    idf_root = tmp_path_factory.mktemp("isolated_idf") / "nonexistent"
     mock_cfg = MagicMock()
     mock_cfg.get.side_effect = lambda section, option: (
         str(pio_root / option) if section == "platformio" else ""
     )
-    with patch(
-        "platformio.project.config.ProjectConfig.get_instance",
-        return_value=mock_cfg,
+    with (
+        patch(
+            "platformio.project.config.ProjectConfig.get_instance",
+            return_value=mock_cfg,
+        ),
+        patch.dict("os.environ", {"ESPHOME_ESP_IDF_PREFIX": str(idf_root)}),
     ):
         yield
 
@@ -988,6 +996,30 @@ def test_clean_all_with_yaml_file(
     # Verify logging mentions the build dir
     assert "Cleaning" in caplog.text
     assert str(build_dir) in caplog.text
+
+
+@patch("esphome.writer.CORE")
+def test_clean_all_removes_global_idf_install(
+    mock_core: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """clean_all removes the machine-global native ESP-IDF install dir."""
+    idf_install = tmp_path / "idf_install"
+    (idf_install / "frameworks").mkdir(parents=True)
+    monkeypatch.setenv("ESPHOME_ESP_IDF_PREFIX", str(idf_install))
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    from esphome.writer import clean_all
+
+    with caplog.at_level("INFO"):
+        clean_all([str(config_dir)])
+
+    assert not idf_install.exists()
+    assert str(idf_install.resolve()) in caplog.text
 
 
 @patch("esphome.writer.CORE")


### PR DESCRIPTION
# What does this implement/fix?

The native ESP-IDF toolchain (`toolchain: esp-idf`) installed the framework, toolchains, Python envs and ccache under `<data_dir>/idf` — i.e. once per *config directory*. ESP-IDF plus its toolchains are multi-GB, so every separate project re-downloaded and re-installed the whole thing, and `clean-all` wiped it.

This defaults the install root to the **OS user cache dir** (via `platformdirs`) so all projects share a single install:

- `_get_idf_tools_path()` now returns `platformdirs.user_cache_dir("esphome") / "idf"` when `ESPHOME_ESP_IDF_PREFIX` is not set (Linux `~/.cache/esphome/idf`, macOS `~/Library/Caches/esphome/idf`, Windows `%LOCALAPPDATA%\esphome\Cache\idf`).
- The user **cache** dir is used deliberately rather than `~/.esphome`: `data_dir` defaults to `<config_dir>/.esphome`, so a user keeping configs in their home directory would otherwise collide the global install with a config's own data dir.
- `ESPHOME_ESP_IDF_PREFIX` still overrides as before.
- `clean-all` now removes the global install explicitly, since it no longer lives under any `.esphome`.
- The Windows path-length warning still checks the (now global) install dir; its advice is updated — moving the project no longer helps, so it now points at `ESPHOME_ESP_IDF_PREFIX` and gives a copy-paste PowerShell command + the official Microsoft long-paths doc.

## docker / add-on

Both pin `ESPHOME_ESP_IDF_PREFIX` onto their persistent cache volume so the install survives container/add-on restarts instead of defaulting to the ephemeral in-container user cache:

- docker: `<cache_root>/idf` (alongside the existing PlatformIO cache). With no `/cache` mount this resolves to `/config/.esphome/idf`, i.e. the previous location — no behavior change.
- HA add-on: `/data/cache/idf` (alongside `/data/cache/platformio`).

**Migration note:** existing add-on installs will re-download ESP-IDF once after upgrade, because the install moves from `/config/esphome/.esphome/idf` to `/data/cache/idf`. The old copy can be deleted.

CI is unaffected — it already sets `ESPHOME_ESP_IDF_PREFIX: ~/.esphome-idf` for the native-IDF jobs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change. To relocate the shared install:
#   export ESPHOME_ESP_IDF_PREFIX=/path/to/idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).