### PR TITLE
[pipsolar] Add automatic inverter clock correction via DAT

### DIFF
--- a/esphome/components/pipsolar/__init__.py
+++ b/esphome/components/pipsolar/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
-from esphome.components import uart
+from esphome.components import time, uart
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_TIME_ID
 
 DEPENDENCIES = ["uart"]
 CODEOWNERS = ["@andreashergert1984"]
@@ -9,6 +9,7 @@ AUTO_LOAD = ["binary_sensor", "text_sensor", "sensor", "switch", "output"]
 MULTI_CONF = True
 
 CONF_PIPSOLAR_ID = "pipsolar_id"
+CONF_CLOCK_CORRECTION_THRESHOLD = "clock_correction_threshold"
 
 pipsolar_ns = cg.esphome_ns.namespace("pipsolar")
 PipsolarComponent = pipsolar_ns.class_("Pipsolar", cg.Component)
@@ -20,7 +21,15 @@ PIPSOLAR_COMPONENT_SCHEMA = cv.Schema(
 )
 
 CONFIG_SCHEMA = cv.All(
-    cv.Schema({cv.GenerateID(): cv.declare_id(PipsolarComponent)})
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(PipsolarComponent),
+            cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
+            cv.Optional(
+                CONF_CLOCK_CORRECTION_THRESHOLD, default="60s"
+            ): cv.positive_time_period_seconds,
+        }
+    )
     .extend(cv.polling_component_schema("1s"))
     .extend(uart.UART_DEVICE_SCHEMA)
 )
@@ -30,3 +39,9 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+
+    if (time_id := config.get(CONF_TIME_ID)) is not None:
+        cg.add(var.set_time(await cg.get_variable(time_id)))
+        cg.add(
+            var.set_clock_correction_threshold(config[CONF_CLOCK_CORRECTION_THRESHOLD])
+        )

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -680,7 +680,73 @@ void Pipsolar::handle_qt_(const char *message) {
   if (this->last_qt_) {
     this->last_qt_->publish_state(message);
   }
+#ifdef USE_TIME
+  if (this->time_ != nullptr) {
+    this->correct_clock_if_needed_(message);
+  }
+#endif
 }
