### PR TITLE
[ci] Carry native-toolchain needs on component test batches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -795,7 +795,7 @@ jobs:
         if: always()
 
   test-build-components-split:
-    name: Test components batch (${{ matrix.components }})
+    name: Test components batch (${{ matrix.batch.components }})
     runs-on: ubuntu-24.04
     needs:
       - common
@@ -809,7 +809,7 @@ jobs:
       fail-fast: false
       max-parallel: ${{ (startsWith(github.base_ref, 'beta') || startsWith(github.base_ref, 'release')) && 8 || 4 }}
       matrix:
-        components: ${{ fromJson(needs.determine-jobs.outputs.component-test-batches) }}
+        batch: ${{ fromJson(needs.determine-jobs.outputs.component-test-batches) }}
     steps:
       - name: Show disk space
         run: |
@@ -817,7 +817,7 @@ jobs:
           df -h
 
       - name: List components
-        run: echo ${{ matrix.components }}
+        run: echo ${{ matrix.batch.components }}
 
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
@@ -833,8 +833,10 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
       - name: Cache ESP-IDF install (restore-only)
-        # A batch may contain no esp32 build, so never save -- just reuse the
-        # shared install the dev tidy jobs already cached when present.
+        # Only batches whose test platforms include esp32 need the native
+        # ESP-IDF install; never save -- just reuse the shared install the
+        # dev tidy jobs already cached when present.
+        if: matrix.batch.needs_idf
         uses: ./.github/actions/cache-esp-idf
         with:
           restore-only: true
@@ -868,7 +870,7 @@ jobs:
           fi
 
           # Convert space-separated components to comma-separated for Python script
-          components_csv=$(echo "${{ matrix.components }}" | tr ' ' ',')
+          components_csv=$(echo "${{ matrix.batch.components }}" | tr ' ' ',')
 
           # Only isolate directly changed components when targeting dev branch
           # For beta/release branches, group everything for faster CI

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -1338,7 +1338,7 @@ def main() -> None:
 
     # Split components into batches for CI testing
     # This intelligently groups components with similar bus configurations
-    component_test_batches: list[str]
+    component_test_batches: list[dict[str, Any]] = []
     if changed_components_with_tests:
         tests_dir = Path(root_path) / ESPHOME_TESTS_COMPONENTS_PATH
 
@@ -1363,10 +1363,22 @@ def main() -> None:
             batch_size=COMPONENT_TEST_BATCH_SIZE,
             directly_changed=batch_directly_changed,
         )
-        # Convert batches to space-separated strings for CI matrix
-        component_test_batches = [" ".join(batch) for batch in batches]
-    else:
-        component_test_batches = []
+        # Convert batches to CI matrix entries: the component list plus which
+        # native toolchain installs the batch's test platforms need, so the
+        # workflow only restores the matching multi-GB toolchain caches.
+        # needs_sdk_nrf has no consumer yet; it becomes live once the nrf52
+        # component tests build with the native sdk-nrf toolchain.
+        for batch in batches:
+            platforms: set[str] = set()
+            for component in batch:
+                platforms.update(get_component_test_platforms(component))
+            component_test_batches.append(
+                {
+                    "components": " ".join(batch),
+                    "needs_idf": any(p.startswith("esp32") for p in platforms),
+                    "needs_sdk_nrf": any(p.startswith("nrf52") for p in platforms),
+                }
+            )
 
     output: dict[str, Any] = {
         "core_ci": run_core_ci,

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -1366,7 +1366,7 @@ def main() -> None:
         # Convert batches to CI matrix entries: the component list plus which
         # native toolchain installs the batch's test platforms need, so the
         # workflow only restores the matching multi-GB toolchain caches.
-        # needs_sdk_nrf has no consumer yet; it becomes live once the nrf52
+        # needs_nrf has no consumer yet; it becomes live once the nrf52
         # component tests build with the native sdk-nrf toolchain.
         for batch in batches:
             platforms: set[str] = set()
@@ -1376,7 +1376,7 @@ def main() -> None:
                 {
                     "components": " ".join(batch),
                     "needs_idf": any(p.startswith("esp32") for p in platforms),
-                    "needs_sdk_nrf": any(p.startswith("nrf52") for p in platforms),
+                    "needs_nrf": any(p.startswith("nrf52") for p in platforms),
                 }
             )
 

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -1366,8 +1366,6 @@ def main() -> None:
         # Convert batches to CI matrix entries: the component list plus which
         # native toolchain installs the batch's test platforms need, so the
         # workflow only restores the matching multi-GB toolchain caches.
