### PR TITLE
Add TX/RX pin aliases for Seeed Studio XIAO ESP32C6

### DIFF
--- a/esphome/components/esp32/boards.py
+++ b/esphome/components/esp32/boards.py
@@ -1289,6 +1289,8 @@ ESP32_BOARD_PINS = {
         "D8": 19,
         "D9": 20,
         "D10": 18,
+        "TX": 16,  # Silkscreen label on D6
+        "RX": 17,  # Silkscreen label on D7
         "MTDO": 7,
         "MTCK": 6,
         "MTDI": 5,


### PR DESCRIPTION
D6/D7 are silkscreened TX/RX on this board; adds the same named-pin convention other boards already have.