### PR TITLE
[hoermann] Add hoermann component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -230,6 +230,7 @@ esphome/components/hlw8032/* @rici4kubicek
 esphome/components/hm3301/* @freekode
 esphome/components/hmac_md5/* @dwmw2
 esphome/components/hmac_sha256/* @dwmw2
+esphome/components/hoermann/* @zweckj
 esphome/components/homeassistant/* @esphome/core @OttoWinter
 esphome/components/homeassistant/number/* @landonr
 esphome/components/homeassistant/switch/* @Links2004

--- a/esphome/components/hoermann/__init__.py
+++ b/esphome/components/hoermann/__init__.py
@@ -1,0 +1,29 @@
+import esphome.codegen as cg
+from esphome.components import modbus
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+CODEOWNERS = ["@zweckj"]
+DEPENDENCIES = ["modbus"]
+
+CONF_HOERMANN_ID = "hoermann_id"
+
+hoermann_ns = cg.esphome_ns.namespace("hoermann")
+Hoermann = hoermann_ns.class_(
+    "Hoermann", cg.PollingComponent, modbus.ModbusServerDevice
+)
+
+# The Hoermann UAP module answers on Modbus server address 2.
+CONFIG_SCHEMA = (
+    cv.Schema({cv.GenerateID(): cv.declare_id(Hoermann)})
+    .extend(cv.polling_component_schema("500ms"))
+    .extend(modbus.modbus_device_schema(0x02, role="server"))
+)
+
+FINAL_VALIDATE_SCHEMA = modbus.final_validate_modbus_device("hoermann", role="server")
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await modbus.register_modbus_server_device(var, config)

--- a/esphome/components/hoermann/cover/__init__.py
+++ b/esphome/components/hoermann/cover/__init__.py
@@ -1,0 +1,22 @@
+import esphome.codegen as cg
+from esphome.components import cover
+import esphome.config_validation as cv
+
+from .. import CONF_HOERMANN_ID, Hoermann, hoermann_ns
+
+DEPENDENCIES = ["hoermann"]
+
+HoermannCover = hoermann_ns.class_("HoermannCover", cover.Cover, cg.Component)
+
+CONFIG_SCHEMA = (
+    cover.cover_schema(HoermannCover)
+    .extend({cv.GenerateID(CONF_HOERMANN_ID): cv.use_id(Hoermann)})
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = await cover.new_cover(config)
+    await cg.register_component(var, config)
+    parent = await cg.get_variable(config[CONF_HOERMANN_ID])
+    cg.add(var.set_parent(parent))

--- a/esphome/components/hoermann/cover/hoermann_cover.cpp
+++ b/esphome/components/hoermann/cover/hoermann_cover.cpp
@@ -1,0 +1,77 @@
+#include "hoermann_cover.h"
+
+namespace esphome::hoermann {
+
+cover::CoverTraits HoermannCover::get_traits() {
+  auto traits = cover::CoverTraits();
+  traits.set_is_assumed_state(false);
+  traits.set_supports_position(true);
+  traits.set_supports_tilt(false);
+  traits.set_supports_stop(true);
+  traits.set_supports_toggle(true);
+  return traits;
+}
+
+void HoermannCover::setup() {
+  this->parent_->add_on_state_callback([this]() { this->update_from_state_(); });
+}
+
+void HoermannCover::control(const cover::CoverCall &call) {
+  if (call.get_stop()) {
+    this->parent_->stop_door();
+  }
+  if (call.get_toggle().has_value()) {
+    this->parent_->impulse_door();
+  }
+  if (call.get_position().has_value()) {
+    float pos = call.get_position().value();
+    if (pos >= 1.0f) {
+      this->parent_->open_door();
+    } else if (pos <= 0.0f) {
+      this->parent_->close_door();
+    } else {
+      this->parent_->set_position(static_cast<int>(pos * 100.0f));
+    }
+  }
+}
+
+void HoermannCover::update_from_state_() {
+  if (!this->parent_->is_valid()) {
+    this->status_set_warning();
+    return;
+  }
+  this->status_clear_warning();
+
+  float current_position = this->parent_->get_current_position();
+  switch (this->parent_->get_door_state()) {
+    case DoorState::OPENING:
+      this->current_operation = cover::COVER_OPERATION_OPENING;
+      break;
+    case DoorState::CLOSING:
+      this->current_operation = cover::COVER_OPERATION_CLOSING;
+      break;
+    case DoorState::MOVE_VENTING:
+    case DoorState::MOVE_HALF:
+      this->current_operation =
+          this->previous_position_ > current_position ? cover::COVER_OPERATION_OPENING : cover::COVER_OPERATION_CLOSING;
+      break;
+    default:
+      this->current_operation = cover::COVER_OPERATION_IDLE;
+      break;
+  }
+  this->position = current_position;
+
+  bool operation_changed = this->previous_operation_ != this->current_operation;
+  bool position_changed = this->previous_position_ != this->position;
+  if (operation_changed) {
+    this->publish_state();
+    this->previous_operation_ = this->current_operation;
+  } else if (position_changed) {
+    this->publish_state(false);
+  }
+  if (position_changed) {
+    this->previous_position_ = this->position;
+  }
+}
+
+}  // namespace esphome::hoermann

--- a/esphome/components/hoermann/cover/hoermann_cover.h
+++ b/esphome/components/hoermann/cover/hoermann_cover.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/components/cover/cover.h"
+#include "esphome/core/component.h"
+#include "../hoermann.h"
+
+namespace esphome::hoermann {
+
+class HoermannCover : public cover::Cover, public Component {
+ public:
+  void setup() override;
+  void set_parent(Hoermann *parent) { this->parent_ = parent; }
+  cover::CoverTraits get_traits() override;
+  void control(const cover::CoverCall &call) override;
+
+ protected:
+  void update_from_state_();
+  Hoermann *parent_{nullptr};
+  float previous_position_{0.0f};
+  cover::CoverOperation previous_operation_{cover::COVER_OPERATION_IDLE};
+};
+
+}  // namespace esphome::hoermann

--- a/esphome/components/hoermann/hoermann.cpp
+++ b/esphome/components/hoermann/hoermann.cpp
@@ -17,10 +17,10 @@ static constexpr uint16_t COMMAND_REG = 0x9C41;    // Commands written by the bu
 static constexpr uint16_t STATE_REG = 0x9CB9;      // Internal state read back by the bus controller
 static constexpr uint16_t BROADCAST_REG = 0x9D31;  // Door status broadcast by the bus controller
 
-// Command definitions: {reg_plus2_start, reg_plus2_end, reg_plus3_start, reg_plus3_end}.
-static constexpr HoermannCommand COMMAND_OPEN{0x0210, 0x0110, 0x0000, 0x0000};
-static constexpr HoermannCommand COMMAND_CLOSE{0x0220, 0x0120, 0x0000, 0x0000};
-static constexpr HoermannCommand COMMAND_IMPULSE{0x0240, 0x0140, 0x0000, 0x0000};
+// Command definitions: {name, reg_plus2_start, reg_plus2_end, reg_plus3_start, reg_plus3_end}.
+static constexpr HoermannCommand COMMAND_OPEN{"open", 0x0210, 0x0110, 0x0000, 0x0000};
+static constexpr HoermannCommand COMMAND_CLOSE{"close", 0x0220, 0x0120, 0x0000, 0x0000};
+static constexpr HoermannCommand COMMAND_IMPULSE{"impulse", 0x0240, 0x0140, 0x0000, 0x0000};
 
 void Hoermann::setup() {
   ESP_LOGCONFIG(TAG, "Waiting for the bus controller to start polling Modbus address 0x%02X", this->get_address());
@@ -130,10 +130,12 @@ void Hoermann::get_command_values_to_read_(uint16_t &reg_plus2, uint16_t &reg_pl
     reg_plus2 = this->next_command_->reg_plus2_start;
     reg_plus3 = this->next_command_->reg_plus3_start;
     this->command_written_at_ = millis();
+    ESP_LOGI(TAG, "Sending '%s' command to door", this->next_command_->name);
   } else if (millis() - this->command_written_at_ > SIMULATE_KEY_PRESS_DELAY_MS) {
     // Enough time passed: present the "key released" values and clear the command.
     reg_plus2 = this->next_command_->reg_plus2_end;
     reg_plus3 = this->next_command_->reg_plus3_end;
+    ESP_LOGD(TAG, "Released '%s' command", this->next_command_->name);
     this->command_written_at_ = 0;
     this->next_command_ = nullptr;
   }

--- a/esphome/components/hoermann/hoermann.cpp
+++ b/esphome/components/hoermann/hoermann.cpp
@@ -1,0 +1,245 @@
+#include "hoermann.h"
+
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome::hoermann {
+
+static const char *const TAG = "hoermann";
+
+// Simulated key-press duration: a command is "pressed" for this long before its end value is sent.
+static constexpr uint32_t SIMULATE_KEY_PRESS_DELAY_MS = 100;
+// Drop the "connected" flag if the bus controller has not polled us for this long.
+static constexpr uint32_t CONNECTION_TIMEOUT_MS = 2000;
+
+// Hoermann HCP holding-register blocks.
+static constexpr uint16_t COMMAND_REG = 0x9C41;    // Commands written by the bus controller
+static constexpr uint16_t STATE_REG = 0x9CB9;      // Internal state read back by the bus controller
+static constexpr uint16_t BROADCAST_REG = 0x9D31;  // Door status broadcast by the bus controller
+
+// Command definitions: {reg_plus2_start, reg_plus2_end, reg_plus3_start, reg_plus3_end}.
+static constexpr HoermannCommand COMMAND_OPEN{0x0210, 0x0110, 0x0000, 0x0000};
+static constexpr HoermannCommand COMMAND_CLOSE{0x0220, 0x0120, 0x0000, 0x0000};
+static constexpr HoermannCommand COMMAND_IMPULSE{0x0240, 0x0140, 0x0000, 0x0000};
+
+void Hoermann::update() {
+  // Time out the connection flag if the bus controller stopped polling.
+  if (this->valid_ && millis() - this->last_response_ > CONNECTION_TIMEOUT_MS) {
+    this->set_valid_(false);
+  }
+  if (this->changed_) {
+    this->changed_ = false;
+    this->state_callback_.call();
+  }
+}
+
+void Hoermann::dump_config() {
+  ESP_LOGCONFIG(TAG, "Hoermann HCP bridge:");
+  ESP_LOGCONFIG(TAG, "  Modbus server address: 0x%02X", this->get_address());
+}
+
+modbus::ServerResponseStatus Hoermann::on_modbus_read_write_registers(uint16_t read_start_address,
+                                                                      uint16_t number_of_registers,
+                                                                      uint16_t write_start_address,
+                                                                      const modbus::RegisterValues &write_registers,
+                                                                      modbus::RegisterValues &read_registers) {
+  this->record_response_();
+
+  if (write_start_address == COMMAND_REG && read_start_address == STATE_REG && !write_registers.empty()) {
+    // High byte of the first written register is a message counter, low byte is the command.
+    uint16_t counter = write_registers[0] & 0xFF00;
+    uint16_t command = (write_registers[0] & 0x00FF) << 8;
+
+    if (write_registers.size() == 2 && number_of_registers == 8) {
+      // Command request: return the internal state, injecting any pending command.
+      uint16_t reg_plus2;
+      uint16_t reg_plus3;
+      this->get_command_values_to_read_(reg_plus2, reg_plus3);
+      read_registers.push_back(static_cast<uint16_t>(0x0000 | counter));
+      read_registers.push_back(static_cast<uint16_t>(0x0001 | command));
+      read_registers.push_back(reg_plus2);
+      read_registers.push_back(reg_plus3);
+      read_registers.push_back(0x0000);
+      read_registers.push_back(0x0000);
+      read_registers.push_back(0x0000);
+      read_registers.push_back(0x0000);
+    } else if (write_registers.size() == 2 && number_of_registers == 2) {
+      // Empty command request.
+      read_registers.push_back(static_cast<uint16_t>(0x0004 | counter));
+      read_registers.push_back(static_cast<uint16_t>(0x0000 | command));
+    } else if (write_registers.size() == 3 && number_of_registers == 5) {
+      // Bus scan.
+      read_registers.push_back(static_cast<uint16_t>(0x0000 | counter));
+      read_registers.push_back(static_cast<uint16_t>(0x0005 | command));
+      read_registers.push_back(0x0430);
+      read_registers.push_back(0x10ff);
+      read_registers.push_back(0xa845);
+    } else {
+      ESP_LOGW(TAG, "Unknown read/write request (write %u, read %u)", static_cast<unsigned>(write_registers.size()),
+               number_of_registers);
+      for (uint16_t i = 0; i < number_of_registers; i++)
+        read_registers.push_back(0x0000);
+    }
+  } else {
+    ESP_LOGW(TAG, "Unknown read/write addresses write=0x%04X read=0x%04X", write_start_address, read_start_address);
+    for (uint16_t i = 0; i < number_of_registers; i++)
+      read_registers.push_back(0x0000);
+  }
+
+  return {};
+}
+
+modbus::ServerResponseStatus Hoermann::on_modbus_write_registers(uint16_t start_address,
+                                                                 const modbus::RegisterValues &registers) {
+  this->record_response_();
+
+  if (start_address != BROADCAST_REG) {
+    ESP_LOGW(TAG, "Unknown write address 0x%04X", start_address);
+    return {};
+  }
+
+  // Door status broadcast. Each handler compares the previous register value with the new one to detect
+  // high/low byte changes, so the previous values are tracked between broadcasts.
+  if (registers.size() > 1) {
+    this->on_door_position_changed_(this->prev_position_reg_, registers[1]);
+    this->prev_position_reg_ = registers[1];
+  }
+  if (registers.size() > 2) {
+    this->on_current_state_changed_(this->prev_state_reg_, registers[2]);
+    this->prev_state_reg_ = registers[2];
+  }
+  return {};
+}
+
+void Hoermann::get_command_values_to_read_(uint16_t &reg_plus2, uint16_t &reg_plus3) {
+  reg_plus2 = 0x0000;
+  reg_plus3 = 0x0000;
+  if (this->next_command_ == nullptr)
+    return;
+
+  if (this->command_written_at_ == 0) {
+    // First read after the command was queued: present the "key pressed" values.
+    reg_plus2 = this->next_command_->reg_plus2_start;
+    reg_plus3 = this->next_command_->reg_plus3_start;
+    this->command_written_at_ = millis();
+  } else if (millis() - this->command_written_at_ > SIMULATE_KEY_PRESS_DELAY_MS) {
+    // Enough time passed: present the "key released" values and clear the command.
+    reg_plus2 = this->next_command_->reg_plus2_end;
+    reg_plus3 = this->next_command_->reg_plus3_end;
+    this->command_written_at_ = 0;
+    this->next_command_ = nullptr;
+  }
+  // Within the key-press window we keep presenting 0x0000.
+}
+
+void Hoermann::on_door_position_changed_(uint16_t old_value, uint16_t new_value) {
+  // Low byte: current position.
+  if ((old_value & 0x00FF) != (new_value & 0x00FF)) {
+    this->set_current_position_(static_cast<float>(new_value & 0x00FF) / 200.0f);
+    bool reached = (this->goto_position_ > 0.0f && this->door_state_ == DoorState::CLOSING &&
+                    this->goto_position_ >= this->current_position_) ||
+                   (this->goto_position_ > 0.0f && this->door_state_ == DoorState::OPENING &&
+                    this->goto_position_ <= this->current_position_);
+    if (reached) {
+      this->stop_door();
+      this->goto_position_ = 0.0f;
+    }
+  }
+}
+
+void Hoermann::on_current_state_changed_(uint16_t old_value, uint16_t new_value) {
+  if ((old_value & 0xFF00) == (new_value & 0xFF00))
+    return;
+
+  switch ((new_value & 0xFF00) >> 8) {
+    case 0x01:
+      this->set_door_state_(DoorState::OPENING);
+      break;
+    case 0x02:
+      this->set_door_state_(DoorState::CLOSING);
+      break;
+    case 0x20:
+      this->set_door_state_(DoorState::OPEN);
+      break;
+    case 0x40:
+      this->set_door_state_(DoorState::CLOSED);
+      break;
+    case 0x80:
+      this->set_door_state_(DoorState::HALF_OPEN);
+      break;
+    case 0x09:
+      this->set_door_state_(DoorState::MOVE_VENTING);
+      break;
+    case 0x05:
+      this->set_door_state_(DoorState::MOVE_HALF);
+      break;
+    case 0x0A:
+      this->set_door_state_(DoorState::VENT);
+      break;
+    case 0x00:
+      this->set_door_state_((new_value & 0x00FF) == 0x61 ? DoorState::VENT : DoorState::STOPPED);
+      break;
+    default:
+      ESP_LOGW(TAG, "Unknown door state 0x%02X", (new_value & 0xFF00) >> 8);
+  }
+}
+
+void Hoermann::queue_command_(bool condition, const HoermannCommand &command) {
+  if (!condition)
+    return;
+  if (this->next_command_ != nullptr) {
+    ESP_LOGW(TAG, "Previous command not yet fetched by the bus controller");
+    return;
+  }
+  this->next_command_ = &command;
+}
+
+void Hoermann::open_door() { this->queue_command_(true, COMMAND_OPEN); }
+void Hoermann::close_door() { this->queue_command_(true, COMMAND_CLOSE); }
+void Hoermann::impulse_door() { this->queue_command_(true, COMMAND_IMPULSE); }
+
+void Hoermann::stop_door() {
+  // Only send an impulse if the door is actually moving.
+  this->queue_command_(this->door_state_ == DoorState::CLOSING || this->door_state_ == DoorState::OPENING ||
+                           this->door_state_ == DoorState::MOVE_HALF || this->door_state_ == DoorState::MOVE_VENTING,
+                       COMMAND_IMPULSE);
+}
+
+void Hoermann::set_position(int percent) {
+  // The first and last movement segments are inconsistent on some doors, so snap to fully open/closed.
+  if (percent <= 5) {
+    this->close_door();
+  } else if (percent >= 95) {
+    this->open_door();
+  } else {
+    this->goto_position_ = static_cast<float>(percent) / 100.0f;
+    this->queue_command_(this->current_position_ < this->goto_position_, COMMAND_OPEN);
+    this->queue_command_(this->current_position_ > this->goto_position_, COMMAND_CLOSE);
+  }
+}
+
+void Hoermann::record_response_() {
+  this->last_response_ = millis();
+  this->set_valid_(true);
+}
+
+void Hoermann::set_valid_(bool valid) {
+  if (this->valid_ != valid) {
+    this->valid_ = valid;
+    this->changed_ = true;
+  }
+}
+void Hoermann::set_door_state_(DoorState state) {
+  if (this->door_state_ != state) {
+    this->door_state_ = state;
+    this->changed_ = true;
+  }
+}
+void Hoermann::set_current_position_(float position) {
+  if (this->current_position_ != position) {
+    this->current_position_ = position;
+    this->changed_ = true;
+  }
+}
+
+}  // namespace esphome::hoermann

--- a/esphome/components/hoermann/hoermann.cpp
+++ b/esphome/components/hoermann/hoermann.cpp
@@ -22,6 +22,10 @@ static constexpr HoermannCommand COMMAND_OPEN{0x0210, 0x0110, 0x0000, 0x0000};
 static constexpr HoermannCommand COMMAND_CLOSE{0x0220, 0x0120, 0x0000, 0x0000};
 static constexpr HoermannCommand COMMAND_IMPULSE{0x0240, 0x0140, 0x0000, 0x0000};
 
+void Hoermann::setup() {
+  ESP_LOGCONFIG(TAG, "Waiting for the bus controller to start polling Modbus address 0x%02X", this->get_address());
+}
+
 void Hoermann::update() {
   // Time out the connection flag if the bus controller stopped polling.
   if (this->valid_ && millis() - this->last_response_ > CONNECTION_TIMEOUT_MS) {
@@ -34,8 +38,11 @@ void Hoermann::update() {
 }
 
 void Hoermann::dump_config() {
-  ESP_LOGCONFIG(TAG, "Hoermann HCP bridge:");
-  ESP_LOGCONFIG(TAG, "  Modbus server address: 0x%02X", this->get_address());
+  ESP_LOGCONFIG(TAG,
+                "Hoermann HCP bridge:\n"
+                "  Modbus server address: 0x%02X\n"
+                "  Connection timeout: %ums",
+                this->get_address(), static_cast<unsigned>(CONNECTION_TIMEOUT_MS));
 }
 
 modbus::ServerResponseStatus Hoermann::on_modbus_read_write_registers(uint16_t read_start_address,
@@ -68,7 +75,8 @@ modbus::ServerResponseStatus Hoermann::on_modbus_read_write_registers(uint16_t r
       read_registers.push_back(static_cast<uint16_t>(0x0004 | counter));
       read_registers.push_back(static_cast<uint16_t>(0x0000 | command));
     } else if (write_registers.size() == 3 && number_of_registers == 5) {
-      // Bus scan.
+      // Bus scan (the bus controller discovering us, typically at startup).
+      ESP_LOGD(TAG, "Bus scan received from bus controller");
       read_registers.push_back(static_cast<uint16_t>(0x0000 | counter));
       read_registers.push_back(static_cast<uint16_t>(0x0005 | command));
       read_registers.push_back(0x0430);
@@ -224,9 +232,15 @@ void Hoermann::record_response_() {
 }
 
 void Hoermann::set_valid_(bool valid) {
-  if (this->valid_ != valid) {
-    this->valid_ = valid;
-    this->changed_ = true;
+  if (this->valid_ == valid)
+    return;
+  this->valid_ = valid;
+  this->changed_ = true;
+  if (valid) {
+    ESP_LOGI(TAG, "Bus controller connected");
+  } else {
+    ESP_LOGW(TAG, "Bus controller connection lost (no request for %ums)",
+             static_cast<unsigned>(millis() - this->last_response_));
   }
 }
 void Hoermann::set_door_state_(DoorState state) {

--- a/esphome/components/hoermann/hoermann.h
+++ b/esphome/components/hoermann/hoermann.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <utility>
+
+#include "esphome/components/modbus/modbus.h"
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome::hoermann {
+
+// Door state as reported by the Hoermann bus controller.
+enum class DoorState : uint8_t {
+  OPEN,
+  OPENING,
+  CLOSED,
+  CLOSING,
+  HALF_OPEN,
+  MOVE_VENTING,
+  VENT,
+  MOVE_HALF,
+  STOPPED,
+};
+
+// A HCP command is a simulated key press: the "start" values are presented to the bus controller, then after a
+// short delay the "end" values, mimicking a button being pressed and released.
+struct HoermannCommand {
+  uint16_t reg_plus2_start;
+  uint16_t reg_plus2_end;
+  uint16_t reg_plus3_start;
+  uint16_t reg_plus3_end;
+};
+
+class Hoermann : public PollingComponent, public modbus::ModbusServerDevice {
+ public:
+  void update() override;
+  void dump_config() override;
+
+  // Registered by child entities to be notified when the door state changes.
+  template<typename F> void add_on_state_callback(F &&callback) {
+    this->state_callback_.add(std::forward<F>(callback));
+  }
+
+  // Modbus server callbacks. The bus controller polls state and pushes commands with READ_WRITE_MULTIPLE_REGISTERS
+  // (0x17) and broadcasts status with WRITE_MULTIPLE_REGISTERS (0x10).
+  modbus::ServerResponseStatus on_modbus_read_write_registers(uint16_t read_start_address, uint16_t number_of_registers,
+                                                              uint16_t write_start_address,
+                                                              const modbus::RegisterValues &write_registers,
+                                                              modbus::RegisterValues &read_registers) override;
+  modbus::ServerResponseStatus on_modbus_write_registers(uint16_t start_address,
+                                                         const modbus::RegisterValues &registers) override;
+
+  // Control functions.
+  void open_door();
+  void close_door();
+  void impulse_door();
+  void stop_door();
+  void set_position(int percent);
+
+  // State accessors used by child entities.
+  DoorState get_door_state() const { return this->door_state_; }
+  float get_current_position() const { return this->current_position_; }
+  bool is_valid() const { return this->valid_; }
+
+ protected:
+  void record_response_();
+  void queue_command_(bool condition, const HoermannCommand &command);
+  void get_command_values_to_read_(uint16_t &reg_plus2, uint16_t &reg_plus3);
+  void on_door_position_changed_(uint16_t old_value, uint16_t new_value);
+  void on_current_state_changed_(uint16_t old_value, uint16_t new_value);
+
+  void set_valid_(bool valid);
+  void set_door_state_(DoorState state);
+  void set_current_position_(float position);
+
+  CallbackManager<void()> state_callback_;
+
+  DoorState door_state_{DoorState::CLOSED};
+  float current_position_{0.0f};
+  float goto_position_{0.0f};
+  bool valid_{false};
+  bool changed_{false};
+
+  // Pending command / key-press state machine.
+  const HoermannCommand *next_command_{nullptr};
+  uint32_t command_written_at_{0};
+  uint32_t last_response_{0};
+
+  // Previous broadcast register values (to detect high/low byte changes).
+  uint16_t prev_position_reg_{0};
+  uint16_t prev_state_reg_{0};
+};
+
+}  // namespace esphome::hoermann

--- a/esphome/components/hoermann/hoermann.h
+++ b/esphome/components/hoermann/hoermann.h
@@ -32,6 +32,7 @@ struct HoermannCommand {
 
 class Hoermann : public PollingComponent, public modbus::ModbusServerDevice {
  public:
+  void setup() override;
   void update() override;
   void dump_config() override;
 

--- a/esphome/components/hoermann/hoermann.h
+++ b/esphome/components/hoermann/hoermann.h
@@ -24,6 +24,7 @@ enum class DoorState : uint8_t {
 // A HCP command is a simulated key press: the "start" values are presented to the bus controller, then after a
 // short delay the "end" values, mimicking a button being pressed and released.
 struct HoermannCommand {
+  const char *name;
   uint16_t reg_plus2_start;
   uint16_t reg_plus2_end;
   uint16_t reg_plus3_start;

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -441,6 +441,56 @@ void ModbusServerHub::process_modbus_client_frame_(uint8_t address, uint8_t func
       response_len = 4;
       break;
     }
+    case ModbusFunctionCode::READ_WRITE_MULTIPLE_REGISTERS: {
+      // PDU data: read start address(2) + read quantity(2) + write start address(2) + write quantity(2) +
+      // write byte count(1) + write register values. Per Modbus 6.17 the write is performed before the read.
+      uint16_t read_start_address = helpers::get_data<uint16_t>(data, 0);
+      uint16_t number_of_registers = helpers::get_data<uint16_t>(data, 2);
+      uint16_t write_start_address = helpers::get_data<uint16_t>(data, 4);
+      uint16_t number_of_write_registers = helpers::get_data<uint16_t>(data, 6);
+      uint8_t number_of_bytes = helpers::get_data<uint8_t>(data, 8);
+      if (number_of_registers == 0 || number_of_registers > MAX_NUM_OF_REGISTERS_TO_READ ||
+          number_of_write_registers == 0 || number_of_write_registers > MAX_NUM_OF_REGISTERS_TO_WRITE ||
+          number_of_write_registers * 2 != number_of_bytes) {
+        ESP_LOGW(TAG, "Invalid number of registers (read %" PRIu16 ", write %" PRIu16 ") or bytes %" PRIu8,
+                 number_of_registers, number_of_write_registers, number_of_bytes);
+        this->send_exception_(address, function_code, ModbusExceptionCode::ILLEGAL_DATA_VALUE);
+        return;
+      }
+      if (!this->check_register_range_(address, function_code, read_start_address, number_of_registers) ||
+          !this->check_register_range_(address, function_code, write_start_address, number_of_write_registers)) {
+        return;
+      }
+      // Assemble the written register values (host byte order); they follow the 9-byte request header.
+      RegisterValues write_registers;
+      for (uint16_t i = 0; i < number_of_write_registers; i++) {
+        write_registers.push_back(helpers::get_data<uint16_t>(data, 9 + i * 2));
+      }
+      RegisterValues registers;
+      status = device->on_modbus_read_write_registers(read_start_address, number_of_registers, write_start_address,
+                                                      write_registers, registers);
+
+      // A handler that returns an exception leaves registers partially filled, so check the exception
+      // first and forward it before validating the register count on the success path.
+      if (status.has_value()) {
+        this->send_exception_(address, function_code, status.value());
+        return;
+      }
+
+      if (registers.size() != number_of_registers) {
+        ESP_LOGE(TAG, "Incorrect response %" PRIu16 " requested, %zu returned", number_of_registers, registers.size());
+        this->send_exception_(address, function_code, ModbusExceptionCode::SERVICE_DEVICE_FAILURE);
+        return;
+      }
+
+      response_buffer[response_len++] = static_cast<uint8_t>(number_of_registers * 2);  // actual byte count
+      for (auto r : registers) {
+        auto register_bytes = decode_value(r);
+        response_buffer[response_len++] = register_bytes[0];
+        response_buffer[response_len++] = register_bytes[1];
+      }
+      break;
+    }
     default:
       ESP_LOGW(TAG, "Unsupported function code %" PRIu8, function_code);
       this->send_exception_(address, function_code, ModbusExceptionCode::ILLEGAL_FUNCTION);

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -232,6 +232,12 @@ class ModbusServerDevice {
   virtual ServerResponseStatus on_modbus_write_registers(uint16_t start_address, const RegisterValues &registers) {
     return ModbusExceptionCode::ILLEGAL_FUNCTION;
   };
+  virtual ServerResponseStatus on_modbus_read_write_registers(uint16_t read_start_address, uint16_t number_of_registers,
+                                                              uint16_t write_start_address,
+                                                              const RegisterValues &write_registers,
+                                                              RegisterValues &read_registers) {
+    return ModbusExceptionCode::ILLEGAL_FUNCTION;
+  };
 
  protected:
   uint8_t address_{0};

--- a/esphome/components/modbus/modbus_definitions.h
+++ b/esphome/components/modbus/modbus_definitions.h
@@ -28,12 +28,12 @@ enum class ModbusFunctionCode : uint8_t {
   GET_COMM_EVENT_LOG = 0x0C,      // not implemented
   WRITE_MULTIPLE_COILS = 0x0F,
   WRITE_MULTIPLE_REGISTERS = 0x10,
-  REPORT_SERVER_ID = 0x11,               // not implemented
-  READ_FILE_RECORD = 0x14,               // not implemented
-  WRITE_FILE_RECORD = 0x15,              // not implemented
-  MASK_WRITE_REGISTER = 0x16,            // not implemented
-  READ_WRITE_MULTIPLE_REGISTERS = 0x17,  // not implemented
-  READ_FIFO_QUEUE = 0x18,                // not implemented
+  REPORT_SERVER_ID = 0x11,     // not implemented
+  READ_FILE_RECORD = 0x14,     // not implemented
+  WRITE_FILE_RECORD = 0x15,    // not implemented
+  MASK_WRITE_REGISTER = 0x16,  // not implemented
+  READ_WRITE_MULTIPLE_REGISTERS = 0x17,
+  READ_FIFO_QUEUE = 0x18,  // not implemented
 };
 
 /*Allow direct comparison operators between ModbusFunctionCode and uint8_t*/

