### PR TITLE
[libretiny] Use standard logger tag names

### DIFF
--- a/esphome/components/libretiny/gpio_arduino.cpp
+++ b/esphome/components/libretiny/gpio_arduino.cpp
@@ -5,7 +5,7 @@
 
 namespace esphome::libretiny {
 
-static const char *const TAG = "lt.gpio";
+static const char *const TAG = "libretiny.gpio";
 
 static int IRAM_ATTR flags_to_mode(gpio::Flags flags) {
   if (flags == gpio::FLAG_INPUT) {

--- a/esphome/components/libretiny/lt_component.cpp
+++ b/esphome/components/libretiny/lt_component.cpp
@@ -6,7 +6,7 @@
 
 namespace esphome::libretiny {
 
-static const char *const TAG = "lt.component";
+static const char *const TAG = "libretiny";
 
 void LTComponent::dump_config() {
   ESP_LOGCONFIG(TAG,


### PR DESCRIPTION
# What does this implement/fix?

The LibreTiny platform logs its config dump with the tags `lt.component` and `lt.gpio`. These do not match the component name, so the dashboard log viewer cannot link them to the component like it does for `wifi`, `api` and the other tags. This renames them to `libretiny` and `libretiny.gpio`, matching the existing `libretiny.pwm` tag.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
