### PR TITLE
[web_server] Add max_connections to raise the HTTP server socket limit

### DIFF
--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -20,6 +20,7 @@ from esphome.const import (
     CONF_JS_URL,
     CONF_LOCAL,
     CONF_LOG,
+    CONF_MAX_CONNECTIONS,
     CONF_NAME,
     CONF_OTA,
     CONF_PASSWORD,
@@ -34,6 +35,7 @@ from esphome.const import (
     PLATFORM_LN882X,
     PLATFORM_RP2040,
     PLATFORM_RTL87XX,
+    Framework,
 )
 from esphome.core import CORE, CoroPriority, coroutine_with_priority
 import esphome.final_validate as fv
@@ -152,6 +154,12 @@ def _final_validate_sorting(config: ConfigType) -> ConfigType:
 FINAL_VALIDATE_SCHEMA = _final_validate_sorting
 
 
+# esp_http_server also needs a few lwIP sockets beyond max_open_sockets (its
+# listener plus internal control sockets); reserve this headroom so its
+# requirement of CONFIG_LWIP_MAX_SOCKETS >= max_open_sockets + 3 always holds.
+HTTPD_SOCKET_OVERHEAD = 3
+
+
 def _consume_web_server_sockets(config: ConfigType) -> ConfigType:
     """Register socket needs for web_server component."""
     from esphome.components import socket
@@ -160,7 +168,12 @@ def _consume_web_server_sockets(config: ConfigType) -> ConfigType:
     # (browser opens connections for page resources, SSE event stream, and POST
     # requests for entity control which may linger before closing)
     # The listening socket is registered by web_server_base (shared with captive_portal)
-    socket.consume_sockets(5, "web_server")(config)
+    if (max_connections := config.get(CONF_MAX_CONNECTIONS)) is not None:
+        socket.consume_sockets(max_connections + HTTPD_SOCKET_OVERHEAD, "web_server")(
+            config
+        )
+    else:
+        socket.consume_sockets(5, "web_server")(config)
     return config
 
 
@@ -194,6 +207,14 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(WebServer),
             cv.Optional(CONF_PORT, default=80): cv.port,
+            # Concurrent client connections the ESP-IDF HTTP server keeps open
+            # (its max_open_sockets, default 7). Raise it when multiple dashboard
+            # tabs / event-stream clients would otherwise be evicted. ESP-IDF only:
+            # the socket component sizes CONFIG_LWIP_MAX_SOCKETS to match.
+            cv.Optional(CONF_MAX_CONNECTIONS): cv.All(
+                cv.only_with_framework(Framework.ESP_IDF),
+                cv.int_range(min=1, max=24),
+            ),
             cv.Optional(CONF_VERSION, default=2): cv.one_of(1, 2, 3, int=True),
             cv.Optional(CONF_CSS_URL): cv.string,
             cv.Optional(CONF_CSS_INCLUDE): cv.file_,
@@ -312,6 +333,8 @@ async def to_code(config):
     version = config[CONF_VERSION]
 
     cg.add(paren.set_port(config[CONF_PORT]))
+    if (max_connections := config.get(CONF_MAX_CONNECTIONS)) is not None:
+        cg.add(paren.set_max_open_sockets(max_connections))
     cg.add_define("USE_WEBSERVER")
     cg.add_define("USE_WEBSERVER_PORT", config[CONF_PORT])
     cg.add_define("USE_WEBSERVER_VERSION", version)

--- a/esphome/components/web_server_base/web_server_base.h
+++ b/esphome/components/web_server_base/web_server_base.h
@@ -96,6 +96,12 @@ class WebServerBase {
       return;
     }
     this->server_ = new AsyncWebServer(this->port_);
+#if USE_ESP32
+    // Only the ESP-IDF HTTP server exposes a configurable concurrent-connection
+    // ceiling; 0 keeps its default. Must be applied before begin().
+    if (this->max_open_sockets_ != 0)
+      this->server_->set_max_open_sockets(this->max_open_sockets_);
+#endif
     // All content is controlled and created by user - so allowing all origins is fine here.
     // NOTE: Currently 1 header. If more are added, update in __init__.py:
     //   cg.add_define("WEB_SERVER_DEFAULT_HEADERS_COUNT", 1)
@@ -134,9 +140,17 @@ class WebServerBase {
   void set_port(uint16_t port) { port_ = port; }
   uint16_t get_port() const { return port_; }
 
+#if USE_ESP32
+  // Raise the ESP-IDF HTTP server's concurrent-connection ceiling (0 = default).
+  void set_max_open_sockets(uint8_t max_open_sockets) { this->max_open_sockets_ = max_open_sockets; }
+#endif
+
  protected:
   uint8_t initialized_{0};
   uint16_t port_{80};
+#if USE_ESP32
+  uint8_t max_open_sockets_{0};  // 0 = ESP-IDF default
+#endif
   AsyncWebServer *server_{nullptr};
   std::vector<AsyncWebHandler *> handlers_;
 #ifdef USE_WEBSERVER_AUTH

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -126,6 +126,12 @@ void AsyncWebServer::begin() {
   httpd_config_t config = HTTPD_DEFAULT_CONFIG();
   config.stack_size = config.stack_size + 256;
   config.server_port = this->port_;
+  // Optionally raise the concurrent-connection ceiling (default 7). The socket
+  // component reserves matching lwIP headroom so esp_http_server's requirement of
+  // CONFIG_LWIP_MAX_SOCKETS >= max_open_sockets + 3 holds.
+  if (this->max_open_sockets_ != 0) {
+    config.max_open_sockets = this->max_open_sockets_;
+  }
   config.uri_match_fn = [](const char * /*unused*/, const char * /*unused*/, size_t /*unused*/) { return true; };
   // Always enable LRU purging to handle socket exhaustion gracefully.
   // When max sockets is reached, the oldest connection is closed to make room for new ones.

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -218,6 +218,11 @@ class AsyncWebServer {
   void begin();
   void end();
 
+  // Override the number of concurrent client sockets the underlying esp_http_server
+  // keeps open (its `max_open_sockets`). 0 keeps the ESP-IDF default. Must be set
+  // before begin(); the socket component sizes CONFIG_LWIP_MAX_SOCKETS to match.
+  void set_max_open_sockets(uint8_t max_open_sockets) { this->max_open_sockets_ = max_open_sockets; }
+
   // NOLINTNEXTLINE(readability-identifier-naming)
   AsyncWebHandler &addHandler(AsyncWebHandler *handler) {
     this->handlers_.push_back(handler);
@@ -229,6 +234,7 @@ class AsyncWebServer {
  protected:
   uint16_t port_{};
   httpd_handle_t server_{};
+  uint8_t max_open_sockets_{0};  // 0 = use the ESP-IDF HTTPD_DEFAULT_CONFIG value
   static esp_err_t request_handler(httpd_req_t *r);
   static esp_err_t request_post_handler(httpd_req_t *r);
   esp_err_t request_handler_(AsyncWebServerRequest *request) const;

--- a/tests/components/web_server/test_max_connections.esp32-idf.yaml
+++ b/tests/components/web_server/test_max_connections.esp32-idf.yaml
@@ -1,0 +1,4 @@
+<<: !include common_v2.yaml
+
+web_server:
+  max_connections: 12


### PR DESCRIPTION
# What does this implement/fix?

Adds an optional `max_connections:` to the `web_server:` component so users can raise the ESP-IDF HTTP server's concurrent-connection ceiling (its `max_open_sockets`) above the fixed default of **7**.

On ESP32 (ESP-IDF), `web_server_base` starts `esp_http_server` from `HTTPD_DEFAULT_CONFIG()`, which pins `max_open_sockets` to 7 with no way to change it. That is easily exhausted when several clients hold connections open at the same time — multiple dashboard tabs, the `/events` SSE stream, and REST/polling integrations. When the limit is reached the LRU purge (enabled for graceful degradation, see #12464) closes the oldest connection, which is frequently a live event stream, so an extra viewer can silently drop someone else's stream. Until now the only workaround was patching the component.

What this does:

- `web_server: max_connections: N` sets `httpd_config_t.max_open_sockets = N`, applied in `AsyncWebServer::begin()`. Unset keeps the current default (no behavior change).
- The `socket` component reserves `N + 3` TCP sockets for the web server, so ESPHome's existing `CONFIG_LWIP_MAX_SOCKETS` auto-sizing grows the lwIP pool to satisfy `esp_http_server`'s requirement that `CONFIG_LWIP_MAX_SOCKETS >= max_open_sockets + 3` (its listener + control sockets). No manual `sdkconfig` edits are needed.
- ESP-IDF only: the httpd knob and the lwIP auto-sizing are IDF-specific, so the option is rejected with a clear message on Arduino / other platforms.

Verified locally via `esphome config` and codegen (`esphome compile` up to the generation step): `max_connections: 12` produces `Setting CONFIG_LWIP_MAX_SOCKETS to 18 (TCP=15 [web_server=15], UDP=2 [mdns=2], TCP_LISTEN=1 [web_server_base=1])` and `set_max_open_sockets(12)` in the generated `main.cpp`. Rejection on `arduino` / `esp8266` was confirmed to raise "This feature is only available with framework(s) esp-idf."

Marked as **draft** pending a full on-hardware compile/soak and the documentation PR.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A — feature addition. Related context: socket exhaustion / LRU eviction under multiple concurrent clients (#12464).

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<pending — will add the `web_server` docs PR before marking ready for review>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
web_server:
  max_connections: 12
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
