### PR TITLE
[core] Support RFC2217 URLs for UART logs

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -640,9 +640,14 @@ def run_miniterm(config: ConfigType, port: str, args) -> int:
         )
 
     backtrace_state = False
-    ser = serial.Serial()
+
+    if "://" in port:
+        ser = serial.serial_for_url(port)
+    else:
+        ser = serial.Serial()
+        ser.port = port
+
     ser.baudrate = baud_rate
-    ser.port = port
 
     # We can't set to False by default since it leads to toggling and hence
     # ESP32 resets on some platforms.

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -5554,6 +5554,32 @@ class MockSerial:
         raise serial.SerialException("Port closed")
 
 
+
+def test_run_miniterm_uses_serial_for_url_for_rfc2217() -> None:
+    """Test that RFC2217 URLs use serial_for_url() instead of Serial()."""
+
+    mock_serial = MockSerial([MOCK_SERIAL_END])
+
+    CORE.data[KEY_CORE] = {KEY_TARGET_PLATFORM: PLATFORM_ESP32}
+    config = {
+        CONF_LOGGER: {
+            CONF_BAUD_RATE: 115200,
+            "deassert_rts_dtr": False,
+        }
+    }
+    args = MockArgs()
+
+    with (
+        patch("serial.serial_for_url", return_value=mock_serial) as mock_url,
+        patch("serial.Serial") as mock_serial_ctor,
+        patch.object(esp32, "process_stacktrace", return_value=False),
+    ):
+        run_miniterm(config, "rfc2217://192.168.1.126:3333", args)
+
+    mock_url.assert_called_once_with("rfc2217://192.168.1.126:3333")
+    mock_serial_ctor.assert_not_called()
+
+
 def test_run_miniterm_batches_lines_with_same_timestamp(
     capfd: CaptureFixture[str],
 ) -> None:

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -5554,7 +5554,6 @@ class MockSerial:
         raise serial.SerialException("Port closed")
 
 
-
 def test_run_miniterm_uses_serial_for_url_for_rfc2217() -> None:
     """Test that RFC2217 URLs use serial_for_url() instead of Serial()."""
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