--- a/tests/components/hoermann/common.yaml
+++ b/tests/components/hoermann/common.yaml
@@ -1,0 +1,12 @@
+modbus:
+  id: modbus_hoermann
+  uart_id: uart_bus
+  role: server
+
+hoermann:
+  id: hoermann_hub
+
+cover:
+  - platform: hoermann
+    name: Garage Door
+    device_class: garage

--- a/tests/components/hoermann/common.yaml
+++ b/tests/components/hoermann/common.yaml
@@ -4,7 +4,7 @@ modbus:
   role: server
 
 hoermann:
-  id: hoermann_hub
+  id: hoermann_hcp
 
 cover:
   - platform: hoermann

--- a/tests/components/hoermann/hoermann_test.cpp
+++ b/tests/components/hoermann/hoermann_test.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+
+#include "esphome/components/hoermann/hoermann.h"
+
+namespace esphome::hoermann {
+
+using modbus::RegisterValues;
+
+namespace {
+
+// Register block addresses the Hoermann bus controller polls (see hoermann.cpp).
+constexpr uint16_t COMMAND_REG = 0x9C41;
+constexpr uint16_t STATE_REG = 0x9CB9;
+constexpr uint16_t BROADCAST_REG = 0x9D31;
+
+RegisterValues make_registers(std::initializer_list<uint16_t> values) {
+  RegisterValues registers;
+  for (uint16_t value : values)
+    registers.push_back(value);
+  return registers;
+}
+
+}  // namespace
+
+// An empty poll (write 2 / read 2) answers with the fixed status word 0x0004.
+TEST(HoermannReadWrite, EmptyPollReturnsStatusWord) {
+  Hoermann door;
+  RegisterValues response;
+  auto status =
+      door.on_modbus_read_write_registers(STATE_REG, 2, COMMAND_REG, make_registers({0x0000, 0x0000}), response);
+  EXPECT_FALSE(status.has_value());
+  ASSERT_EQ(response.size(), 2u);
+  EXPECT_EQ(response[0], 0x0004);
+  EXPECT_EQ(response[1], 0x0000);
+}
+
+// A bus scan (write 3 / read 5) answers with the fixed device identification block.
+TEST(HoermannReadWrite, BusScanReturnsIdentification) {
+  Hoermann door;
+  RegisterValues response;
+  auto status = door.on_modbus_read_write_registers(STATE_REG, 5, COMMAND_REG, make_registers({0x0000, 0x0000, 0x0000}),
+                                                    response);
+  EXPECT_FALSE(status.has_value());
+  ASSERT_EQ(response.size(), 5u);
+  EXPECT_EQ(response[1], 0x0005);
+  EXPECT_EQ(response[2], 0x0430);
+  EXPECT_EQ(response[3], 0x10ff);
+  EXPECT_EQ(response[4], 0xa845);
+}
+
+// Without a queued command, the command poll (write 2 / read 8) reports idle and no key press.
+TEST(HoermannReadWrite, IdleCommandPollHasNoCommand) {
+  Hoermann door;
+  RegisterValues response;
+  auto status =
+      door.on_modbus_read_write_registers(STATE_REG, 8, COMMAND_REG, make_registers({0x0000, 0x0000}), response);
+  EXPECT_FALSE(status.has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], 0x0001);
+  EXPECT_EQ(response[2], 0x0000);
+  EXPECT_EQ(response[3], 0x0000);
+}
+
+// A queued control command is injected into the next command poll as a simulated key press.
+TEST(HoermannReadWrite, QueuedCommandIsInjectedIntoPoll) {
+  Hoermann door;
+  door.open_door();
+  RegisterValues response;
+  auto status =
+      door.on_modbus_read_write_registers(STATE_REG, 8, COMMAND_REG, make_registers({0x0000, 0x0000}), response);
+  EXPECT_FALSE(status.has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[2], 0x0210);  // COMMAND_OPEN "key pressed" value
+  EXPECT_EQ(response[3], 0x0000);
+}
+
+// A status broadcast (function code 0x10 to 0x9D31) updates the decoded door state and position.
+TEST(HoermannWrite, BroadcastUpdatesStateAndPosition) {
+  Hoermann door;
+  // registers[1] low byte = position (value / 200), registers[2] high byte = state (0x01 -> opening).
+  auto status = door.on_modbus_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0064, 0x0100}));
+  EXPECT_FALSE(status.has_value());
+  EXPECT_EQ(door.get_door_state(), DoorState::OPENING);
+  EXPECT_FLOAT_EQ(door.get_current_position(), 0.5f);
+}
+
+}  // namespace esphome::hoermann

--- a/tests/components/hoermann/test.esp32-idf.yaml
+++ b/tests/components/hoermann/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/hoermann/test.esp8266-ard.yaml
+++ b/tests/components/hoermann/test.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Add a component to control Hörmann garage doors + required modbus changes to support code `0x17` through a ` virtual on_modbus_read_write_registers`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
