### PR TITLE
[docs] Document web server as an open HTTP API by design in threat model

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -79,6 +79,44 @@ These *are* security bugs in this repo, and we want to hear about them privately
 - Flaws that weaken the device's API encryption (Noise), OTA, or web server auth
   below their documented guarantees.
 
+## The web server is an open HTTP API by design
+
+The `web_server` component exposes a plain HTTP interface for viewing and
+controlling entities, and, when the `web_server` OTA platform is enabled, for
+uploading firmware at `/update`. Its only access controls are the optional
+`web_server` `auth:` credentials and the network the device sits on.
+
+When `auth:` is not configured, every endpoint is reachable by any client that
+can reach the device. This is intentional; enabling `web_server` without `auth:`
+is choosing an open control surface, in the same way that running native OTA
+without a password leaves OTA open. The API is documented and is meant to be
+called by other devices, scripts, and pages.
+
+The device performs no CSRF token, `Origin`, or `Referer` validation and returns
+a permissive CORS policy. Cross-origin requests are handled the same as any other
+network request, including requests a browser is induced to make by a page the
+operator visits (the "confused deputy", or CSRF, pattern). The following are
+therefore **not** vulnerabilities in this repository:
+
+- Cross-origin or CSRF requests to the control endpoints (for example, a page the
+  operator opens toggling a switch), whether or not `web_server` `auth:` is set.
+- Cross-origin reads of device state permitted by the CORS policy.
+- Cross-origin firmware upload through the web OTA endpoint (`/update`) when web
+  OTA is enabled without `web_server` `auth:`. This is the same exposure as
+  running OTA without a password.
+
+The supported defenses are `web_server` `auth:`, protecting OTA (a web password or
+a native OTA password), and keeping devices on a trusted, segmented network. See
+the security best practices guide linked above.
+
+What remains in scope is bypassing `web_server` `auth:` when it *is* configured,
+and any memory-safety or protocol bug in the server reachable without credentials.
+
+This section documents the current design and scope; it is not a judgment that the
+design is optimal or that it will not change. Optional hardening (for example an
+origin allowlist or opt-in CSRF checks) is welcome as a normal enhancement PR,
+framed as defense-in-depth rather than a security fix.
+
 ## Explicitly out of scope
 
 - Local attackers who already have shell access on the host that runs `esphome`.
@@ -86,6 +124,9 @@ These *are* security bugs in this repo, and we want to hear about them privately
 - Operator-supplied hostile YAML (covered above — config authoring is trusted).
 - Attacks that require an already-authenticated device peer (someone who already
   holds the API key / OTA / web credentials).
+- Cross-site (CSRF), cross-origin, or CORS behavior of the device web server and
+  its web OTA endpoint. The web server is an open HTTP API by design (see above);
+  gate it with `web_server` `auth:` and network isolation.
 - Anything in the dashboard / device-builder — report that in its own repository
   (linked at the top).
 - Deployments where the operator removed protections or exposed credentials. See


### PR DESCRIPTION
# What does this implement/fix?

Adds a section to `THREAT_MODEL.md` documenting that the `web_server` component is an intentionally open HTTP API. Its only access controls are the optional `web_server` `auth:` credentials and the network the device sits on, mirroring how native OTA without a password leaves OTA open.

The device does no CSRF token, `Origin`, or `Referer` validation and returns a permissive CORS policy, so cross-origin/CSRF requests to the control endpoints — and cross-origin firmware upload through the web OTA `/update` endpoint when web OTA is enabled without `auth:` — are handled like any other network request and are not treated as vulnerabilities in this repository. What remains in scope is bypassing `web_server` `auth:` when it is configured, and any memory-safety or protocol bug reachable without credentials. The new "Explicitly out of scope" bullet cross-references the section. The section also notes that optional hardening (origin allowlist, opt-in CSRF checks) is welcome as a normal defense-in-depth enhancement rather than a security fix.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).