### PR TITLE
[equitherm] Add sensor staleness and fault detection

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -157,6 +157,7 @@ esphome/components/ens160_i2c/* @latonita
 esphome/components/ens160_spi/* @latonita
 esphome/components/ens210/* @itn3rd77
 esphome/components/epaper_spi/* @esphome/core
+esphome/components/equitherm/* @P4uLT
 esphome/components/es7210/* @kahrendt
 esphome/components/es7243e/* @kbx81
 esphome/components/es8156/* @kbx81

--- a/esphome/components/equitherm/__init__.py
+++ b/esphome/components/equitherm/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@P4uLT"]

--- a/esphome/components/equitherm/binary_sensor/__init__.py
+++ b/esphome/components/equitherm/binary_sensor/__init__.py
@@ -1,0 +1,80 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+from esphome.components.const import CONF_CLIMATE_ID
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, DEVICE_CLASS_PROBLEM, ENTITY_CATEGORY_DIAGNOSTIC
+
+from ..climate import EquithermClimate, equitherm_ns
+
+# Explicit binary sensor classes for each type
+OutdoorSensorFaultBinarySensor = equitherm_ns.class_(
+    "OutdoorSensorFaultBinarySensor", binary_sensor.BinarySensor, cg.Component
+)
+IndoorSensorFaultBinarySensor = equitherm_ns.class_(
+    "IndoorSensorFaultBinarySensor", binary_sensor.BinarySensor, cg.Component
+)
+IndoorSensorCoastingBinarySensor = equitherm_ns.class_(
+    "IndoorSensorCoastingBinarySensor", binary_sensor.BinarySensor, cg.Component
+)
+
+# Configuration keys for each binary sensor type
+CONF_OUTDOOR_SENSOR_FAULT = "outdoor_sensor_fault"
+CONF_INDOOR_SENSOR_FAULT = "indoor_sensor_fault"
+CONF_INDOOR_SENSOR_COASTING = "indoor_sensor_coasting"
+
+
+def _problem_sensor_schema(binary_sensor_class, icon="mdi:alert-circle-outline"):
+    """Generate schema for problem-indicating binary sensors (fault sensors)."""
+    return binary_sensor.binary_sensor_schema(
+        binary_sensor_class,
+        device_class=DEVICE_CLASS_PROBLEM,
+        icon=icon,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ).extend(cv.COMPONENT_SCHEMA)
+
+
+def _status_sensor_schema(binary_sensor_class, icon="mdi:alert-circle-outline"):
+    """Generate schema for status binary sensors (normal operation indicators)."""
+    return binary_sensor.binary_sensor_schema(
+        binary_sensor_class,
+        icon=icon,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ).extend(cv.COMPONENT_SCHEMA)
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
+        cv.GenerateID(CONF_CLIMATE_ID): cv.use_id(EquithermClimate),
+        cv.Optional(CONF_OUTDOOR_SENSOR_FAULT): _problem_sensor_schema(
+            OutdoorSensorFaultBinarySensor
+        ),
+        cv.Optional(CONF_INDOOR_SENSOR_FAULT): _problem_sensor_schema(
+            IndoorSensorFaultBinarySensor
+        ),
+        cv.Optional(CONF_INDOOR_SENSOR_COASTING): _status_sensor_schema(
+            IndoorSensorCoastingBinarySensor, icon="mdi:thermometer-off"
+        ),
+    }
+)
+
+
+async def _register_binary_sensor(config, parent_id):
+    """Helper to register a binary sensor entity."""
+    bs = await binary_sensor.new_binary_sensor(config)
+    await cg.register_component(bs, config)
+    await cg.register_parented(bs, parent_id)
+    return bs
+
+
+async def to_code(config):
+    parent_id = config[CONF_CLIMATE_ID]
+
+    if outdoor_config := config.get(CONF_OUTDOOR_SENSOR_FAULT):
+        await _register_binary_sensor(outdoor_config, parent_id)
+
+    if indoor_config := config.get(CONF_INDOOR_SENSOR_FAULT):
+        await _register_binary_sensor(indoor_config, parent_id)
+
+    if coasting_config := config.get(CONF_INDOOR_SENSOR_COASTING):
+        await _register_binary_sensor(coasting_config, parent_id)

--- a/esphome/components/equitherm/binary_sensor/equitherm_binary_sensor_base.cpp
+++ b/esphome/components/equitherm/binary_sensor/equitherm_binary_sensor_base.cpp
@@ -1,0 +1,19 @@
+#include "equitherm_binary_sensor_base.h"
+
+namespace esphome::equitherm {
+
+void EquithermBinarySensorBase::init_state_(bool value) {
+  if (this->restore_value_) {
+    this->pref_ = this->make_entity_preference<bool>();
+    this->pref_.load(&value);  // overwrites on success, keeps default on failure
+  }
+  this->publish_state(value);
+}
+
+void EquithermBinarySensorBase::save_state_(bool value) {
+  if (this->restore_value_) {
+    this->pref_.save(&value);
+  }
+}
+
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/binary_sensor/equitherm_binary_sensor_base.h
+++ b/esphome/components/equitherm/binary_sensor/equitherm_binary_sensor_base.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+
+namespace esphome::equitherm {
+
+/// Base class for equitherm climate binary sensor entities
+class EquithermBinarySensorBase : public binary_sensor::BinarySensor, public Component {
+ public:
+  void set_restore_value(bool restore_value) { restore_value_ = restore_value; }
+
+ protected:
+  void init_state_(bool value);
+  void save_state_(bool value);
+
+  bool restore_value_{false};
+  ESPPreferenceObject pref_;
+};
+
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/binary_sensor/indoor_sensor_coasting_binary_sensor.cpp
+++ b/esphome/components/equitherm/binary_sensor/indoor_sensor_coasting_binary_sensor.cpp
@@ -1,0 +1,22 @@
+#include "indoor_sensor_coasting_binary_sensor.h"
+#include "esphome/core/log.h"
+#include "../equitherm.h"
+
+namespace esphome::equitherm {
+
+static const char *const TAG = "indoor_sensor_coasting_binary_sensor";
+
+void IndoorSensorCoastingBinarySensor::setup() {
+  this->parent_->add_on_state_callback([this]() { this->update_from_parent_(); });
+  this->update_from_parent_();
+}
+
+void IndoorSensorCoastingBinarySensor::update_from_parent_() {
+  this->publish_state(this->parent_->is_indoor_sensor_coasting());
+}
+
+void IndoorSensorCoastingBinarySensor::dump_config() {
+  LOG_BINARY_SENSOR("", "IndoorSensorCoastingBinarySensor", this);
+}
+
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/binary_sensor/indoor_sensor_coasting_binary_sensor.h
+++ b/esphome/components/equitherm/binary_sensor/indoor_sensor_coasting_binary_sensor.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "equitherm_binary_sensor_base.h"
+
+namespace esphome::equitherm {
+
+class EquithermClimate;
+
+/// Indoor sensor coasting indicator - ON when indoor data is quiet-but-plausible
+/// (PID off, pure equitherm). Informational, not an alarm.
+class IndoorSensorCoastingBinarySensor : public EquithermBinarySensorBase, public Parented<EquithermClimate> {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void update_from_parent_();
+};
+
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/binary_sensor/indoor_sensor_fault_binary_sensor.cpp
+++ b/esphome/components/equitherm/binary_sensor/indoor_sensor_fault_binary_sensor.cpp
@@ -1,0 +1,21 @@
+#include "indoor_sensor_fault_binary_sensor.h"
+#include "esphome/core/log.h"
+#include "../equitherm.h"
+
+namespace esphome::equitherm {
+
+static const char *const TAG = "indoor_sensor_fault_binary_sensor";
+
+void IndoorSensorFaultBinarySensor::setup() {
+  this->parent_->add_on_state_callback([this]() { this->update_from_parent_(); });
+  this->update_from_parent_();
+}
+
+void IndoorSensorFaultBinarySensor::update_from_parent_() {
+  bool state = this->parent_->is_indoor_sensor_fault();
+  this->publish_state(state);
+}
+
+void IndoorSensorFaultBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "IndoorSensorFaultBinarySensor", this); }
+
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/binary_sensor/indoor_sensor_fault_binary_sensor.h
+++ b/esphome/components/equitherm/binary_sensor/indoor_sensor_fault_binary_sensor.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "equitherm_binary_sensor_base.h"
+
+namespace esphome::equitherm {
+
+class EquithermClimate;
+
+/// Indoor sensor fault indicator - ON when indoor sensor has failed and PID is disabled (pure equitherm mode)
+class IndoorSensorFaultBinarySensor : public EquithermBinarySensorBase, public Parented<EquithermClimate> {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void update_from_parent_();
+};
+
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/binary_sensor/outdoor_sensor_fault_binary_sensor.cpp
+++ b/esphome/components/equitherm/binary_sensor/outdoor_sensor_fault_binary_sensor.cpp
@@ -1,0 +1,21 @@
+#include "outdoor_sensor_fault_binary_sensor.h"
+#include "esphome/core/log.h"
+#include "../equitherm.h"
+
+namespace esphome::equitherm {
+
+static const char *const TAG = "outdoor_sensor_fault_binary_sensor";
+
+void OutdoorSensorFaultBinarySensor::setup() {
+  this->parent_->add_on_state_callback([this]() { this->update_from_parent_(); });
+  this->update_from_parent_();
+}
+
+void OutdoorSensorFaultBinarySensor::update_from_parent_() {
+  bool state = this->parent_->is_outdoor_sensor_fault();
+  this->publish_state(state);
+}
+
+void OutdoorSensorFaultBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "OutdoorSensorFaultBinarySensor", this); }
+
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/binary_sensor/outdoor_sensor_fault_binary_sensor.h
+++ b/esphome/components/equitherm/binary_sensor/outdoor_sensor_fault_binary_sensor.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "equitherm_binary_sensor_base.h"
+
+namespace esphome::equitherm {
+
+class EquithermClimate;
+
+/// Outdoor sensor fault indicator - ON when outdoor sensor is stale or reading out of range
+class OutdoorSensorFaultBinarySensor : public EquithermBinarySensorBase, public Parented<EquithermClimate> {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void update_from_parent_();
+};
+
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/climate.py
+++ b/esphome/components/equitherm/climate.py
@@ -1,0 +1,237 @@
+from esphome import automation
+import esphome.codegen as cg
+from esphome.components import climate, number, output, sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+CODEOWNERS = ["@P4uLT"]
+
+CONF_DEFAULT_TARGET_TEMPERATURE = "default_target_temperature"
+CONF_OUTDOOR_SENSOR = "outdoor_sensor"
+CONF_INDOOR_SENSOR = "indoor_sensor"
+CONF_FLOW_SETPOINT = "flow_setpoint"
+CONF_MANUAL_FLOW_TEMP = "manual_flow_temp"
+CONF_HEAT_OUTPUT = "heat_output"
+CONF_CONTROL_PARAMETERS = "control_parameters"
+CONF_OUTPUT_PARAMETERS = "output_parameters"
+CONF_DEADBAND_PARAMETERS = "deadband_parameters"
+
+# Heating curve parameters
+CONF_HEAT_CURVE_COEFFICIENT = "heat_curve_coefficient"
+CONF_HEAT_CURVE_EXPONENT = "heat_curve_exponent"
+CONF_HEAT_CURVE_SHIFT = "heat_curve_shift"
+
+CONF_MIN_FLOW_TEMP = "min_flow_temp"
+CONF_MAX_FLOW_TEMP = "max_flow_temp"
+
+# Output behavior parameters
+CONF_WRITE_DEADBAND = "write_deadband"
+
+# PID parameters
+CONF_KP = "kp"
+CONF_KI = "ki"
+CONF_KD = "kd"
+CONF_MIN_INTEGRAL = "min_integral"
+CONF_MAX_INTEGRAL = "max_integral"
+CONF_DERIVATIVE_AVERAGING_SAMPLES = "derivative_averaging_samples"
+
+# Deadband parameters
+CONF_THRESHOLD_HIGH = "threshold_high"
+CONF_THRESHOLD_LOW = "threshold_low"
+CONF_KP_MULTIPLIER = "kp_multiplier"
+CONF_KI_MULTIPLIER = "ki_multiplier"
+CONF_KD_MULTIPLIER = "kd_multiplier"
+
+# Action configuration
+CONF_UPDATE_PID = "update_pid"
+
+# Automation triggers
+CONF_ON_HEATING_START = "on_heating_start"
+CONF_ON_HEATING_STOP = "on_heating_stop"
+
+equitherm_ns = cg.esphome_ns.namespace("equitherm")
+EquithermClimate = equitherm_ns.class_(
+    "EquithermClimate", climate.Climate, cg.Component
+)
+EquithermForceRecalculateAction = equitherm_ns.class_(
+    "EquithermForceRecalculateAction", automation.Action
+)
+
+CONTROL_PARAMETERS_SCHEMA = cv.Schema(
+    {
+        # Heating curve parameters
+        cv.Required(CONF_HEAT_CURVE_COEFFICIENT): cv.float_range(min=0.5, max=5.0),
+        cv.Required(CONF_HEAT_CURVE_EXPONENT): cv.float_range(min=0.5, max=3.0),
+        cv.Optional(CONF_HEAT_CURVE_SHIFT, default="0°C"): cv.temperature_delta,
+        # PID parameters for room temperature correction
+        cv.Optional(CONF_KP, default=0.0): cv.float_range(min=0.0),
+        cv.Optional(CONF_KI, default=0.0): cv.float_range(min=0.0),
+        cv.Optional(CONF_KD, default=0.0): cv.float_range(min=0.0),
+        cv.Optional(CONF_MIN_INTEGRAL, default=-1): cv.float_,
+        cv.Optional(CONF_MAX_INTEGRAL, default=1): cv.float_,
+        cv.Optional(CONF_DERIVATIVE_AVERAGING_SAMPLES, default=1): cv.int_range(
+            min=1, max=16
+        ),
+    }
+)
+
+
+def _validate_output_parameters(config):
+    """Validate output_parameters."""
+    # Validate min/max flow temp
+    if config[CONF_MIN_FLOW_TEMP] >= config[CONF_MAX_FLOW_TEMP]:
+        raise cv.Invalid(
+            f"{CONF_MIN_FLOW_TEMP} ({config[CONF_MIN_FLOW_TEMP]}) must be less than "
+            f"{CONF_MAX_FLOW_TEMP} ({config[CONF_MAX_FLOW_TEMP]})"
+        )
+
+    return config
+
+
+OUTPUT_PARAMETERS_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Required(CONF_MIN_FLOW_TEMP): cv.temperature,
+            cv.Required(CONF_MAX_FLOW_TEMP): cv.temperature,
+            cv.Optional(CONF_WRITE_DEADBAND, default="0.05°C"): cv.temperature_delta,
+        }
+    ),
+    _validate_output_parameters,
+)
+
+
+def _validate_deadband_thresholds(config):
+    """Validate that threshold_high > threshold_low for a valid deadband range."""
+    threshold_low = config[CONF_THRESHOLD_LOW]
+    threshold_high = config[CONF_THRESHOLD_HIGH]
+    if threshold_high <= threshold_low:
+        raise cv.Invalid(
+            f"threshold_high ({threshold_high}) must be greater than "
+            f"threshold_low ({threshold_low})"
+        )
+    return config
+
+
+DEADBAND_PARAMETERS_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Required(CONF_THRESHOLD_LOW): cv.temperature_delta,
+            cv.Required(CONF_THRESHOLD_HIGH): cv.temperature_delta,
+            cv.Optional(CONF_KP_MULTIPLIER, default=0.0): cv.float_range(min=0.0),
+            cv.Optional(CONF_KI_MULTIPLIER, default=0.0): cv.float_range(min=0.0),
+            cv.Optional(CONF_KD_MULTIPLIER, default=0.0): cv.float_range(min=0.0),
+        }
+    ),
+    _validate_deadband_thresholds,
+)
+
+CONFIG_SCHEMA = cv.All(
+    climate.climate_schema(EquithermClimate)
+    .extend(
+        {
+            cv.Required(CONF_OUTDOOR_SENSOR): cv.use_id(sensor.Sensor),
+            cv.Required(CONF_INDOOR_SENSOR): cv.use_id(sensor.Sensor),
+            cv.Required(CONF_DEFAULT_TARGET_TEMPERATURE): cv.temperature,
+            cv.Optional(CONF_FLOW_SETPOINT): cv.use_id(number.Number),
+            cv.Optional(CONF_MANUAL_FLOW_TEMP): cv.use_id(number.Number),
+            cv.Optional(CONF_HEAT_OUTPUT): cv.use_id(output.FloatOutput),
+            cv.Required(CONF_CONTROL_PARAMETERS): CONTROL_PARAMETERS_SCHEMA,
+            cv.Required(CONF_OUTPUT_PARAMETERS): OUTPUT_PARAMETERS_SCHEMA,
+            cv.Optional(CONF_DEADBAND_PARAMETERS): DEADBAND_PARAMETERS_SCHEMA,
+            cv.Optional(CONF_ON_HEATING_START): automation.validate_automation({}),
+            cv.Optional(CONF_ON_HEATING_STOP): automation.validate_automation({}),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA),
+    cv.has_exactly_one_key(CONF_FLOW_SETPOINT, CONF_HEAT_OUTPUT),
+)
+
+
+async def to_code(config):
+    var = await climate.new_climate(config)
+    await cg.register_component(var, config)
+
+    # Sensors
+    outdoor = await cg.get_variable(config[CONF_OUTDOOR_SENSOR])
+    cg.add(var.set_outdoor_sensor(outdoor))
+
+    indoor = await cg.get_variable(config[CONF_INDOOR_SENSOR])
+    cg.add(var.set_indoor_sensor(indoor))
+
+    # Output (mutually exclusive)
+    if CONF_FLOW_SETPOINT in config:
+        flow_setpoint = await cg.get_variable(config[CONF_FLOW_SETPOINT])
+        cg.add(var.set_flow_setpoint_output(flow_setpoint))
+    if CONF_HEAT_OUTPUT in config:
+        heat_output = await cg.get_variable(config[CONF_HEAT_OUTPUT])
+        cg.add(var.set_heat_output(heat_output))
+        cg.add_define("USE_EQUITHERM_HEAT_OUTPUT")
+
+    # Manual flow temperature number entity (for CLIMATE_PRESET_MANUAL)
+    if CONF_MANUAL_FLOW_TEMP in config:
+        manual_flow_temp = await cg.get_variable(config[CONF_MANUAL_FLOW_TEMP])
+        cg.add(var.set_manual_flow_temp(manual_flow_temp))
+
+    # Climate defaults
+    cg.add(var.set_default_target_temperature(config[CONF_DEFAULT_TARGET_TEMPERATURE]))
+
+    # Control parameters (heating curve + PID)
+    params = config[CONF_CONTROL_PARAMETERS]
+    cg.add(var.set_heat_curve_coefficient(params[CONF_HEAT_CURVE_COEFFICIENT]))
+    cg.add(var.set_heat_curve_exponent(params[CONF_HEAT_CURVE_EXPONENT]))
+    cg.add(var.set_heat_curve_shift(params[CONF_HEAT_CURVE_SHIFT]))
+    # PID parameters
+    cg.add(var.set_kp(params[CONF_KP]))
+    cg.add(var.set_ki(params[CONF_KI]))
+    cg.add(var.set_kd(params[CONF_KD]))
+    cg.add(var.set_min_integral(params[CONF_MIN_INTEGRAL]))
+    cg.add(var.set_max_integral(params[CONF_MAX_INTEGRAL]))
+    cg.add(var.set_derivative_samples(params[CONF_DERIVATIVE_AVERAGING_SAMPLES]))
+
+    # Output parameters
+    params = config[CONF_OUTPUT_PARAMETERS]
+    cg.add(var.set_min_flow_temp(params[CONF_MIN_FLOW_TEMP]))
+    cg.add(var.set_max_flow_temp(params[CONF_MAX_FLOW_TEMP]))
+    cg.add(var.set_write_deadband(params[CONF_WRITE_DEADBAND]))
+
+    # Deadband parameters - optional
+    if CONF_DEADBAND_PARAMETERS in config:
+        params = config[CONF_DEADBAND_PARAMETERS]
+        cg.add(var.set_threshold_high(params[CONF_THRESHOLD_HIGH]))
+        cg.add(var.set_threshold_low(params[CONF_THRESHOLD_LOW]))
+        cg.add(var.set_kp_multiplier(params[CONF_KP_MULTIPLIER]))
+        cg.add(var.set_ki_multiplier(params[CONF_KI_MULTIPLIER]))
+        cg.add(var.set_kd_multiplier(params[CONF_KD_MULTIPLIER]))
+
+    # Automation triggers (callback-based, supports multiple entries)
+    for conf in config.get(CONF_ON_HEATING_START, []):
+        await automation.build_callback_automation(
+            var, "add_on_heating_start_callback", [], conf
+        )
+    for conf in config.get(CONF_ON_HEATING_STOP, []):
+        await automation.build_callback_automation(
+            var, "add_on_heating_stop_callback", [], conf
+        )
+
+
+# Action: equitherm.force_recalculate
+EQUITHERM_FORCE_RECALCULATE_ACTION_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.Required(CONF_ID): cv.use_id(EquithermClimate),
+        cv.Optional(CONF_UPDATE_PID, default=True): cv.templatable(cv.boolean),
+    }
+)
+
+
+@automation.register_action(
+    "climate.equitherm.force_recalculate",
+    EquithermForceRecalculateAction,
+    EQUITHERM_FORCE_RECALCULATE_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def equitherm_force_recalculate_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    update_pid_template_ = await cg.templatable(config[CONF_UPDATE_PID], args, bool)
+    cg.add(var.set_update_pid(update_pid_template_))
+    return var

--- a/esphome/components/equitherm/climate.py
+++ b/esphome/components/equitherm/climate.py
@@ -12,6 +12,9 @@ CONF_INDOOR_SENSOR = "indoor_sensor"
 CONF_FLOW_SETPOINT = "flow_setpoint"
 CONF_MANUAL_FLOW_TEMP = "manual_flow_temp"
 CONF_HEAT_OUTPUT = "heat_output"
+CONF_SENSOR_STALE_TIMEOUT = "sensor_stale_timeout"  # outdoor-only (back-compat)
+CONF_INDOOR_FRESH_WINDOW = "indoor_fresh_window"
+CONF_INDOOR_FAULT_HORIZON = "indoor_fault_horizon"
 CONF_CONTROL_PARAMETERS = "control_parameters"
 CONF_OUTPUT_PARAMETERS = "output_parameters"
 CONF_DEADBAND_PARAMETERS = "deadband_parameters"
@@ -88,6 +91,18 @@ def _validate_output_parameters(config):
     return config
 
 
+def _validate_indoor_timeouts(config):
+    """fresh_window must be strictly less than fault_horizon."""
+    fw = config[CONF_INDOOR_FRESH_WINDOW]
+    fh = config[CONF_INDOOR_FAULT_HORIZON]
+    if fw >= fh:
+        raise cv.Invalid(
+            f"{CONF_INDOOR_FRESH_WINDOW} ({fw}) must be less than "
+            f"{CONF_INDOOR_FAULT_HORIZON} ({fh})"
+        )
+    return config
+
+
 OUTPUT_PARAMETERS_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -135,6 +150,15 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_FLOW_SETPOINT): cv.use_id(number.Number),
             cv.Optional(CONF_MANUAL_FLOW_TEMP): cv.use_id(number.Number),
             cv.Optional(CONF_HEAT_OUTPUT): cv.use_id(output.FloatOutput),
+            cv.Optional(
+                CONF_SENSOR_STALE_TIMEOUT, default="10min"
+            ): cv.positive_time_period_milliseconds,  # outdoor-only now
+            cv.Optional(
+                CONF_INDOOR_FRESH_WINDOW, default="30min"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_INDOOR_FAULT_HORIZON, default="4h"
+            ): cv.positive_time_period_milliseconds,
             cv.Required(CONF_CONTROL_PARAMETERS): CONTROL_PARAMETERS_SCHEMA,
             cv.Required(CONF_OUTPUT_PARAMETERS): OUTPUT_PARAMETERS_SCHEMA,
             cv.Optional(CONF_DEADBAND_PARAMETERS): DEADBAND_PARAMETERS_SCHEMA,
@@ -144,6 +168,7 @@ CONFIG_SCHEMA = cv.All(
     )
     .extend(cv.COMPONENT_SCHEMA),
     cv.has_exactly_one_key(CONF_FLOW_SETPOINT, CONF_HEAT_OUTPUT),
+    _validate_indoor_timeouts,
 )
 
 
@@ -174,6 +199,11 @@ async def to_code(config):
 
     # Climate defaults
     cg.add(var.set_default_target_temperature(config[CONF_DEFAULT_TARGET_TEMPERATURE]))
+
+    # Sensor staleness / indoor health timeouts
+    cg.add(var.set_outdoor_stale_timeout_ms(config[CONF_SENSOR_STALE_TIMEOUT]))
+    cg.add(var.set_indoor_fresh_window_ms(config[CONF_INDOOR_FRESH_WINDOW]))
+    cg.add(var.set_indoor_fault_horizon_ms(config[CONF_INDOOR_FAULT_HORIZON]))
 
     # Control parameters (heating curve + PID)
     params = config[CONF_CONTROL_PARAMETERS]

--- a/esphome/components/equitherm/equitherm.cpp
+++ b/esphome/components/equitherm/equitherm.cpp
@@ -14,14 +14,41 @@ static const char *const TAG = "equitherm";
 // Covers all realistic climates: --55°C (extreme cold) to +50°C (extreme heat).
 static constexpr float OUTDOOR_SENSOR_MIN_VALID = -55.0f;
 static constexpr float OUTDOOR_SENSOR_MAX_VALID = 50.0f;
+// How often loop() re-checks sensor staleness. Only matters when BOTH sensors have stopped
+// publishing (no callback fires to re-evaluate staleness). See EquithermClimate::loop().
+static constexpr uint32_t STALENESS_RECHECK_INTERVAL_MS = 30000;
 
 void EquithermClimate::setup() {
-  // Register callback for indoor sensor updates — recompute on every update so the climate
-  // reflects the latest reading (the validity check itself lives in compute_and_apply_()).
-  this->indoor_sensor_->add_on_state_callback([this](float) { this->compute_and_apply_(); });
+  // Register callback for indoor sensor updates
+  this->indoor_sensor_->add_on_state_callback([this](float state) {
+    const uint32_t now = millis();
+    // NAN: don't poison the held last-known-good value (it's the display source,
+    // initialised NAN). Just recompute so age-based health can advance.
+    if (std::isnan(state)) {
+      this->compute_and_apply_();
+      return;
+    }
+    // Any real reading (in- or out-of-range) is trusted, consistent with the
+    // outdoor path: record freshness and recover to FRESH. No transient filter.
+    this->last_valid_indoor_temp_ = state;
+    this->last_valid_indoor_time_ = now;
+    this->indoor_ever_received_ = true;
+    this->indoor_data_health_ = IndoorDataHealth::FRESH;
+    this->compute_and_apply_();
+  });
 
-  // Register callback for outdoor sensor updates — same rationale.
-  this->outdoor_sensor_->add_on_state_callback([this](float) { this->compute_and_apply_(); });
+  // Register callback for outdoor sensor updates
+  this->outdoor_sensor_->add_on_state_callback([this](float state) {
+    // Refresh the freshness timestamp ONLY on a genuine, in-range outdoor update. This must NOT
+    // happen inside compute_and_apply_(): that method also runs on indoor-driven recomputations, so
+    // refreshing the timestamp there would reset the staleness timer even when no new outdoor reading
+    // arrived — masking a dead outdoor sensor (the timer would measure recompute frequency, not the
+    // time since the last real reading).
+    if (!std::isnan(state) && state >= OUTDOOR_SENSOR_MIN_VALID && state <= OUTDOOR_SENSOR_MAX_VALID) {
+      this->last_valid_outdoor_time_ = millis();
+    }
+    this->compute_and_apply_();
+  });
 
   // Restore previous state or set defaults
   auto restore = this->restore_state_();
@@ -31,6 +58,39 @@ void EquithermClimate::setup() {
     this->mode = climate::CLIMATE_MODE_HEAT;
     this->target_temperature = this->default_target_temperature_;
     // On first boot, trigger initial calculation
+    this->compute_and_apply_();
+  }
+}
+
+void EquithermClimate::loop() {
+  // Safety net for the case no sensor callback covers.
+  //
+  // compute_and_apply_() is event-driven: it runs on sensor callbacks and climate control() calls.
+  // As long as at least one sensor keeps publishing, its callback re-evaluates the other sensor's
+  // age, so a dead sensor is detected. But if BOTH sensors stop publishing callbacks entirely, no
+  // callback ever fires — the boiler would be left on its last setpoint with no fault flagged.
+  //
+  // This loop closes that gap. It only acts when BOTH sensors have stopped publishing: the outdoor
+  // sensor is past its stale timeout (outdoor_stale_timeout_ms_) AND the indoor sensor is past its
+  // fresh window (indoor_fresh_window_ms_) — i.e. no callback has fired for either side. In that
+  // sole case it calls compute_and_apply_() so the age-based indoor transitions (FRESH -> COASTING
+  // -> FAULT) and the both-dead hold can advance. It does not use the outdoor "stale" notion for the
+  // indoor side: indoor is evaluated by its own fresh/fault window, which is the "quiet" threshold.
+  // The throttle interval is deliberately keyed to the (longer) indoor fresh window, not the outdoor
+  // timeout.
+  uint32_t now = millis();
+  // Recheck no slower than half the fresh window so a short window is still detected promptly;
+  // cap at STALENESS_RECHECK_INTERVAL_MS and floor at 1s to avoid recomputing every loop iteration.
+  uint32_t interval =
+      std::clamp(this->indoor_fresh_window_ms_ / 2, static_cast<uint32_t>(1000), STALENESS_RECHECK_INTERVAL_MS);
+  if (now - this->last_loop_check_time_ < interval)
+    return;
+  this->last_loop_check_time_ = now;
+
+  bool outdoor_stale = (now - this->last_valid_outdoor_time_) > this->outdoor_stale_timeout_ms_;
+  bool indoor_quiet = (now - this->last_valid_indoor_time_) > this->indoor_fresh_window_ms_;
+
+  if (outdoor_stale && indoor_quiet) {
     this->compute_and_apply_();
   }
 }
@@ -105,6 +165,13 @@ void EquithermClimate::dump_config() {
                 "  Output Parameters:\n"
                 "    min_flow_temp: %.1f°C, max_flow_temp: %.1f°C",
                 heating_curve_.get_min_flow_temp(), heating_curve_.get_max_flow_temp());
+
+  ESP_LOGCONFIG(TAG,
+                "  Sensor Health:\n"
+                "    outdoor_stale_timeout: %.1f min\n"
+                "    indoor fresh_window: %.1f min, fault_horizon: %.1f h",
+                this->outdoor_stale_timeout_ms_ / 60000.0f, this->indoor_fresh_window_ms_ / 60000.0f,
+                this->indoor_fault_horizon_ms_ / 3600000.0f);
 }
 
 void EquithermClimate::write_setpoint_(float temp_c) {
@@ -169,6 +236,25 @@ void EquithermClimate::write_setpoint_off_() {
 #endif
 }
 
+void EquithermClimate::update_indoor_health_(uint32_t now_ms) {
+  // No good reading yet: hold WARM_UP (no alarm). FAULT is reached only via the
+  // age-based fault_horizon timeout below, which is gated on last_valid_indoor_time_
+  // having been set by a real reading — so it cannot fire before the first read.
+  if (!this->indoor_ever_received_) {
+    this->indoor_data_health_ = IndoorDataHealth::WARM_UP;  // no alarm until first good read
+    return;
+  }
+  const uint32_t age = now_ms - this->last_valid_indoor_time_;
+  if (age > this->indoor_fault_horizon_ms_) {
+    this->indoor_data_health_ = IndoorDataHealth::FAULT;
+  } else if (age > this->indoor_fresh_window_ms_) {
+    // Only relax FRESH -> COASTING; never downgrade an existing FAULT here.
+    if (this->indoor_data_health_ == IndoorDataHealth::FRESH) {
+      this->indoor_data_health_ = IndoorDataHealth::COASTING;
+    }
+  }
+}
+
 void EquithermClimate::compute_and_apply_(bool update_pid) {
   // Target temperature must be valid
   if (std::isnan(this->target_temperature)) {
@@ -177,20 +263,53 @@ void EquithermClimate::compute_and_apply_(bool update_pid) {
   }
 
   // --- OUTDOOR SENSOR HANDLING ---
-  // Straight read: if the outdoor reading is present, finite and in range use it; otherwise
-  // mark it invalid. With no configured substitute in core, an invalid outdoor sensor skips
-  // recalculation and holds the last setpoint (see guard below). No fault flag here.
-  bool outdoor_valid = this->outdoor_sensor_->has_state() && !std::isnan(this->outdoor_sensor_->state) &&
-                       this->outdoor_sensor_->state >= OUTDOOR_SENSOR_MIN_VALID &&
-                       this->outdoor_sensor_->state <= OUTDOOR_SENSOR_MAX_VALID;
+  // A reading is usable only when present, finite, in range, AND not stale (updated within
+  // outdoor_stale_timeout_ms_). The freshness timestamp is refreshed in the outdoor sensor
+  // callback (see setup()), NOT here — refreshing it here would reset the staleness timer on
+  // every recomputation, including indoor-driven ones, and mask a dead outdoor sensor.
+  uint32_t now = millis();
+  bool outdoor_reading_valid = this->outdoor_sensor_->has_state() && !std::isnan(this->outdoor_sensor_->state) &&
+                               this->outdoor_sensor_->state >= OUTDOOR_SENSOR_MIN_VALID &&
+                               this->outdoor_sensor_->state <= OUTDOOR_SENSOR_MAX_VALID;
+  bool outdoor_stale = (now - this->last_valid_outdoor_time_) > this->outdoor_stale_timeout_ms_;
+  bool outdoor_valid = outdoor_reading_valid && !outdoor_stale;
+
+  if (outdoor_valid) {
+    this->last_valid_outdoor_temp_ = this->outdoor_sensor_->state;
+    if (this->outdoor_sensor_fault_) {
+      ESP_LOGI(TAG, "Outdoor sensor recovered (%.1f°C), resuming normal operation", this->outdoor_sensor_->state);
+      this->outdoor_sensor_fault_ = false;
+    }
+  } else {
+    if (!this->outdoor_sensor_fault_) {
+      if (outdoor_stale) {
+        ESP_LOGW(TAG, "Outdoor sensor stale (no update for %.1f min), latching fault",
+                 (now - this->last_valid_outdoor_time_) / 60000.0f);
+      } else {
+        ESP_LOGW(TAG, "Outdoor sensor invalid, latching fault");
+      }
+      this->outdoor_sensor_fault_ = true;
+    }
+  }
 
   // --- INDOOR SENSOR HANDLING ---
-  // Straight read: t_indoor is the current indoor state when present and finite, else NAN.
-  // No range check (the transient filter is gone). current_temperature is published only
-  // when the reading is not NAN so HA does not show a garbage value.
-  bool indoor_valid = this->indoor_sensor_->has_state() && !std::isnan(this->indoor_sensor_->state);
-  float t_indoor = indoor_valid ? this->indoor_sensor_->state : NAN;
+  this->update_indoor_health_(now);
 
+  // FAULT -> FRESH recovery: reset PID integral to avoid windup spike.
+  if (this->prev_indoor_health_ == IndoorDataHealth::FAULT && this->indoor_data_health_ == IndoorDataHealth::FRESH) {
+    ESP_LOGI(TAG, "Indoor sensor recovered, resetting PID integral");
+    this->pid_controller_.reset_accumulated_integral();
+    this->pid_correction_ = 0.0f;
+  }
+  this->prev_indoor_health_ = this->indoor_data_health_;
+
+  const bool indoor_valid_for_pid = (this->indoor_data_health_ == IndoorDataHealth::FRESH);
+  float t_indoor = this->last_valid_indoor_temp_;  // held value (NAN until first good read)
+
+  // Publish only when a real last-known-good value exists. last_valid_indoor_temp_ is
+  // initialised NAN and written only on a validated in-range read, so WARM_UP (and a
+  // garbage-only FAULT) leave it NAN -> current_temperature stays unset (HA "unavailable",
+  // the honest state). FRESH/COASTING/FAULT-after-good-read publish the held value.
   if (!std::isnan(t_indoor)) {
     this->current_temperature = t_indoor;
   }
@@ -227,16 +346,6 @@ void EquithermClimate::compute_and_apply_(bool update_pid) {
                   !std::isnan(this->manual_flow_temp_->state);
 #endif
 
-  // Without a configured substitute, an invalid outdoor reading makes the curve incalculable.
-  // In normal (non-manual, non-OFF) mode we hold the last setpoint rather than drive the
-  // boiler from a garbage reading. Manual mode bypasses the curve entirely.
-  if (!manual_active && !outdoor_valid) {
-    ESP_LOGD(TAG, "Outdoor sensor invalid, holding last setpoint");
-    this->publish_state();
-    this->state_callback_.call();
-    return;
-  }
-
   float t_flow;
 
   if (manual_active) {
@@ -250,6 +359,27 @@ void EquithermClimate::compute_and_apply_(bool update_pid) {
     this->pid_adjusted_output_ = t_flow;
 #endif
   } else {
+    // No configured outdoor substitute: an invalid/stale outdoor reading makes the curve
+    // incalculable. Hold the boiler on its last known-good setpoint (the last value actually
+    // written) and flag the fault rather than drive the boiler from a guessed temperature.
+    // (OFF mode already returned above; Manual mode is handled in the branch above and is
+    // exempt — explicit user control keeps applying manual_flow_temp_.)
+    if (!outdoor_valid) {
+      // "Freeze where it was": leave wws_active_ and action untouched so the diagnostics stay
+      // coherent. In particular, if the system was in WWS (active_setpoint_ == 0) when the
+      // outdoor sensor died, keeping wws_active_ true avoids the contradictory "0 setpoint +
+      // WWS off". The outdoor fault flag is set above; an indoor fault (when present) is
+      // already reflected in indoor_data_health_ (FAULT — invalid-for-hold). So either/both
+      // fault binary sensors go ON as appropriate. We deliberately do not write to the
+      // boiler — it holds its last setpoint.
+      this->heating_curve_output_ = NAN;
+      this->pid_adjusted_output_ = NAN;
+      this->flow_setpoint_ = this->active_setpoint_;  // reflect the setpoint we're holding
+      this->publish_state();
+      this->state_callback_.call();
+      return;
+    }
+
     // Normal equitherm curve (outdoor_valid is guaranteed true here)
     float t_outdoor = this->outdoor_sensor_->state;
     // WWS decision is owned by the controller, not the curve calculator.
@@ -266,15 +396,15 @@ void EquithermClimate::compute_and_apply_(bool update_pid) {
     // Store raw curve output for diagnostics (before PID)
     this->heating_curve_output_ = t_flow;
 
-    // PID correction (ONLY when indoor sensor is valid)
-    if (indoor_valid && update_pid) {
+    // PID correction (ONLY when indoor sensor is FRESH)
+    if (indoor_valid_for_pid && update_pid) {
       this->pid_correction_ = this->pid_controller_.update(this->target_temperature, t_indoor);
       // Guard against nan from PID controller (can happen on first call)
       if (std::isnan(this->pid_correction_)) {
         this->pid_correction_ = 0.0f;
       }
     } else {
-      // Indoor sensor invalid - disable PID correction (pure equitherm mode)
+      // Indoor sensor not FRESH (COASTING/WARM_UP/FAULT) - disable PID correction (pure equitherm)
       this->pid_correction_ = 0.0f;
     }
 

--- a/esphome/components/equitherm/equitherm.cpp
+++ b/esphome/components/equitherm/equitherm.cpp
@@ -1,0 +1,347 @@
+#include "equitherm.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+
+#ifdef USE_NUMBER
+#include "esphome/components/number/number.h"
+#endif
+
+namespace esphome {
+namespace equitherm {
+
+static const char *const TAG = "equitherm";
+
+// Outdoor sensor validation range (°C). Readings outside this range are considered sensor failure.
+// Covers all realistic climates: --55°C (extreme cold) to +50°C (extreme heat).
+static constexpr float OUTDOOR_SENSOR_MIN_VALID = -55.0f;
+static constexpr float OUTDOOR_SENSOR_MAX_VALID = 50.0f;
+
+void EquithermClimate::setup() {
+  // Register callback for indoor sensor updates — recompute on every update so the climate
+  // reflects the latest reading (the validity check itself lives in compute_and_apply_()).
+  this->indoor_sensor_->add_on_state_callback([this](float) { this->compute_and_apply_(); });
+
+  // Register callback for outdoor sensor updates — same rationale.
+  this->outdoor_sensor_->add_on_state_callback([this](float) { this->compute_and_apply_(); });
+
+  // Restore previous state or set defaults
+  auto restore = this->restore_state_();
+  if (restore.has_value()) {
+    restore->to_call(this).perform();
+  } else {
+    this->mode = climate::CLIMATE_MODE_HEAT;
+    this->target_temperature = this->default_target_temperature_;
+    // On first boot, trigger initial calculation
+    this->compute_and_apply_();
+  }
+}
+
+void EquithermClimate::control(const climate::ClimateCall &call) {
+  auto mode_opt = call.get_mode();
+  if (mode_opt.has_value()) {
+    auto mode = *mode_opt;
+    // Only accept supported modes (OFF and HEAT)
+    if (mode == climate::CLIMATE_MODE_OFF || mode == climate::CLIMATE_MODE_HEAT) {
+      this->mode = mode;
+    }
+  }
+  auto target_opt = call.get_target_temperature();
+  if (target_opt.has_value()) {
+    float new_target = *target_opt;
+    // Reset PID integral on setpoint change to prevent overshoot from old error context
+    if (new_target != this->target_temperature) {
+      ESP_LOGD(TAG, "Target temperature changed: %.1f°C → %.1f°C, resetting PID integral", this->target_temperature,
+               new_target);
+      this->pid_controller_.reset_accumulated_integral();
+      this->pid_correction_ = 0.0f;
+    }
+    this->target_temperature = new_target;
+  }
+
+  if (call.has_custom_preset()) {
+    this->set_custom_preset_(call.get_custom_preset());
+    ESP_LOGI(TAG, "Preset changed to 'manual' — bypassing heating curve");
+  } else {
+    auto preset_opt = call.get_preset();
+    if (preset_opt.has_value() && *preset_opt == climate::CLIMATE_PRESET_NONE) {
+      this->clear_custom_preset_();
+      ESP_LOGI(TAG, "Preset cleared — resuming normal equitherm calculation");
+    }
+  }
+
+  this->compute_and_apply_();
+}
+
+climate::ClimateTraits EquithermClimate::traits() {
+  auto traits = climate::ClimateTraits();
+  traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
+  traits.set_supported_modes({
+      climate::CLIMATE_MODE_OFF,
+      climate::CLIMATE_MODE_HEAT,
+  });
+  traits.set_visual_min_temperature(15.0f);
+  traits.set_visual_max_temperature(25.0f);
+  traits.set_visual_temperature_step(0.5f);
+  if (this->manual_flow_temp_ != nullptr) {
+    traits.add_supported_preset(climate::CLIMATE_PRESET_NONE);
+    traits.set_supported_custom_presets({"Manual"});
+  }
+  return traits;
+}
+
+void EquithermClimate::dump_config() {
+  LOG_CLIMATE("", "Equitherm", this);
+
+  ESP_LOGCONFIG(TAG,
+                "  Heating Curve (industry standard):\n"
+                "    hc: %.2f, n: %.2f, shift: %.2f",
+                heating_curve_.get_hc(), heating_curve_.get_n(), heating_curve_.get_shift());
+
+  ESP_LOGCONFIG(TAG,
+                "  PID Parameters:\n"
+                "    kp: %.3f, ki: %.3f, kd: %.3f",
+                pid_controller_.kp_, pid_controller_.ki_, pid_controller_.kd_);
+
+  ESP_LOGCONFIG(TAG,
+                "  Output Parameters:\n"
+                "    min_flow_temp: %.1f°C, max_flow_temp: %.1f°C",
+                heating_curve_.get_min_flow_temp(), heating_curve_.get_max_flow_temp());
+}
+
+void EquithermClimate::write_setpoint_(float temp_c) {
+  // Don't write invalid values to output
+  if (std::isnan(temp_c)) {
+    ESP_LOGW(TAG, "write_setpoint_ called with NAN, ignoring");
+    return;
+  }
+
+  // Curve returns 0.0f in WWS — that's a stop signal, not a temperature.
+  // Without this guard, clamp(0, min_flow_temp, max_flow_temp) would
+  // raise 0 to min_flow_temp and produce unwanted heat output.
+  if (temp_c == 0.0f) {
+    this->write_setpoint_off_();
+    return;
+  }
+
+  // Defensive clamp (heating_curve also clamps, but this ensures safety)
+  float clamped_flow = clamp(temp_c, heating_curve_.get_min_flow_temp(), heating_curve_.get_max_flow_temp());
+
+  ESP_LOGD(TAG, "write_setpoint_: %.1f°C (clamped: %.1f°C)", temp_c, clamped_flow);
+
+#ifdef USE_NUMBER
+  if (this->flow_setpoint_output_ != nullptr) {
+    // Direct °C for OpenTherm - preferred
+    ESP_LOGD(TAG, "Writing to flow_setpoint_output: %.1f°C", clamped_flow);
+    this->flow_setpoint_output_->make_call().set_value(clamped_flow).perform();
+    return;
+  }
+#endif
+
+#ifdef USE_EQUITHERM_HEAT_OUTPUT
+  if (this->heat_output_ != nullptr) {
+    // Normalize only at boundary - never in calculation
+    float flow_range = heating_curve_.get_max_flow_temp() - heating_curve_.get_min_flow_temp();
+    // Guard against division by zero
+    if (flow_range < 0.01f) {
+      this->heat_output_->set_level(0.0f);
+      return;
+    }
+    float normalized_level = clamp((clamped_flow - heating_curve_.get_min_flow_temp()) / flow_range, 0.0f, 1.0f);
+    ESP_LOGD(TAG, "Writing to heat_output: %.2f (normalized)", normalized_level);
+    this->heat_output_->set_level(normalized_level);
+    return;
+  }
+#endif
+
+  ESP_LOGW(TAG, "write_setpoint_: No output configured (flow_setpoint and heat_output are both null)");
+}
+
+void EquithermClimate::write_setpoint_off_() {
+  // For flow_setpoint_ (number): no action. There is no universal "off" value for a number —
+  // min_value is still a heat request, not an off signal. Use on_heating_stop to do
+  // whatever your hardware requires (turn off ch_enable, send MQTT, etc.).
+
+#ifdef USE_EQUITHERM_HEAT_OUTPUT
+  if (this->heat_output_ != nullptr) {
+    // For normalized float output: 0.0 is universally correct — no signal, no heat.
+    // Built-in so users get safe default behavior without needing on_heating_stop.
+    this->heat_output_->set_level(0.0f);
+  }
+#endif
+}
+
+void EquithermClimate::compute_and_apply_(bool update_pid) {
+  // Target temperature must be valid
+  if (std::isnan(this->target_temperature)) {
+    this->state_callback_.call();
+    return;
+  }
+
+  // --- OUTDOOR SENSOR HANDLING ---
+  // Straight read: if the outdoor reading is present, finite and in range use it; otherwise
+  // mark it invalid. With no configured substitute in core, an invalid outdoor sensor skips
+  // recalculation and holds the last setpoint (see guard below). No fault flag here.
+  bool outdoor_valid = this->outdoor_sensor_->has_state() && !std::isnan(this->outdoor_sensor_->state) &&
+                       this->outdoor_sensor_->state >= OUTDOOR_SENSOR_MIN_VALID &&
+                       this->outdoor_sensor_->state <= OUTDOOR_SENSOR_MAX_VALID;
+
+  // --- INDOOR SENSOR HANDLING ---
+  // Straight read: t_indoor is the current indoor state when present and finite, else NAN.
+  // No range check (the transient filter is gone). current_temperature is published only
+  // when the reading is not NAN so HA does not show a garbage value.
+  bool indoor_valid = this->indoor_sensor_->has_state() && !std::isnan(this->indoor_sensor_->state);
+  float t_indoor = indoor_valid ? this->indoor_sensor_->state : NAN;
+
+  if (!std::isnan(t_indoor)) {
+    this->current_temperature = t_indoor;
+  }
+
+  if (this->mode == climate::CLIMATE_MODE_OFF) {
+    // Reset PID integral only on transition to OFF (not every update)
+    if (this->action != climate::CLIMATE_ACTION_OFF) {
+      this->pid_controller_.reset_accumulated_integral();
+      this->pid_correction_ = 0.0f;
+      // Turn off output only on transition - boiler's frost protection handles freeze prevention
+      this->write_setpoint_off_();
+      // Fire stop callback only if we were actually heating
+      if (this->action == climate::CLIMATE_ACTION_HEATING) {
+        this->on_heating_stop_callback_.call();
+      }
+    }
+    this->action = climate::CLIMATE_ACTION_OFF;
+    this->prev_action_ = climate::CLIMATE_ACTION_OFF;
+    this->heating_curve_output_ = NAN;
+    this->pid_adjusted_output_ = NAN;
+    this->wws_active_ = false;
+    this->flow_setpoint_ = NAN;
+    this->active_setpoint_ = NAN;
+    this->publish_state();
+    this->state_callback_.call();
+    return;  // Don't write any setpoint to boiler
+  }
+
+  // --- MANUAL PRESET OR NORMAL EQUITHERM ---
+  bool manual_active = false;
+#ifdef USE_NUMBER
+  manual_active = this->has_custom_preset() && strcmp(this->get_custom_preset().c_str(), "Manual") == 0 &&
+                  this->manual_flow_temp_ != nullptr && this->manual_flow_temp_->has_state() &&
+                  !std::isnan(this->manual_flow_temp_->state);
+#endif
+
+  // Without a configured substitute, an invalid outdoor reading makes the curve incalculable.
+  // In normal (non-manual, non-OFF) mode we hold the last setpoint rather than drive the
+  // boiler from a garbage reading. Manual mode bypasses the curve entirely.
+  if (!manual_active && !outdoor_valid) {
+    ESP_LOGD(TAG, "Outdoor sensor invalid, holding last setpoint");
+    this->publish_state();
+    this->state_callback_.call();
+    return;
+  }
+
+  float t_flow;
+
+  if (manual_active) {
+#ifdef USE_NUMBER
+    // Bypass curve and PID: use manual flow temperature directly
+    t_flow = this->manual_flow_temp_->state;
+    ESP_LOGD(TAG, "Manual preset active: using manual flow temp %.1f°C", t_flow);
+    this->wws_active_ = false;
+    this->heating_curve_output_ = t_flow;
+    this->pid_correction_ = 0.0f;
+    this->pid_adjusted_output_ = t_flow;
+#endif
+  } else {
+    // Normal equitherm curve (outdoor_valid is guaranteed true here)
+    float t_outdoor = this->outdoor_sensor_->state;
+    // WWS decision is owned by the controller, not the curve calculator.
+    // This keeps HeatingCurve stateless and allows the formula to change independently.
+    this->wws_active_ = (this->target_temperature - t_outdoor) <= 0.0f;
+
+    t_flow = heating_curve_.compute_flow_temperature(this->target_temperature, t_outdoor);
+
+    // Clamp to [min, max] only when there's positive heating demand
+    if (!this->wws_active_) {
+      t_flow = std::clamp(t_flow, heating_curve_.get_min_flow_temp(), heating_curve_.get_max_flow_temp());
+    }
+
+    // Store raw curve output for diagnostics (before PID)
+    this->heating_curve_output_ = t_flow;
+
+    // PID correction (ONLY when indoor sensor is valid)
+    if (indoor_valid && update_pid) {
+      this->pid_correction_ = this->pid_controller_.update(this->target_temperature, t_indoor);
+      // Guard against nan from PID controller (can happen on first call)
+      if (std::isnan(this->pid_correction_)) {
+        this->pid_correction_ = 0.0f;
+      }
+    } else {
+      // Indoor sensor invalid - disable PID correction (pure equitherm mode)
+      this->pid_correction_ = 0.0f;
+    }
+
+    // Apply PID correction to flow temperature
+    t_flow += this->pid_correction_;
+
+    // Store setpoint for diagnostics (curve + PID)
+    this->pid_adjusted_output_ = t_flow;
+  }
+
+  // Set action based on heating demand
+  // Manual mode always calls for heat. In normal mode, WWS = off (no demand).
+  // Any positive demand (delta_t > 0) = heating, even when clamped to minimum flow temp.
+  bool calling_for_heat = manual_active || !this->wws_active_;
+  climate::ClimateAction new_action = calling_for_heat ? climate::CLIMATE_ACTION_HEATING : climate::CLIMATE_ACTION_IDLE;
+
+  if (new_action != this->prev_action_) {
+    if (new_action == climate::CLIMATE_ACTION_HEATING) {
+      this->on_heating_start_callback_.call();
+    } else if (this->prev_action_ == climate::CLIMATE_ACTION_HEATING) {
+      this->on_heating_stop_callback_.call();
+    }
+    this->prev_action_ = new_action;
+  }
+  this->action = new_action;
+
+  // WWS: don't send a setpoint to the boiler (only in normal mode — manual mode bypasses curve)
+  if (!manual_active && this->wws_active_) {
+    this->flow_setpoint_ = 0.0f;
+    if (std::isnan(this->active_setpoint_) || this->active_setpoint_ != 0.0f) {
+      this->active_setpoint_ = 0.0f;
+      this->write_setpoint_off_();
+    }
+    this->publish_state();
+    this->state_callback_.call();
+    return;
+  }
+
+  // Final guard: never write nan to output
+  if (std::isnan(t_flow)) {
+    this->state_callback_.call();
+    return;
+  }
+
+  // Round to 0.1°C precision before write deadband check.
+  // Matches real thermostat behavior and eliminates sub-0.1°C noise.
+  t_flow = roundf(t_flow * 10.0f) / 10.0f;
+
+  // Store the rounded value for diagnostics
+  this->flow_setpoint_ = t_flow;
+
+  // Only write to output if setpoint actually changed (avoid spamming boiler)
+  // Uses half-step threshold so any 0.1°C change triggers a write
+  bool setpoint_changed =
+      std::isnan(this->active_setpoint_) || fabsf(t_flow - this->active_setpoint_) > this->write_deadband_;
+
+  ESP_LOGD(TAG, "setpoint check: t_flow=%.1f°C, active_setpoint=%.1f°C, delta=%.2f°C, changed=%s", t_flow,
+           this->active_setpoint_, fabsf(t_flow - this->active_setpoint_), setpoint_changed ? "YES" : "NO");
+
+  if (setpoint_changed) {
+    this->active_setpoint_ = t_flow;
+    this->write_setpoint_(t_flow);
+  }
+  this->publish_state();
+  this->state_callback_.call();
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/equitherm.cpp
+++ b/esphome/components/equitherm/equitherm.cpp
@@ -6,8 +6,7 @@
 #include "esphome/components/number/number.h"
 #endif
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 static const char *const TAG = "equitherm";
 
@@ -343,5 +342,4 @@ void EquithermClimate::compute_and_apply_(bool update_pid) {
   this->state_callback_.call();
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/equitherm.h
+++ b/esphome/components/equitherm/equitherm.h
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <functional>
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/climate/climate.h"
+#include "esphome/components/sensor/sensor.h"
+
+#ifdef USE_EQUITHERM_HEAT_OUTPUT
+#include "esphome/components/output/float_output.h"
+#endif
+
+#include "equitherm_controller.h"
+#include "pid_controller.h"
+
+namespace esphome {
+namespace number {
+class Number;  // Forward declaration
+}
+namespace equitherm {
+
+class EquithermClimate : public climate::Climate, public Component {
+ public:
+  EquithermClimate() = default;
+  void setup() override;
+  void dump_config() override;
+
+  // Sensor inputs
+  void set_outdoor_sensor(sensor::Sensor *sensor) { outdoor_sensor_ = sensor; }
+  void set_indoor_sensor(sensor::Sensor *sensor) { indoor_sensor_ = sensor; }
+
+  // Output (mutually exclusive - only one should be set)
+  void set_flow_setpoint_output(number::Number *number) { flow_setpoint_output_ = number; }
+#ifdef USE_EQUITHERM_HEAT_OUTPUT
+  void set_heat_output(output::FloatOutput *output) { heat_output_ = output; }
+#endif
+
+  // Optional manual flow temperature (used when manual preset is active)
+  void set_manual_flow_temp(number::Number *number) { manual_flow_temp_ = number; }
+
+  // Climate defaults
+  void set_default_target_temperature(float temp) { default_target_temperature_ = temp; }
+
+  // Heating curve parameters (delegated to heating curve)
+  void set_heat_curve_coefficient(float hc) { heating_curve_.set_hc(hc); }
+  void set_heat_curve_exponent(float n) { heating_curve_.set_n(n); }
+  void set_heat_curve_shift(float shift) { heating_curve_.set_shift(shift); }
+
+  // Output parameters
+  void set_min_flow_temp(float temp) { heating_curve_.set_min_flow_temp(temp); }
+  void set_max_flow_temp(float temp) { heating_curve_.set_max_flow_temp(temp); }
+  void set_write_deadband(float deadband) { write_deadband_ = deadband; }
+
+  // PID parameters
+  void set_kp(float kp) { pid_controller_.kp_ = kp; }
+  void set_ki(float ki) { pid_controller_.ki_ = ki; }
+  void set_kd(float kd) { pid_controller_.kd_ = kd; }
+  void set_min_integral(float min_integral) { pid_controller_.min_integral_ = min_integral; }
+  void set_max_integral(float max_integral) { pid_controller_.max_integral_ = max_integral; }
+  void set_derivative_samples(int samples) {
+    pid_controller_.derivative_samples_ = samples;
+    if (samples > 1)  // No allocation needed when samples=1 (ring_buffer_average_ short-circuits)
+      pid_controller_.derivative_window_.init(samples);
+  }
+
+  // Deadband parameters
+  void set_threshold_low(float threshold) { pid_controller_.threshold_low_ = threshold; }
+  void set_threshold_high(float threshold) { pid_controller_.threshold_high_ = threshold; }
+  void set_kp_multiplier(float mult) { pid_controller_.kp_multiplier_ = mult; }
+  void set_ki_multiplier(float mult) { pid_controller_.ki_multiplier_ = mult; }
+  void set_kd_multiplier(float mult) { pid_controller_.kd_multiplier_ = mult; }
+
+  bool is_wws_active() const { return wws_active_; }
+
+  // State getters (for diagnostics)
+  float get_heating_curve_output() const { return heating_curve_output_; }
+  float get_pid_adjusted_output() const { return pid_adjusted_output_; }
+  float get_flow_setpoint() const { return flow_setpoint_; }
+  float get_active_setpoint() const { return active_setpoint_; }
+  float get_pid_correction() const { return pid_correction_; }
+  bool in_deadband() { return pid_controller_.in_deadband(); }
+  bool is_pid_active() const {
+    // Check if any PID gain is effectively non-zero (handles runtime tuning)
+    constexpr float epsilon = 0.0001f;
+    return fabsf(pid_controller_.kp_) > epsilon || fabsf(pid_controller_.ki_) > epsilon ||
+           fabsf(pid_controller_.kd_) > epsilon;
+  }
+
+  // Parameter getters (for runtime tuning)
+  float get_hc() const { return heating_curve_.get_hc(); }
+  float get_n() const { return heating_curve_.get_n(); }
+  float get_shift() const { return heating_curve_.get_shift(); }
+  float get_min_flow_temp() const { return heating_curve_.get_min_flow_temp(); }
+  float get_max_flow_temp() const { return heating_curve_.get_max_flow_temp(); }
+  float get_kp() const { return pid_controller_.kp_; }
+  float get_ki() const { return pid_controller_.ki_; }
+  float get_kd() const { return pid_controller_.kd_; }
+  float get_proportional_term() const { return pid_controller_.proportional_term_; }
+  float get_integral_term() const { return pid_controller_.integral_term_; }
+  float get_derivative_term() const { return pid_controller_.derivative_term_; }
+
+  // Callback for diagnostic sensors
+  void add_on_state_callback(std::function<void()> &&callback) { state_callback_.add(std::move(callback)); }
+
+  // Callbacks for heating state transitions
+  template<typename F> void add_on_heating_start_callback(F &&callback) {
+    this->on_heating_start_callback_.add(std::forward<F>(callback));
+  }
+  template<typename F> void add_on_heating_stop_callback(F &&callback) {
+    this->on_heating_stop_callback_.add(std::forward<F>(callback));
+  }
+
+  // Force immediate recalculation (used by runtime tuning numbers)
+  void force_recalculate(bool update_pid = false) { this->compute_and_apply_(update_pid); }
+
+ protected:
+  /// Override control to handle climate calls from HA
+  void control(const climate::ClimateCall &call) override;
+  /// Return the traits of this controller
+  climate::ClimateTraits traits() override;
+
+  void compute_and_apply_(bool update_pid = true);
+  void write_setpoint_(float temp_c);
+  void write_setpoint_off_();
+
+  /// Outdoor temperature sensor (required)
+  sensor::Sensor *outdoor_sensor_{nullptr};
+  /// Indoor temperature sensor (required - for current_temperature display and room correction)
+  sensor::Sensor *indoor_sensor_{nullptr};
+  /// Flow temperature setpoint output (direct °C control, e.g., OpenTherm)
+  number::Number *flow_setpoint_output_{nullptr};
+#ifdef USE_EQUITHERM_HEAT_OUTPUT
+  /// Alternative: generic float output (normalized 0-1)
+  output::FloatOutput *heat_output_{nullptr};
+#endif
+  /// Manual flow temperature override (used when custom preset "manual" is active)
+  number::Number *manual_flow_temp_{nullptr};
+
+  /// Curve calculation engine
+  HeatingCurve heating_curve_;
+  /// PID controller for fine-tuning equitherm output
+  PIDController pid_controller_;
+  /// Default target temperature when no state restored
+  float default_target_temperature_{20.0f};
+  /// Raw heating curve output before PID (for diagnostics)
+  float heating_curve_output_{NAN};
+  /// Setpoint after PID (for diagnostics)
+  float pid_adjusted_output_{NAN};
+  /// Whether warm weather shutdown is active (delta_t <= 0, no heating demand)
+  bool wws_active_{false};
+  /// Flow setpoint (after PID, for diagnostics)
+  float flow_setpoint_{NAN};
+  /// Last value actually written to boiler (confirmed active setpoint)
+  float active_setpoint_{NAN};
+  /// PID correction (for diagnostics)
+  float pid_correction_{NAN};
+  /// Minimum setpoint change (°C) required to write to boiler output
+  float write_deadband_{0.05f};
+
+  /// Callback for diagnostic sensors
+  CallbackManager<void()> state_callback_;
+  /// Previous climate action — used to detect heating start/stop transitions
+  climate::ClimateAction prev_action_{climate::CLIMATE_ACTION_OFF};
+  /// Callback fired when transitioning into CLIMATE_ACTION_HEATING
+  CallbackManager<void()> on_heating_start_callback_;
+  /// Callback fired when transitioning out of CLIMATE_ACTION_HEATING
+  CallbackManager<void()> on_heating_stop_callback_;
+};
+
+template<typename... Ts> class EquithermForceRecalculateAction : public Action<Ts...> {
+ public:
+  EquithermForceRecalculateAction(EquithermClimate *parent) : parent_(parent) {}
+
+  void set_update_pid(bool update_pid) { update_pid_ = update_pid; }
+
+  void play(const Ts &...x) override { this->parent_->force_recalculate(this->update_pid_); }
+
+ protected:
+  EquithermClimate *parent_;
+  bool update_pid_{true};
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/equitherm.h
+++ b/esphome/components/equitherm/equitherm.h
@@ -25,6 +25,7 @@ class EquithermClimate : public climate::Climate, public Component {
  public:
   EquithermClimate() = default;
   void setup() override;
+  void loop() override;
   void dump_config() override;
 
   // Sensor inputs
@@ -72,6 +73,14 @@ class EquithermClimate : public climate::Climate, public Component {
   void set_ki_multiplier(float mult) { pid_controller_.ki_multiplier_ = mult; }
   void set_kd_multiplier(float mult) { pid_controller_.kd_multiplier_ = mult; }
 
+  // Indoor data-health timeouts (split from the old shared sensor_stale_timeout)
+  void set_indoor_fresh_window_ms(uint32_t ms) { this->indoor_fresh_window_ms_ = ms; }
+  void set_indoor_fault_horizon_ms(uint32_t ms) { this->indoor_fault_horizon_ms_ = ms; }
+  void set_outdoor_stale_timeout_ms(uint32_t ms) { this->outdoor_stale_timeout_ms_ = ms; }
+
+  bool is_outdoor_sensor_fault() const { return outdoor_sensor_fault_; }
+  bool is_indoor_sensor_coasting() const { return this->indoor_data_health_ == IndoorDataHealth::COASTING; }
+  bool is_indoor_sensor_fault() const { return this->indoor_data_health_ == IndoorDataHealth::FAULT; }
   bool is_wws_active() const { return wws_active_; }
 
   // State getters (for diagnostics)
@@ -124,6 +133,8 @@ class EquithermClimate : public climate::Climate, public Component {
   void compute_and_apply_(bool update_pid = true);
   void write_setpoint_(float temp_c);
   void write_setpoint_off_();
+  /// Advance indoor health from reading age (indoor-only; the both-dead hold owns outdoor interaction).
+  void update_indoor_health_(uint32_t now_ms);
 
   /// Outdoor temperature sensor (required)
   sensor::Sensor *outdoor_sensor_{nullptr};
@@ -150,6 +161,8 @@ class EquithermClimate : public climate::Climate, public Component {
   float pid_adjusted_output_{NAN};
   /// Whether warm weather shutdown is active (delta_t <= 0, no heating demand)
   bool wws_active_{false};
+  /// Last time loop() ran its staleness safety-net check (throttle)
+  uint32_t last_loop_check_time_{0};
   /// Flow setpoint (after PID, for diagnostics)
   float flow_setpoint_{NAN};
   /// Last value actually written to boiler (confirmed active setpoint)
@@ -158,7 +171,34 @@ class EquithermClimate : public climate::Climate, public Component {
   float pid_correction_{NAN};
   /// Minimum setpoint change (°C) required to write to boiler output
   float write_deadband_{0.05f};
+  /// Timeout for outdoor sensor staleness (ms)
+  uint32_t outdoor_stale_timeout_ms_{600000};  // 10 min, unchanged
+  /// Indoor reading is considered quiet (-> COASTING) after this (ms)
+  uint32_t indoor_fresh_window_ms_{1800000};  // 30 min
+  /// Indoor reading is considered failed (-> FAULT) after this (ms)
+  uint32_t indoor_fault_horizon_ms_{14400000};  // 4 h
+  /// Last known valid outdoor temperature for stale data window
+  float last_valid_outdoor_temp_{NAN};
+  /// Last known valid indoor temperature for display when sensor fails
+  float last_valid_indoor_temp_{NAN};
+  /// Whether outdoor sensor has failed (stale / out of range)
+  bool outdoor_sensor_fault_{false};
+  /// Timestamp of last valid outdoor sensor reading
+  uint32_t last_valid_outdoor_time_{0};
+  /// Timestamp of last valid indoor sensor reading
+  uint32_t last_valid_indoor_time_{0};
 
+  /// Indoor data-health state machine (protected; accessors expose booleans)
+  enum class IndoorDataHealth : uint8_t {
+    WARM_UP = 0,   // no valid reading seen yet
+    FRESH = 1,     // within fresh_window — PID on
+    COASTING = 2,  // quiet but plausible — PID off, curve-only, no alarm
+    FAULT = 3,     // dead / implausible / both-dead — alarm on
+  };
+
+  IndoorDataHealth indoor_data_health_{IndoorDataHealth::WARM_UP};
+  bool indoor_ever_received_{false};
+  IndoorDataHealth prev_indoor_health_{IndoorDataHealth::WARM_UP};  // for FAULT->FRESH reset
   /// Callback for diagnostic sensors
   CallbackManager<void()> state_callback_;
   /// Previous climate action — used to detect heating start/stop transitions

--- a/esphome/components/equitherm/equitherm.h
+++ b/esphome/components/equitherm/equitherm.h
@@ -15,11 +15,11 @@
 #include "equitherm_controller.h"
 #include "pid_controller.h"
 
-namespace esphome {
-namespace number {
+namespace esphome::number {
 class Number;  // Forward declaration
-}
-namespace equitherm {
+}  // namespace esphome::number
+
+namespace esphome::equitherm {
 
 class EquithermClimate : public climate::Climate, public Component {
  public:
@@ -182,5 +182,4 @@ template<typename... Ts> class EquithermForceRecalculateAction : public Action<T
   bool update_pid_{true};
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/equitherm_controller.cpp
+++ b/esphome/components/equitherm/equitherm_controller.cpp
@@ -1,8 +1,7 @@
 #include "equitherm_controller.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 float HeatingCurve::compute_flow_temperature(float t_target, float t_outdoor) {
   // Guard against invalid inputs
@@ -29,5 +28,4 @@ float HeatingCurve::compute_flow_temperature(float t_target, float t_outdoor) {
   return clamp(t_flow, this->min_flow_temp_, this->max_flow_temp_);
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/equitherm_controller.cpp
+++ b/esphome/components/equitherm/equitherm_controller.cpp
@@ -1,0 +1,33 @@
+#include "equitherm_controller.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace equitherm {
+
+float HeatingCurve::compute_flow_temperature(float t_target, float t_outdoor) {
+  // Guard against invalid inputs
+  if (std::isnan(t_target) || std::isnan(t_outdoor)) {
+    return min_flow_temp_;
+  }
+
+  float delta_t = t_target - t_outdoor;
+
+  // Warm weather shutdown: outdoor >= target — bypass formula entirely.
+  // Return 0 to signal no heating demand.
+  // Shift is only valid within the heating domain (delta_t > 0); applying it
+  // at delta_t <= 0 would defeat warm weather shutdown and supply heat
+  // unnecessarily. See: Viessmann, Buderus, EN 12831, Versatile Thermostat.
+  if (delta_t <= 0.0f) {
+    return 0.0f;
+  }
+
+  // Industry-standard European heating curve:
+  // t_flow = t_target + shift + hc * (t_target - t_outdoor)^(1/n)
+  float t_flow = t_target + this->shift_ + this->hc_ * powf(delta_t, 1.0f / this->n_);
+
+  // Clamp to boiler limits
+  return clamp(t_flow, this->min_flow_temp_, this->max_flow_temp_);
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/equitherm_controller.h
+++ b/esphome/components/equitherm/equitherm_controller.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "esphome/core/hal.h"
+#include <cmath>
+
+namespace esphome {
+namespace equitherm {
+
+/// Standard European heating curve (Buderus/Viessmann style).
+/// Pure calculator — no side effects, testable in isolation.
+///
+/// Formula: t_flow = t_target + shift + hc * (t_target - t_outdoor)^(1/n)
+///
+/// Parameters:
+///   hc: heat curve coefficient (0.5-1.5), maps to building insulation
+///   n:  radiator exponent (1.2-1.33 panels, 1.0 underfloor) per EN 442
+///   shift: flat offset in °C for fine-tuning
+class HeatingCurve {
+ public:
+  /// Compute supply temperature from target and outdoor temperatures
+  /// @param t_target Room target temperature in °C
+  /// @param t_outdoor Outdoor temperature in °C
+  /// @return Calculated supply temperature in °C, clamped to [min_flow_temp_, max_flow_temp_].
+  ///         Returns 0.0f when delta_t <= 0 (warm weather shutdown).
+  float compute_flow_temperature(float t_target, float t_outdoor);
+
+  // Parameter setters (called from EquithermClimate)
+  void set_hc(float hc) { hc_ = hc; }
+  void set_n(float n) { n_ = n; }
+  void set_shift(float shift) { shift_ = shift; }
+  void set_min_flow_temp(float temp) { min_flow_temp_ = temp; }
+  void set_max_flow_temp(float temp) { max_flow_temp_ = temp; }
+
+  // Parameter getters (for dump_config and diagnostics)
+  float get_hc() const { return hc_; }
+  float get_n() const { return n_; }
+  float get_shift() const { return shift_; }
+  float get_min_flow_temp() const { return min_flow_temp_; }
+  float get_max_flow_temp() const { return max_flow_temp_; }
+
+ protected:
+  /// Heat curve coefficient (industry: 0.5-1.5 depending on insulation)
+  /// Higher values = more aggressive heating
+  float hc_{1.0f};
+  /// Radiator exponent (industry: 1.2-1.33 for panel radiators, 1.0 for underfloor)
+  float n_{1.25f};
+  /// Flat offset in °C for fine-tuning
+  float shift_{0.0f};
+  /// Minimum supply temperature to boiler
+  float min_flow_temp_{25.0f};
+  /// Maximum supply temperature to boiler
+  float max_flow_temp_{70.0f};
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/equitherm_controller.h
+++ b/esphome/components/equitherm/equitherm_controller.h
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include <cmath>
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 /// Standard European heating curve (Buderus/Viessmann style).
 /// Pure calculator — no side effects, testable in isolation.
@@ -52,5 +51,4 @@ class HeatingCurve {
   float max_flow_temp_{70.0f};
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/pid_controller.cpp
+++ b/esphome/components/equitherm/pid_controller.cpp
@@ -1,7 +1,6 @@
 #include "pid_controller.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 float PIDController::update(float setpoint, float process_value) {
   // e(t) ... error at timestamp t
@@ -123,5 +122,4 @@ float PIDController::calculate_relative_time_() {
   return dt / 1000.0f;
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/pid_controller.cpp
+++ b/esphome/components/equitherm/pid_controller.cpp
@@ -1,0 +1,127 @@
+#include "pid_controller.h"
+
+namespace esphome {
+namespace equitherm {
+
+float PIDController::update(float setpoint, float process_value) {
+  // e(t) ... error at timestamp t
+  // r(t) ... setpoint
+  // y(t) ... process value (sensor reading)
+  // u(t) ... output value
+
+  dt_ = calculate_relative_time_();
+
+  // e(t) := r(t) - y(t)
+  error_ = setpoint - process_value;
+
+  calculate_proportional_term_();
+  calculate_integral_term_();
+  calculate_derivative_term_(setpoint);
+
+  // u(t) := p(t) + i(t) + d(t)
+  float output = proportional_term_ + integral_term_ + derivative_term_;
+
+  // smooth/sample the output using shared buffer with mode-appropriate sample count
+  int samples = in_deadband() ? deadband_output_samples_ : output_samples_;
+  return ring_buffer_average_(output_window_, output, samples);
+}
+
+bool PIDController::in_deadband() {
+  // return (fabs(error) < deadband_threshold);
+  float err = -error_;
+  return (threshold_low_ < err && err < threshold_high_);
+}
+
+void PIDController::calculate_proportional_term_() {
+  // p(t) := K_p * e(t)
+  proportional_term_ = kp_ * error_;
+
+  // set dead-zone to -X to +X
+  if (in_deadband()) {
+    // shallow the proportional_term in the deadband by the pdm
+    proportional_term_ *= kp_multiplier_;
+
+  } else {
+    // pdm_offset prevents a jump when leaving the deadband
+    float threshold = (error_ < 0) ? threshold_high_ : threshold_low_;
+    float pdm_offset = (threshold - (kp_multiplier_ * threshold)) * kp_;
+    proportional_term_ += pdm_offset;
+  }
+}
+
+void PIDController::calculate_integral_term_() {
+  // i(t) := K_i * \int_{0}^{t} e(t) dt
+  float new_integral = error_ * dt_ * ki_;
+
+  if (in_deadband()) {
+    // shallow the integral when in the deadband
+    accumulated_integral_ += new_integral * ki_multiplier_;
+  } else {
+    accumulated_integral_ += new_integral;
+  }
+
+  // constrain accumulated integral value
+  if (!std::isnan(min_integral_) && accumulated_integral_ < min_integral_)
+    accumulated_integral_ = min_integral_;
+  if (!std::isnan(max_integral_) && accumulated_integral_ > max_integral_)
+    accumulated_integral_ = max_integral_;
+
+  integral_term_ = accumulated_integral_;
+}
+
+void PIDController::calculate_derivative_term_(float setpoint) {
+  // derivative_term_
+  // d(t) := K_d * de(t)/dt
+  float derivative = 0.0f;
+  if (dt_ != 0.0f) {
+    // remove changes to setpoint from error
+    if (!std::isnan(previous_setpoint_) && previous_setpoint_ != setpoint)
+      previous_error_ -= previous_setpoint_ - setpoint;
+    derivative = (error_ - previous_error_) / dt_;
+  }
+  previous_error_ = error_;
+  previous_setpoint_ = setpoint;
+
+  // smooth the derivative samples
+  derivative = ring_buffer_average_(derivative_window_, derivative, derivative_samples_);
+
+  derivative_term_ = kd_ * derivative;
+
+  if (in_deadband()) {
+    // shallow the derivative when in the deadband
+    derivative_term_ *= kd_multiplier_;
+  }
+}
+
+float PIDController::ring_buffer_average_(FixedRingBuffer<float> &buf, float new_value, int max_samples) {
+  // if only 1 sample needed (or invalid), clear the buffer and return
+  if (max_samples <= 1) {
+    buf.clear();
+    return new_value;
+  }
+
+  // Trim oldest entries to make room (handles mode-switching where buffer
+  // may have more entries than the current mode needs)
+  while (buf.size() >= static_cast<size_t>(max_samples))
+    buf.pop();
+  buf.push(new_value);
+
+  float sum = 0;
+  for (auto val : buf)
+    sum += val;
+  return sum / buf.size();
+}
+
+float PIDController::calculate_relative_time_() {
+  uint32_t now = millis();
+  uint32_t dt = now - this->last_time_;
+  if (last_time_ == 0) {
+    last_time_ = now;
+    return 0.0f;
+  }
+  last_time_ = now;
+  return dt / 1000.0f;
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/pid_controller.h
+++ b/esphome/components/equitherm/pid_controller.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include <cmath>
+
+namespace esphome {
+namespace equitherm {
+
+/// Embedded PID controller — avoids dependency on pid component.
+/// Kept in sync with esphome/components/pid/pid_controller.
+struct PIDController {
+  float update(float setpoint, float process_value);
+
+  void reset_accumulated_integral() { accumulated_integral_ = 0; }
+  void set_starting_integral_term(float in) { accumulated_integral_ = in; }
+
+  bool in_deadband();
+
+  friend class EquithermClimate;
+
+ private:
+  /// Proportional gain K_p.
+  float kp_ = 0;
+  /// Integral gain K_i.
+  float ki_ = 0;
+  /// Differential gain K_d.
+  float kd_ = 0;
+
+  // smooth the derivative value using an average over X samples
+  int derivative_samples_ = 1;
+
+  /// smooth the output value using an average over X values
+  int output_samples_ = 1;
+
+  float threshold_low_ = 0.0f;
+  float threshold_high_ = 0.0f;
+  float kp_multiplier_ = 0.0f;
+  float ki_multiplier_ = 0.0f;
+  float kd_multiplier_ = 0.0f;
+  int deadband_output_samples_ = 1;
+
+  float min_integral_ = NAN;
+  float max_integral_ = NAN;
+
+  // Store computed values in struct so that values can be monitored through sensors
+  float error_;
+  float dt_;
+  float proportional_term_;
+  float integral_term_;
+  float derivative_term_;
+
+  void calculate_proportional_term_();
+  void calculate_integral_term_();
+  void calculate_derivative_term_(float setpoint);
+
+  /// Ring buffer smoothing using FixedRingBuffer (single allocation at setup)
+  float ring_buffer_average_(FixedRingBuffer<float> &buf, float new_value, int max_samples);
+
+  float calculate_relative_time_();
+
+  /// Error from previous update used for derivative term
+  float previous_error_ = 0;
+  float previous_setpoint_ = NAN;
+  /// Accumulated integral value
+  float accumulated_integral_ = 0;
+  uint32_t last_time_ = 0;
+
+  // Ring buffer for derivative smoothing
+  FixedRingBuffer<float> derivative_window_;
+
+  // Ring buffer for output smoothing (shared between normal and deadband modes)
+  FixedRingBuffer<float> output_window_;
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/pid_controller.h
+++ b/esphome/components/equitherm/pid_controller.h
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include <cmath>
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 /// Embedded PID controller — avoids dependency on pid component.
 /// Kept in sync with esphome/components/pid/pid_controller.
@@ -73,5 +72,4 @@ struct PIDController {
   FixedRingBuffer<float> output_window_;
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/tests/components/equitherm/common.yaml
+++ b/tests/components/equitherm/common.yaml
@@ -1,0 +1,58 @@
+sensor:
+  - platform: template
+    id: outdoor_sensor
+    lambda: return 12.0;
+    update_interval: 60s
+
+  - platform: template
+    id: indoor_sensor
+    lambda: return 19.5;
+    update_interval: 60s
+
+output:
+  - platform: slow_pwm
+    pin: 4
+    id: heat_output
+    period: 15s
+
+climate:
+  - platform: equitherm
+    id: heating_controller
+    name: Equitherm Climate
+    outdoor_sensor: outdoor_sensor
+    indoor_sensor: indoor_sensor
+    default_target_temperature: 20°C
+    heat_output: heat_output
+    control_parameters:
+      heat_curve_coefficient: 3.0
+      heat_curve_exponent: 1.5
+      heat_curve_shift: 0.0
+      kp: 2.0
+      ki: 0.5
+      kd: 0.0
+      min_integral: -5.0
+      max_integral: 5.0
+      derivative_averaging_samples: 4
+    output_parameters:
+      min_flow_temp: 25.0
+      max_flow_temp: 70.0
+    deadband_parameters:
+      threshold_high: 0.5
+      threshold_low: -0.5
+      kp_multiplier: 0.1
+      ki_multiplier: 0.0
+
+# Test action
+wifi:
+  ssid: "test"
+
+api:
+  actions:
+    - action: test_force_recalculate
+      then:
+        - climate.equitherm.force_recalculate: heating_controller
+    - action: test_force_recalculate_no_pid
+      then:
+        - climate.equitherm.force_recalculate:
+            id: heating_controller
+            update_pid: false

--- a/tests/components/equitherm/common.yaml
+++ b/tests/components/equitherm/common.yaml
@@ -9,6 +9,20 @@ sensor:
     lambda: return 19.5;
     update_interval: 60s
 
+# Staleness fault/coasting binary sensors
+binary_sensor:
+  - platform: equitherm
+    climate_id: heating_controller
+    outdoor_sensor_fault:
+      name: "Outdoor Sensor Fault"
+      id: outdoor_sensor_fault_sensor
+    indoor_sensor_fault:
+      name: "Indoor Sensor Fault"
+      id: indoor_sensor_fault_sensor
+    indoor_sensor_coasting:
+      name: "Indoor Sensor Coasting"
+      id: indoor_sensor_coasting_sensor
+
 output:
   - platform: slow_pwm
     pin: 4

--- a/tests/components/equitherm/test.esp32-idf.yaml
+++ b/tests/components/equitherm/test.esp32-idf.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: test-equitherm-esp32-idf
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+logger:
+  level: DEBUG
+
+<<: !include common.yaml

--- a/tests/components/equitherm/test.esp8266-ard.yaml
+++ b/tests/components/equitherm/test.esp8266-ard.yaml
@@ -1,0 +1,10 @@
+esphome:
+  name: test-equitherm-climate-esp8266
+
+esp8266:
+  board: esp01_1m
+
+logger:
+  level: DEBUG
+
+<<: !include common.yaml

--- a/tests/components/equitherm/test.rp2040-ard.yaml
+++ b/tests/components/equitherm/test.rp2040-ard.yaml
@@ -1,0 +1,10 @@
+esphome:
+  name: test-equitherm-climate-rp2040
+
+rp2040:
+  board: rpipicow
+
+logger:
+  level: DEBUG
+
+<<: !include common.yaml

--- a/tests/components/equitherm/test_indoor_staleness.yaml
+++ b/tests/components/equitherm/test_indoor_staleness.yaml
@@ -1,0 +1,43 @@
+esphome:
+  name: test-eq-staleness
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+logger:
+  level: DEBUG
+
+sensor:
+  - platform: template
+    id: outdoor_temp
+    lambda: "return 5.0f;"
+  - platform: template
+    id: indoor_temp
+    lambda: "return 20.0f;"
+
+number:
+  - platform: template
+    id: ch_setpoint
+    min_value: 20
+    max_value: 85
+    step: 0.5
+    optimistic: true
+
+climate:
+  - platform: equitherm
+    id: equitherm_climate
+    outdoor_sensor: outdoor_temp
+    indoor_sensor: indoor_temp
+    default_target_temperature: 20
+    flow_setpoint: ch_setpoint
+    sensor_stale_timeout: 10min  # outdoor-only
+    indoor_fresh_window: 45min
+    indoor_fault_horizon: 6h
+    control_parameters:
+      heat_curve_coefficient: 1.4
+      heat_curve_exponent: 1.3
+    output_parameters:
+      min_flow_temp: 20
+      max_flow_temp: 70

--- a/tests/components/equitherm/test_indoor_staleness_defaults.yaml
+++ b/tests/components/equitherm/test_indoor_staleness_defaults.yaml
@@ -1,0 +1,45 @@
+# Config-validation test — all three indoor/outdoor staleness keys OMITTED so the
+# schema defaults apply (sensor_stale_timeout 10min, indoor_fresh_window 30min,
+# indoor_fault_horizon 4h). Must validate cleanly.
+# NOT a build fixture (underscore name) — run: esphome config <this file>.
+esphome:
+  name: test-eq-staleness-def
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+logger:
+  level: DEBUG
+
+sensor:
+  - platform: template
+    id: outdoor_temp
+    lambda: "return 5.0f;"
+  - platform: template
+    id: indoor_temp
+    lambda: "return 20.0f;"
+
+number:
+  - platform: template
+    id: ch_setpoint
+    min_value: 20
+    max_value: 85
+    step: 0.5
+    optimistic: true
+
+climate:
+  - platform: equitherm
+    id: equitherm_climate
+    outdoor_sensor: outdoor_temp
+    indoor_sensor: indoor_temp
+    default_target_temperature: 20
+    flow_setpoint: ch_setpoint
+    # No staleness keys — defaults must apply.
+    control_parameters:
+      heat_curve_coefficient: 1.4
+      heat_curve_exponent: 1.3
+    output_parameters:
+      min_flow_temp: 20
+      max_flow_temp: 70

--- a/tests/components/equitherm/test_indoor_staleness_invalid.yaml
+++ b/tests/components/equitherm/test_indoor_staleness_invalid.yaml
@@ -1,0 +1,44 @@
+# Config-validation rejection test (NOT a build fixture) — run: esphome config <this file>; expect failure.
+# Underscore-prefixed name excludes it from script/test_build_components discovery (glob: test[.-]*.yaml).
+esphome:
+  name: test-eq-stale-bad
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+logger:
+  level: DEBUG
+
+sensor:
+  - platform: template
+    id: outdoor_temp
+    lambda: "return 5.0f;"
+  - platform: template
+    id: indoor_temp
+    lambda: "return 20.0f;"
+
+number:
+  - platform: template
+    id: ch_setpoint
+    min_value: 20
+    max_value: 85
+    step: 0.5
+    optimistic: true
+
+climate:
+  - platform: equitherm
+    id: equitherm_climate
+    outdoor_sensor: outdoor_temp
+    indoor_sensor: indoor_temp
+    default_target_temperature: 20
+    flow_setpoint: ch_setpoint
+    indoor_fresh_window: 5h  # >= fault_horizon — must be rejected
+    indoor_fault_horizon: 1h
+    control_parameters:
+      heat_curve_coefficient: 1.4
+      heat_curve_exponent: 1.3
+    output_parameters:
+      min_flow_temp: 20
+      max_flow_temp: 70

--- a/tests/components/equitherm/test_manual_preset.yaml
+++ b/tests/components/equitherm/test_manual_preset.yaml
@@ -1,0 +1,45 @@
+esphome:
+  name: test-equitherm-manual
+
+esp32:
+  board: esp32dev
+
+sensor:
+  - platform: template
+    id: outdoor_temp
+    lambda: "return 5.0f;"
+  - platform: template
+    id: indoor_temp
+    lambda: "return 20.0f;"
+
+number:
+  - platform: template
+    id: ch_setpoint
+    min_value: 20
+    max_value: 85
+    step: 0.5
+    optimistic: true
+
+  - platform: template
+    id: manual_flow_temp
+    name: "Manual Flow Temperature"
+    min_value: 20
+    max_value: 85
+    step: 0.5
+    optimistic: true
+    initial_value: 45
+
+climate:
+  - platform: equitherm
+    id: equitherm_climate
+    outdoor_sensor: outdoor_temp
+    indoor_sensor: indoor_temp
+    default_target_temperature: 20
+    flow_setpoint: ch_setpoint
+    manual_flow_temp: manual_flow_temp
+    control_parameters:
+      heat_curve_coefficient: 1.4
+      heat_curve_exponent: 1.3
+    output_parameters:
+      min_flow_temp: 20
+      max_flow_temp: 70

--- a/tests/components/equitherm/test_triggers.yaml
+++ b/tests/components/equitherm/test_triggers.yaml
@@ -1,0 +1,49 @@
+esphome:
+  name: test-equitherm-triggers
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+logger:
+  level: DEBUG
+
+sensor:
+  - platform: template
+    id: outdoor_temp
+    lambda: "return 5.0f;"
+  - platform: template
+    id: indoor_temp
+    lambda: "return 20.0f;"
+
+number:
+  - platform: template
+    id: ch_setpoint
+    min_value: 20
+    max_value: 85
+    step: 0.5
+    optimistic: true
+
+switch:
+  - platform: template
+    id: ch_enable
+    optimistic: true
+
+climate:
+  - platform: equitherm
+    id: equitherm_climate
+    outdoor_sensor: outdoor_temp
+    indoor_sensor: indoor_temp
+    default_target_temperature: 20
+    flow_setpoint: ch_setpoint
+    on_heating_start:
+      - switch.turn_on: ch_enable
+    on_heating_stop:
+      - switch.turn_off: ch_enable
+    control_parameters:
+      heat_curve_coefficient: 1.4
+      heat_curve_exponent: 1.3
+    output_parameters:
+      min_flow_temp: 20
+      max_flow_temp: 70


### PR DESCRIPTION
# What does this implement/fix?

Adds sensor-staleness and fault detection to the `equitherm` climate component, so a failed or stale indoor/outdoor sensor degrades gracefully instead of driving the boiler on frozen readings.

**Outdoor sensor**
- `sensor_stale_timeout` — an outdoor reading older than this is treated as stale and no longer trusted.
- When both sensors are stale/dead, the controller holds its output rather than acting on the last cached values.

**Indoor health state machine** — governed by two windows:
- `indoor_fresh_window` — how recently the indoor reading must have updated to stay `FRESH`.
- `indoor_fault_horizon` — beyond this age the indoor sensor is declared `FAULT`.
- States: `WARM_UP → FRESH → COASTING → FAULT`. When the indoor reading is stale but still within the fault horizon (`COASTING`), the controller rides the last known error term instead of abandoning control. `FAULT` only clears on a fresh good reading.

**Binary sensors (3)**
- `outdoor_sensor_fault` — outdoor sensor is stale/invalid (`DEVICE_CLASS_PROBLEM`)
- `indoor_sensor_fault` — indoor sensor exceeded the fault horizon (`DEVICE_CLASS_PROBLEM`)
- `indoor_sensor_coasting` — controller is coasting on stale-but-recent indoor data

Part of the equitherm PR split (#14738):
- **Prerequisite:** #15672 (core climate, PID, automations)
- **Sibling:** #15674 (diagnostic sensors and binary sensors) — this PR delivers the sensor-fault follow-up noted there.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

**Related issue or feature (if applicable):**

- Part of #14738 split

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6271 *(closed; documentation pending resubmission)*

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Core climate (from PR #15672)
climate:
  - platform: equitherm
    id: heating_controller
    name: "Equitherm Climate"
    outdoor_sensor: outdoor_temp_sensor
    indoor_sensor: indoor_temp_sensor
    default_target_temperature: 20degC
    heat_output: boiler_output
    sensor_stale_timeout: 10min
    indoor_fresh_window: 45min
    indoor_fault_horizon: 6h
    control_parameters:
      heat_curve_coefficient: 1.4
      heat_curve_exponent: 1.3
    output_parameters:
      min_flow_temp: 20
      max_flow_temp: 70

# Sensor-fault binary sensors (this PR)
binary_sensor:
  - platform: equitherm
    climate_id: heating_controller
    outdoor_sensor_fault:
      name: "Outdoor Sensor Fault"
    indoor_sensor_fault:
      name: "Indoor Sensor Fault"
    indoor_sensor_coasting:
      name: "Indoor Sensor Coasting"
```

## Checklist:

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
