### PR TITLE
[ci] Stop per-PR cache copies from crowding the 10GB Actions cache quota

### DIFF
--- a/.github/actions/restore-python/action.yml
+++ b/.github/actions/restore-python/action.yml
@@ -35,6 +35,11 @@ runs:
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         enable-cache: true
+        # Pull request runs restore the uv cache from the dev branch scope
+        # but must not save: a save from a pull request lands in that pull
+        # request's own scope where no other run can use it, and dozens of
+        # such copies crowd the repository's 10GB cache quota.
+        save-cache: ${{ github.event_name != 'pull_request' }}
         # Pin uv version so the action does not have to fetch the
         # manifest from raw.githubusercontent.com on every cache
         # miss; that fetch flakes on Windows runners.

--- a/.github/actions/restore-python/action.yml
+++ b/.github/actions/restore-python/action.yml
@@ -35,10 +35,8 @@ runs:
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         enable-cache: true
-        # Pull request runs restore the uv cache from the dev branch scope
-        # but must not save: a save from a pull request lands in that pull
-        # request's own scope where no other run can use it, and dozens of
-        # such copies crowd the repository's 10GB cache quota.
+        # Pull request saves land in per-PR scopes nothing else can
+        # reuse; dev pushes seed the shared copy instead.
         save-cache: ${{ github.event_name != 'pull_request' }}
         # Pin uv version so the action does not have to fetch the
         # manifest from raw.githubusercontent.com on every cache

--- a/.github/workflows/ci-api-proto.yml
+++ b/.github/workflows/ci-api-proto.yml
@@ -32,6 +32,10 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
+          # This workflow only runs on pull requests, so a save would land
+          # in the pull request's own cache scope where no other run can
+          # use it; those copies only crowd the repository's 10GB quota.
+          save-cache: "false"
           # Pin uv version so the action does not have to fetch the
           # manifest from raw.githubusercontent.com on every cache
           # miss; that fetch flakes on Windows runners.

--- a/.github/workflows/ci-api-proto.yml
+++ b/.github/workflows/ci-api-proto.yml
@@ -32,9 +32,8 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
-          # This workflow only runs on pull requests, so a save would land
-          # in the pull request's own cache scope where no other run can
-          # use it; those copies only crowd the repository's 10GB quota.
+          # Pull-request-only workflow: a save could never be shared and
+          # would only consume quota.
           save-cache: "false"
           # Pin uv version so the action does not have to fetch the
           # manifest from raw.githubusercontent.com on every cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1037,7 +1037,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
-          # Must match the key esphome/pre-commit-action computes in pre-commit-ci-lite
+          # Must match the restore key in pre-commit-ci-lite
           # yamllint disable-line rule:line-length
           key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install pre-commit hook environments
@@ -1061,9 +1061,22 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
-      - uses: esphome/pre-commit-action@43cd1109c09c544d97196f7730ee5b2e0cc6d81e # v3.0.1 fork with pinned actions/cache
+      # Inlined from esphome/pre-commit-action with a restore-only cache
+      # step: the pre-commit-seed-cache job owns saving this cache, so
+      # pull request runs never write per-PR copies.
+      - name: Restore pre-commit cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pre-commit
+          # Must match the key pre-commit-seed-cache saves
+          # yamllint disable-line rule:line-length
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit
         env:
           SKIP: pylint,ci-custom
+        run: |
+          python -m pip install pre-commit
+          pre-commit run --show-diff-on-failure --color=always --all-files
       - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
         if: always()
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,8 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
-          # Pull request runs restore the uv cache from the dev branch scope
-          # but must not save: a save from a pull request lands in that pull
-          # request's own scope where no other run can use it, and dozens of
-          # such copies crowd the repository's 10GB cache quota.
+          # Pull request saves land in per-PR scopes nothing else can
+          # reuse; dev pushes seed the shared copy instead.
           save-cache: ${{ github.event_name != 'pull_request' }}
           # Pin uv version so the action does not have to fetch the
           # manifest from raw.githubusercontent.com on every cache
