### PR TITLE
[nrf52] add better error message for OTA error

### DIFF
--- a/esphome/components/nrf52/ota.py
+++ b/esphome/components/nrf52/ota.py
@@ -5,7 +5,7 @@ import logging
 from pathlib import Path
 
 from bleak import BleakScanner
-from bleak.exc import BleakDeviceNotFoundError
+from bleak.exc import BleakDBusError, BleakDeviceNotFoundError
 from smp.exceptions import SMPBadStartDelimiter
 from smpclient import SMPClient
 from smpclient.generics import error, success
@@ -98,6 +98,12 @@ async def _smpmgr_upload(device: str, firmware: Path) -> None:
         await smp_client.connect()
     except BleakDeviceNotFoundError as exc:
         raise EsphomeError(f"Device {device} not found") from exc
+    except BleakDBusError as exc:
+        if "NotPermitted" in exc.dbus_error:
+            raise EsphomeError(
+                f"Cannot connect to {device}: Make sure the device is paired."
+            ) from exc
+        raise EsphomeError(f"BLE error connecting to {device}: {exc}") from exc
     except SMPBLETransportException as exc:
         raise EsphomeError(f"Connection error with {device}") from exc
 


### PR DESCRIPTION
# What does this implement/fix?

If you have 

```yaml
zephyr_ble_server:
  on_numeric_comparison_request:
    then:
      - logger.log:
          format: "Compare this passkey with the one on your BLE device: %06d"
          args: [passkey]
      - ble_server.numeric_comparison_reply:
          accept: true
```

BLE OTA fails with strange exception. Make the error message cleaner.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
