### PR TITLE
[api] Register homeassistant.action with synchronous=False to fix stale trigger args in response callbacks

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -540,17 +540,20 @@ HOMEASSISTANT_ACTION_ACTION_SCHEMA = cv.All(
 )
 
 
+# synchronous=False: when on_success/on_error is configured, play() stores the
+# trigger args until the HomeassistantActionResponse arrives, so non-owning args
+# (StringRef into the API receive buffer) must not be used.
 @automation.register_action(
     "homeassistant.action",
     HomeAssistantServiceCallAction,
     HOMEASSISTANT_ACTION_ACTION_SCHEMA,
-    synchronous=True,
+    synchronous=False,
 )
 @automation.register_action(
     "homeassistant.service",
     HomeAssistantServiceCallAction,
     HOMEASSISTANT_ACTION_ACTION_SCHEMA,
-    synchronous=True,
+    synchronous=False,
 )
 async def homeassistant_service_to_code(
     config: ConfigType,
@@ -644,6 +647,8 @@ HOMEASSISTANT_EVENT_ACTION_SCHEMA = cv.Schema(
 )
 
 
+# synchronous=True is safe here: the event schema has no on_success/on_error,
+# so play() never stores the trigger args.
 @automation.register_action(
     "homeassistant.event",
     HomeAssistantServiceCallAction,

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -4,6 +4,8 @@
 #ifdef USE_API
 #ifdef USE_API_HOMEASSISTANT_SERVICES
 #include <functional>
+#include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include "api_pb2.h"
@@ -102,6 +104,14 @@ class ActionResponse {
 
 // Callback type for action responses
 template<typename... Ts> using ActionResponseCallback = std::function<void(const ActionResponse &, Ts...)>;
+
+// Storage type used to capture trigger args until the action response arrives.
+// StringRef args are non-owning views into transient storage (for example the API
+// connection's receive buffer, which is reused before the response arrives), so
+// they must be deep-copied into an owning std::string. Other args are stored by value.
+template<typename T> struct CapturedArg { using type = std::decay_t<T>; };
+template<> struct CapturedArg<StringRef> { using type = std::string; };
+template<typename T> using captured_arg_t = typename CapturedArg<T>::type;
 #endif
 
 template<typename... Ts> class HomeAssistantServiceCallAction final : public Action<Ts...> {
@@ -197,25 +207,32 @@ template<typename... Ts> class HomeAssistantServiceCallAction final : public Act
       }
 #endif
 
-      auto captured_args = std::make_tuple(x...);
-      this->parent_->register_action_response_callback(call_id, [this, captured_args](const ActionResponse &response) {
-        std::apply(
-            [this, &response](auto &&...args) {
-              if (response.is_success()) {
+      // Deep-copy the trigger args for the deferred callback: StringRef args are
+      // non-owning views into transient storage (for example the connection's receive
+      // buffer, which is reused before the response arrives) and would dangle if
+      // captured as-is.
+      std::tuple<captured_arg_t<Ts>...> captured_args{x...};
+      this->parent_->register_action_response_callback(
+          call_id, [this, captured_args = std::move(captured_args)](const ActionResponse &response) {
+            std::apply(
+                [this, &response](const auto &...args) {
+                  // Ts(args) rebuilds the original arg types; for StringRef args this is a
+                  // view into the owned copy, which stays alive for the trigger call.
+                  if (response.is_success()) {
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
-                if (this->flags_.wants_response) {
-                  this->success_trigger_with_response_.trigger(response.get_json(), args...);
-                } else
+                    if (this->flags_.wants_response) {
+                      this->success_trigger_with_response_.trigger(response.get_json(), Ts(args)...);
+                    } else
 #endif
-                {
-                  this->success_trigger_.trigger(args...);
-                }
-              } else {
-                this->error_trigger_.trigger(response.get_error_message(), args...);
-              }
-            },
-            captured_args);
-      });
+                    {
+                      this->success_trigger_.trigger(Ts(args)...);
+                    }
+                  } else {
+                    this->error_trigger_.trigger(response.get_error_message(), Ts(args)...);
+                  }
+                },
+                captured_args);
+          });
     }
 #endif
 

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -4,8 +4,6 @@
 #ifdef USE_API
 #ifdef USE_API_HOMEASSISTANT_SERVICES
 #include <functional>
-#include <tuple>
-#include <type_traits>
 #include <utility>
 #include <vector>
 #include "api_pb2.h"
@@ -104,14 +102,6 @@ class ActionResponse {
 
 // Callback type for action responses
 template<typename... Ts> using ActionResponseCallback = std::function<void(const ActionResponse &, Ts...)>;
-
-// Storage type used to capture trigger args until the action response arrives.
-// StringRef args are non-owning views into transient storage (for example the API
-// connection's receive buffer, which is reused before the response arrives), so
-// they must be deep-copied into an owning std::string. Other args are stored by value.
-template<typename T> struct CapturedArg { using type = std::decay_t<T>; };
-template<> struct CapturedArg<StringRef> { using type = std::string; };
-template<typename T> using captured_arg_t = typename CapturedArg<T>::type;
 #endif
 
 template<typename... Ts> class HomeAssistantServiceCallAction final : public Action<Ts...> {
@@ -207,32 +197,25 @@ template<typename... Ts> class HomeAssistantServiceCallAction final : public Act
       }
 #endif
 
-      // Deep-copy the trigger args for the deferred callback: StringRef args are
-      // non-owning views into transient storage (for example the connection's receive
-      // buffer, which is reused before the response arrives) and would dangle if
-      // captured as-is.
-      std::tuple<captured_arg_t<Ts>...> captured_args{x...};
-      this->parent_->register_action_response_callback(
-          call_id, [this, captured_args = std::move(captured_args)](const ActionResponse &response) {
-            std::apply(
-                [this, &response](const auto &...args) {
-                  // Ts(args) rebuilds the original arg types; for StringRef args this is a
-                  // view into the owned copy, which stays alive for the trigger call.
-                  if (response.is_success()) {
+      auto captured_args = std::make_tuple(x...);
+      this->parent_->register_action_response_callback(call_id, [this, captured_args](const ActionResponse &response) {
+        std::apply(
+            [this, &response](auto &&...args) {
+              if (response.is_success()) {
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
-                    if (this->flags_.wants_response) {
-                      this->success_trigger_with_response_.trigger(response.get_json(), Ts(args)...);
-                    } else
+                if (this->flags_.wants_response) {
+                  this->success_trigger_with_response_.trigger(response.get_json(), args...);
+                } else
 #endif
-                    {
-                      this->success_trigger_.trigger(Ts(args)...);
-                    }
-                  } else {
-                    this->error_trigger_.trigger(response.get_error_message(), Ts(args)...);
-                  }
-                },
-                captured_args);
-          });
+                {
+                  this->success_trigger_.trigger(args...);
+                }
+              } else {
+                this->error_trigger_.trigger(response.get_error_message(), args...);
+              }
+            },
+            captured_args);
+      });
     }
 #endif
 

--- a/tests/component_tests/api/test_homeassistant_action.py
+++ b/tests/component_tests/api/test_homeassistant_action.py
@@ -1,0 +1,28 @@
+"""Tests for arg-type selection of api user-defined services with homeassistant.action."""
+
+CONFIG = "tests/component_tests/api/test_homeassistant_action.yaml"
+
+
+def test_synchronous_chain_keeps_zero_copy_args(generate_main):
+    """A chain of synchronous actions keeps the non-owning StringRef arg type."""
+    main_cpp = generate_main(CONFIG)
+
+    assert (
+        "api::UserServiceTrigger<api::enums::SUPPORTS_RESPONSE_NONE, StringRef>"
+        '("zero_copy_args", {"message"})' in main_cpp
+    )
+
+
+def test_response_callback_args_are_owning(generate_main):
+    """homeassistant.action with on_success/on_error stores the trigger args
+    until the HomeassistantActionResponse arrives, so string args must fall
+    back to owning std::string; StringRef would point into the connection's
+    receive buffer, which is reused before the response arrives."""
+    main_cpp = generate_main(CONFIG)
+
+    assert (
+        "api::UserServiceTrigger<api::enums::SUPPORTS_RESPONSE_NONE, std::string>"
+        '("response_args", {"message"})' in main_cpp
+    )
+    assert "api::HomeAssistantServiceCallAction<std::string>" in main_cpp
+    assert "api::HomeAssistantServiceCallAction<StringRef>" not in main_cpp

--- a/tests/component_tests/api/test_homeassistant_action.yaml
+++ b/tests/component_tests/api/test_homeassistant_action.yaml
@@ -1,0 +1,43 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+
+wifi:
+  ssid: SomeNetwork
+  password: SomePassword
+
+logger:
+
+api:
+  actions:
+    # Chain of synchronous actions that never store the args:
+    # keeps the zero-copy StringRef arg type.
+    - action: zero_copy_args
+      variables:
+        message: string
+      then:
+        - logger.log:
+            format: "%s"
+            args: [message.c_str()]
+    # homeassistant.action with on_success/on_error stores the trigger args
+    # until the action response arrives, so the codegen must fall back to
+    # owning std::string args (StringRef would dangle once the receive
+    # buffer is reused).
+    - action: response_args
+      variables:
+        message: string
+      then:
+        - homeassistant.action:
+            action: notify.notify
+            data:
+              message: !lambda return message;
+            on_success:
+              - logger.log:
+                  format: "sent %s"
+                  args: [message.c_str()]
+            on_error:
+              - logger.log:
+                  format: "failed (%s): %s"
+                  args: [error.c_str(), message.c_str()]

--- a/tests/components/api/common-base.yaml
+++ b/tests/components/api/common-base.yaml
@@ -109,6 +109,34 @@ api:
               - name.c_str()
               - int_arr.size()
               - string_arr.size()
+    # Test string + array args used by homeassistant.action's deferred
+    # on_success/on_error response callback.  homeassistant.action registers
+    # synchronous=False, so the api codegen must fall back to owning
+    # std::string / std::vector args here: the non-owning defaults would
+    # dangle once rx_buf_ is reused before the response arrives, and the
+    # non-copyable FixedVector would fail to compile when captured into
+    # the response callback.
+    - action: action_response_args
+      variables:
+        name: string
+        int_arr: int[]
+      then:
+        - homeassistant.action:
+            action: notify.notify
+            data:
+              message: !lambda 'return name;'
+            on_success:
+              - logger.log:
+                  format: "Notified %s (%u ints)"
+                  args:
+                    - name.c_str()
+                    - int_arr.size()
+            on_error:
+              - logger.log:
+                  format: "Notify failed (%s): %s"
+                  args:
+                    - error.c_str()
+                    - name.c_str()
     # Test ContinuationAction (IfAction with then/else branches)
     - action: test_if_action
       variables:


### PR DESCRIPTION
# What does this implement/fix?

When `homeassistant.action` is used inside an API user-defined service with `on_success`/`on_error` configured, `play()` captures the service's trigger args into the deferred action-response callback (`std::make_tuple(x...)` in `homeassistant_service.h`). String args of user-defined services are `StringRef` views into the connection's receive buffer, so the tuple stores raw pointers into `rx_buf_`. The callback only fires when the `HomeassistantActionResponse` arrives from Home Assistant — and since HA is the API client on that same connection, reading the response message into the buffer is itself what overwrites the captured bytes. The `on_success`/`on_error` automation then sees stale wire data at best, dangling memory if the buffer was reallocated in between.

The codegen already has a mechanism for exactly this: `has_non_synchronous_actions()` falls back to owning arg types (`std::string` / `std::vector`) when the action chain contains an action registered with `synchronous=False`. But `homeassistant.action` / `homeassistant.service` were registered `synchronous=True`, so the fallback never engaged even though the response callback stores the args for deferred use.

This PR registers `homeassistant.action` and `homeassistant.service` with `synchronous=False`, matching the flag's documented contract (actions that store trigger args for later use must not be marked synchronous). `homeassistant.event` stays `synchronous=True` since its schema has no response handling and never stores args.

Trade-off: any user-defined service chain containing `homeassistant.action` now uses owning `std::string` args even without `on_success`/`on_error`, since the flag is per-action-type. This also incidentally fixes array variables (`string[]` etc.) combined with `on_success`, which previously failed to compile (the captured tuple tried to copy the non-copyable `FixedVector`).

Verified by compiling the example config below for the host platform and checking the generated code: service arg instantiations switch from `HomeAssistantServiceCallAction<StringRef, ...>` to `HomeAssistantServiceCallAction<std::string, ...>`, and all shapes (scalar args, `capture_response: true`, empty arg pack, `delay` in chain) build cleanly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (found by code review)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Tested on the host platform (compile + generated-code inspection).

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
  actions:
    - action: notify_someone
      variables:
        message: string
      then:
        - homeassistant.action:
            action: notify.mobile_app_phone
            data:
              message: !lambda return message;
            on_error:
              # `message` previously pointed into the reused receive buffer here
              - logger.log:
                  format: "notify failed: %s, message was: %s"
                  args: [error.c_str(), message.c_str()]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