@@ -179,10 +177,8 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
-          # Pull request runs restore the uv cache from the dev branch scope
-          # but must not save: a save from a pull request lands in that pull
-          # request's own scope where no other run can use it, and dozens of
-          # such copies crowd the repository's 10GB cache quota.
+          # Pull request saves land in per-PR scopes nothing else can
+          # reuse; dev pushes seed the shared copy instead.
           save-cache: ${{ github.event_name != 'pull_request' }}
           # Pin uv version so the action does not have to fetch the
           # manifest from raw.githubusercontent.com on every cache
@@ -385,10 +381,8 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
-          # Pull request runs restore the uv cache from the dev branch scope
-          # but must not save: a save from a pull request lands in that pull
-          # request's own scope where no other run can use it, and dozens of
-          # such copies crowd the repository's 10GB cache quota.
+          # Pull request saves land in per-PR scopes nothing else can
+          # reuse; dev pushes seed the shared copy instead.
           save-cache: ${{ github.event_name != 'pull_request' }}
           # Pin uv version so the action does not have to fetch the
           # manifest from raw.githubusercontent.com on every cache
@@ -844,10 +838,8 @@ jobs:
         run: echo ${{ matrix.batch.components }}
 
       - name: Install apt packages
-        # Installed directly instead of through cache-apt-pkgs-action: this
-        # job only runs on pull requests, so the action saved a ~21MB cache
-        # into every pull request's own scope that no other run could reuse.
-        # A plain install takes seconds and costs no cache quota.
+        # Not cached: this job is pull-request-only, so a cache save could
+        # never be shared and would only consume quota.
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends libsdl2-dev ccache
@@ -1029,12 +1021,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - common
-    # pre-commit.ci lite only runs on pull requests, so it can never save its
-    # cache to the dev branch scope. Without a dev-scoped copy every pull
-    # request misses, rebuilds the hook environments, and saves a private
-    # ~32MB copy into its own merge ref, which crowds out more valuable
-    # caches once the repository hits the 10GB quota. This job saves one
-    # shared copy on every dev push that changes the pre-commit config.
+    # Saves a dev-scoped pre-commit cache that pull request runs can
+    # restore, since pre-commit.ci lite itself never runs on dev pushes.
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     steps:
       - name: Check out code from GitHub
@@ -1049,9 +1037,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
-          # Must match the key esphome/pre-commit-action computes in the
-          # pre-commit-ci-lite job so pull request runs restore this entry
-          # from the dev scope instead of saving their own copies.
+          # Must match the key esphome/pre-commit-action computes in pre-commit-ci-lite
           # yamllint disable-line rule:line-length
           key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install pre-commit hook environments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
+          # Pull request runs restore the uv cache from the dev branch scope
+          # but must not save: a save from a pull request lands in that pull
+          # request's own scope where no other run can use it, and dozens of
+          # such copies crowd the repository's 10GB cache quota.
+          save-cache: ${{ github.event_name != 'pull_request' }}
           # Pin uv version so the action does not have to fetch the
           # manifest from raw.githubusercontent.com on every cache
           # miss; that fetch flakes on Windows runners.
@@ -174,6 +179,11 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
+          # Pull request runs restore the uv cache from the dev branch scope
+          # but must not save: a save from a pull request lands in that pull
+          # request's own scope where no other run can use it, and dozens of
+          # such copies crowd the repository's 10GB cache quota.
+          save-cache: ${{ github.event_name != 'pull_request' }}
           # Pin uv version so the action does not have to fetch the
           # manifest from raw.githubusercontent.com on every cache
           # miss; that fetch flakes on Windows runners.
@@ -375,6 +385,11 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
+          # Pull request runs restore the uv cache from the dev branch scope
+          # but must not save: a save from a pull request lands in that pull
+          # request's own scope where no other run can use it, and dozens of
+          # such copies crowd the repository's 10GB cache quota.
+          save-cache: ${{ github.event_name != 'pull_request' }}
           # Pin uv version so the action does not have to fetch the
           # manifest from raw.githubusercontent.com on every cache
           # miss; that fetch flakes on Windows runners.
@@ -828,11 +843,14 @@ jobs:
       - name: List components
         run: echo ${{ matrix.batch.components }}
 
