### PR TITLE
[cst328] Use dict-style packages so batch grouping deduplicates the i2c bus

### DIFF
--- a/tests/components/cst328/test.esp32-idf.yaml
+++ b/tests/components/cst328/test.esp32-idf.yaml
@@ -4,5 +4,6 @@ substitutions:
   reset_pin: "21"
 
 packages:
-  - !include ../../test_build_components/common/i2c/esp32-idf.yaml
-  - !include common.yaml
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

``tests/components/cst328/test.esp32-idf.yaml`` declared its packages as an unnamed list:

```yaml
packages:
  - !include ../../test_build_components/common/i2c/esp32-idf.yaml
  - !include common.yaml
```

When the CI batch-merger groups cst328 with any other component that uses the standard dict form (``i2c:`` keyed include from ``test_build_components/common/i2c/esp32-idf.yaml``), both includes land unnamed and produce two ``i2c_bus`` definitions in the merged config, tripping ``ID i2c_bus redefined! Check i2c->0->id.``. This has already broken CI on unrelated PRs whose diff pulls cst328 into a batch with a dict-style i2c neighbour.

Switch cst328 to the dict-style packages + ``<<:`` mixin used by every other i2c component (see ``bme68x_bsec2_i2c``, ``wk2168_i2c``, etc.) so batch grouping deduplicates the shared bus correctly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for ``config.yaml``:

```yaml
# n/a — this only changes the test-harness YAML format
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).