### PR TITLE
[nrf52] let user select libc version

### DIFF
--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -200,8 +200,12 @@ DeviceFirmwareUpdate = nrf52_ns.class_("DeviceFirmwareUpdate", cg.Component)
 
 CONF_DFU = "dfu"
 CONF_DCDC = "dcdc"
+CONF_LIBC = "libc"
 CONF_REG0 = "reg0"
 CONF_UICR_ERASE = "uicr_erase"
+
+LIBC_NEWLIB_NANO = "newlib_libc_nano"
+LIBC_NEWLIB = "newlib_libc"
 
 VOLTAGE_LEVELS = [1.8, 2.1, 2.4, 2.7, 3.0, 3.3]
 
@@ -248,6 +252,9 @@ CONFIG_SCHEMA = cv.All(
             ): cv.Schema(
                 {
                     cv.Optional(CONF_VERSION): cv.string_strict,
+                    cv.Optional(CONF_LIBC, default=LIBC_NEWLIB_NANO): cv.one_of(
+                        LIBC_NEWLIB_NANO, LIBC_NEWLIB, lower=True
+                    ),
                     cv.Optional(CONF_ADVANCED, default={}): cv.Schema(
                         {
                             cv.Optional(
@@ -273,6 +280,7 @@ def _validate_mcumgr(config):
 
 
 def _final_validate(config):
+
     if CONF_DFU in config:
         _validate_mcumgr(config)
     if config[KEY_BOOTLOADER] == BOOTLOADER_ADAFRUIT:
@@ -282,6 +290,15 @@ def _final_validate(config):
     full_config = fv.full_config.get()
     conf = config[CONF_FRAMEWORK]
     advanced = conf[CONF_ADVANCED]
+
+    if conf[CONF_LIBC] == LIBC_NEWLIB_NANO and "logger" in CORE.loaded_integrations:
+        _LOGGER.warning(
+            "Logger is enabled with %s. Some format specifiers such as %%zu are "
+            "not supported by newlib-nano and will print incorrectly. "
+            "Set 'libc: %s' under 'framework:' to use the full newlib.",
+            LIBC_NEWLIB_NANO,
+            LIBC_NEWLIB,
+        )
 
     if advanced[CONF_ENABLE_OTA_ROLLBACK]:
         # "disabled: false" means safe mode *is* enabled.
@@ -379,6 +396,12 @@ async def to_code(config: ConfigType) -> None:
     # Enable OTA rollback support
     if advanced[CONF_ENABLE_OTA_ROLLBACK]:
         cg.add_define("USE_OTA_ROLLBACK")
+    zephyr_add_prj_conf("NEWLIB_LIBC", True)
+    zephyr_add_prj_conf("NEWLIB_LIBC_FLOAT_PRINTF", True)
+    if conf[CONF_LIBC] == LIBC_NEWLIB_NANO:
+        zephyr_add_prj_conf("NEWLIB_LIBC_NANO", True)
+    else:
+        zephyr_add_prj_conf("NEWLIB_LIBC_NANO", False)
     # c++ support
     if framework_ver < cv.Version(2, 9, 2):
         zephyr_add_prj_conf("CPLUSPLUS", True)

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -200,12 +200,9 @@ DeviceFirmwareUpdate = nrf52_ns.class_("DeviceFirmwareUpdate", cg.Component)
 
 CONF_DFU = "dfu"
 CONF_DCDC = "dcdc"
-CONF_LIBC = "libc"
+CONF_LIBC_NANO = "libc_nano"
 CONF_REG0 = "reg0"
 CONF_UICR_ERASE = "uicr_erase"
-
-LIBC_NEWLIB_NANO = "newlib_libc_nano"
-LIBC_NEWLIB = "newlib_libc"
 
 VOLTAGE_LEVELS = [1.8, 2.1, 2.4, 2.7, 3.0, 3.3]
 
@@ -252,9 +249,7 @@ CONFIG_SCHEMA = cv.All(
             ): cv.Schema(
                 {
                     cv.Optional(CONF_VERSION): cv.string_strict,
-                    cv.Optional(CONF_LIBC, default=LIBC_NEWLIB_NANO): cv.one_of(
-                        LIBC_NEWLIB_NANO, LIBC_NEWLIB, lower=True
-                    ),
+                    cv.Optional(CONF_LIBC_NANO, default=True): cv.boolean,
                     cv.Optional(CONF_ADVANCED, default={}): cv.Schema(
                         {
                             cv.Optional(
@@ -291,13 +286,11 @@ def _final_validate(config):
     conf = config[CONF_FRAMEWORK]
     advanced = conf[CONF_ADVANCED]
 
-    if conf[CONF_LIBC] == LIBC_NEWLIB_NANO and "logger" in CORE.loaded_integrations:
+    if conf[CONF_LIBC_NANO] and "logger" in CORE.loaded_integrations:
         _LOGGER.warning(
-            "Logger is enabled with %s. Some format specifiers such as %%zu are "
-            "not supported by newlib-nano and will print incorrectly. "
-            "Set 'libc: %s' under 'framework:' to use the full newlib.",
-            LIBC_NEWLIB_NANO,
-            LIBC_NEWLIB,
+            "Logger is enabled with newlib-nano (libc_nano: true). Some format specifiers "
+            "such as %%zu are not supported and will print incorrectly. "
+            "Set 'libc_nano: false' under 'framework:' to use the full newlib."
         )
 
     if advanced[CONF_ENABLE_OTA_ROLLBACK]:
@@ -398,10 +391,7 @@ async def to_code(config: ConfigType) -> None:
         cg.add_define("USE_OTA_ROLLBACK")
     zephyr_add_prj_conf("NEWLIB_LIBC", True)
     zephyr_add_prj_conf("NEWLIB_LIBC_FLOAT_PRINTF", True)
-    if conf[CONF_LIBC] == LIBC_NEWLIB_NANO:
-        zephyr_add_prj_conf("NEWLIB_LIBC_NANO", True)
-    else:
-        zephyr_add_prj_conf("NEWLIB_LIBC_NANO", False)
+    zephyr_add_prj_conf("NEWLIB_LIBC_NANO", conf[CONF_LIBC_NANO])
     # c++ support
     if framework_ver < cv.Version(2, 9, 2):
         zephyr_add_prj_conf("CPLUSPLUS", True)

--- a/esphome/components/zephyr/__init__.py
+++ b/esphome/components/zephyr/__init__.py
@@ -134,9 +134,7 @@ def zephyr_to_code(config: ConfigType) -> None:
     cg.add_define("USE_NATIVE_64BIT_TIME")
     cg.set_cpp_standard("gnu++20")
     # c++ support
-    zephyr_add_prj_conf("NEWLIB_LIBC", True)
     zephyr_add_prj_conf("FPU", True)
-    zephyr_add_prj_conf("NEWLIB_LIBC_FLOAT_PRINTF", True)
     zephyr_add_prj_conf("STD_CPP20", True)
     # random_bytes() uses sys_rand_get() which requires the entropy subsystem
     zephyr_add_prj_conf("ENTROPY_GENERATOR", True)

--- a/tests/components/nrf52/test.nrf52-xiao-ble.yaml
+++ b/tests/components/nrf52/test.nrf52-xiao-ble.yaml
@@ -3,4 +3,4 @@ nrf52:
   reg0:
     voltage: 1.8V
   framework:
-    libc: newlib_libc
+    libc_nano: false

--- a/tests/components/nrf52/test.nrf52-xiao-ble.yaml
+++ b/tests/components/nrf52/test.nrf52-xiao-ble.yaml
@@ -2,3 +2,5 @@ nrf52:
   dfu: true
   reg0:
     voltage: 1.8V
+  framework:
+    libc: newlib_libc


### PR DESCRIPTION
# What does this implement/fix?

Let user to select libc version. new libc nano is smaller but do not support some printf formats like %zu or printing 64-bits. Add warning if logger is selected with libc nano.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16352

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- https://github.com/esphome/esphome.io/pull/6920

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
