### PR TITLE
[modbus] Add support for swapped word types (U_WORD_R, S_WORD_R)

### DIFF
--- a/esphome/components/modbus/helpers.py
+++ b/esphome/components/modbus/helpers.py
@@ -37,7 +37,9 @@ SensorValueType = SensorValueType_ns.enum("SensorValueType")
 SENSOR_VALUE_TYPE = {
     "RAW": SensorValueType.RAW,
     "U_WORD": SensorValueType.U_WORD,
+    "U_WORD_R": SensorValueType.U_WORD_R,
     "S_WORD": SensorValueType.S_WORD,
+    "S_WORD_R": SensorValueType.S_WORD_R,
     "U_DWORD": SensorValueType.U_DWORD,
     "U_DWORD_R": SensorValueType.U_DWORD_R,
     "S_DWORD": SensorValueType.S_DWORD,
@@ -53,7 +55,9 @@ SENSOR_VALUE_TYPE = {
 TYPE_REGISTER_MAP = {
     "RAW": 1,
     "U_WORD": 1,
+    "U_WORD_R": 1,
     "S_WORD": 1,
+    "S_WORD_R": 1,
     "U_DWORD": 2,
     "U_DWORD_R": 2,
     "S_DWORD": 2,
@@ -69,7 +73,9 @@ TYPE_REGISTER_MAP = {
 CPP_TYPE_REGISTER_MAP = {
     "RAW": cg.uint16,
     "U_WORD": cg.uint16,
+    "U_WORD_R": cg.uint16,
     "S_WORD": cg.int16,
+    "S_WORD_R": cg.int16,
     "U_DWORD": cg.uint32,
     "U_DWORD_R": cg.uint32,
     "S_DWORD": cg.int32,

--- a/esphome/components/modbus/modbus_helpers.cpp
+++ b/esphome/components/modbus/modbus_helpers.cpp
@@ -81,7 +81,9 @@ uint16_t client_frame_length(const uint8_t *frame, size_t size) {
 static size_t required_payload_size(SensorValueType sensor_value_type) {
   switch (sensor_value_type) {
     case SensorValueType::U_WORD:
+    case SensorValueType::U_WORD_R:
     case SensorValueType::S_WORD:
+    case SensorValueType::S_WORD_R:
       return 2;
     case SensorValueType::U_DWORD:
     case SensorValueType::FP32:
@@ -132,6 +134,12 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
     case SensorValueType::U_WORD:
       value = mask_and_shift_by_rightbit(get_data<uint16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
+    case SensorValueType::U_WORD_R: {
+      value = get_data<uint16_t>(data, offset);
+      value = static_cast<uint16_t>((value << 8) | (value >> 8));
+      value = mask_and_shift_by_rightbit(value, bitmask);
+      break;
+    }
     case SensorValueType::U_DWORD:
     case SensorValueType::FP32:
       value = get_data<uint32_t>(data, offset);
@@ -146,6 +154,12 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
     case SensorValueType::S_WORD:
       value = mask_and_shift_by_rightbit(get_data<int16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
+    case SensorValueType::S_WORD_R: {
+      value = get_data<uint16_t>(data, offset);
+      value = static_cast<uint16_t>((value << 8) | (value >> 8));
+      value = mask_and_shift_by_rightbit(static_cast<int16_t>(value), bitmask);
+      break;
+    }
     case SensorValueType::S_DWORD:
       value = mask_and_shift_by_rightbit(get_data<int32_t>(data, offset), bitmask);
       break;

--- a/esphome/components/modbus/modbus_helpers.h
+++ b/esphome/components/modbus/modbus_helpers.h
@@ -77,7 +77,9 @@ enum class SensorValueType : uint8_t {
   U_QWORD_R = 0xA,
   S_QWORD_R = 0xB,
   FP32 = 0xC,
-  FP32_R = 0xD
+  FP32_R = 0xD,
+  U_WORD_R = 0xE,  // 1 Register unsigned, bytes swapped
+  S_WORD_R = 0xF,  // 1 Register signed, bytes swapped
 };
 
 inline bool value_type_is_float(SensorValueType v) {
@@ -242,6 +244,12 @@ template<typename Container> void number_to_payload(Container &data, int64_t val
     case SensorValueType::S_WORD:
       data.push_back(value & 0xFFFF);
       break;
+    case SensorValueType::U_WORD_R:
+    case SensorValueType::S_WORD_R: {
+      uint16_t word = value & 0xFFFF;
+      data.push_back(static_cast<uint16_t>((word << 8) | (word >> 8)));
+      break;
+    }
     case SensorValueType::U_DWORD:
     case SensorValueType::S_DWORD:
     case SensorValueType::FP32:

--- a/esphome/components/modbus_server/modbus_server.h
+++ b/esphome/components/modbus_server/modbus_server.h
@@ -61,6 +61,7 @@ class ServerRegister {
   const char *format_value(int64_t value, char *buf, size_t buf_size) const {
     switch (this->value_type) {
       case SensorValueType::U_WORD:
+      case SensorValueType::U_WORD_R:
       case SensorValueType::U_DWORD:
       case SensorValueType::U_DWORD_R:
       case SensorValueType::U_QWORD:
@@ -68,6 +69,7 @@ class ServerRegister {
         buf_append_printf(buf, buf_size, 0, "%" PRIu64, static_cast<uint64_t>(value));
         return buf;
       case SensorValueType::S_WORD:
+      case SensorValueType::S_WORD_R:
       case SensorValueType::S_DWORD:
       case SensorValueType::S_DWORD_R:
       case SensorValueType::S_QWORD:

--- a/tests/component_tests/modbus_server/test_modbus_server.py
+++ b/tests/component_tests/modbus_server/test_modbus_server.py
@@ -82,3 +82,5 @@ def test_raw_value_type_rejected() -> None:
     with pytest.raises(cv.Invalid):
         validator("RAW")
     assert validator("U_WORD") == "U_WORD"
+    assert validator("U_WORD_R") == "U_WORD_R"
+    assert validator("S_WORD_R") == "S_WORD_R"

--- a/tests/components/modbus/modbus_helpers_test.cpp
+++ b/tests/components/modbus/modbus_helpers_test.cpp
@@ -194,12 +194,27 @@ TEST(ModbusHelpersTest, PayloadToNumberDecodesValidWord) {
   EXPECT_EQ(payload_to_number(std::span<const uint8_t>(data), SensorValueType::U_WORD, 0, 0xFFFFFFFF), 0x1234);
 }
 
+TEST(ModbusHelpersTest, PayloadToNumberDecodesSwappedUnsignedWord) {
+  const std::vector<uint8_t> data{0x34, 0x12};
+  EXPECT_EQ(payload_to_number(std::span<const uint8_t>(data), SensorValueType::U_WORD_R, 0, 0xFFFFFFFF), 0x1234);
+}
+
+TEST(ModbusHelpersTest, PayloadToNumberDecodesSwappedSignedWord) {
+  const std::vector<uint8_t> data{0xFE, 0xFF};
+  EXPECT_EQ(payload_to_number(std::span<const uint8_t>(data), SensorValueType::S_WORD_R, 0, 0xFFFFFFFF), -2);
+}
+
 // --- registers_to_number ---------------------------------------------------
 // Register words are host byte order; results must match the byte-based payload_to_number.
 
 TEST(ModbusHelpersTest, RegistersToNumberDecodesWord) {
   const uint16_t registers[] = {0x1234};
   EXPECT_EQ(registers_to_number(registers, 1, SensorValueType::U_WORD), 0x1234);
+}
+
+TEST(ModbusHelpersTest, RegistersToNumberDecodesSwappedWord) {
+  const uint16_t registers[] = {0x3412};
+  EXPECT_EQ(registers_to_number(registers, 1, SensorValueType::U_WORD_R), 0x1234);
 }
 
 TEST(ModbusHelpersTest, RegistersToNumberDecodesDwordHighWordFirst) {

--- a/tests/components/modbus_server/modbus_server_test.cpp
+++ b/tests/components/modbus_server/modbus_server_test.cpp
@@ -34,6 +34,21 @@ TEST(ModbusServerWrite, SingleWordSucceeds) {
   EXPECT_EQ(written, 0x1234);
 }
 
+TEST(ModbusServerWrite, SwappedWordSucceeds) {
+  ModbusServer server;
+  int64_t written = -1;
+  ServerRegister reg(0x0000, SensorValueType::U_WORD_R, 1);
+  reg.write_lambda = [&written](int64_t value) {
+    written = value;
+    return true;
+  };
+  server.add_server_register(&reg);
+
+  auto status = server.on_write_registers(0x0000, make_registers({0x3412}));
+  EXPECT_FALSE(status.has_value());
+  EXPECT_EQ(written, 0x1234);
+}
+
 // A multi-register value is decoded high word first and applied as a single number.
 TEST(ModbusServerWrite, DwordSucceeds) {
   ModbusServer server;
@@ -134,6 +149,19 @@ TEST(ModbusServerRead, SingleWordSucceeds) {
   EXPECT_FALSE(status.has_value());
   ASSERT_EQ(out.size(), 1u);
   EXPECT_EQ(out[0], 0x1234);
+}
+
+TEST(ModbusServerRead, SwappedWordReturnsByteSwappedRegister) {
+  ModbusServer server;
+  ServerRegister reg(0x0000, SensorValueType::U_WORD_R, 1);
+  reg.read_lambda = []() -> int64_t { return 0x1234; };
+  server.add_server_register(&reg);
+
+  RegisterValues out;
+  auto status = server.on_read_registers(0x0000, 1, out);
+  EXPECT_FALSE(status.has_value());
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0], 0x3412);
 }
 
 TEST(ModbusServerRead, DwordReturnsTwoWordsHighFirst) {

--- a/tests/integration/fixtures/uart_mock_modbus_server_controller.yaml
+++ b/tests/integration/fixtures/uart_mock_modbus_server_controller.yaml
@@ -64,9 +64,15 @@ modbus_server:
       - address: 0x01
         value_type: U_WORD
         read_lambda: return 99;
+      - address: 0x02
+        value_type: U_WORD_R
+        read_lambda: return 4660;
       - address: 0x03
         value_type: S_WORD
         read_lambda: return -99;
+      - address: 0x04
+        value_type: S_WORD_R
+        read_lambda: return -2;
       - address: 0x05
         value_type: U_DWORD
         read_lambda: return 16909060;
@@ -107,10 +113,22 @@ sensor:
     value_type: U_WORD
   - platform: modbus_controller
     modbus_controller_id: modbus_controller_1
+    name: "reg_u_word_r"
+    address: 0x02
+    register_type: holding
+    value_type: U_WORD_R
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller_1
     name: "reg_s_word"
     address: 0x03
     register_type: holding
     value_type: S_WORD
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller_1
+    name: "reg_s_word_r"
+    address: 0x04
+    register_type: holding
+    value_type: S_WORD_R
   - platform: modbus_controller
     modbus_controller_id: modbus_controller_1
     name: "reg_u_dword"

--- a/tests/integration/fixtures/uart_mock_modbus_server_controller_write.yaml
+++ b/tests/integration/fixtures/uart_mock_modbus_server_controller_write.yaml
@@ -45,9 +45,15 @@ globals:
   - id: stored_u_word
     type: uint16_t
     initial_value: "11"
+  - id: stored_u_word_r
+    type: uint16_t
+    initial_value: "4660"
   - id: stored_s_word
     type: int16_t
     initial_value: "-11"
+  - id: stored_s_word_r
+    type: int16_t
+    initial_value: "-2"
   - id: stored_u_dword
     type: uint32_t
     initial_value: "1001"
@@ -103,10 +109,18 @@ modbus_server:
         value_type: U_WORD
         read_lambda: return id(stored_u_word);
         write_lambda: id(stored_u_word) = x; return true;
+      - address: 0x02
+        value_type: U_WORD_R
+        read_lambda: return id(stored_u_word_r);
+        write_lambda: id(stored_u_word_r) = x; return true;
       - address: 0x03
         value_type: S_WORD
         read_lambda: return id(stored_s_word);
         write_lambda: id(stored_s_word) = x; return true;
+      - address: 0x04
+        value_type: S_WORD_R
+        read_lambda: return id(stored_s_word_r);
+        write_lambda: id(stored_s_word_r) = x; return true;
       - address: 0x05
         value_type: U_DWORD
         read_lambda: return id(stored_u_dword);
@@ -157,10 +171,22 @@ sensor:
     value_type: U_WORD
   - platform: modbus_controller
     modbus_controller_id: modbus_controller_1
+    name: "reg_u_word_r"
+    address: 0x02
+    register_type: holding
+    value_type: U_WORD_R
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller_1
     name: "reg_s_word"
     address: 0x03
     register_type: holding
     value_type: S_WORD
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller_1
+    name: "reg_s_word_r"
+    address: 0x04
+    register_type: holding
+    value_type: S_WORD_R
   - platform: modbus_controller
     modbus_controller_id: modbus_controller_1
     name: "reg_u_dword"
@@ -233,10 +259,26 @@ number:
     max_value: 65535
   - platform: modbus_controller
     modbus_controller_id: modbus_controller_1
+    name: "write_u_word_r"
+    address: 0x02
+    register_type: holding
+    value_type: U_WORD_R
+    min_value: 0
+    max_value: 65535
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller_1
     name: "write_s_word"
     address: 0x03
     register_type: holding
     value_type: S_WORD
+    min_value: -16777215
+    max_value: 16777215
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller_1
+    name: "write_s_word_r"
+    address: 0x04
+    register_type: holding
+    value_type: S_WORD_R
     min_value: -16777215
     max_value: 16777215
   - platform: modbus_controller

--- a/tests/integration/test_uart_mock_modbus.py
+++ b/tests/integration/test_uart_mock_modbus.py
@@ -211,7 +211,9 @@ async def test_uart_mock_modbus_server_controller(
 
     expected_values = {
         "reg_u_word": 99,
+        "reg_u_word_r": 4660,
         "reg_s_word": -99,
+        "reg_s_word_r": -2,
         "reg_u_dword": 16909060,
         "reg_s_dword": -16909060,
         "reg_u_dword_r": pytest.approx(67305985),
@@ -245,14 +247,16 @@ async def test_uart_mock_modbus_server_controller_write(
 
     Verifies that writing to modbus server registers via the controller updates
     the server's stored values, which are then read back correctly on the next poll.
-    All 12 value types are tested: U/S_WORD, U/S_DWORD(_R), U/S_QWORD(_R), FP32(_R).
+    All 14 value types are tested: U/S_WORD(_R), U/S_DWORD(_R), U/S_QWORD(_R), FP32(_R).
     """
 
     line_callback, error_log_lines, warning_log_lines = _make_modbus_line_callback()
 
     register_test_cases: dict[str, RegisterTestCase] = {
         "reg_u_word": RegisterTestCase(11, "write_u_word", 42, 42),
+        "reg_u_word_r": RegisterTestCase(4660, "write_u_word_r", 17185, 17185),
         "reg_s_word": RegisterTestCase(-11, "write_s_word", -42, -42),
+        "reg_s_word_r": RegisterTestCase(-2, "write_s_word_r", -257, -257),
         "reg_u_dword": RegisterTestCase(1001, "write_u_dword", 2002, 2002),
         "reg_s_dword": RegisterTestCase(-1001, "write_s_dword", -2002, -2002),
         "reg_u_dword_r": RegisterTestCase(3003, "write_u_dword_r", 4004, 4004),


### PR DESCRIPTION
# What does this implement/fix?

This pull request adds support for two new Modbus sensor value types: `U_WORD_R` (unsigned 16-bit word, bytes swapped) and `S_WORD_R` (signed 16-bit word, bytes swapped). These types are now fully supported across the Modbus component, including helpers, server, and controller logic, as well as in tests and configuration schemas. This enhancement allows for correct handling of devices that use byte-swapped single-word registers.

Added and extended unit tests for the new types in both C++ and Python test suites to verify correct decoding, encoding, and server/controller operations.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/orgs/esphome/discussions/3659

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6949

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  # P01 — DHW temperature [°C × 0.1]
  - platform: modbus_controller
    modbus_controller_id: hpi4
    id: p01
    name: "P01 DHW temperature"
    register_type: holding
    address: 170
    value_type: S_WORD_R
    unit_of_measurement: "°C"
    accuracy_decimals: 1
    device_class: temperature
    state_class: measurement
    filters:
      - multiply: 0.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