-        # needs_nrf has no consumer yet; it becomes live once the nrf52
-        # component tests build with the native sdk-nrf toolchain.
         for batch in batches:
             platforms: set[str] = set()
             for component in batch:

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -240,7 +240,7 @@ def test_main_all_tests_should_run(
         # Should contain at least one component (no empty batches)
         assert len(batch["components"]) > 0
         assert isinstance(batch["needs_idf"], bool)
-        assert isinstance(batch["needs_sdk_nrf"], bool)
+        assert isinstance(batch["needs_nrf"], bool)
 
 
 def test_main_no_tests_should_run(

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -231,14 +231,16 @@ def test_main_all_tests_should_run(
     assert output["memory_impact"]["should_run"] == "false"
     assert output["cpp_unit_tests_run_all"] is False
     assert output["cpp_unit_tests_components"] == ["wifi", "api", "sensor"]
-    # component_test_batches should be present and be a list of space-separated strings
+    # component_test_batches should be a list of matrix entries carrying the
+    # space-separated component list and the toolchain-need flags
     assert "component_test_batches" in output
     assert isinstance(output["component_test_batches"], list)
-    # Each batch should be a space-separated string of component names
     for batch in output["component_test_batches"]:
-        assert isinstance(batch, str)
+        assert isinstance(batch, dict)
         # Should contain at least one component (no empty batches)
-        assert len(batch) > 0
+        assert len(batch["components"]) > 0
+        assert isinstance(batch["needs_idf"], bool)
+        assert isinstance(batch["needs_sdk_nrf"], bool)
 
 
 def test_main_no_tests_should_run(
@@ -2417,16 +2419,16 @@ def test_component_batching_beta_branch_40_per_batch(
     assert len(batches) == 3, f"Expected 3 batches, got {len(batches)}"
 
     # Each batch should have approximately 40 components (all weight=1, groupable)
-    for i, batch_str in enumerate(batches):
-        batch_components = batch_str.split()
+    for i, batch in enumerate(batches):
+        batch_components = batch["components"].split()
         assert len(batch_components) == 40, (
             f"Batch {i} should have 40 components, got {len(batch_components)}"
         )
 
     # Verify all 120 components are in batches
     all_components = []
-    for batch_str in batches:
-        all_components.extend(batch_str.split())
+    for batch in batches:
+        all_components.extend(batch["components"].split())
     assert len(all_components) == 120
     assert set(all_components) == set(component_names)
 


### PR DESCRIPTION
# What does this implement/fix?

The component test batch jobs restored the native ESP-IDF cache unconditionally — the step comment even noted "a batch may contain no esp32 build". Since a batch's platforms are fully determined by its components' `test.<platform>.yaml` files, `determine-jobs` can decide this up front.

- `component_test_batches` entries are now objects instead of space-separated strings: `{"components": "a b c", "needs_idf": bool, "needs_nrf": bool}`. The flags come from the union of each batch's `get_component_test_platforms()` (`esp32*` → IDF, `nrf52*` → nRF).
- The workflow's "Cache ESP-IDF install (restore-only)" step in `test-build-components-split` is gated on `matrix.batch.needs_idf`, so batches without an esp32 build (e.g. an isolated nrf52 batch) skip the multi-GB cache restore entirely.
- `needs_nrf` has no consumer yet; it becomes live once the nrf52 component tests build with the native sdk-nrf toolchain and get their own cached install (groundwork for the sdk-nrf migration, see #17353).

Batch shape assertions in `tests/script/test_determine_jobs.py` updated accordingly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).