### PR TITLE
[gsl3670] Reference the test display explicitly so grouped CI builds validate

### DIFF
--- a/tests/components/gsl3670/test.esp32-s3-idf.yaml
+++ b/tests/components/gsl3670/test.esp32-s3-idf.yaml
@@ -6,7 +6,8 @@ xl9535:
   id: expander
 
 display:
-  - platform: mipi_spi
+  - id: gsl3670_display
+    platform: mipi_spi
     spi_id: spi_bus
     model: t-display-s3-pro
 
@@ -17,10 +18,12 @@ touchscreen:
   # Firmware downloaded from the model's default release URL and cached.
   - platform: gsl3670
     model: seeed-reterminal-d1001
+    display: gsl3670_display
     interrupt_pin: 18
   # Explicit firmware URL + SHA-256 override.
   - platform: gsl3670
     model: seeed-reterminal-d1001
+    display: gsl3670_display
     reset_pin: 10
     interrupt_pin: 11
     firmware:

--- a/tests/components/gsl3670/test.esp32-s3-idf.yaml
+++ b/tests/components/gsl3670/test.esp32-s3-idf.yaml
@@ -6,8 +6,8 @@ xl9535:
   id: expander
 
 display:
-  - id: gsl3670_display
-    platform: mipi_spi
+  - platform: mipi_spi
+    id: gsl3670_display
     spi_id: spi_bus
     model: t-display-s3-pro
 


### PR DESCRIPTION
# What does this implement/fix?

The gsl3670 test config defines its own `mipi_spi` display but never gives it an id, and neither `touchscreen:` entry sets `display:`. The touchscreen schema then auto-resolves the display reference by type, which works when the config contains exactly one display — but fails when CI's component grouping merges the test with other display components (e.g. `qspi_dbi`, `epaper_spi`):

```
touchscreen.gsl3670: Too many candidates found for 'display' type 'display::Display' One is 'qspi_dbi_main_lcd'.
```

This is currently failing the 2026.7.0b1 beta CI (#17460), where gsl3670 got grouped with qspi_dbi and epaper_spi for the first time:
https://github.com/esphome/esphome/actions/runs/28985578984/job/86014447348?pr=17460

Fix is the same pattern the other touchscreen tests use (e.g. cst816): give the display an explicit id and reference it from both touchscreen entries.

Verified locally with the CI repro command:

```
script/test_build_components.py -c epaper_spi,gsl3670,micro_wake_word,mixer,qspi_dbi,resampler,sound_level -t esp32-s3-idf -e config
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Test-only change, no user-facing configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).