### PR TITLE
[ci] Cache the native sdk-nrf install for nrf52 component test batches

### DIFF
--- a/.github/actions/cache-sdk-nrf/action.yml
+++ b/.github/actions/cache-sdk-nrf/action.yml
@@ -1,0 +1,44 @@
+name: Cache sdk-nrf
+description: >
+  Resolve the pinned sdk-nrf version and cache the native sdk-nrf install
+  (west workspace, Zephyr SDK toolchain, python env) at ~/.esphome-sdk-nrf.
+  Every job that installs sdk-nrf natively (the nrf52 clang-tidy job and,
+  once the component tests build natively, their batches) shares one cache.
+  Callers must set env ESPHOME_SDK_NRF_PREFIX: ~/.esphome-sdk-nrf and have
+  the Python venv already restored.
+inputs:
+  restore-only:
+    description: >
+      When "true", only restore -- never save the cache, even on dev. Use from
+      jobs that may not produce a complete install (e.g. a component batch
+      that fails mid-install), so a partial install is never written.
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - name: Resolve sdk-nrf version for cache key
+      # The version is pinned in code, not in any file that feeds the other
+      # cache keys, so resolve it explicitly. Keying on it means the cache
+      # invalidates on a version bump (actions/cache never overwrites a key).
+      id: version
+      shell: bash
+      run: |
+        . venv/bin/activate
+        echo "version=$(python -c 'from esphome.components.nrf52 import RECOMMENDED_SDK_NRF_VERSION as V; print(V)')" >> "$GITHUB_OUTPUT"
+    # Mirror cache-esp-idf: only dev-branch runs write the shared cache (so it
+    # lives in the default-branch scope readable by all PRs); PRs are
+    # restore-only and never push multi-GB artifacts into their own scope.
+    - name: Cache sdk-nrf install (write on dev)
+      if: github.ref == 'refs/heads/dev' && inputs.restore-only != 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.esphome-sdk-nrf
+        # yamllint disable-line rule:line-length
+        key: ${{ runner.os }}-esphome-sdk-nrf-${{ steps.version.outputs.version }}-${{ hashFiles('esphome/components/nrf52/requirements.txt') }}
+    - name: Cache sdk-nrf install (restore-only off dev)
+      if: github.ref != 'refs/heads/dev' || inputs.restore-only == 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.esphome-sdk-nrf
+        # yamllint disable-line rule:line-length
+        key: ${{ runner.os }}-esphome-sdk-nrf-${{ steps.version.outputs.version }}-${{ hashFiles('esphome/components/nrf52/requirements.txt') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -805,6 +805,9 @@ jobs:
       # esp32 component builds use the native ESP-IDF toolchain (default), so
       # share the tidy jobs' install location -- the restore below lands here.
       ESPHOME_ESP_IDF_PREFIX: ~/.esphome-idf
+      # nrf52 component builds install sdk-nrf natively; pin it to the shared
+      # cacheable path so the restore below lands where the build looks.
+      ESPHOME_SDK_NRF_PREFIX: ~/.esphome-sdk-nrf
     strategy:
       fail-fast: false
       max-parallel: ${{ (startsWith(github.base_ref, 'beta') || startsWith(github.base_ref, 'release')) && 8 || 4 }}
@@ -838,6 +841,14 @@ jobs:
         # dev tidy jobs already cached when present.
         if: matrix.batch.needs_idf
         uses: ./.github/actions/cache-esp-idf
+        with:
+          restore-only: true
+      - name: Cache sdk-nrf install (restore-only)
+        # Only batches whose test platforms include nrf52 need the native
+        # sdk-nrf install; never save -- just reuse the shared install the
+        # dev-branch jobs cached when present.
+        if: matrix.batch.needs_nrf
+        uses: ./.github/actions/cache-sdk-nrf
         with:
           restore-only: true
       - name: Validate and compile components with intelligent grouping

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -79,6 +79,11 @@ AUTO_LOAD = ["zephyr", "preferences"]
 IS_TARGET_PLATFORM = True
 _LOGGER = logging.getLogger(__name__)
 
+# Default framework versions per toolchain. The sdk-nrf one also keys the CI
+# sdk-nrf install cache and pins the clang-tidy project's SDK.
+RECOMMENDED_PLATFORMIO_VERSION = "2.6.1-b"
+RECOMMENDED_SDK_NRF_VERSION = "2.9.2"
+
 FAKE_BOARD_MANIFEST = """
 {
     "frameworks": [
@@ -123,7 +128,11 @@ def _resolve_toolchain(config: ConfigType) -> ConfigType:
 
 def set_framework(config: ConfigType) -> ConfigType:
     if CONF_VERSION not in config[CONF_FRAMEWORK]:
-        default_version = "2.6.1-b" if CORE.using_toolchain_platformio else "2.9.2"
+        default_version = (
+            RECOMMENDED_PLATFORMIO_VERSION
+            if CORE.using_toolchain_platformio
+            else RECOMMENDED_SDK_NRF_VERSION
+        )
         config = {
             **config,
             CONF_FRAMEWORK: {**config[CONF_FRAMEWORK], CONF_VERSION: default_version},

--- a/esphome/components/nrf52/framework.py
+++ b/esphome/components/nrf52/framework.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 from pathlib import Path
@@ -158,9 +159,10 @@ def check_and_install() -> None:
     python_env_path = _get_python_env_path(version)
     env_python_path = get_python_env_executable_path(python_env_path, "python")
     sentinel = python_env_path / ".ready"
+    requirements_hash = hashlib.sha256(_REQUIREMENTS.read_bytes()).hexdigest()
     install_venv = (
         not sentinel.exists()
-        or _REQUIREMENTS.stat().st_mtime > sentinel.stat().st_mtime
+        or sentinel.read_text(encoding="utf-8") != requirements_hash
     )
     if install_venv:
         rmdir(python_env_path, msg=f"Clean up {version} Python environment")
@@ -182,7 +184,7 @@ def check_and_install() -> None:
             raise EsphomeError(
                 f"Install requirements for {version} Python environment failure"
             )
-        sentinel.touch()
+        sentinel.write_text(requirements_hash, encoding="utf-8")
 
     framework_path = _get_framework_path(version)
     sentinel = framework_path / ".ready"

--- a/tests/unit_tests/test_nrf52_framework.py
+++ b/tests/unit_tests/test_nrf52_framework.py
@@ -1,5 +1,6 @@
 """Tests for esphome.components.nrf52.framework helpers."""
 
+import hashlib
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -7,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from esphome.components.nrf52.framework import (
+    _REQUIREMENTS,
     _TOOLCHAIN_VERSION,
     _get_toolchain_platform_info,
     check_and_install,
@@ -113,6 +115,12 @@ def mock_nrf52_ops():
 # ---------------------------------------------------------------------------
 
 
+def _mark_venv_ready(python_env: Path) -> None:
+    """Write the venv sentinel with the current requirements hash."""
+    requirements_hash = hashlib.sha256(_REQUIREMENTS.read_bytes()).hexdigest()
+    (python_env / ".ready").write_text(requirements_hash, encoding="utf-8")
+
+
 class TestCheckAndInstall:
     def test_all_installed_skips_all_steps(
         self,
@@ -120,7 +128,7 @@ class TestCheckAndInstall:
         mock_nrf52_ops: SimpleNamespace,
     ) -> None:
         """All three sentinels present → nothing downloaded or compiled."""
-        (nrf52_dirs.python_env / ".ready").touch()
+        _mark_venv_ready(nrf52_dirs.python_env)
         (nrf52_dirs.python_env / ".zephyr_reqs_ready").touch()
         (nrf52_dirs.framework / ".ready").touch()
         (nrf52_dirs.toolchain / ".ready").touch()
@@ -157,7 +165,7 @@ class TestCheckAndInstall:
         mock_nrf52_ops: SimpleNamespace,
     ) -> None:
         """Venv ready but framework missing → skip venv creation, run SDK init+update."""
-        (nrf52_dirs.python_env / ".ready").touch()
+        _mark_venv_ready(nrf52_dirs.python_env)
 
         check_and_install()
 
@@ -173,7 +181,7 @@ class TestCheckAndInstall:
         mock_nrf52_ops: SimpleNamespace,
     ) -> None:
         """Venv and framework ready → only toolchain downloaded and extracted."""
-        (nrf52_dirs.python_env / ".ready").touch()
+        _mark_venv_ready(nrf52_dirs.python_env)
         (nrf52_dirs.python_env / ".zephyr_reqs_ready").touch()
         (nrf52_dirs.framework / ".ready").touch()
 
@@ -202,7 +210,7 @@ class TestCheckAndInstall:
         mock_nrf52_ops: SimpleNamespace,
     ) -> None:
         """Failing west init raises EsphomeError."""
-        (nrf52_dirs.python_env / ".ready").touch()
+        _mark_venv_ready(nrf52_dirs.python_env)
         mock_nrf52_ops.run_command_ok.return_value = False
 
         with pytest.raises(EsphomeError, match="Can't initialize"):
@@ -214,7 +222,7 @@ class TestCheckAndInstall:
         mock_nrf52_ops: SimpleNamespace,
     ) -> None:
         """Failing west update raises EsphomeError."""
-        (nrf52_dirs.python_env / ".ready").touch()
+        _mark_venv_ready(nrf52_dirs.python_env)
         # init succeeds, update fails
         mock_nrf52_ops.run_command_ok.side_effect = [True, False]
 
@@ -227,7 +235,7 @@ class TestCheckAndInstall:
         mock_nrf52_ops: SimpleNamespace,
     ) -> None:
         """download_from_mirrors receives VERSION + platform triple from _get_toolchain_platform_info."""
-        (nrf52_dirs.python_env / ".ready").touch()
+        _mark_venv_ready(nrf52_dirs.python_env)
         (nrf52_dirs.framework / ".ready").touch()
 
         with patch(


### PR DESCRIPTION
# What does this implement/fix?

Component test batches that build nrf52 targets currently install the multi-GB sdk-nrf (west workspace, Zephyr SDK toolchain, python env) from scratch on every CI run.

This adds a `cache-sdk-nrf` action, mirroring the existing `cache-esp-idf` action: only dev-branch runs write the shared cache (so it lives in the default-branch scope readable by all PRs), while PR jobs are restore-only. The component test batch job consumes it via the `needs_nrf` batch flag that #17359 already computes but nothing used yet.

The sdk-nrf python env reinstall check in `framework.py` is also changed from an mtime comparison to a requirements.txt content hash stored in the sentinel. Git checkouts and CI cache restores assign arbitrary mtimes, so the mtime comparison would rebuild the python env on every CI run with a restored cache (and never on a stale one). Unit tests updated accordingly.

Note: nothing writes the cache yet, since batches only run on pull requests. The dev-side writer is the native nrf52 clang-tidy job in #17364; whichever lands second completes the system. Until then batches miss the cache and install exactly as they do today.

This is the cache portion of #17364, split out so the component test batches can use it independently of the clang-tidy work.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI infrastructure change, no user-facing configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).