### PR TITLE
[mimi_spi] Add Waveshare-ESP32-S3-TOUCH-AMOLED-1.64

### DIFF
--- a/esphome/components/mipi_spi/models/amoled.py
+++ b/esphome/components/mipi_spi/models/amoled.py
@@ -105,3 +105,20 @@ CO5300 = DriverChip(
         (WCE, 0x00),
     ),
 )
+
+SH8601 = DriverChip(
+    "SH8601",
+    data_rate="40MHz",
+    bus_mode=TYPE_QUAD,
+    brightness=0xD0,
+    color_order=MODE_RGB,
+    no_slpout=True,
+    initsequence=(
+        (SLPOUT,),
+        delay(80),
+        (SPIMODESEL, 0x80),
+        (TEON, 0x00),
+        (WRCTRLD, 0x20),
+        (0x63, 0xFF),
+    ),
+)

--- a/esphome/components/mipi_spi/models/waveshare.py
+++ b/esphome/components/mipi_spi/models/waveshare.py
@@ -282,3 +282,13 @@ ST7789V.extend(
     invert_colors=True,
     data_rate="40MHz",
 )
+
+SH8601.extend(
+    "WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.64",
+    width=280,
+    height=456,
+    offset_width=20, 
+    cs_pin=9,
+    reset_pin=21,
+    enable_pin=1,  
+)


### PR DESCRIPTION
# What does this implement/fix?

Added support for [Waveshare ESP32-S3-Touch-Amoled-1.64](https://www.waveshare.com/ESP32-S3-Touch-AMOLED-1.64.htm), using the SH8601 display.

Init sequence and pins extracted from [Waveshare demo - 06_LVGL_Test](https://www.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-1.64#06_LVGL_Test_2)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- 

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6913

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: waveshare-dashboard

esp32:
  board: esp32s3box
  variant: esp32s3
  flash_size: 16MB
  framework:
    type: esp-idf

spi:
  - id: qspi_bus
    type: quad
    interface: spi2
    clk_pin: 10
    data_pins: [11, 12, 13, 14]


display:
  - platform: mipi_spi
    model: WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.64
    id: amoled_display
    spi_id: qspi_bus
    auto_clear_enabled: false
    update_interval: never
    color_order: rgb

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
