### PR TITLE
[ethernet] Fix ETH_SPEED_1000M build on IDF 6.0 (enum added in 6.1)

### DIFF
--- a/esphome/components/ethernet/ethernet_component_esp32.cpp
+++ b/esphome/components/ethernet/ethernet_component_esp32.cpp
@@ -839,7 +839,7 @@ void EthernetComponent::dump_connect_params_() {
     case ETH_SPEED_100M:
       link_speed = 100;
       break;
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0)
     case ETH_SPEED_1000M:
       link_speed = 1000;
       break;


### PR DESCRIPTION
# What does this implement/fix?

The gigabit link-speed reporting added for the RGMII PHYs guards the `ETH_SPEED_1000M` case with `ESP_IDF_VERSION >= 6.0.0`:

```cpp
#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
    case ETH_SPEED_1000M:
      link_speed = 1000;
      break;
#endif
```

But `ETH_SPEED_1000M` was not added to the `eth_speed_t` enum until **IDF 6.1**. On IDF 6.0 the enum only has `ETH_SPEED_10M`/`ETH_SPEED_100M`/`ETH_SPEED_MAX`, so the build fails:

```
ethernet_component_esp32.cpp:843:10: error: 'ETH_SPEED_1000M' was not declared in this scope; did you mean 'ETH_SPEED_100M'?
```

(The enum's header also moved from `hal/include/hal/eth_types.h` to the new `esp_hal_emac/include/hal/eth_types.h` in 6.1.)

This bumps the guard on that one case to `6.1.0` so it compiles on IDF 6.0 and still reports gigabit on 6.1+. The neighboring `>= 6.0.0` guards (the `esp_eth_phy_new_generic` RGMII paths) are correct and unchanged — that function exists in 6.0.

Verified locally by compiling the ethernet LAN8720 test on `esp32` with IDF **6.0.1** (toolchain `esp-15.2.0`/GCC15) — fails before this change, builds clean after.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
ethernet:
  type: LAN8720
  mdc_pin: 23
  mdio_pin: 32
  clk:
    pin: 0
    mode: CLK_EXT_IN
  phy_addr: 0
  power_pin: 33
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).