### PR TITLE
[lvgl] Fix ImageValidator.process signature to match base

### DIFF
--- a/esphome/components/lvgl/lv_validation.py
+++ b/esphome/components/lvgl/lv_validation.py
@@ -422,7 +422,7 @@ class ImageValidator(LValidator):
                 index = await metadata.from_.convert_value(index)
             return mapping_var.get(index)
 
-        return await super().process(value, args)
+        return await super().process(value, args, raw_lambda)
 
 
 lv_image = ImageValidator()

--- a/esphome/components/lvgl/lv_validation.py
+++ b/esphome/components/lvgl/lv_validation.py
@@ -398,7 +398,10 @@ class ImageValidator(LValidator):
         )
 
     async def process(
-        self, value: Any, args: list[tuple[SafeExpType, str]] | None = None
+        self,
+        value: Any,
+        args: list[tuple[SafeExpType, str]] | None = None,
+        raw_lambda: bool = False,
     ) -> Expression:
         # Local import to avoid circular import at module level
         from .lvcode import get_lambda_context_args


### PR DESCRIPTION
# What does this implement/fix?

The base `LValidator.process` gained a `raw_lambda` parameter in #16796 (Add animations). Shortly after, #15863 (Add mapping) added `ImageValidator.process` as an override but without `raw_lambda`, so the override no longer matches the base signature. pylint flags this as `W0221 (arguments-differ)`.

Because #16796 was already merged when #15863 landed, #15863's stale pylint check never re-ran against the 4-parameter base, so the mismatch slipped in. Since the "Check pylint" job runs over the whole codebase, this turns it red on every open PR against `dev`.

This adds the missing `raw_lambda: bool = False` parameter so the override matches the base. `ImageValidator` handles its own lambda/mapping cases and does not use `raw_lambda`; the parameter only needs to exist to match. No behavior change.

The sibling overrides (`TextValidator.process` and the font validator's `process`) already carry the parameter, so `ImageValidator` is the only one affected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - lint-only fix
```

## Checklist:

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).