### PR TITLE
[bluetooth_proxy] Take over stale advertisement subscription instead of rejecting the new subscriber

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -379,9 +379,17 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
 }
 
 void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection, uint32_t flags) {
-  if (this->api_connection_ != nullptr) {
-    ESP_LOGE(TAG, "Only one API subscription is allowed at a time");
-    return;
+  if (this->api_connection_ != nullptr && this->api_connection_ != api_connection) {
+    // A previous subscriber still holds the slot. This is almost always a stale
+    // connection from a client that dropped without a clean disconnect and has
+    // not yet hit the keepalive timeout; rejecting the new subscriber would
+    // silently starve it of advertisements until it reconnects, so the newest
+    // subscriber wins instead.
+    char old_peername[socket::SOCKADDR_STR_LEN];
+    char new_peername[socket::SOCKADDR_STR_LEN];
+    ESP_LOGW(TAG, "Subscription from %s (%s) replaces %s (%s)", api_connection->get_name(),
+             api_connection->get_peername_to(new_peername), this->api_connection_->get_name(),
+             this->api_connection_->get_peername_to(old_peername));
   }
   this->api_connection_ = api_connection;
   this->parent_->recalculate_advertisement_parser_types();


### PR DESCRIPTION
# What does this implement/fix?

**This is a breaking behavior change: the newest advertisement subscriber now always wins.** Previously the first subscriber kept the bluetooth proxy's single subscriber slot and any later subscribe was rejected; now a later subscribe from a different connection takes the slot over, with a warning naming both clients. Anyone relying on first subscriber wins semantics (for example two competing Home Assistant instances pointed at the same proxy) will see the proxy follow the most recent subscriber instead. For the 99% case, a single Home Assistant instance, this is what users want: the only competing subscriber is a stale connection of the same client, and newest wins is the behavior that recovers it.

Why the old behavior is a problem: the rejection is silent, only a local `Only one API subscription is allowed at a time` log; the client is never told and gets no advertisements and no scanner state for the lifetime of an otherwise healthy connection. When Home Assistant drops without a clean disconnect (upgrade, restart, network blip) and reconnects within the keepalive window, the stale connection can hold the slot for up to ~150s; the new connection's subscribe is silently rejected, and once the stale connection is finally reaped nobody is subscribed at all, so the proxy forwards nothing until the next reconnect. The result is a proxy that looks connected but delivers no advertisements.

A repeated subscribe from the same connection stays idempotent. Since a subscriber is always answered with an immediate scanner state response, a client can now also detect that its subscription landed.

Root cause analysis in home-assistant/core#175664; the proxy was verifiably streaming advertisements while Home Assistant received none, and `current_mode: null` in the diagnostics matched the scanner state response going to the stale subscriber as well. The client side workaround for devices running older firmware is Bluetooth-Devices/bleak-esphome#394.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes home-assistant/core#175664

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
bluetooth_proxy:
  active: true
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
