### PR TITLE
[ci] Name the sdk-nrf cache steps after the nRF Connect SDK

### DIFF
--- a/.github/actions/cache-sdk-nrf/action.yml
+++ b/.github/actions/cache-sdk-nrf/action.yml
@@ -1,4 +1,4 @@
-name: Cache sdk-nrf
+name: Cache nRF Connect SDK
 description: >
   Resolve the pinned sdk-nrf version and cache the native sdk-nrf install
   (west workspace, Zephyr SDK toolchain, python env) at ~/.esphome-sdk-nrf.
@@ -33,14 +33,14 @@ runs:
     # Mirror cache-esp-idf: only dev-branch runs write the shared cache (so it
     # lives in the default-branch scope readable by all PRs); PRs are
     # restore-only and never push multi-GB artifacts into their own scope.
-    - name: Cache sdk-nrf install (write on dev)
+    - name: Cache nRF Connect SDK install (write on dev)
       if: github.ref == 'refs/heads/dev' && inputs.restore-only != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.esphome-sdk-nrf
         # yamllint disable-line rule:line-length
         key: ${{ runner.os }}-esphome-sdk-nrf-${{ steps.version.outputs.version }}-${{ hashFiles('esphome/components/nrf52/requirements.txt') }}
-    - name: Cache sdk-nrf install (restore-only off dev)
+    - name: Cache nRF Connect SDK install (restore-only off dev)
       if: github.ref != 'refs/heads/dev' || inputs.restore-only == 'true'
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,7 +529,7 @@ jobs:
         with:
           framework: arduino
 
-      - name: Cache sdk-nrf install
+      - name: Cache nRF Connect SDK install
         if: matrix.cache_sdk_nrf
         uses: ./.github/actions/cache-sdk-nrf
 
@@ -849,7 +849,7 @@ jobs:
         uses: ./.github/actions/cache-esp-idf
         with:
           restore-only: true
-      - name: Cache sdk-nrf install (restore-only)
+      - name: Cache nRF Connect SDK install (restore-only)
         # Only batches whose test platforms include nrf52 need the native
         # sdk-nrf install; never save -- just reuse the shared install the
         # dev nrf52 tidy job cached when present.


### PR DESCRIPTION
# What does this implement/fix?

Renames the sdk-nrf cache step display names from "Cache sdk-nrf install" to "Cache nRF Connect SDK install", matching the official product styling the ESP-IDF cache steps use ("Cache ESP-IDF install") and the log messages in `nrf52/framework.py` ("Initializing nRF Connect SDK ..."). Display names only; the action directory stays `cache-sdk-nrf`.

Follow-up to #17364.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI display names only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).