### PR TITLE
[audio_file] Accept mp1/mp2 puremagic detections as MP3

### DIFF
--- a/esphome/components/audio_file/__init__.py
+++ b/esphome/components/audio_file/__init__.py
@@ -114,9 +114,9 @@ def read_audio_file_and_type(file_config: ConfigType) -> tuple[bytes, MockObj]:
     if file_type == "wav":
         media_file_type = audio.AUDIO_FILE_TYPE_ENUM["WAV"]
     elif file_type in ("mp3", "mpeg", "mpga", "mp1", "mp2"):
-        # puremagic's signature for the 0xFF 0xFB frame sync is ambiguous between MPEG-1
-        # Layer I/II/III and sometimes misidentifies genuine MP3 (Layer III) files as
-        # "mp1"/"mp2". The MP3 decoder handles any MPEG audio layer, so treat them as MP3.
+        # puremagic's signature for the 0xFF 0xFB frame sync is ambiguous between MPEG-1 audio layers.
+        # With puremagic >=2.0 this can cause some MP3 (Layer III) files to be labeled as "mp1"/"mp2".
+        # Treat those labels as MP3 so we still pick the MP3 decoder.
         media_file_type = audio.AUDIO_FILE_TYPE_ENUM["MP3"]
     elif file_type == "flac":
         media_file_type = audio.AUDIO_FILE_TYPE_ENUM["FLAC"]

--- a/esphome/components/audio_file/__init__.py
+++ b/esphome/components/audio_file/__init__.py
@@ -113,8 +113,7 @@ def read_audio_file_and_type(file_config: ConfigType) -> tuple[bytes, MockObj]:
     media_file_type = audio.AUDIO_FILE_TYPE_ENUM["NONE"]
     if file_type == "wav":
         media_file_type = audio.AUDIO_FILE_TYPE_ENUM["WAV"]
-    elif file_type in ("mp3", "mpeg", "mpga", "mp1", "mp2"):
-        # puremagic's signature for the 0xFF 0xFB frame sync is ambiguous between MPEG-1 audio layers.
+    elif file_type in ("mp1", "mp2", "mp3", "mpeg", "mpga"):
         # With puremagic >=2.0 this can cause some MP3 (Layer III) files to be labeled as "mp1"/"mp2".
         # Treat those labels as MP3 so we still pick the MP3 decoder.
         media_file_type = audio.AUDIO_FILE_TYPE_ENUM["MP3"]

--- a/esphome/components/audio_file/__init__.py
+++ b/esphome/components/audio_file/__init__.py
@@ -113,7 +113,10 @@ def read_audio_file_and_type(file_config: ConfigType) -> tuple[bytes, MockObj]:
     media_file_type = audio.AUDIO_FILE_TYPE_ENUM["NONE"]
     if file_type == "wav":
         media_file_type = audio.AUDIO_FILE_TYPE_ENUM["WAV"]
-    elif file_type in ("mp3", "mpeg", "mpga"):
+    elif file_type in ("mp3", "mpeg", "mpga", "mp1", "mp2"):
+        # puremagic's signature for the 0xFF 0xFB frame sync is ambiguous between MPEG-1
+        # Layer I/II/III and sometimes misidentifies genuine MP3 (Layer III) files as
+        # "mp1"/"mp2". The MP3 decoder handles any MPEG audio layer, so treat them as MP3.
         media_file_type = audio.AUDIO_FILE_TYPE_ENUM["MP3"]
     elif file_type == "flac":
         media_file_type = audio.AUDIO_FILE_TYPE_ENUM["FLAC"]


### PR DESCRIPTION
# What does this implement/fix?

`audio_file` uses the `puremagic` library to sniff the type of a media file so it can be
routed to the right decoder. With `puremagic` **2.0 and higher**, the signature table for
the MPEG frame sync bytes `0xFF 0xFB` changed and became ambiguous between MPEG-1 Layer
I/II/III. For some real-world MP3s (Layer III), `puremagic>=2.0` now returns `mp1`
(MPEG-1 Layer I) instead of `mp3`/`mpga`, even though the file is a perfectly valid MP3.

Since `audio_file` only accepted `mp3`, `mpeg`, and `mpga` as MP3 matches, any file that
puremagic mis-tags as `mp1` (or `mp2`) was rejected outright with:

Unsupported media file from '<url>' (detected type: audio::AudioFileType::NONE).



**Example that reproduces this:**

```yaml
audio_file:
  - id: factory_reset_sound
    file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/factory_reset_confirmed.mp3
```

I confirmed with puremagic==2.2.0 (the version currently pinned in requirements.txt)
that puremagic.from_string() returns .mp1 for this exact file, with a low confidence
score of 0.2 and no other candidate matches, it's simply guessing wrong on the
ambiguous frame sync, not detecting an actually-different format. With puremagic<2.0
the same file correctly comes back as mpga, which is why this only started failing
after the puremagic 2.x upgrade.

The MP3 decoder ESPHome uses is a generic MPEG audio decoder (not Layer-III-only), so
mp1/mp2 detections can safely be treated the same as mp3 for the purposes of
choosing a decoder, the fix just widens the accepted set of puremagic labels rather
than trying to work around puremagic's internal ambiguity.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
audio_file:
  - id: factory_reset_sound
    file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/factory_reset_confirmed.mp3

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
