### PR TITLE
[wifi] Accept boolean-like strings for fast_connect again

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from typing import Any
 
 from esphome import automation, preferences
 from esphome.automation import Condition
@@ -444,9 +445,10 @@ FAST_CONNECT_SCHEMA = cv.Schema(
 )
 
 
-def _fast_connect_schema(value):
-    """Accept the historic plain boolean or a dict with enabled/storage keys."""
-    if isinstance(value, bool):
+def _fast_connect_schema(value: Any) -> ConfigType:
+    """Accept the historic plain boolean (including boolean-like strings from
+    substitutions) or a dict with enabled/storage keys."""
+    if not isinstance(value, dict):
         value = {CONF_ENABLED: value}
     return FAST_CONNECT_SCHEMA(value)
 

--- a/tests/components/wifi/validate-fast-connect-substitution.esp8266-ard.yaml
+++ b/tests/components/wifi/validate-fast-connect-substitution.esp8266-ard.yaml
@@ -1,0 +1,9 @@
+# fast_connect passed through a substitution arrives as a string ("false"),
+# which must be accepted like the historic plain boolean form.
+substitutions:
+  fast_connect_value: "false"
+
+wifi:
+  ssid: MySSID
+  password: password1
+  fast_connect: ${fast_connect_value}


### PR DESCRIPTION
# What does this implement/fix?

#17073 changed `fast_connect` from `cv.boolean` to a validator that accepts a plain boolean or a dict, but it only special cases real Python bools. Substitutions always produce strings, so configs that set `fast_connect: ${wifi_fast_connect}` (the Athom packages for example) now fail with "expected a dictionary". This wraps any value that is not a dict as the `enabled` flag so `cv.boolean` validates it, restoring the old string handling while keeping the new dict form.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
substitutions:
  wifi_fast_connect: "false"

wifi:
  ssid: MySSID
  password: password1
  fast_connect: ${wifi_fast_connect}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
