### PR TITLE
[esp8266] Strip lwIP glue dhcp stub message strings from DRAM

### DIFF
--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -332,6 +332,12 @@ async def to_code(config):
         for symbol in ("vprintf", "printf", "fprintf"):
             cg.add_build_flag(f"-Wl,--wrap={symbol}")
 
+    # Wrap the lwIP2 glue's do-nothing dhcp_cleanup()/dhcp_release() stubs so the
+    # linker can drop their "STUB: ..." message strings from DRAM.
+    # See lwip_glue_stubs.cpp for implementation.
+    for symbol in ("dhcp_cleanup", "dhcp_release"):
+        cg.add_build_flag(f"-Wl,--wrap={symbol}")
+
     # Wrap Arduino's millis() so all callers (including Arduino libraries and ISR
     # handlers) use our fast accumulator instead of the expensive 4x 64-bit multiply
     # implementation in the Arduino ESP8266 core.

--- a/esphome/components/esp8266/lwip_glue_stubs.cpp
+++ b/esphome/components/esp8266/lwip_glue_stubs.cpp
@@ -18,6 +18,8 @@
 
 #if defined(USE_ESP8266)
 
+namespace esphome::esp8266 {}
+
 // NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
 extern "C" {
 

--- a/esphome/components/esp8266/lwip_glue_stubs.cpp
+++ b/esphome/components/esp8266/lwip_glue_stubs.cpp
@@ -1,0 +1,33 @@
+/*
+ * Linker wrap stubs for the lwIP2 glue's dead DHCP entry points.
+ *
+ * The ESP8266 SDK blobs call dhcp_cleanup() and dhcp_release() when the
+ * station leaves an access point (cnx_sta_leave, wifi_station_dhcpc_stop).
+ * In the prebuilt lwIP2 glue (liblwip2-*.a, glue-esp/lwip-esp.c) these are
+ * stubs whose only effect is printing "STUB: dhcp_cleanup" and
+ * "STUB: dhcp_release"; the real DHCP teardown happens through lwIP2's
+ * renamed dhcp_cleanup_LWIP2()/dhcp_release_LWIP2() functions.
+ *
+ * On ESP8266 .rodata lives in DRAM, so those message strings waste scarce
+ * RAM. Wrapping the stubs with silent equivalents lets the linker garbage
+ * collect the glue stub bodies together with their strings.
+ *
+ * Saves 38 bytes of RAM and removes the "STUB:" log noise on Wi-Fi
+ * disconnect. Behavior is otherwise unchanged.
+ */
+
+#if defined(USE_ESP8266)
+
+// NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
+extern "C" {
+
+// The callers are closed-source SDK blobs; the netif argument is unused.
+void __wrap_dhcp_cleanup(void * /*netif*/) {}
+
+// The glue stub returns ERR_ABRT (-8; lwIP 1.4 err_t is a signed char).
+signed char __wrap_dhcp_release(void * /*netif*/) { return -8; }
+
+}  // extern "C"
+// NOLINTEND(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
+
+#endif  // USE_ESP8266


### PR DESCRIPTION
# What does this implement/fix?

The ESP8266 SDK blobs call `dhcp_cleanup()` and `dhcp_release()` when the station leaves an access point. In the prebuilt lwIP2 glue these are stubs whose only effect is printing `STUB: dhcp_cleanup` and `STUB: dhcp_release`; the real DHCP teardown goes through lwIP2's renamed `dhcp_cleanup_LWIP2()` and `dhcp_release_LWIP2()`. Since `.rodata` lives in DRAM on ESP8266, those message strings sit in RAM for the life of the device. This wraps the two stubs with silent equivalents so the linker can garbage collect the stub bodies together with their strings. It frees 48 bytes of RAM and 88 bytes of flash on a test build, and the STUB log noise on WiFi disconnect goes away.

The remaining glue strings (`STUB: sys_timeout`, `STUB: sys_untimeout`, `lwESP: pbuf_alloc BAD CASE`) share a single merged rodata section that is anchored by the live glue `pbuf_alloc`, so they cannot be removed this way and stay.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes, applies automatically to all ESP8266 builds
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
