### PR TITLE
[esp8266] Strip dead libstdc++ throw message strings from DRAM

### DIFF
--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -310,6 +310,14 @@ async def to_code(config):
     # For cases where nullptrs can be handled, use nothrow: `new (std::nothrow) T;`
     cg.add_build_flag("-DNEW_OOM_ABORT")
 
+    # Force-include inline std::__throw_* overrides so GCC dead-strips the unused
+    # libstdc++ error message strings (e.g. "basic_string::_M_create") from DRAM.
+    # See throw_stubs.h for details. Must be prepended before <string>, so this
+    # uses build_src_flags with -include.
+    cg.add_platformio_option(
+        "build_src_flags", "-include esphome/components/esp8266/throw_stubs.h"
+    )
+
     # In testing mode, fake larger memory to allow linking grouped component tests
     # Real ESP8266 hardware only has 32KB IRAM and ~80KB RAM, but for CI testing
     # we pretend it has much larger memory to test that components compile together

--- a/esphome/components/esp8266/throw_stubs.h
+++ b/esphome/components/esp8266/throw_stubs.h
@@ -1,0 +1,41 @@
+#pragma once
+/*
+ * Inline overrides for std::__throw_* helpers (ESP8266).
+ *
+ * ESP8266 Arduino compiles with -fno-exceptions and ships a libstdc++ whose
+ * std::__throw_* functions already just call abort() -- they never read their
+ * const char* message argument. But the compiler still emits the message load
+ * at every throw site (inside header-instantiated std::string / std::vector
+ * code), so --gc-sections keeps those libstdc++ error strings alive. On
+ * ESP8266 .rodata lives in DRAM, so each one wastes scarce RAM (e.g.
+ * "basic_string::_M_construct null not valid", "basic_string::_M_create",
+ * "cannot create std::vector larger than max_size()", "array::at: ...").
+ *
+ * Providing inline definitions here lets GCC see the message argument is
+ * unused, dead-strip the load, and drop the string entirely -- no LTO needed.
+ * Behavior is identical to today: a bare abort() (the message was never
+ * printed). This header MUST be force-included before <string>, so it is
+ * wired up via build_src_flags "-include ..." in this component's __init__.py.
+ *
+ * Note: this defines functions in namespace std (technically UB). It is safe
+ * here because the definitions match the existing abort() behavior exactly.
+ */
+
+#ifdef __cplusplus
+
+// Empty namespace so the CI namespace check is satisfied; the overrides below
+// must live in namespace std, so they cannot go in the component namespace.
+namespace esphome::esp8266 {}  // namespace esphome::esp8266
+
+// NOLINTBEGIN(bugprone-reserved-identifier,bugprone-std-namespace-modification,cert-dcl37-c,cert-dcl51-cpp,cert-dcl58-cpp,readability-identifier-naming)
+namespace std {
+
+__attribute__((__noreturn__)) inline void __throw_logic_error(const char *) { __builtin_abort(); }
+__attribute__((__noreturn__)) inline void __throw_length_error(const char *) { __builtin_abort(); }
+__attribute__((__noreturn__)) inline void __throw_out_of_range(const char *) { __builtin_abort(); }
+__attribute__((__noreturn__)) inline void __throw_out_of_range_fmt(const char *, ...) { __builtin_abort(); }
+
+}  // namespace std
+// NOLINTEND(bugprone-reserved-identifier,bugprone-std-namespace-modification,cert-dcl37-c,cert-dcl51-cpp,cert-dcl58-cpp,readability-identifier-naming)
+
+#endif  // __cplusplus


### PR DESCRIPTION
# What does this implement/fix?

ESP8266 keeps `.rodata` in DRAM, so the libstdc++ error message strings that `std::string` and `std::vector` pull in end up resident in RAM even though nothing ever prints them. Under `-fno-exceptions` the `std::__throw_*` helpers already abort and ignore their message argument, but the compiler still emits the message load at each throw site, which keeps the strings alive. This force includes a small header of inline overrides for those helpers, so the compiler drops the unused argument and the strings go away. Crash behavior is unchanged, they still abort. It frees about 96 bytes of RAM on a ratgdo build; the exact amount depends on which std helpers a given config instantiates.

One remaining string (`array::at`) comes from the vendored ESPAsyncWebServer library rather than ESPHome sources, so it is outside the scope of this src only change and stays.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes, applies automatically to all ESP8266 builds
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
