### PR TITLE
[tests] Document dict-style packages requirement for batch grouping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,13 +427,14 @@ This document provides essential context for AI models interacting with this pro
 
         When a PR's only edits to a component are `validate.*.yaml` files (no source changes, no `test.*.yaml` changes, and the component isn't pulled in as a dependency of another changed component), CI skips the compile stage for that component entirely and only runs config validation. This is decided in `script/determine-jobs.py` via `_component_change_is_validate_only` and surfaced as the `validate_only_components` output that the `test-build-components-split` job consumes.
 
-    *   **Test Grouping with Packages:** Components that use shared bus packages can be grouped together in CI to reduce build count. **Never define buses (uart, i2c, spi, modbus) directly in test YAML files** — always use packages from `test_build_components/common/`:
+    *   **Test Grouping with Packages:** Components that use shared bus packages can be grouped together in CI to reduce build count. **Never define buses (uart, i2c, spi, modbus) directly in test YAML files** — always use packages from `test_build_components/common/`.
+
+        All includes in test files must go through dict-style `packages:` so that batch grouping works correctly — the grouping scripts only understand dict-style packages. Never use list-style packages (`packages: [- !include ...]`) or top-level merge keys (`<<: !include common.yaml`). Bus packages are keyed by the bus name; the component's `common.yaml` is keyed by the component name (e.g. `cst328: !include common.yaml`):
         ```yaml
-        # test.esp32-idf.yaml — use packages for buses
+        # test.esp32-idf.yaml — everything included via named packages
         packages:
           uart: !include ../../test_build_components/common/uart_115200/esp32-idf.yaml
-
-        <<: !include common.yaml
+          my_component: !include common.yaml
         ```
         ```yaml
         # common.yaml — component config only, NO bus definitions

--- a/tests/test_build_components/common/README.md
+++ b/tests/test_build_components/common/README.md
@@ -45,14 +45,13 @@ common/
 ## How It Works
 
 ### Component Test Structure
-Each component test includes the common bus config:
+Each component test includes the common bus config and its own `common.yaml` through dict-style `packages:`. Always use packages for every include — the grouping scripts only understand dict-style packages, so list-style packages or top-level `<<:` merge keys prevent correct batch grouping. Key the bus package by the bus name and the component's `common.yaml` by the component name:
 
 ```yaml
 # tests/components/bh1750/test.esp32-idf.yaml
 packages:
   i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
-
-<<: !include common.yaml
+  bh1750: !include common.yaml
 ```
 
 The common config provides:


### PR DESCRIPTION
# What does this implement/fix?

Documents the convention that component test YAML files must include everything through dict-style `packages:` so that CI batch grouping works correctly. The grouping scripts (`script/analyze_component_buses.py`) only understand dict-style packages, so list-style packages or top-level `<<: !include common.yaml` merge keys prevent a component from being grouped. Bus packages are keyed by the bus name and the component's `common.yaml` is keyed by the component name (e.g. `cst328: !include common.yaml`).

Updates the examples in `AGENTS.md` and `tests/test_build_components/common/README.md` to show the named-package form.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).