+
+#ifdef USE_TIME
+// Keep the inverter's clock aligned with the ESP's *local* civil time. The inverter has no
+// timezone concept, so we compare wall-clock readings: both the device time and now() are
+// turned into a timestamp with recalc_timestamp_utc(false), i.e. their fields are taken
+// as-is. This means the configured time source must have the correct timezone; the inverter
+// then follows local time, including a one-off correction across each DST transition.
+void Pipsolar::correct_clock_if_needed_(const char *message) {
+  ESPTime rt = this->time_->now();
+  if (!rt.is_valid()) {
+    // real time not synced yet, nothing to compare against
+    return;
+  }
+
+  // QT response is "(YYYYMMDDHHMMSS"; bail out if it does not parse (e.g. empty error message)
+  int year, month, day, hour, minute, second;
+  if (sscanf(message, "(%4d%2d%2d%2d%2d%2d", &year, &month, &day, &hour, &minute,  // NOLINT
+             &second) != 6) {
+    return;
+  }
+
+  ESPTime dev{};
+  dev.year = year;
+  dev.month = month;
+  dev.day_of_month = day;
+  dev.hour = hour;
+  dev.minute = minute;
+  dev.second = second;
+  // Compute both timestamps with the same convention (fields treated as UTC) so the
+  // difference is a timezone-agnostic wall-clock drift.
+  dev.recalc_timestamp_utc(false);
+  rt.recalc_timestamp_utc(false);
+  if (dev.timestamp < 0) {
+    // device clock fields out of range
+    return;
+  }
+
+  int32_t drift = (int32_t) ((int64_t) rt.timestamp - (int64_t) dev.timestamp);
+  uint32_t abs_drift = drift < 0 ? -drift : drift;
+  ESP_LOGD(TAG, "Inverter clock drift %d s (threshold %u s)", (int) drift,
+           (unsigned) this->clock_correction_threshold_);
+  if (abs_drift < this->clock_correction_threshold_) {
+    return;
+  }
+
+  const uint32_t now = millis();
+  if (this->last_clock_correction_millis_ != 0 &&
+      now - this->last_clock_correction_millis_ < CLOCK_CORRECTION_COOLDOWN_MS) {
+    // recently corrected, wait for the next QT to reflect the new time
+    return;
+  }
+
+  char buf[16];
+  snprintf(buf, sizeof(buf), "DAT%02u%02u%02u%02u%02u%02u", (unsigned) (rt.year % 100), (unsigned) rt.month,
+           (unsigned) rt.day_of_month, (unsigned) rt.hour, (unsigned) rt.minute, (unsigned) rt.second);
+  ESP_LOGI(TAG, "Inverter clock drift %d s exceeds threshold %u s, correcting via %s", (int) drift,
+           (unsigned) this->clock_correction_threshold_, buf);
+  this->queue_command(buf);
+  this->last_clock_correction_millis_ = now;
+}
+#endif
 
 void Pipsolar::handle_qmn_(const char *message) {
   if (this->last_qmn_) {
@@ -768,9 +834,23 @@ void Pipsolar::dump_config() {
 }
 void Pipsolar::update() {
   for (auto &enabled_polling_command : this->enabled_polling_commands_) {
-    if (enabled_polling_command.length != 0) {
-      enabled_polling_command.needs_update = true;
+    if (enabled_polling_command.length == 0) {
+      continue;
     }
+#ifdef USE_TIME
+    // QT is registered only to drive clock correction. If the raw value is not exposed via a
+    // last_qt text sensor, there is no reason to poll it every update_interval — the inverter
+    // clock drifts only minutes per year — so throttle it to CLOCK_CHECK_INTERVAL_MS and keep
+    // the UART bus free for the live-data polls.
+    if (this->time_ != nullptr && this->last_qt_ == nullptr && enabled_polling_command.identifier == POLLING_QT) {
+      const uint32_t now = millis();
+      if (this->last_clock_check_millis_ != 0 && now - this->last_clock_check_millis_ < CLOCK_CHECK_INTERVAL_MS) {
+        continue;
+      }
+      this->last_clock_check_millis_ = now;
+    }
+#endif
+    enabled_polling_command.needs_update = true;
   }
 }
 

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -9,6 +9,10 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
+#ifdef USE_TIME
+#include "esphome/components/time/real_time_clock.h"
+#endif
+
 namespace esphome::pipsolar {
 
 enum ENUMPollingCommand {
@@ -184,6 +188,15 @@ class Pipsolar final : public uart::UARTDevice, public PollingComponent {
   PIPSOLAR_SWITCH(pv_ok_condition_for_parallel_switch, QPIRI)
   PIPSOLAR_SWITCH(pv_power_balance_switch, QPIRI)
 
+#ifdef USE_TIME
+  void set_time(time::RealTimeClock *rtc) {
+    this->time_ = rtc;
+    // ensure QT is polled so the device clock can be compared against real time
+    this->add_polling_command_("QT", POLLING_QT);
+  }
+#endif
+  void set_clock_correction_threshold(uint32_t seconds) { this->clock_correction_threshold_ = seconds; }
+
   void queue_command(const std::string &command);
   void setup() override;
   void loop() override;
@@ -195,6 +208,8 @@ class Pipsolar final : public uart::UARTDevice, public PollingComponent {
   static const size_t COMMAND_QUEUE_LENGTH = 10;
   static const size_t COMMAND_TIMEOUT = 5000;
   static const size_t POLLING_COMMANDS_MAX = 15;
+  static const uint32_t CLOCK_CORRECTION_COOLDOWN_MS = 60000;
+  static const uint32_t CLOCK_CHECK_INTERVAL_MS = 3600000;  // poll QT for drift once per hour
   void add_polling_command_(const char *command, ENUMPollingCommand polling_command);
   void empty_uart_buffer_();
   uint8_t check_incoming_crc_();
@@ -213,6 +228,9 @@ class Pipsolar final : public uart::UARTDevice, public PollingComponent {
   void handle_qpiws_(const char *message);
   void handle_qt_(const char *message);
   void handle_qmn_(const char *message);
+#ifdef USE_TIME
+  void correct_clock_if_needed_(const char *message);
+#endif
 
   void skip_start_(const char *message, size_t *pos);
   void skip_field_(const char *message, size_t *pos);
@@ -243,6 +261,13 @@ class Pipsolar final : public uart::UARTDevice, public PollingComponent {
 
   uint8_t last_polling_command_ = 0;
   PollingCommand enabled_polling_commands_[POLLING_COMMANDS_MAX];
+
+#ifdef USE_TIME
+  time::RealTimeClock *time_{nullptr};
+  uint32_t last_clock_correction_millis_{0};
+  uint32_t last_clock_check_millis_{0};
+#endif
+  uint32_t clock_correction_threshold_{60};
 };
 
 }  // namespace esphome::pipsolar

--- a/tests/components/pipsolar/common.yaml
+++ b/tests/components/pipsolar/common.yaml
@@ -5,8 +5,18 @@ esphome:
           id: inverter0_battery_recharge_voltage_out
           value: 48.0
 
+wifi:
+  ssid: MySSID
+  password: password1
+
+time:
+  - platform: sntp
+    id: pipsolar_time
+
 pipsolar:
   id: inverter0
+  time_id: pipsolar_time
+  clock_correction_threshold: 30s
 
 binary_sensor:
   - platform: pipsolar


### PR DESCRIPTION
# What does this implement/fix?

Adds optional automatic correction of the inverter's real-time clock, which drifts by a couple of minutes per year on PIP-compatible inverters.

When a `time_id` (any `time:` source) is configured, the component reads the inverter clock internally via `QT`, compares it against the local time from that source, and issues a single `DAT` command whenever the drift exceeds `clock_correction_threshold` (default `60s`). A cooldown prevents repeated corrections while the next `QT` reflects the new time. Everything is logged only — no Home Assistant entities are added.

Design notes:
- Fully opt-in and guarded by `USE_TIME`. Existing users without a `time:` source compile and behave exactly as before; `time` is **not** added to `DEPENDENCIES`.
- The inverter has no timezone concept, so the device clock is compared as a wall-clock reading against the time source's **local** time. This means the configured time source must have the correct timezone; the inverter then tracks local civil time (with a one-off correction across each DST transition). This is documented on the esphome.io page.
- To avoid flooding the UART bus, `QT` is polled once per hour for the drift check. If the user also exposes the raw value via a `last_qt` text sensor, `QT` keeps the normal poll rate (they clearly want the value); the actual `DAT` write is still gated by the threshold and cooldown regardless.

Verified on real hardware (PI30MAX, ESP32-C6): with the inverter clock deliberately set ~69 min ahead, a single `DAT` was sent, acknowledged by the inverter, the clock resynced to local time, and no further corrections occurred.

This PR is independent of #17347 (QET/QLT sensors).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6905

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
time:
  - platform: sntp
    id: sntp_time
    timezone: "Europe/Berlin"

pipsolar:
  - id: inverter0
    time_id: sntp_time
    clock_correction_threshold: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).