### PR TITLE
2026.6.5

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.6.4
+PROJECT_NUMBER         = 2026.6.5
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     -r /requirements.txt
 
 # Install the ESPHome Device Builder dashboard.
-RUN uv pip install --no-cache-dir esphome-device-builder==1.0.27
+RUN uv pip install --no-cache-dir esphome-device-builder==1.0.28
 
 RUN \
     platformio settings set enable_telemetry No \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     -r /requirements.txt
 
 # Install the ESPHome Device Builder dashboard.
-RUN uv pip install --no-cache-dir esphome-device-builder==1.0.23
+RUN uv pip install --no-cache-dir esphome-device-builder==1.0.24
 
 RUN \
     platformio settings set enable_telemetry No \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     -r /requirements.txt
 
 # Install the ESPHome Device Builder dashboard.
-RUN uv pip install --no-cache-dir esphome-device-builder==1.0.28
+RUN uv pip install --no-cache-dir esphome-device-builder==1.0.29
 
 RUN \
     platformio settings set enable_telemetry No \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     -r /requirements.txt
 
 # Install the ESPHome Device Builder dashboard.
-RUN uv pip install --no-cache-dir esphome-device-builder==1.0.26
+RUN uv pip install --no-cache-dir esphome-device-builder==1.0.27
 
 RUN \
     platformio settings set enable_telemetry No \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     -r /requirements.txt
 
 # Install the ESPHome Device Builder dashboard.
-RUN uv pip install --no-cache-dir esphome-device-builder==1.0.29
+RUN uv pip install --no-cache-dir esphome-device-builder==1.1.0
 
 RUN \
     platformio settings set enable_telemetry No \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     -r /requirements.txt
 
 # Install the ESPHome Device Builder dashboard.
-RUN uv pip install --no-cache-dir esphome-device-builder==1.0.25
+RUN uv pip install --no-cache-dir esphome-device-builder==1.0.26
 
 RUN \
     platformio settings set enable_telemetry No \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     -r /requirements.txt
 
 # Install the ESPHome Device Builder dashboard.
-RUN uv pip install --no-cache-dir esphome-device-builder==1.0.24
+RUN uv pip install --no-cache-dir esphome-device-builder==1.0.25
 
 RUN \
     platformio settings set enable_telemetry No \

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2026.6.4"
+__version__ = "2026.6.5"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Bump bundled esphome-device-builder to 1.0.24 [esphome#17332](https://github.com/esphome/esphome/pull/17332)
- Bump bundled esphome-device-builder to 1.0.25 [esphome#17333](https://github.com/esphome/esphome/pull/17333)
- Bump bundled esphome-device-builder to 1.0.26 [esphome#17369](https://github.com/esphome/esphome/pull/17369)
- Bump bundled esphome-device-builder to 1.0.27 [esphome#17370](https://github.com/esphome/esphome/pull/17370)
- Bump bundled esphome-device-builder to 1.0.28 [esphome#17382](https://github.com/esphome/esphome/pull/17382)
- Bump bundled esphome-device-builder to 1.0.29 [esphome#17384](https://github.com/esphome/esphome/pull/17384)
- Bump bundled esphome-device-builder to 1.1.0 [esphome#17412](https://github.com/esphome/esphome/pull/17412)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
