### PR TITLE
[usb_uart] Fix format specifier warnings for uint32_t in ft23xx and pl2303

### DIFF
--- a/esphome/components/usb_uart/ft23xx.cpp
+++ b/esphome/components/usb_uart/ft23xx.cpp
@@ -6,6 +6,7 @@
 #include "esphome/components/uart/uart_debugger.h"
 
 #include "esphome/components/bytebuffer/bytebuffer.h"
+#include <cinttypes>
 
 namespace esphome::usb_uart {
 
@@ -288,16 +289,16 @@ int USBUartTypeFT23XX::set_baudrate_(USBUartChannel *channel, uint32_t baudrate)
       ESP_LOGE(TAG, "Set baudrate failed, status=%s", esp_err_to_name(status.error_code));
       channel->initialised_.store(false);
     } else {
-      ESP_LOGD(TAG, "Baudrate %d set, setting line properties...", channel->baud_rate_);
+      ESP_LOGD(TAG, "Baudrate %" PRIu32 " set, setting line properties...", channel->baud_rate_);
       this->set_line_properties_(channel);
     }
   };
   if (baudrate == 0) {
     baudrate = channel->baud_rate_;
   }
-  uint16_t value, ftdi_index;
+  uint16_t value = 0, ftdi_index = 0;
   ftdi_convert_baudrate(baudrate, this->chip_type_, channel->index_, &value, &ftdi_index);
-  ESP_LOGD(TAG, "Baudrate: %d, value=0x%04X, ftdi_index=0x%04X", baudrate, value, ftdi_index);
+  ESP_LOGD(TAG, "Baudrate: %" PRIu32 ", value=0x%04X, ftdi_index=0x%04X", baudrate, value, ftdi_index);
   uint16_t usb_index = (ftdi_index & 0xFF00) | (channel->cdc_dev_.bulk_interface_number + 1);
   bool ok = this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, 0x03, value, usb_index, callback);
   if (!ok) {

--- a/esphome/components/usb_uart/pl2303.cpp
+++ b/esphome/components/usb_uart/pl2303.cpp
@@ -3,6 +3,7 @@
 #include "usb_uart.h"
 #include "usb/usb_host.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome::usb_uart {
 
@@ -282,7 +283,7 @@ void USBUartTypePL2303::enable_channels() {
   // Data bits
   line_coding[6] = channel->get_data_bits();
 
-  ESP_LOGD(TAG, "PL2303: SET_LINE_REQUEST baud=%u stop=%u parity=%u data=%u", baud, line_coding[4], line_coding[5],
+  ESP_LOGD(TAG, "PL2303: SET_LINE_REQUEST baud=%" PRIu32 " stop=%u parity=%u data=%u", baud, line_coding[4], line_coding[5],
            line_coding[6]);
 
   std::vector<uint8_t> lc_vec(line_coding, line_coding + 7);

--- a/esphome/components/usb_uart/pl2303.cpp
+++ b/esphome/components/usb_uart/pl2303.cpp
@@ -283,8 +283,8 @@ void USBUartTypePL2303::enable_channels() {
   // Data bits
   line_coding[6] = channel->get_data_bits();
 
-  ESP_LOGD(TAG, "PL2303: SET_LINE_REQUEST baud=%" PRIu32 " stop=%u parity=%u data=%u", baud, line_coding[4], line_coding[5],
-           line_coding[6]);
+  ESP_LOGD(TAG, "PL2303: SET_LINE_REQUEST baud=%" PRIu32 " stop=%u parity=%u data=%u", baud, line_coding[4],
+           line_coding[5], line_coding[6]);
 
   std::vector<uint8_t> lc_vec(line_coding, line_coding + 7);
   uint16_t iface = channel->cdc_dev_.bulk_interface_number;


### PR DESCRIPTION


# What does this implement/fix?

# What does this implement/fix?

Fix compiler warnings in the `usb_uart` component on ESP32-S3 (and other variants).
`uint32_t` values were logged with `%d` or `%u` format specifiers, which are incorrect
on platforms where `uint32_t` is `long unsigned int`. Changed to `PRIu32` from `<cinttypes>`.
Also initializes `value` and `ftdi_index` to zero in `ft23xx.cpp` to fix potential
uninitialized variable warnings.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
