### PR TITLE
[mipi_spi] Add M5STACK ATOM3SR display

### DIFF
--- a/esphome/components/mipi_spi/models/ili.py
+++ b/esphome/components/mipi_spi/models/ili.py
@@ -10,7 +10,6 @@ from esphome.components.mipi import (
     GMCTR,
     GMCTRN1,
     GMCTRP1,
-    IDMOFF,
     IFCTR,
     IFMODE,
     INVCTR,
@@ -23,7 +22,6 @@ from esphome.components.mipi import (
     PWCTR5,
     PWSET,
     PWSETN,
-    SETEXTC,
     VMCTR,
     VMCTR1,
     VMCTR2,
@@ -32,60 +30,6 @@ from esphome.components.mipi import (
 )
 from esphome.components.spi import TYPE_OCTAL
 
-DriverChip(
-    "M5CORE",
-    width=320,
-    height=240,
-    cs_pin=14,
-    dc_pin=27,
-    reset_pin=33,
-    initsequence=(
-        (SETEXTC, 0xFF, 0x93, 0x42),
-        (PWCTR1, 0x12, 0x12),
-        (PWCTR2, 0x03),
-        (VMCTR1, 0xF2),
-        (IFMODE, 0xE0),
-        (0xF6, 0x01, 0x00, 0x00),
-        (
-            GMCTRP1,
-            0x00,
-            0x0C,
-            0x11,
-            0x04,
-            0x11,
-            0x08,
-            0x37,
-            0x89,
-            0x4C,
-            0x06,
-            0x0C,
-            0x0A,
-            0x2E,
-            0x34,
-            0x0F,
-        ),
-        (
-            GMCTRN1,
-            0x00,
-            0x0B,
-            0x11,
-            0x05,
-            0x13,
-            0x09,
-            0x33,
-            0x67,
-            0x48,
-            0x07,
-            0x0E,
-            0x0B,
-            0x2E,
-            0x33,
-            0x0F,
-        ),
-        (DFUNCTR, 0x08, 0x82, 0x1D, 0x04),
-        (IDMOFF,),
-    ),
-)
 ILI9341 = DriverChip(
     "ILI9341",
     mirror_x=True,
@@ -172,22 +116,6 @@ ILI9342 = DriverChip(
         (0xE0, 0x0F, 0x1F, 0x1C, 0x0C, 0x0F, 0x08, 0x48, 0x98, 0x37, 0x0A, 0x13, 0x04, 0x11, 0x0D, 0x00),  # Positive Gamma
         (0xE1, 0x0F, 0x32, 0x2E, 0x0B, 0x0D, 0x05, 0x47, 0x75, 0x37, 0x06, 0x10, 0x03, 0x24, 0x20, 0x00),  # Negative Gamma
     ),
-)
-
-# M5Stack Core2 uses ILI9341 chip - mirror_x disabled for correct orientation
-ILI9341.extend(
-    "M5CORE2",
-    # Reset native dimensions due to axis swap.
-    native_width=320,
-    native_height=240,
-    width=320,
-    height=240,
-    mirror_x=False,
-    cs_pin=5,
-    dc_pin=15,
-    invert_colors=True,
-    pixel_mode="18bit",
-    data_rate="40MHz",
 )
 
 DriverChip(

--- a/esphome/components/mipi_spi/models/m5stack.py
+++ b/esphome/components/mipi_spi/models/m5stack.py
@@ -1,0 +1,55 @@
+from esphome.components.mipi import (
+    DFUNCTR,
+    GMCTRN1,
+    GMCTRP1,
+    IDMOFF,
+    IFMODE,
+    PWCTR1,
+    PWCTR2,
+    SETEXTC,
+    VMCTR1,
+    DriverChip,
+)
+
+from .ili import ST7789V
+
+# fmt: off
+DriverChip(
+    "M5CORE",
+    width=320,
+    height=240,
+    cs_pin=14,
+    dc_pin=27,
+    reset_pin=33,
+    initsequence=(
+        (SETEXTC, 0xFF, 0x93, 0x42),
+        (PWCTR1, 0x12, 0x12),
+        (PWCTR2, 0x03),
+        (VMCTR1, 0xF2),
+        (IFMODE, 0xE0),
+        (0xF6, 0x01, 0x00, 0x00),
+        (GMCTRP1, 0x00, 0x0C, 0x11, 0x04, 0x11, 0x08, 0x37, 0x89, 0x4C, 0x06, 0x0C, 0x0A, 0x2E, 0x34, 0x0F,),
+        (GMCTRN1, 0x00, 0x0B, 0x11, 0x05, 0x13, 0x09, 0x33, 0x67, 0x48, 0x07, 0x0E, 0x0B, 0x2E, 0x33, 0x0F,),
+        (DFUNCTR, 0x08, 0x82, 0x1D, 0x04),
+        (IDMOFF,),
+    ),
+)
+
+GC9107 = ST7789V.extend(
+    "GC9107",
+    width=128,
+    height=128,
+    offset_width=2,
+    offset_height=1,
+    pad_width=2,
+    pad_height=1,
+)
+
+GC9107.extend(
+    "M5STACKS3R-GC9107",
+    data_rate="40MHz",
+    invert_colors=True,
+    reset_pin=48,
+    dc_pin=42,
+    cs_pin=14,
+)

--- a/esphome/components/mipi_spi/models/m5stack.py
+++ b/esphome/components/mipi_spi/models/m5stack.py
@@ -11,7 +11,7 @@ from esphome.components.mipi import (
     DriverChip,
 )
 
-from .ili import ST7789V
+from .ili import ILI9341, ST7789V
 
 # fmt: off
 DriverChip(
@@ -33,6 +33,22 @@ DriverChip(
         (DFUNCTR, 0x08, 0x82, 0x1D, 0x04),
         (IDMOFF,),
     ),
+)
+
+# M5Stack Core2 uses ILI9341 chip - mirror_x disabled for correct orientation
+ILI9341.extend(
+    "M5CORE2",
+    # Reset native dimensions due to axis swap.
+    native_width=320,
+    native_height=240,
+    width=320,
+    height=240,
+    mirror_x=False,
+    cs_pin=5,
+    dc_pin=15,
+    invert_colors=True,
+    pixel_mode="18bit",
+    data_rate="40MHz",
 )
 
 GC9107 = ST7789V.extend(

--- a/esphome/components/mipi_spi/models/m5stack.py
+++ b/esphome/components/mipi_spi/models/m5stack.py
@@ -46,7 +46,7 @@ GC9107 = ST7789V.extend(
 )
 
 GC9107.extend(
-    "M5STACKS3R-GC9107",
+    "M5STACK-ATOMS3R-GC9107",
     data_rate="40MHz",
     invert_colors=True,
     reset_pin=48,


### PR DESCRIPTION
# What does this implement/fix?

Adds new models in `mipi_spi`.
<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #17050

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6897

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