-      - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
-        with:
-          packages: libsdl2-dev ccache
-          version: 1.1
+      - name: Install apt packages
+        # Installed directly instead of through cache-apt-pkgs-action: this
+        # job only runs on pull requests, so the action saved a ~21MB cache
+        # into every pull request's own scope that no other run could reuse.
+        # A plain install takes seconds and costs no cache quota.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libsdl2-dev ccache
 
       - name: Check out code from GitHub
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -1005,6 +1023,42 @@ jobs:
 
           # Arduino framework via PlatformIO (only components with an esp32-ard test are built):
           python3 script/test_build_components.py -e compile -t esp32-ard -c "$TEST_COMPONENTS" -f --toolchain platformio
+
+  pre-commit-seed-cache:
+    name: Seed pre-commit cache
+    runs-on: ubuntu-latest
+    needs:
+      - common
+    # pre-commit.ci lite only runs on pull requests, so it can never save its
+    # cache to the dev branch scope. Without a dev-scoped copy every pull
+    # request misses, rebuilds the hook environments, and saves a private
+    # ~32MB copy into its own merge ref, which crowds out more valuable
+    # caches once the repository hits the 10GB quota. This job saves one
+    # shared copy on every dev push that changes the pre-commit config.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Cache pre-commit environments
+        id: cache-pre-commit
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pre-commit
+          # Must match the key esphome/pre-commit-action computes in the
+          # pre-commit-ci-lite job so pull request runs restore this entry
+          # from the dev scope instead of saving their own copies.
+          # yamllint disable-line rule:line-length
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install pre-commit hook environments
+        if: steps.cache-pre-commit.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install pre-commit
+          pre-commit install-hooks
 
   pre-commit-ci-lite:
     name: pre-commit.ci lite


### PR DESCRIPTION
# What does this implement/fix?

The repository is pinned at its 10GB Actions cache quota (440 entries, every one last-accessed within 3 days because LRU eviction is churning constantly). Roughly 4GB of that is byte-identical data saved once per pull request into merge-ref scopes that no other run can read:

- **pre-commit hook environments**: 69 identical ~32MB copies (2.25GB). `pre-commit.ci lite` only runs on pull requests, so a dev-scoped copy never exists; every new PR misses, rebuilds (~25s measured), and saves a private copy.
- **apt packages** (`libsdl2-dev ccache`) in `test-build-components-split`: 63 identical ~21MB copies (1.33GB) caching a few seconds of `apt-get install` in a PR-only job.
- **setup-uv wheel caches**: ~0.8GB of per-PR copies across jobs.

The churn this causes evicts the caches that are actually expensive to rebuild (ESP-IDF install 1.6GB, sdk-nrf 1.4GB, clang-tidy PlatformIO objects — only the esp8266 tidy cache was still alive when we looked).

Changes:

1. **New `pre-commit-seed-cache` job**: runs on pushes to dev, saves one shared copy of `~/.cache/pre-commit` under the exact key the lint job restores (`pre-commit-3|<pythonLocation>|<config hash>`). No-op (seconds) when the key already exists.
2. **`pre-commit-ci-lite` is now restore-only**: the `esphome/pre-commit-action` composite (whose embedded `actions/cache` did the per-PR saves) is inlined as `actions/cache/restore` + `pip install pre-commit` + `pre-commit run`, same `SKIP` set, lite-action untouched. PR runs can no longer write this cache at all. A PR that edits `.pre-commit-config.yaml` rebuilds hook envs each push (~25s) instead of saving a private copy. This also removes ci.yml's only use of the pre-commit-action fork.
3. **`setup-uv` saves gated to non-PR events** (`save-cache: ${{ github.event_name != 'pull_request' }}`) in ci.yml and the `restore-python` composite; dev pushes seed, PRs restore. `ci-api-proto.yml` is PR-only so it gets a hard `save-cache: "false"`.
4. **apt cache dropped**: plain `apt-get install` in `test-build-components-split`; the job is PR-only so its cache could never be shared.

Measured on recent runs: the pre-commit cache is worth ~25s per miss (61–64s step on miss vs 35–41s on hit), so it stays — but as one shared 32MB entry instead of 2.25GB of duplicates. Existing per-PR copies drain on their own (7-day unused eviction / PR-close cleanup), so the quota relief lands within a week of merging.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

CI-only change; workflow YAML validated with yamllint and parse-checked. The seed job and the pre-commit restore use the same key expression, and the `common` job already runs on dev pushes to seed the venv/uv caches.

## Example entry for `config.yaml`:

```yaml
# CI-only change, no user-facing configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).