### PR TITLE
[internal_temperature] Support all ESP32 variants with a temperature sensor

### DIFF
--- a/esphome/components/internal_temperature/internal_temperature_esp32.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_esp32.cpp
@@ -8,10 +8,8 @@
 extern "C" {
 uint8_t temprature_sens_read();
 }
-#elif defined(USE_ESP32_VARIANT_ESP32C2) || defined(USE_ESP32_VARIANT_ESP32C3) || \
-    defined(USE_ESP32_VARIANT_ESP32C5) || defined(USE_ESP32_VARIANT_ESP32C6) || defined(USE_ESP32_VARIANT_ESP32C61) || \
-    defined(USE_ESP32_VARIANT_ESP32H2) || defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || \
-    defined(USE_ESP32_VARIANT_ESP32S3)
+#elif !defined(USE_ESP32_VARIANT_ESP32H21)
+// the ESP32-H21 has no temperature sensor in ESP-IDF yet (IDF-11624)
 #include "driver/temperature_sensor.h"
 #endif  // USE_ESP32_VARIANT
 
@@ -27,10 +25,7 @@ void InternalTemperatureSensor::update() {
   ESP_LOGV(TAG, "Raw temperature value: %d", raw);
   temperature = (raw - 32) / 1.8f;
   success = (raw != 128);
-#elif defined(USE_ESP32_VARIANT_ESP32C2) || defined(USE_ESP32_VARIANT_ESP32C3) || \
-    defined(USE_ESP32_VARIANT_ESP32C5) || defined(USE_ESP32_VARIANT_ESP32C6) || defined(USE_ESP32_VARIANT_ESP32C61) || \
-    defined(USE_ESP32_VARIANT_ESP32H2) || defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || \
-    defined(USE_ESP32_VARIANT_ESP32S3)
+#elif !defined(USE_ESP32_VARIANT_ESP32H21)
   esp_err_t result = temperature_sensor_get_celsius(this->tsens_, &temperature);
   success = (result == ESP_OK);
   if (!success) {
@@ -49,9 +44,7 @@ void InternalTemperatureSensor::update() {
 }
 
 void InternalTemperatureSensor::setup() {
-#if defined(USE_ESP32_VARIANT_ESP32C2) || defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C5) || \
-    defined(USE_ESP32_VARIANT_ESP32C6) || defined(USE_ESP32_VARIANT_ESP32C61) || defined(USE_ESP32_VARIANT_ESP32H2) || \
-    defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if !defined(USE_ESP32_VARIANT_ESP32) && !defined(USE_ESP32_VARIANT_ESP32H21)
   temperature_sensor_config_t tsens_config = TEMPERATURE_SENSOR_CONFIG_DEFAULT(-10, 80);
 
   esp_err_t result = temperature_sensor_install(&tsens_config, &this->tsens_);

--- a/esphome/components/internal_temperature/internal_temperature_esp32.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_esp32.cpp
@@ -3,14 +3,16 @@
 #include "esphome/core/log.h"
 #include "internal_temperature.h"
 
+#include <soc/soc_caps.h>
+
 #if defined(USE_ESP32_VARIANT_ESP32)
 // there is no official API available on the original ESP32
 extern "C" {
 uint8_t temprature_sens_read();
 }
-#else
+#elif SOC_TEMP_SENSOR_SUPPORTED
 #include "driver/temperature_sensor.h"
-#endif  // USE_ESP32_VARIANT
+#endif
 
 namespace esphome::internal_temperature {
 
@@ -24,7 +26,7 @@ void InternalTemperatureSensor::update() {
   ESP_LOGV(TAG, "Raw temperature value: %d", raw);
   temperature = (raw - 32) / 1.8f;
   success = (raw != 128);
-#else
+#elif SOC_TEMP_SENSOR_SUPPORTED
   esp_err_t result = temperature_sensor_get_celsius(this->tsens_, &temperature);
   success = (result == ESP_OK);
   if (!success) {
@@ -43,7 +45,7 @@ void InternalTemperatureSensor::update() {
 }
 
 void InternalTemperatureSensor::setup() {
-#ifndef USE_ESP32_VARIANT_ESP32
+#if !defined(USE_ESP32_VARIANT_ESP32) && SOC_TEMP_SENSOR_SUPPORTED
   temperature_sensor_config_t tsens_config = TEMPERATURE_SENSOR_CONFIG_DEFAULT(-10, 80);
 
   esp_err_t result = temperature_sensor_install(&tsens_config, &this->tsens_);

--- a/esphome/components/internal_temperature/internal_temperature_esp32.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_esp32.cpp
@@ -45,7 +45,7 @@ void InternalTemperatureSensor::update() {
 }
 
 void InternalTemperatureSensor::setup() {
-#if !defined(USE_ESP32_VARIANT_ESP32) && SOC_TEMP_SENSOR_SUPPORTED
+#if SOC_TEMP_SENSOR_SUPPORTED
   temperature_sensor_config_t tsens_config = TEMPERATURE_SENSOR_CONFIG_DEFAULT(-10, 80);
 
   esp_err_t result = temperature_sensor_install(&tsens_config, &this->tsens_);

--- a/esphome/components/internal_temperature/internal_temperature_esp32.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_esp32.cpp
@@ -8,8 +8,7 @@
 extern "C" {
 uint8_t temprature_sens_read();
 }
-#elif !defined(USE_ESP32_VARIANT_ESP32H21)
-// the ESP32-H21 has no temperature sensor in ESP-IDF yet (IDF-11624)
+#else
 #include "driver/temperature_sensor.h"
 #endif  // USE_ESP32_VARIANT
 
@@ -25,7 +24,7 @@ void InternalTemperatureSensor::update() {
   ESP_LOGV(TAG, "Raw temperature value: %d", raw);
   temperature = (raw - 32) / 1.8f;
   success = (raw != 128);
-#elif !defined(USE_ESP32_VARIANT_ESP32H21)
+#else
   esp_err_t result = temperature_sensor_get_celsius(this->tsens_, &temperature);
   success = (result == ESP_OK);
   if (!success) {
@@ -44,7 +43,7 @@ void InternalTemperatureSensor::update() {
 }
 
 void InternalTemperatureSensor::setup() {
-#if !defined(USE_ESP32_VARIANT_ESP32) && !defined(USE_ESP32_VARIANT_ESP32H21)
+#ifndef USE_ESP32_VARIANT_ESP32
   temperature_sensor_config_t tsens_config = TEMPERATURE_SENSOR_CONFIG_DEFAULT(-10, 80);
 
   esp_err_t result = temperature_sensor_install(&tsens_config, &this->tsens_);


### PR DESCRIPTION
# What does this implement/fix?

The ESP32 implementation gated the ESP-IDF temperature sensor driver behind a whitelist of variants that predates the ESP32-S31 and ESP32-H4 scaffolding from #16700, so those chips fell through to the no-op path (sensor reports NAN). Instead of extending the list, exclude only the original ESP32 (which uses the legacy `temprature_sens_read()` API) — the same form `internal_temperature.h` already uses — so any variant with the sensor is supported without further changes.

ESP32-S31 and ESP32-H4 both have `SOC_TEMP_SENSOR_SUPPORTED` in ESP-IDF v6.1-beta1. The ESP32-H21 does not yet (`IDF-11624`, [soc_caps.h#L39](https://github.com/espressif/esp-idf/blob/v6.1-beta1/components/soc/esp32h21/include/soc/soc_caps.h#L39)); it has no boards and cannot be meaningfully built today, and it starts working here automatically once that lands.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: internal_temperature
    name: "Internal Temperature"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).