### PR TITLE
[modbus] Add byte-swapped word types U_WORD_S and S_WORD_S

### DIFF
--- a/esphome/components/modbus/helpers.py
+++ b/esphome/components/modbus/helpers.py
@@ -38,7 +38,9 @@ SensorValueType = SensorValueType_ns.enum("SensorValueType")
 SENSOR_VALUE_TYPE = {
     "RAW": SensorValueType.RAW,
     "U_WORD": SensorValueType.U_WORD,
+    "U_WORD_S": SensorValueType.U_WORD_S,
     "S_WORD": SensorValueType.S_WORD,
+    "S_WORD_S": SensorValueType.S_WORD_S,
     "U_DWORD": SensorValueType.U_DWORD,
     "U_DWORD_R": SensorValueType.U_DWORD_R,
     "S_DWORD": SensorValueType.S_DWORD,
@@ -54,7 +56,9 @@ SENSOR_VALUE_TYPE = {
 TYPE_REGISTER_MAP = {
     "RAW": 1,
     "U_WORD": 1,
+    "U_WORD_S": 1,
     "S_WORD": 1,
+    "S_WORD_S": 1,
     "U_DWORD": 2,
     "U_DWORD_R": 2,
     "S_DWORD": 2,
@@ -70,7 +74,9 @@ TYPE_REGISTER_MAP = {
 CPP_TYPE_REGISTER_MAP = {
     "RAW": cg.uint16,
     "U_WORD": cg.uint16,
+    "U_WORD_S": cg.uint16,
     "S_WORD": cg.int16,
+    "S_WORD_S": cg.int16,
     "U_DWORD": cg.uint32,
     "U_DWORD_R": cg.uint32,
     "S_DWORD": cg.int32,

--- a/esphome/components/modbus/modbus_helpers.cpp
+++ b/esphome/components/modbus/modbus_helpers.cpp
@@ -169,7 +169,9 @@ bool is_client_pdu_standard(const uint8_t *pdu, size_t size) {
 static size_t required_payload_size(SensorValueType sensor_value_type) {
   switch (sensor_value_type) {
     case SensorValueType::U_WORD:
+    case SensorValueType::U_WORD_S:
     case SensorValueType::S_WORD:
+    case SensorValueType::S_WORD_S:
       return 2;
     case SensorValueType::U_DWORD:
     case SensorValueType::FP32:
@@ -220,6 +222,12 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
     case SensorValueType::U_WORD:
       value = mask_and_shift_by_rightbit(get_data<uint16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
+    case SensorValueType::U_WORD_S: {
+      value = get_data<uint16_t>(data, offset);
+      value = static_cast<uint16_t>((value << 8) | (value >> 8));
+      value = mask_and_shift_by_rightbit(value, bitmask);
+      break;
+    }
     case SensorValueType::U_DWORD:
     case SensorValueType::FP32:
       value = get_data<uint32_t>(data, offset);
@@ -234,6 +242,12 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
     case SensorValueType::S_WORD:
       value = mask_and_shift_by_rightbit(get_data<int16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
+    case SensorValueType::S_WORD_S: {
+      value = get_data<uint16_t>(data, offset);
+      value = static_cast<uint16_t>((value << 8) | (value >> 8));
+      value = mask_and_shift_by_rightbit(static_cast<int16_t>(value), bitmask);
+      break;
+    }
     case SensorValueType::S_DWORD:
       value = mask_and_shift_by_rightbit(get_data<int32_t>(data, offset), bitmask);
       break;

--- a/esphome/components/modbus/modbus_helpers.cpp
+++ b/esphome/components/modbus/modbus_helpers.cpp
@@ -223,9 +223,9 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
       value = mask_and_shift_by_rightbit(get_data<uint16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
     case SensorValueType::U_WORD_S: {
-      value = get_data<uint16_t>(data, offset);
-      value = static_cast<uint16_t>((value << 8) | (value >> 8));
-      value = mask_and_shift_by_rightbit(value, bitmask);
+      uint16_t word = get_data<uint16_t>(data, offset);
+      word = static_cast<uint16_t>((word << 8) | (word >> 8));
+      value = mask_and_shift_by_rightbit(word, bitmask);
       break;
     }
     case SensorValueType::U_DWORD:
@@ -243,9 +243,9 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
       value = mask_and_shift_by_rightbit(get_data<int16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
     case SensorValueType::S_WORD_S: {
-      value = get_data<uint16_t>(data, offset);
-      value = static_cast<uint16_t>((value << 8) | (value >> 8));
-      value = mask_and_shift_by_rightbit(static_cast<int16_t>(value), bitmask);
+      uint16_t word = get_data<uint16_t>(data, offset);
+      word = static_cast<uint16_t>((word << 8) | (word >> 8));
+      value = mask_and_shift_by_rightbit(static_cast<int16_t>(word), bitmask);
       break;
     }
     case SensorValueType::S_DWORD:

--- a/esphome/components/modbus/modbus_helpers.cpp
+++ b/esphome/components/modbus/modbus_helpers.cpp
@@ -223,8 +223,7 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
       value = mask_and_shift_by_rightbit(get_data<uint16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
     case SensorValueType::U_WORD_S: {
-      uint16_t word = get_data<uint16_t>(data, offset);
-      word = static_cast<uint16_t>((word << 8) | (word >> 8));
+      uint16_t word = byteswap(get_data<uint16_t>(data, offset));
       value = mask_and_shift_by_rightbit(word, bitmask);
       break;
     }
@@ -243,8 +242,7 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
       value = mask_and_shift_by_rightbit(get_data<int16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
     case SensorValueType::S_WORD_S: {
-      uint16_t word = get_data<uint16_t>(data, offset);
-      word = static_cast<uint16_t>((word << 8) | (word >> 8));
+      uint16_t word = byteswap(get_data<uint16_t>(data, offset));
       value = mask_and_shift_by_rightbit(static_cast<int16_t>(word), bitmask);
       break;
     }

--- a/esphome/components/modbus/modbus_helpers.h
+++ b/esphome/components/modbus/modbus_helpers.h
@@ -119,7 +119,9 @@ enum class SensorValueType : uint8_t {
   U_QWORD_R = 0xA,
   S_QWORD_R = 0xB,
   FP32 = 0xC,
-  FP32_R = 0xD
+  FP32_R = 0xD,
+  U_WORD_S = 0xE,  // 1 Register unsigned, bytes swapped
+  S_WORD_S = 0xF,  // 1 Register signed, bytes swapped
 };
 
 inline bool value_type_is_float(SensorValueType v) {
@@ -284,6 +286,12 @@ template<typename Container> void number_to_payload(Container &data, int64_t val
     case SensorValueType::S_WORD:
       data.push_back(value & 0xFFFF);
       break;
+    case SensorValueType::U_WORD_S:
+    case SensorValueType::S_WORD_S: {
+      uint16_t word = value & 0xFFFF;
+      data.push_back(static_cast<uint16_t>((word << 8) | (word >> 8)));
+      break;
+    }
     case SensorValueType::U_DWORD:
     case SensorValueType::S_DWORD:
     case SensorValueType::FP32:

--- a/esphome/components/modbus/modbus_helpers.h
+++ b/esphome/components/modbus/modbus_helpers.h
@@ -287,11 +287,9 @@ template<typename Container> void number_to_payload(Container &data, int64_t val
       data.push_back(value & 0xFFFF);
       break;
     case SensorValueType::U_WORD_S:
-    case SensorValueType::S_WORD_S: {
-      uint16_t word = value & 0xFFFF;
-      data.push_back(static_cast<uint16_t>((word << 8) | (word >> 8)));
+    case SensorValueType::S_WORD_S:
+      data.push_back(byteswap(static_cast<uint16_t>(value & 0xFFFF)));
       break;
-    }
     case SensorValueType::U_DWORD:
     case SensorValueType::S_DWORD:
     case SensorValueType::FP32:


### PR DESCRIPTION
This PR is part of a series for byte-swapped Modbus word types (`U_WORD_S` / `S_WORD_S`).

esphome/esphome:
- #17469
- #17829 (merge after 17469)
- #17831 (merge after 17469)
- #17832 (merge after 17829)

esphome/esphome.io:
- esphome/esphome.io#6949
- esphome/esphome.io#7042 (merge after 6949; depends on esphome 17469)
- esphome/esphome.io#7043 (merge after 6949; depends on esphome 17469/17829)

Series notes (esphbot / review follow-up):
- Adding `U_WORD_S` / `S_WORD_S` to `SENSOR_VALUE_TYPE` intentionally enables the types in `modbus_server` as well (shared map minus `RAW` only); exciton retracted the server objection on #17831.
- #17829 is `format_value` polish, not schema enablement.

---

# What does this implement/fix?

**This PR is part of a series** — adds Modbus helper encode/decode and Python schema for byte-swapped single-register word types `U_WORD_S` and `S_WORD_S` only.

Per review feedback (exciton), the new byte-swap word types use the `_S` suffix (byte swap within a register), not `_R` (register-order swap used by existing multi-register types such as `U_DWORD_R`). Existing `*_R` multi-register types are unchanged.

Server wiring, unit/integration tests, and docs land in follow-up PRs so this change stays reviewable and mergeable on its own.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/orgs/esphome/discussions/3659

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6949
- esphome/esphome.io#7042 (merge after 6949)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  # P01 — DHW temperature [°C × 0.1]
  - platform: modbus_controller
    modbus_controller_id: hpi4
    id: p01
    name: "P01 DHW temperature"
    register_type: holding
    address: 170
    value_type: S_WORD_S
    unit_of_measurement: "°C"
    accuracy_decimals: 1
    device_class: temperature
    state_class: measurement
    filters:
      - multiply: 0.1

number:
  # N01 — desired DWH tank temperature (20–55°C, step 1°C)
  - platform: modbus_controller
    modbus_controller_id: hpi4
    id: num_n01
    name: "N01 Desired DWH temperature"
    icon: "mdi:thermometer-water"
    register_type: holding
    address: 202
    value_type: U_WORD_S
    min_value: 20
    max_value: 55
    step: 1
    mode: box
    use_write_multiple: true
    unit_of_measurement: "°C"
    multiply: 10
```

## Checklist:

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

Note: tests and docs are deferred to follow-up PRs in this series (see list above). Helper encode/decode was previously covered by the combined draft; will be restored in the dedicated test PRs.

