### PR TITLE
[esp_audio_stack] Add ESP audio stack component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -176,6 +176,9 @@ esphome/components/esp32_improv/* @jesserockz
 esphome/components/esp32_rmt/* @jesserockz
 esphome/components/esp32_rmt_led_strip/* @jesserockz
 esphome/components/esp8266/* @esphome/core
+esphome/components/esp_audio_stack/* @n-IA-hane
+esphome/components/esp_audio_stack/microphone/* @n-IA-hane
+esphome/components/esp_audio_stack/speaker/* @n-IA-hane
 esphome/components/esp_ldo/* @clydebarrow
 esphome/components/espnow/* @jesserockz
 esphome/components/espnow/packet_transport/* @EasilyBoredEngineer

--- a/esphome/components/esp_audio_stack/__init__.py
+++ b/esphome/components/esp_audio_stack/__init__.py
@@ -1,0 +1,927 @@
+"""ESP Audio Stack Component - full-duplex I2S for simultaneous mic and speaker.
+
+Exposes standard ESPHome microphone and speaker platforms for compatibility with
+Voice Assistant, wake word, media playback and custom audio consumers.
+
+Multi-rate support: set output_sample_rate to convert mic audio internally.
+  sample_rate: I2S bus rate (e.g. 48000 for high-quality DAC output)
+  output_sample_rate: mic/AEC/MWW/VA rate (e.g. 16000, must divide sample_rate evenly)
+If output_sample_rate is omitted, no rate conversion occurs (backward compatible).
+"""
+
+from esphome import automation, pins
+import esphome.codegen as cg
+from esphome.components import i2c, psram
+from esphome.components.esp32 import (
+    add_idf_component,
+    add_idf_sdkconfig_option,
+    get_esp32_variant,
+    include_builtin_idf_component,
+)
+from esphome.components.esp32.const import VARIANT_ESP32P4, VARIANT_ESP32S3
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ADDRESS,
+    CONF_BITS_PER_SAMPLE,
+    CONF_I2C_ID,
+    CONF_ID,
+    CONF_INPUT,
+    CONF_NUM_CHANNELS,
+    CONF_ON_IDLE,
+    CONF_ON_START,
+    CONF_ON_STATE,
+    CONF_OUTPUT,
+    CONF_SAMPLE_RATE,
+    CONF_TYPE,
+    Framework,
+)
+
+CODEOWNERS = ["@n-IA-hane"]
+DEPENDENCIES = ["esp32"]
+
+CONF_I2S_LRCLK_PIN = "i2s_lrclk_pin"
+CONF_I2S_BCLK_PIN = "i2s_bclk_pin"
+CONF_I2S_MCLK_PIN = "i2s_mclk_pin"
+CONF_I2S_DIN_PIN = "i2s_din_pin"
+CONF_I2S_DOUT_PIN = "i2s_dout_pin"
+CONF_OUTPUT_SAMPLE_RATE = "output_sample_rate"
+CONF_PROCESSOR_ID = "processor_id"
+CONF_INPUT_GAIN = "input_gain"
+CONF_MASTER_VOLUME_MIN_DB = "master_volume_min_db"
+CONF_USE_STEREO_AEC_REFERENCE = "use_stereo_aec_reference"
+CONF_REFERENCE_CHANNEL = "reference_channel"
+CONF_SLOT_BIT_WIDTH = "slot_bit_width"
+CONF_CORRECT_DC_OFFSET = "correct_dc_offset"
+CONF_MIC_CHANNEL = "mic_channel"
+CONF_RX_SLOT_MODE = "rx_slot_mode"
+CONF_I2S_MODE = "i2s_mode"
+CONF_USE_APLL = "use_apll"
+CONF_I2S_NUM = "i2s_num"
+CONF_MCLK_MULTIPLE = "mclk_multiple"
+CONF_I2S_COMM_FMT = "i2s_comm_fmt"
+CONF_RX_BUS = "rx_bus"
+CONF_TX_BUS = "tx_bus"
+CONF_USE_TDM_REFERENCE = "use_tdm_reference"
+CONF_TDM_TOTAL_SLOTS = "tdm_total_slots"
+CONF_TDM_MIC_SLOT = "tdm_mic_slot"
+CONF_TDM_MIC_SLOTS = "tdm_mic_slots"
+CONF_TDM_REF_SLOT = "tdm_ref_slot"
+CONF_TDM_TX_SLOT = "tdm_tx_slot"
+CONF_ESP_AUDIO_STACK_ID = "esp_audio_stack_id"
+CONF_TASK_PRIORITY = "task_priority"
+CONF_TASK_CORE = "task_core"
+CONF_TASK_STACK_SIZE = "task_stack_size"
+CONF_DMA_DESC_NUM = "dma_desc_num"
+CONF_DMA_FRAME_NUM = "dma_frame_num"
+CONF_TX_CHANNEL = "tx_channel"
+CONF_SPEAKER_CHANNELS = "speaker_channels"
+CONF_BUFFERS_IN_PSRAM = "buffers_in_psram"
+CONF_AEC_REF_RING_IN_PSRAM = "aec_ref_ring_in_psram"
+CONF_AUDIO_TASK_STACK_IN_PSRAM = "audio_task_stack_in_psram"
+CONF_AEC_REFERENCE = "aec_reference"
+CONF_AEC_REFERENCE_BUFFER_MS = "aec_reference_buffer_ms"
+CONF_TELEMETRY = "telemetry"
+CONF_TELEMETRY_LOG_INTERVAL_FRAMES = "telemetry_log_interval_frames"
+CONF_AUDIO_EFFECTS = "audio_effects"
+CONF_RATE_CVT_COMPLEXITY = "rate_cvt_complexity"
+CONF_RATE_CVT_PERF_TYPE = "rate_cvt_perf_type"
+CONF_CODEC = "codec"
+CONF_MIC_SELECTED = "mic_selected"
+CONF_GAIN_DB = "gain_db"
+CONF_REF_CHANNEL = "ref_channel"
+CONF_REF_GAIN_DB = "ref_gain_db"
+CONF_USE_MCLK = "use_mclk"
+CONF_NO_DAC_REF = "no_dac_ref"
+CONF_ON_MIC_START = "on_mic_start"
+CONF_ON_MIC_IDLE = "on_mic_idle"
+CONF_ON_SPEAKER_START = "on_speaker_start"
+CONF_ON_SPEAKER_IDLE = "on_speaker_idle"
+CONF_ON_AMPLIFIER_REQUIRED = "on_amplifier_required"
+CONF_ON_AMPLIFIER_IDLE = "on_amplifier_idle"
+
+CODEC_KIND = {
+    "es8311": 1,
+    "es8388": 2,
+    "es8374": 3,
+    "es8389": 4,
+}
+RATE_CVT_PERF_TYPES = ("speed", "memory")
+
+# Keep realtime audio builds reproducible. These component-manager versions
+# are validated with the maintained ESP32-S3 and ESP32-P4 builds.
+ESP_AUDIO_EFFECTS_REF = "1.3.0~1"
+ESP_CODEC_DEV_REF = "1.5.10"
+
+I2S_OPTIONAL_MCLK = cv.Any(
+    cv.int_range(min=-1, max=-1),
+    pins.internal_gpio_output_pin_number,
+)
+
+I2S_RX_BUS_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_I2S_NUM): cv.int_range(min=0, max=2),
+        cv.Required(CONF_I2S_LRCLK_PIN): pins.internal_gpio_output_pin_number,
+        cv.Required(CONF_I2S_BCLK_PIN): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_I2S_MCLK_PIN, default=-1): I2S_OPTIONAL_MCLK,
+        cv.Required(CONF_I2S_DIN_PIN): pins.internal_gpio_input_pin_number,
+    }
+)
+
+I2S_TX_BUS_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_I2S_NUM): cv.int_range(min=0, max=2),
+        cv.Required(CONF_I2S_LRCLK_PIN): pins.internal_gpio_output_pin_number,
+        cv.Required(CONF_I2S_BCLK_PIN): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_I2S_MCLK_PIN, default=-1): I2S_OPTIONAL_MCLK,
+        cv.Required(CONF_I2S_DOUT_PIN): pins.internal_gpio_output_pin_number,
+    }
+)
+
+CODEC_INPUT_SCHEMA = cv.typed_schema(
+    {
+        "es7210": cv.Schema(
+            {
+                cv.Optional(CONF_ADDRESS, default=0x40): cv.i2c_address,
+                cv.Optional(CONF_MIC_SELECTED, default=0x0F): cv.hex_uint8_t,
+                cv.Optional(CONF_GAIN_DB, default=30.0): cv.float_range(
+                    min=0.0, max=37.5
+                ),
+                cv.Optional(CONF_REF_CHANNEL): cv.int_range(min=0, max=15),
+                cv.Optional(CONF_REF_GAIN_DB, default=0.0): cv.float_range(
+                    min=0.0, max=37.5
+                ),
+            }
+        ),
+        "es8311": cv.Schema(
+            {
+                cv.Optional(CONF_ADDRESS, default=0x18): cv.i2c_address,
+                cv.Optional(CONF_GAIN_DB, default=30.0): cv.float_range(
+                    min=0.0, max=37.5
+                ),
+                cv.Optional(CONF_USE_MCLK, default=True): cv.boolean,
+                cv.Optional(CONF_NO_DAC_REF, default=False): cv.boolean,
+            }
+        ),
+        "es8388": cv.Schema(
+            {
+                cv.Optional(CONF_ADDRESS, default=0x20): cv.i2c_address,
+                cv.Optional(CONF_GAIN_DB, default=30.0): cv.float_range(
+                    min=0.0, max=37.5
+                ),
+            }
+        ),
+        "es8374": cv.Schema(
+            {
+                cv.Optional(CONF_ADDRESS, default=0x20): cv.i2c_address,
+                cv.Optional(CONF_GAIN_DB, default=30.0): cv.float_range(
+                    min=0.0, max=37.5
+                ),
+            }
+        ),
+        "es8389": cv.Schema(
+            {
+                cv.Optional(CONF_ADDRESS, default=0x20): cv.i2c_address,
+                cv.Optional(CONF_GAIN_DB, default=30.0): cv.float_range(
+                    min=0.0, max=37.5
+                ),
+                cv.Optional(CONF_USE_MCLK, default=True): cv.boolean,
+                cv.Optional(CONF_NO_DAC_REF, default=False): cv.boolean,
+            }
+        ),
+    },
+    lower=True,
+    default_type="es7210",
+)
+
+CODEC_OUTPUT_SCHEMA = cv.typed_schema(
+    {
+        "es8311": cv.Schema(
+            {
+                cv.Optional(CONF_ADDRESS, default=0x18): cv.i2c_address,
+                cv.Optional(CONF_USE_MCLK, default=True): cv.boolean,
+                cv.Optional(CONF_NO_DAC_REF, default=True): cv.boolean,
+            }
+        ),
+        "es8388": cv.Schema(
+            {
+                cv.Optional(CONF_ADDRESS, default=0x20): cv.i2c_address,
+            }
+        ),
+        "es8374": cv.Schema(
+            {
+                cv.Optional(CONF_ADDRESS, default=0x20): cv.i2c_address,
+            }
+        ),
+        "es8389": cv.Schema(
+            {
+                cv.Optional(CONF_ADDRESS, default=0x20): cv.i2c_address,
+                cv.Optional(CONF_USE_MCLK, default=True): cv.boolean,
+                cv.Optional(CONF_NO_DAC_REF, default=True): cv.boolean,
+            }
+        ),
+    },
+    lower=True,
+    default_type="es8311",
+)
+
+esp_audio_stack_ns = cg.esphome_ns.namespace("esp_audio_stack")
+ESPAudioStack = esp_audio_stack_ns.class_("ESPAudioStack", cg.Component)
+StartAction = esp_audio_stack_ns.class_("StartAction", automation.Action)
+StopAction = esp_audio_stack_ns.class_("StopAction", automation.Action)
+StopAndWaitAction = esp_audio_stack_ns.class_("StopAndWaitAction", automation.Action)
+IsIdleCondition = esp_audio_stack_ns.class_("IsIdleCondition", automation.Condition)
+
+# AudioProcessor abstract interface (internal esp_audio_stack internal audio core headers)
+# Both esp_aec::EspAec and esp_afe::EspAfe inherit from this adapter.
+AudioProcessor = cg.esphome_ns.namespace("audio_core").class_("AudioProcessor")
+
+# Maintained targets. All require PSRAM and ESP-IDF.
+I2S_PORTS = {
+    VARIANT_ESP32P4: 3,
+    VARIANT_ESP32S3: 2,
+}
+
+# Supported targets with TDM support (from SOC_I2S_SUPPORTS_TDM in soc_caps.h)
+TDM_VARIANTS = {
+    VARIANT_ESP32S3,
+    VARIANT_ESP32P4,
+}
+
+
+def _validate_sample_rates(config):
+    """Validate that output_sample_rate divides sample_rate evenly."""
+    if CONF_OUTPUT_SAMPLE_RATE in config:
+        sr = config[CONF_SAMPLE_RATE]
+        osr = config[CONF_OUTPUT_SAMPLE_RATE]
+        if sr % osr != 0:
+            raise cv.Invalid(
+                f"sample_rate ({sr}) must be an exact multiple of "
+                f"output_sample_rate ({osr})"
+            )
+        ratio = sr // osr
+        if ratio > 6:
+            raise cv.Invalid(
+                f"Decimation ratio {ratio} (={sr}/{osr}) exceeds maximum of 6"
+            )
+    return config
+
+
+def _validate_tdm_config(config):
+    """Validate TDM reference configuration."""
+    use_tdm = config.get(CONF_USE_TDM_REFERENCE, False)
+    use_tdm_bus = use_tdm or CONF_TDM_MIC_SLOTS in config
+    use_stereo = config.get(CONF_USE_STEREO_AEC_REFERENCE, False)
+
+    if use_tdm and use_stereo:
+        raise cv.Invalid(
+            "use_tdm_reference and use_stereo_aec_reference are mutually exclusive"
+        )
+
+    if use_tdm_bus:
+        if config.get(CONF_SPEAKER_CHANNELS, 1) != 1:
+            raise cv.Invalid(
+                "speaker_channels: 2 is only supported on STD I2S, not TDM"
+            )
+        total_slots = config.get(CONF_TDM_TOTAL_SLOTS, 4)
+        ref_slot = config.get(CONF_TDM_REF_SLOT, 1)
+        tx_slot = config.get(CONF_TDM_TX_SLOT, 0)
+        mic_slots = config.get(CONF_TDM_MIC_SLOTS, [config.get(CONF_TDM_MIC_SLOT, 0)])
+
+        if len(set(mic_slots)) != len(mic_slots):
+            raise cv.Invalid("tdm_mic_slots must not contain duplicates")
+
+        for mic_slot in mic_slots:
+            if mic_slot == ref_slot:
+                raise cv.Invalid(
+                    f"tdm_mic_slots contains ref slot {ref_slot}; microphone and reference slots must differ"
+                )
+
+        max_slot = max([ref_slot, tx_slot, *mic_slots])
+        if total_slots <= max_slot:
+            raise cv.Invalid(
+                f"tdm_total_slots ({total_slots}) must be > {max_slot} "
+                f"(highest slot index)"
+            )
+    elif config.get(CONF_SPEAKER_CHANNELS, 1) > config.get(CONF_NUM_CHANNELS, 1):
+        raise cv.Invalid(
+            "speaker_channels: 2 requires num_channels: 2 on the physical TX bus"
+        )
+
+    return config
+
+
+def _validate_pcm_format(config):
+    """Validate that PCM short/long formats require TDM mode."""
+    fmt = config.get(CONF_I2S_COMM_FMT, "philips")
+    use_tdm_bus = (
+        config.get(CONF_USE_TDM_REFERENCE, False) or CONF_TDM_MIC_SLOTS in config
+    )
+    if fmt in ("pcm_short", "pcm_long") and not use_tdm_bus:
+        raise cv.Invalid(
+            f"i2s_comm_fmt '{fmt}' requires TDM slots "
+            f"(PCM short/long are TDM-only in ESP-IDF)"
+        )
+    return config
+
+
+def _validate_dual_bus_config(config):
+    """Validate optional RX/TX bus split."""
+    has_rx_bus = CONF_RX_BUS in config
+    has_tx_bus = CONF_TX_BUS in config
+    if has_rx_bus != has_tx_bus:
+        raise cv.Invalid("rx_bus and tx_bus must be configured together")
+
+    if has_rx_bus:
+        if config.get(CONF_USE_TDM_REFERENCE, False) or CONF_TDM_MIC_SLOTS in config:
+            raise cv.Invalid("rx_bus/tx_bus dual-bus mode does not support TDM yet")
+        if config[CONF_RX_BUS][CONF_I2S_NUM] == config[CONF_TX_BUS][CONF_I2S_NUM]:
+            raise cv.Invalid("rx_bus and tx_bus must use different i2s_num values")
+        for pin_key in (
+            CONF_I2S_LRCLK_PIN,
+            CONF_I2S_BCLK_PIN,
+            CONF_I2S_DIN_PIN,
+            CONF_I2S_DOUT_PIN,
+        ):
+            if config.get(pin_key, -1) != -1:
+                raise cv.Invalid(
+                    f"{pin_key} must be set inside rx_bus/tx_bus when dual-bus mode is used"
+                )
+    else:
+        if config.get(CONF_I2S_LRCLK_PIN, -1) == -1:
+            raise cv.Invalid(
+                "i2s_lrclk_pin is required when rx_bus/tx_bus are not used"
+            )
+        if config.get(CONF_I2S_BCLK_PIN, -1) == -1:
+            raise cv.Invalid("i2s_bclk_pin is required when rx_bus/tx_bus are not used")
+
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.only_with_framework(Framework.ESP_IDF),
+    cv.requires_component(psram.DOMAIN),
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ESPAudioStack),
+            cv.Optional(CONF_I2S_LRCLK_PIN, default=-1): cv.Any(
+                cv.int_range(min=-1, max=-1),
+                pins.internal_gpio_output_pin_number,
+            ),
+            cv.Optional(CONF_I2S_BCLK_PIN, default=-1): cv.Any(
+                cv.int_range(min=-1, max=-1),
+                pins.internal_gpio_output_pin_number,
+            ),
+            cv.Optional(CONF_I2S_MCLK_PIN, default=-1): I2S_OPTIONAL_MCLK,
+            cv.Optional(CONF_I2S_DIN_PIN, default=-1): cv.Any(
+                cv.int_range(min=-1, max=-1),
+                pins.internal_gpio_input_pin_number,
+            ),
+            cv.Optional(CONF_I2S_DOUT_PIN, default=-1): cv.Any(
+                cv.int_range(min=-1, max=-1),
+                pins.internal_gpio_output_pin_number,
+            ),
+            cv.Optional(CONF_SAMPLE_RATE, default=16000): cv.int_range(
+                min=8000, max=48000
+            ),
+            cv.Optional(CONF_BITS_PER_SAMPLE, default=16): cv.one_of(
+                16, 24, 32, int=True
+            ),
+            cv.Optional(CONF_SLOT_BIT_WIDTH, default="auto"): cv.Any(
+                cv.one_of("auto", lower=True),
+                cv.one_of(16, 24, 32, int=True),
+            ),
+            cv.Optional(CONF_CORRECT_DC_OFFSET, default=False): cv.boolean,
+            cv.Optional(CONF_NUM_CHANNELS, default=1): cv.one_of(1, 2, int=True),
+            cv.Optional(CONF_SPEAKER_CHANNELS, default=1): cv.one_of(1, 2, int=True),
+            cv.Optional(CONF_MIC_CHANNEL, default="left"): cv.one_of(
+                "left", "right", lower=True
+            ),
+            cv.Optional(CONF_RX_SLOT_MODE, default="mono"): cv.one_of(
+                "mono", "stereo", lower=True
+            ),
+            cv.Optional(CONF_TX_CHANNEL, default="left"): cv.one_of(
+                "left", "right", lower=True
+            ),
+            cv.Optional(CONF_I2S_MODE, default="primary"): cv.one_of(
+                "primary", "secondary", lower=True
+            ),
+            cv.Optional(CONF_USE_APLL, default=False): cv.boolean,
+            cv.Optional(CONF_I2S_NUM, default=0): cv.int_range(min=0, max=2),
+            cv.Optional(CONF_RX_BUS): I2S_RX_BUS_SCHEMA,
+            cv.Optional(CONF_TX_BUS): I2S_TX_BUS_SCHEMA,
+            cv.Optional(CONF_MCLK_MULTIPLE, default=256): cv.one_of(
+                128, 256, 384, 512, int=True
+            ),
+            cv.Optional(CONF_I2S_COMM_FMT, default="philips"): cv.one_of(
+                "philips",
+                "msb",
+                "pcm_short",
+                "pcm_long",
+                lower=True,
+            ),
+            # Output sample rate for mic/AEC/MWW/VA (converted from bus rate).
+            # If omitted, equals sample_rate (no rate conversion).
+            cv.Optional(CONF_OUTPUT_SAMPLE_RATE): cv.int_range(min=8000, max=48000),
+            cv.Optional(CONF_PROCESSOR_ID): cv.use_id(AudioProcessor),
+            # Input gain before the processor: <1.0 attenuates hot mics,
+            # >1.0 amplifies weak mics. This is gain staging, not a separate mic output.
+            cv.Optional(CONF_INPUT_GAIN, default=1.0): cv.float_range(
+                min=0.01, max=32.0
+            ),
+            # 0% remains hard mute. This controls how loud mid-range percentages feel:
+            # -49 dB matches ESPHome's software curve, while codec-dev defaults near
+            # -50 dB if this option is omitted on hardware codec outputs.
+            cv.Optional(CONF_MASTER_VOLUME_MIN_DB): cv.float_range(min=-96.0, max=0.0),
+            # ES8311 digital feedback: RX is stereo with L=ADC(mic), R=DAC(reference)
+            # when no_dac_ref is false. Espressif's driver writes REG44=0x58,
+            # documented in-source as "ADCL + DACR".
+            cv.Optional(CONF_USE_STEREO_AEC_REFERENCE, default=False): cv.boolean,
+            # Which stereo channel carries the AEC reference (default: left)
+            cv.Optional(CONF_REFERENCE_CHANNEL, default="left"): cv.one_of(
+                "left", "right", lower=True
+            ),
+            # TDM hardware reference: ES7210 in TDM mode with one slot carrying DAC feedback
+            cv.Optional(CONF_USE_TDM_REFERENCE, default=False): cv.boolean,
+            cv.Optional(CONF_TDM_TOTAL_SLOTS, default=4): cv.int_range(min=2, max=8),
+            cv.Optional(CONF_TDM_MIC_SLOT, default=0): cv.int_range(min=0, max=7),
+            cv.Optional(CONF_TDM_MIC_SLOTS): cv.All(
+                cv.ensure_list(cv.int_range(min=0, max=7)),
+                cv.Length(min=1, max=2),
+            ),
+            cv.Optional(CONF_TDM_REF_SLOT, default=1): cv.int_range(min=0, max=7),
+            cv.Optional(CONF_TDM_TX_SLOT, default=0): cv.int_range(min=0, max=7),
+            # Audio task tuning (advanced)
+            cv.Optional(CONF_TASK_PRIORITY, default=19): cv.int_range(min=1, max=24),
+            cv.Optional(CONF_TASK_CORE, default=0): cv.int_range(min=-1, max=1),
+            cv.Optional(CONF_TASK_STACK_SIZE, default=8192): cv.int_range(
+                min=4096, max=32768
+            ),
+            # Official IDF i2s_chan_config_t DMA knobs. If dma_frame_num is omitted,
+            # the component keeps the historical ~10 ms/descriptor auto sizing.
+            cv.Optional(CONF_DMA_DESC_NUM, default=6): cv.int_range(min=2, max=16),
+            cv.Optional(CONF_DMA_FRAME_NUM): cv.int_range(min=64, max=4092),
+            # Use PSRAM for non-DMA audio buffers (saves ~15KB internal RAM).
+            # Requires PSRAM. DMA buffers (I2S RX/TX) always use internal RAM.
+            cv.Optional(CONF_BUFFERS_IN_PSRAM, default=False): cv.boolean,
+            # Place the audio task's own stack in PSRAM. Saves ~8KB internal RAM
+            # but increases per-frame latency because every function return has
+            # to traverse PSRAM. Only enable on boards that need the internal
+            # headroom (e.g. waveshare-s3 running 2-mic Speech Enhancement plus
+            # concurrent TLS streams). ESPHome's PSRAM helper requests the required
+            # task-stack sdkconfig when enabled.
+            cv.Optional(
+                CONF_AUDIO_TASK_STACK_IN_PSRAM, default=False
+            ): psram.validate_task_stack_in_psram,
+            # AEC reference mode for no-codec setups (ignored if stereo/TDM ref is configured):
+            #   ring_buffer: Espressif ADF TYPE2-style software reference, default
+            #   previous_frame: light mode using the previous TX frame, no TYPE2 ring
+            cv.Optional(CONF_AEC_REFERENCE, default="ring_buffer"): cv.one_of(
+                "previous_frame",
+                "ring_buffer",
+                lower=True,
+            ),
+            # Ring buffer capacity in ms (only used with aec_reference: ring_buffer)
+            cv.Optional(CONF_AEC_REFERENCE_BUFFER_MS, default=80): cv.int_range(
+                min=32, max=500
+            ),
+            # Place AEC reference ring buffer in PSRAM. Default false = internal RAM
+            # (~13.6 us/frame faster on Core 0, costs ~3-5 KB internal). Set true to
+            # save internal RAM at the cost of Core 0 PSRAM traffic.
+            cv.Optional(CONF_AEC_REF_RING_IN_PSRAM, default=False): cv.boolean,
+            # Enable per-stage cycle counting and diagnostics (debug only, adds overhead)
+            cv.Optional(CONF_TELEMETRY, default=False): cv.boolean,
+            cv.Optional(CONF_TELEMETRY_LOG_INTERVAL_FRAMES, default=128): cv.int_range(
+                min=1, max=8192
+            ),
+            cv.Optional(CONF_AUDIO_EFFECTS, default={}): cv.Schema(
+                {
+                    cv.Optional(CONF_RATE_CVT_COMPLEXITY, default=3): cv.int_range(
+                        min=1, max=3
+                    ),
+                    cv.Optional(CONF_RATE_CVT_PERF_TYPE, default="speed"): cv.one_of(
+                        *RATE_CVT_PERF_TYPES,
+                        lower=True,
+                    ),
+                }
+            ),
+            cv.Optional(CONF_CODEC): cv.Schema(
+                {
+                    cv.GenerateID(CONF_I2C_ID): cv.use_id(i2c.I2CBus),
+                    cv.Optional(CONF_INPUT): CODEC_INPUT_SCHEMA,
+                    cv.Optional(CONF_OUTPUT): CODEC_OUTPUT_SCHEMA,
+                }
+            ),
+            # Lifecycle hooks for board-level power policy. Use the speaker hooks
+            # for amp power gating; the generic audio-stack hooks also fire on mic-only
+            # activity such as wake-word listeners.
+            cv.Optional(CONF_ON_START): automation.validate_automation(single=True),
+            cv.Optional(CONF_ON_IDLE): automation.validate_automation(single=True),
+            # Minimal runtime state machine. `state` is one of:
+            # idle, mic, speaker, duplex.
+            cv.Optional(CONF_ON_STATE): automation.validate_automation(single=True),
+            cv.Optional(CONF_ON_MIC_START): automation.validate_automation(single=True),
+            cv.Optional(CONF_ON_MIC_IDLE): automation.validate_automation(single=True),
+            cv.Optional(CONF_ON_SPEAKER_START): automation.validate_automation(
+                single=True
+            ),
+            cv.Optional(CONF_ON_SPEAKER_IDLE): automation.validate_automation(
+                single=True
+            ),
+            # Semantic aliases for board amplifier/power-enable control. They fire
+            # on the same edges as speaker playback, but keep YAML intent separate
+            # from the ESPHome speaker abstraction.
+            cv.Optional(CONF_ON_AMPLIFIER_REQUIRED): automation.validate_automation(
+                single=True
+            ),
+            cv.Optional(CONF_ON_AMPLIFIER_IDLE): automation.validate_automation(
+                single=True
+            ),
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    _validate_sample_rates,
+    _validate_tdm_config,
+    _validate_pcm_format,
+    _validate_dual_bus_config,
+)
+
+
+def _final_validate(config):
+    """Validate i2s_num against SoC port count and TDM against SoC capability."""
+    variant = get_esp32_variant()
+    if variant not in I2S_PORTS:
+        raise cv.Invalid(
+            f"esp_audio_stack requires ESP32-S3 or ESP32-P4 with PSRAM, got {variant}"
+        )
+
+    max_ports = I2S_PORTS[variant]
+    if CONF_RX_BUS in config:
+        if max_ports < 2:
+            raise cv.Invalid(
+                f"rx_bus/tx_bus dual-bus mode requires at least two I2S ports on {variant}"
+            )
+        for bus_key in (CONF_RX_BUS, CONF_TX_BUS):
+            i2s_num = config[bus_key][CONF_I2S_NUM]
+            if i2s_num >= max_ports:
+                raise cv.Invalid(
+                    f"{bus_key}.i2s_num {i2s_num} exceeds available I2S ports on {variant} "
+                    f"(max port index: {max_ports - 1})"
+                )
+    else:
+        i2s_num = config.get(CONF_I2S_NUM, 0)
+        if i2s_num >= max_ports:
+            raise cv.Invalid(
+                f"i2s_num {i2s_num} exceeds available I2S ports on {variant} "
+                f"(max port index: {max_ports - 1})"
+            )
+
+    use_tdm_bus = (
+        config.get(CONF_USE_TDM_REFERENCE, False) or CONF_TDM_MIC_SLOTS in config
+    )
+    if use_tdm_bus and variant not in TDM_VARIANTS:
+        raise cv.Invalid(
+            f"TDM options require TDM support, but {variant} does not have SOC_I2S_SUPPORTS_TDM"
+        )
+
+    # APLL is available on ESP32-P4 in the maintained target set.
+    if config.get(CONF_USE_APLL, False) and variant != VARIANT_ESP32P4:
+        raise cv.Invalid(
+            f"use_apll is not supported on {variant}. "
+            "APLL clock source is only available on ESP32-P4 in the maintained target set."
+        )
+
+    from esphome.core import CORE
+
+    full_config = CORE.config or {}
+
+    # esp_aec and esp_afe are mutually exclusive: both provide AudioProcessor
+    has_aec = "esp_aec" in full_config
+    has_afe = "esp_afe" in full_config
+    if has_aec and has_afe:
+        raise cv.Invalid(
+            "esp_aec and esp_afe are mutually exclusive. "
+            "Use esp_afe (full AFE pipeline with AEC+NS+AGC+Speech Enhancement) "
+            "or esp_aec (standalone echo cancellation), not both."
+        )
+
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
+
+
+def _add_config_setters(var, config, setters):
+    for key, setter in setters:
+        cg.add(setter(config[key]))
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    use_tdm_bus = config[CONF_USE_TDM_REFERENCE] or CONF_TDM_MIC_SLOTS in config
+    use_tdm_ref = config[CONF_USE_TDM_REFERENCE]
+    use_stereo_ref = config[CONF_USE_STEREO_AEC_REFERENCE]
+    has_processor = CONF_PROCESSOR_ID in config
+    output_rate = config.get(CONF_OUTPUT_SAMPLE_RATE, config[CONF_SAMPLE_RATE])
+    use_rate_cvt = output_rate != config[CONF_SAMPLE_RATE]
+    use_32bit = config[CONF_BITS_PER_SAMPLE] > 16
+    use_stereo_tx = config[CONF_NUM_CHANNELS] == 2 and not use_tdm_bus
+    use_rx_slot_stereo = config[CONF_RX_SLOT_MODE] == "stereo"
+    use_multi_rx = use_tdm_bus or use_stereo_ref or use_rx_slot_stereo
+    use_mono_rx_effects = not use_multi_rx and (use_rate_cvt or use_32bit)
+    use_mono_ref = has_processor and not use_tdm_ref and not use_stereo_ref
+    use_ring_ref = use_mono_ref and config[CONF_AEC_REFERENCE] == "ring_buffer"
+    use_previous_frame_ref = (
+        use_mono_ref and config[CONF_AEC_REFERENCE] == "previous_frame"
+    )
+
+    has_hardware_codec = CONF_CODEC in config
+    has_output_codec = has_hardware_codec and CONF_OUTPUT in config[CONF_CODEC]
+    add_idf_component(name="espressif/esp_audio_effects", ref=ESP_AUDIO_EFFECTS_REF)
+    if has_hardware_codec:
+        add_idf_component(name="espressif/esp_codec_dev", ref=ESP_CODEC_DEV_REF)
+    await cg.register_component(var, config)
+
+    # Define USE_ESP_AUDIO_STACK so other components know it's available
+    cg.add_define("USE_ESP_AUDIO_STACK")
+    if CONF_RX_BUS in config:
+        cg.add_define("USE_ESP_AUDIO_STACK_DUAL_BUS")
+    if use_tdm_bus:
+        cg.add_define("USE_ESP_AUDIO_STACK_TDM_BUS")
+    if use_tdm_ref:
+        cg.add_define("USE_ESP_AUDIO_STACK_TDM_REF")
+    if use_stereo_ref:
+        cg.add_define("USE_ESP_AUDIO_STACK_STEREO_REF")
+    if use_multi_rx:
+        cg.add_define("USE_ESP_AUDIO_STACK_MULTI_RX")
+    if use_mono_rx_effects:
+        cg.add_define("USE_ESP_AUDIO_STACK_MONO_RX")
+    if use_mono_ref:
+        cg.add_define("USE_ESP_AUDIO_STACK_MONO_REF")
+    if use_ring_ref:
+        cg.add_define("USE_ESP_AUDIO_STACK_RING_REF")
+    if use_previous_frame_ref:
+        cg.add_define("USE_ESP_AUDIO_STACK_PREVIOUS_FRAME_REF")
+    if use_stereo_tx:
+        cg.add_define("USE_ESP_AUDIO_STACK_STEREO_TX")
+    if use_32bit:
+        cg.add_define("USE_ESP_AUDIO_STACK_32BIT")
+    if has_hardware_codec:
+        cg.add_define("USE_ESP_AUDIO_STACK_HARDWARE_CODEC")
+        codec_conf = config[CONF_CODEC]
+        codec_types = set()
+        if CONF_INPUT in codec_conf:
+            codec_types.add(codec_conf[CONF_INPUT][CONF_TYPE])
+        if CONF_OUTPUT in codec_conf:
+            codec_types.add(codec_conf[CONF_OUTPUT][CONF_TYPE])
+        for codec_type in sorted(codec_types):
+            cg.add_define(f"USE_ESP_AUDIO_STACK_CODEC_{codec_type.upper()}")
+    if has_output_codec:
+        cg.add_define("USE_ESP_AUDIO_STACK_HARDWARE_OUTPUT_CODEC")
+    include_builtin_idf_component("esp_driver_i2s")
+    add_idf_sdkconfig_option("CONFIG_I2S_ISR_IRAM_SAFE", True)
+    if config[CONF_AUDIO_TASK_STACK_IN_PSRAM]:
+        psram.request_external_task_stack()
+
+    _add_config_setters(
+        var,
+        config,
+        (
+            (CONF_I2S_LRCLK_PIN, var.set_lrclk_pin),
+            (CONF_I2S_BCLK_PIN, var.set_bclk_pin),
+            (CONF_I2S_MCLK_PIN, var.set_mclk_pin),
+            (CONF_I2S_DIN_PIN, var.set_din_pin),
+            (CONF_I2S_DOUT_PIN, var.set_dout_pin),
+            (CONF_SAMPLE_RATE, var.set_sample_rate),
+            (CONF_BITS_PER_SAMPLE, var.set_bits_per_sample),
+            (CONF_CORRECT_DC_OFFSET, var.set_correct_dc_offset),
+            (CONF_NUM_CHANNELS, var.set_num_channels),
+            (CONF_SPEAKER_CHANNELS, var.set_speaker_channels),
+            (CONF_USE_APLL, var.set_use_apll),
+            (CONF_I2S_NUM, var.set_i2s_num),
+            (CONF_MCLK_MULTIPLE, var.set_mclk_multiple),
+        ),
+    )
+    cg.add(var.set_i2s_mode_secondary(config[CONF_I2S_MODE] == "secondary"))
+
+    if CONF_RX_BUS in config:
+        rx_bus = config[CONF_RX_BUS]
+        tx_bus = config[CONF_TX_BUS]
+        cg.add(
+            var.configure_rx_bus(
+                rx_bus[CONF_I2S_NUM],
+                rx_bus[CONF_I2S_LRCLK_PIN],
+                rx_bus[CONF_I2S_BCLK_PIN],
+                rx_bus[CONF_I2S_MCLK_PIN],
+                rx_bus[CONF_I2S_DIN_PIN],
+            )
+        )
+        cg.add(
+            var.configure_tx_bus(
+                tx_bus[CONF_I2S_NUM],
+                tx_bus[CONF_I2S_LRCLK_PIN],
+                tx_bus[CONF_I2S_BCLK_PIN],
+                tx_bus[CONF_I2S_MCLK_PIN],
+                tx_bus[CONF_I2S_DOUT_PIN],
+            )
+        )
+
+    # Map comm format string to enum index
+    comm_fmt_map = {"philips": 0, "msb": 1, "pcm_short": 2, "pcm_long": 3}
+    cg.add(var.set_i2s_comm_fmt(comm_fmt_map[config[CONF_I2S_COMM_FMT]]))
+
+    # Mic channel selection (for mono RX: which I2S slot to capture)
+    cg.add(var.set_mic_channel_right(config[CONF_MIC_CHANNEL] == "right"))
+    cg.add(var.set_rx_slot_mode_stereo(config[CONF_RX_SLOT_MODE] == "stereo"))
+
+    # TX channel selection (for mono TX: which I2S slot to output)
+    cg.add(var.set_tx_slot_right(config[CONF_TX_CHANNEL] == "right"))
+
+    # Slot bit width: 0 = auto (match bits_per_sample)
+    sbw = config[CONF_SLOT_BIT_WIDTH]
+    cg.add(var.set_slot_bit_width(0 if sbw == "auto" else sbw))
+
+    # Set output sample rate if specified (enables rate conversion).
+    if CONF_OUTPUT_SAMPLE_RATE in config:
+        cg.add(var.set_output_sample_rate(config[CONF_OUTPUT_SAMPLE_RATE]))
+
+    # Set input gain before the audio processor.
+    cg.add(var.set_input_gain(config[CONF_INPUT_GAIN]))
+    if CONF_MASTER_VOLUME_MIN_DB in config:
+        cg.add(var.set_master_volume_min_db(config[CONF_MASTER_VOLUME_MIN_DB]))
+
+    # ES8311 digital feedback mode: stereo RX with L=mic, R=ref
+    cg.add(var.set_use_stereo_aec_reference(config[CONF_USE_STEREO_AEC_REFERENCE]))
+
+    # Reference channel selection (left or right)
+    cg.add(var.set_reference_channel_right(config[CONF_REFERENCE_CHANNEL] == "right"))
+
+    # TDM slot configuration. `use_tdm_reference` means the AEC reference comes
+    # from a TDM slot; `tdm_mic_slots` alone keeps the TDM bus but lets AEC use
+    # the software speaker reference path.
+    if use_tdm_bus:
+        cg.add(var.set_use_tdm_bus(True))
+        cg.add(var.set_use_tdm_reference(config[CONF_USE_TDM_REFERENCE]))
+        cg.add(var.set_tdm_total_slots(config[CONF_TDM_TOTAL_SLOTS]))
+        mic_slots = config.get(CONF_TDM_MIC_SLOTS, [config[CONF_TDM_MIC_SLOT]])
+        cg.add(var.set_tdm_mic_slot(mic_slots[0]))
+        if len(mic_slots) > 1:
+            cg.add(var.set_secondary_tdm_mic_slot(mic_slots[1]))
+        cg.add(var.set_tdm_ref_slot(config[CONF_TDM_REF_SLOT]))
+        cg.add(var.set_tdm_tx_slot(config[CONF_TDM_TX_SLOT]))
+
+    if has_hardware_codec:
+        codec_conf = config[CONF_CODEC]
+        i2c_bus = await cg.get_variable(codec_conf[CONF_I2C_ID])
+        cg.add(var.set_codec_i2c_bus(i2c_bus))
+        if CONF_INPUT in codec_conf:
+            input_conf = codec_conf[CONF_INPUT]
+            if input_conf[CONF_TYPE] == "es7210":
+                has_ref_gain = CONF_REF_CHANNEL in input_conf
+                cg.add(
+                    var.configure_es7210_codec(
+                        input_conf[CONF_ADDRESS],
+                        input_conf[CONF_MIC_SELECTED],
+                        input_conf[CONF_GAIN_DB],
+                        has_ref_gain,
+                        input_conf.get(CONF_REF_CHANNEL, 0),
+                        input_conf[CONF_REF_GAIN_DB],
+                    )
+                )
+            elif input_conf[CONF_TYPE] == "es8311":
+                cg.add(
+                    var.configure_es8311_input_codec(
+                        input_conf[CONF_ADDRESS],
+                        input_conf.get(CONF_USE_MCLK, True),
+                        input_conf.get(CONF_NO_DAC_REF, False),
+                        input_conf[CONF_GAIN_DB],
+                    )
+                )
+            else:
+                cg.add(
+                    var.configure_input_codec(
+                        CODEC_KIND[input_conf[CONF_TYPE]],
+                        input_conf[CONF_ADDRESS],
+                        input_conf.get(CONF_USE_MCLK, True),
+                        input_conf.get(CONF_NO_DAC_REF, False),
+                        input_conf[CONF_GAIN_DB],
+                    )
+                )
+        if CONF_OUTPUT in codec_conf:
+            output_conf = codec_conf[CONF_OUTPUT]
+            if output_conf[CONF_TYPE] == "es8311":
+                cg.add(
+                    var.configure_es8311_codec(
+                        output_conf[CONF_ADDRESS],
+                        output_conf.get(CONF_USE_MCLK, True),
+                        output_conf.get(CONF_NO_DAC_REF, True),
+                    )
+                )
+            else:
+                cg.add(
+                    var.configure_output_codec(
+                        CODEC_KIND[output_conf[CONF_TYPE]],
+                        output_conf[CONF_ADDRESS],
+                        output_conf.get(CONF_USE_MCLK, True),
+                        output_conf.get(CONF_NO_DAC_REF, True),
+                    )
+                )
+
+    # Audio task tuning
+    _add_config_setters(
+        var,
+        config,
+        (
+            (CONF_TASK_PRIORITY, var.set_task_priority),
+            (CONF_TASK_CORE, var.set_task_core),
+            (CONF_TASK_STACK_SIZE, var.set_task_stack_size),
+            (CONF_DMA_DESC_NUM, var.set_dma_desc_num),
+            (CONF_BUFFERS_IN_PSRAM, var.set_buffers_in_psram),
+            (CONF_AUDIO_TASK_STACK_IN_PSRAM, var.set_audio_task_stack_in_psram),
+        ),
+    )
+    if CONF_DMA_FRAME_NUM in config:
+        cg.add(var.set_dma_frame_num(config[CONF_DMA_FRAME_NUM]))
+    audio_effects = config[CONF_AUDIO_EFFECTS]
+    cg.add(var.set_rate_cvt_complexity(audio_effects[CONF_RATE_CVT_COMPLEXITY]))
+    cg.add(
+        var.set_rate_cvt_perf_type(
+            0 if audio_effects[CONF_RATE_CVT_PERF_TYPE] == "memory" else 1
+        )
+    )
+
+    # AEC reference mode is compile-time selected for no-codec setups:
+    # ring_buffer pulls in the Espressif/ADF TYPE2-style software reference,
+    # previous_frame keeps that path out of the build.
+    if use_ring_ref:
+        _add_config_setters(
+            var,
+            config,
+            (
+                (CONF_AEC_REFERENCE_BUFFER_MS, var.set_aec_ref_buffer_ms),
+                (CONF_AEC_REF_RING_IN_PSRAM, var.set_aec_ref_ring_in_psram),
+            ),
+        )
+
+    # Telemetry: per-stage cycle counting and diagnostics
+    if config[CONF_TELEMETRY]:
+        cg.add_define("USE_ESP_AUDIO_STACK_TELEMETRY")
+        cg.add(
+            var.set_telemetry_log_interval_frames(
+                config[CONF_TELEMETRY_LOG_INTERVAL_FRAMES]
+            )
+        )
+
+    for key, trigger_getter, args in (
+        (CONF_ON_START, var.get_start_trigger, []),
+        (CONF_ON_IDLE, var.get_idle_trigger, []),
+        (CONF_ON_STATE, var.get_state_trigger, [(cg.std_string, "state")]),
+        (CONF_ON_MIC_START, var.get_mic_start_trigger, []),
+        (CONF_ON_MIC_IDLE, var.get_mic_idle_trigger, []),
+        (CONF_ON_SPEAKER_START, var.get_speaker_start_trigger, []),
+        (CONF_ON_SPEAKER_IDLE, var.get_speaker_idle_trigger, []),
+        (CONF_ON_AMPLIFIER_REQUIRED, var.get_speaker_start_trigger, []),
+        (CONF_ON_AMPLIFIER_IDLE, var.get_speaker_idle_trigger, []),
+    ):
+        if key in config:
+            await automation.build_automation(trigger_getter(), args, config[key])
+
+    # Link audio processor if configured
+    if CONF_PROCESSOR_ID in config:
+        processor = await cg.get_variable(config[CONF_PROCESSOR_ID])
+        cg.add(var.set_processor(processor))
+        cg.add_define("USE_AUDIO_PROCESSOR")
+
+
+# === Actions ===
+ESP_AUDIO_STACK_ACTION_SCHEMA = automation.maybe_simple_id(
+    {cv.GenerateID(): cv.use_id(ESPAudioStack)}
+)
+
+
+@automation.register_action(
+    "esp_audio_stack.start",
+    StartAction,
+    ESP_AUDIO_STACK_ACTION_SCHEMA,
+    synchronous=True,
+)
+@automation.register_action(
+    "esp_audio_stack.stop", StopAction, ESP_AUDIO_STACK_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "esp_audio_stack.stop_and_wait",
+    StopAndWaitAction,
+    ESP_AUDIO_STACK_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def esp_audio_stack_action_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+@automation.register_condition(
+    "esp_audio_stack.is_idle", IsIdleCondition, ESP_AUDIO_STACK_ACTION_SCHEMA
+)
+async def esp_audio_stack_is_idle_to_code(config, condition_id, template_arg, args):
+    var = cg.new_Pvariable(condition_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var

--- a/esphome/components/esp_audio_stack/audio_core_audio_utils.h
+++ b/esphome/components/esp_audio_stack/audio_core_audio_utils.h
@@ -6,8 +6,8 @@
 
 namespace esphome::esp_audio_stack {
 
-#ifndef ESPHOME_SCALE_SAMPLE_DEFINED
-#define ESPHOME_SCALE_SAMPLE_DEFINED
+#ifndef ESPHOME_AUDIO_STACK_SCALE_SAMPLE_DEFINED
+#define ESPHOME_AUDIO_STACK_SCALE_SAMPLE_DEFINED
 // Scale a 16-bit PCM sample by a float gain with saturation clamping.
 // Supports gains > 1.0 (amplification) unlike ESPHome's Q15 scale_audio_samples().
 static inline int16_t scale_sample(int16_t sample, float gain) {
@@ -20,8 +20,8 @@ static inline int16_t scale_sample(int16_t sample, float gain) {
 }
 #endif
 
-#ifndef ESPHOME_COMPUTE_RMS_DBFS_DEFINED
-#define ESPHOME_COMPUTE_RMS_DBFS_DEFINED
+#ifndef ESPHOME_AUDIO_STACK_COMPUTE_RMS_DBFS_DEFINED
+#define ESPHOME_AUDIO_STACK_COMPUTE_RMS_DBFS_DEFINED
 // 20*log10(32768): subtract from 10*log10(mean) to get dBFS without an
 // extra sqrt() (more numerically stable for small means).
 static constexpr float RMS_DBFS_OFFSET = 90.30899870f;
@@ -60,8 +60,8 @@ static inline float compute_rms_dbfs_i32_top16(const int32_t *data, size_t sampl
 }
 #endif
 
-#ifndef ESPHOME_DC_BLOCKER_STATE_DEFINED
-#define ESPHOME_DC_BLOCKER_STATE_DEFINED
+#ifndef ESPHOME_AUDIO_STACK_DC_BLOCKER_STATE_DEFINED
+#define ESPHOME_AUDIO_STACK_DC_BLOCKER_STATE_DEFINED
 struct DcBlockerState {
   int32_t prev_input_q16{0};
   int32_t prev_output_q16{0};

--- a/esphome/components/esp_audio_stack/audio_core_audio_utils.h
+++ b/esphome/components/esp_audio_stack/audio_core_audio_utils.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cmath>
+
+namespace esphome::esp_audio_stack {
+
+#ifndef ESPHOME_SCALE_SAMPLE_DEFINED
+#define ESPHOME_SCALE_SAMPLE_DEFINED
+// Scale a 16-bit PCM sample by a float gain with saturation clamping.
+// Supports gains > 1.0 (amplification) unlike ESPHome's Q15 scale_audio_samples().
+static inline int16_t scale_sample(int16_t sample, float gain) {
+  int32_t s = static_cast<int32_t>(sample * gain);
+  if (s > 32767)
+    return 32767;
+  if (s < -32768)
+    return -32768;
+  return static_cast<int16_t>(s);
+}
+#endif
+
+#ifndef ESPHOME_COMPUTE_RMS_DBFS_DEFINED
+#define ESPHOME_COMPUTE_RMS_DBFS_DEFINED
+// 20*log10(32768): subtract from 10*log10(mean) to get dBFS without an
+// extra sqrt() (more numerically stable for small means).
+static constexpr float RMS_DBFS_OFFSET = 90.30899870f;
+static constexpr float RMS_DBFS_SILENCE = -120.0f;
+
+// RMS power in dBFS for int16 PCM samples. Returns -120 dBFS for silence.
+// `stride` lets callers walk channel-interleaved buffers (e.g. TDM slots).
+static inline float compute_rms_dbfs_i16(const int16_t *data, size_t samples, size_t stride = 1) {
+  if (data == nullptr || samples == 0)
+    return RMS_DBFS_SILENCE;
+  uint64_t sumsq = 0;
+  for (size_t i = 0; i < samples; i++) {
+    int32_t s = data[i * stride];
+    sumsq += static_cast<uint64_t>(s * s);
+  }
+  float mean = static_cast<float>(sumsq) / static_cast<float>(samples);
+  if (mean <= 0.0f)
+    return RMS_DBFS_SILENCE;
+  return 10.0f * log10f(mean) - RMS_DBFS_OFFSET;
+}
+
+// Variant for int32 (e.g. TDM slot data with top 16 bits used). Each sample
+// is right-shifted by 16 to land in int16 range before squaring.
+static inline float compute_rms_dbfs_i32_top16(const int32_t *data, size_t samples, size_t stride = 1) {
+  if (data == nullptr || samples == 0)
+    return RMS_DBFS_SILENCE;
+  uint64_t sumsq = 0;
+  for (size_t i = 0; i < samples; i++) {
+    int32_t s = data[i * stride] >> 16;
+    sumsq += static_cast<uint64_t>(s * s);
+  }
+  float mean = static_cast<float>(sumsq) / static_cast<float>(samples);
+  if (mean <= 0.0f)
+    return RMS_DBFS_SILENCE;
+  return 10.0f * log10f(mean) - RMS_DBFS_OFFSET;
+}
+#endif
+
+#ifndef ESPHOME_DC_BLOCKER_STATE_DEFINED
+#define ESPHOME_DC_BLOCKER_STATE_DEFINED
+struct DcBlockerState {
+  int32_t prev_input_q16{0};
+  int32_t prev_output_q16{0};
+
+  // y[n]=x[n]-x[n-1]+(1-2^-10)y[n-1]; cutoff is about fs/(2*pi*1024).
+  inline int16_t process(int16_t sample) {
+    int32_t input = static_cast<int32_t>(sample) << 16;
+    int32_t output = input - this->prev_input_q16 + this->prev_output_q16 - (this->prev_output_q16 >> 10);
+    this->prev_input_q16 = input;
+    this->prev_output_q16 = output;
+    return static_cast<int16_t>(output >> 16);
+  }
+};
+#endif
+
+}  // namespace esphome::esp_audio_stack

--- a/esphome/components/esp_audio_stack/audio_core_log_utils.cpp
+++ b/esphome/components/esp_audio_stack/audio_core_log_utils.cpp
@@ -1,0 +1,65 @@
+#include "audio_core_log_utils.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/log.h"
+
+#include <cstdarg>
+#include <cstdio>
+
+namespace esphome::esp_audio_stack {
+
+namespace {
+
+void log_vprintf(int level, const char *tag, const char *format, va_list args) {
+  char buffer[192];
+  vsnprintf(buffer, sizeof(buffer), format, args);
+  switch (level) {
+    case ESPHOME_LOG_LEVEL_CONFIG:
+      ::esphome::esp_log_printf_(ESPHOME_LOG_LEVEL_CONFIG, tag, __LINE__, "%s", buffer);
+      break;
+    case ESPHOME_LOG_LEVEL_INFO:
+      ::esphome::esp_log_printf_(ESPHOME_LOG_LEVEL_INFO, tag, __LINE__, "%s", buffer);
+      break;
+    case ESPHOME_LOG_LEVEL_WARN:
+      ::esphome::esp_log_printf_(ESPHOME_LOG_LEVEL_WARN, tag, __LINE__, "%s", buffer);
+      break;
+    default:
+      ::esphome::esp_log_printf_(ESPHOME_LOG_LEVEL_ERROR, tag, __LINE__, "%s", buffer);
+      break;
+  }
+}
+
+}  // namespace
+
+void log_config(const char *tag, const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  log_vprintf(ESPHOME_LOG_LEVEL_CONFIG, tag, format, args);
+  va_end(args);
+}
+
+void log_info(const char *tag, const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  log_vprintf(ESPHOME_LOG_LEVEL_INFO, tag, format, args);
+  va_end(args);
+}
+
+void log_warn(const char *tag, const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  log_vprintf(ESPHOME_LOG_LEVEL_WARN, tag, format, args);
+  va_end(args);
+}
+
+void log_error(const char *tag, const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  log_vprintf(ESPHOME_LOG_LEVEL_ERROR, tag, format, args);
+  va_end(args);
+}
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/audio_core_log_utils.h
+++ b/esphome/components/esp_audio_stack/audio_core_log_utils.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include <cstdint>
+
+namespace esphome::esp_audio_stack {
+
+void log_config(const char *tag, const char *format, ...);
+void log_info(const char *tag, const char *format, ...);
+void log_warn(const char *tag, const char *format, ...);
+void log_error(const char *tag, const char *format, ...);
+
+// Rate-limited WARN for hot audio paths: emit on the first 5 occurrences and
+// then every 100th. Each expansion site owns its static counter.
+//
+// The macro expects a `TAG` symbol in scope, matching ESPHome logging
+// conventions used by esp_audio_stack .cpp files.
+#define LOG_W_THROTTLED(fmt, ...) \
+  do { \
+    static uint32_t _throttled_n = 0; \
+    _throttled_n++; \
+    if (_throttled_n <= 5 || _throttled_n % 100 == 0) { \
+      esphome::esp_audio_stack::log_warn(TAG, fmt " [n=%u]", ##__VA_ARGS__, (unsigned) _throttled_n); \
+    } \
+  } while (0)
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/audio_core_processor.h
+++ b/esphome/components/esp_audio_stack/audio_core_processor.h
@@ -1,0 +1,122 @@
+#pragma once
+#ifndef ESPHOME_AUDIO_CORE_PROCESSOR_H
+#define ESPHOME_AUDIO_CORE_PROCESSOR_H
+
+#include <cstdint>
+#include <cstddef>
+
+namespace esphome::esp_audio_stack {
+
+/// Audio processing features that can be queried and toggled.
+enum class AudioFeature : uint8_t {
+  AEC = 0,  // Acoustic Echo Cancellation
+  NS,       // Noise Suppression
+  VAD,      // Voice Activity Detection
+  AGC,      // Automatic Gain Control
+  SE,       // Speech Enhancement (requires 2+ mics)
+};
+
+/// How a feature can be controlled at runtime.
+enum class FeatureControl : uint8_t {
+  NOT_SUPPORTED,     // feature not available in this processor
+  BOOT_ONLY,         // set at boot, cannot change at runtime
+  RESTART_REQUIRED,  // toggle requires processor reinit (~70ms gap)
+  LIVE_TOGGLE,       // toggle is immediate, no audio gap
+};
+
+/// Describes the frame layout expected by process().
+struct FrameSpec {
+  uint32_t sample_rate{16000};
+  uint8_t mic_channels{1};     // number of mic channels in input
+  uint8_t ref_channels{1};     // number of reference channels (0 or 1)
+  size_t input_samples{512};   // per-channel samples expected by process()
+  size_t output_samples{512};  // per-channel samples produced by process()
+};
+
+/// Snapshot of processor telemetry (thread-safe reads via atomics in impl).
+struct ProcessorTelemetry {
+  bool voice_present{false};
+  float input_volume_dbfs{-120.0f};
+  float output_rms_dbfs{-120.0f};
+  float ringbuf_free_pct{1.0f};
+  uint32_t glitch_count{0};
+  uint32_t frame_count{0};
+  uint32_t input_ring_drop{0};
+  uint32_t feed_ok{0};
+  uint32_t feed_rejected{0};
+  uint32_t fetch_ok{0};
+  uint32_t fetch_timeout{0};
+  uint32_t output_ring_drop{0};
+  uint32_t feed_queue_frames{0};
+  uint32_t feed_queue_peak{0};
+  uint32_t fetch_queue_frames{0};
+  uint32_t fetch_queue_peak{0};
+  uint32_t process_us_last{0};
+  uint32_t process_us_max{0};
+  uint32_t feed_us_last{0};
+  uint32_t feed_us_max{0};
+  uint32_t fetch_us_last{0};
+  uint32_t fetch_us_max{0};
+};
+
+/// Abstract audio processor interface.
+///
+/// Implementations: EspAec (standalone AEC), EspAfe (full AFE pipeline).
+/// Consumers: esp_audio_stack and other audio components.
+class AudioProcessor {
+ public:
+  virtual ~AudioProcessor() = default;
+
+  virtual bool is_initialized() const = 0;
+
+  /// Frame layout this processor expects and produces.
+  virtual FrameSpec frame_spec() const = 0;
+
+  /// Process one frame.
+  /// @param in_mic  mic input buffer. Layout depends on mic_channels_in:
+  ///                1 = mono (input_samples contiguous samples)
+  ///                2 = interleaved stereo [mic1_0, mic2_0, mic1_1, mic2_1, ...]
+  /// @param in_ref  reference input (speaker loopback), input_samples. May be nullptr.
+  /// @param out     output buffer, output_samples
+  /// @param mic_channels_in  how many mic channels are interleaved in in_mic
+  /// @return true if processed by DSP, false if not processed (implementation
+  ///         may emit silence rather than raw audio)
+  virtual bool process(const int16_t *in_mic, const int16_t *in_ref, int16_t *out, uint8_t mic_channels_in) = 0;
+
+  /// Query how a feature can be controlled.
+  virtual FeatureControl feature_control(AudioFeature feature) const = 0;
+
+  /// Toggle a feature on or off. Check feature_control() first.
+  /// @return true if the change was applied successfully
+  virtual bool set_feature(AudioFeature feature, bool enabled) = 0;
+
+  /// Current telemetry snapshot.
+  virtual ProcessorTelemetry telemetry() const = 0;
+
+  /// Reconfigure the processor (e.g., switch SR/VC mode). Requires audio stop.
+  /// @return true if reconfiguration succeeded
+  virtual bool reconfigure(int type, int mode) = 0;
+
+  /// Monotonic revision counter for frame_spec changes.
+  /// Consumers cache this at init and poll in the audio loop.
+  /// When it changes, the consumer must restart to re-read frame_spec().
+  virtual uint32_t frame_spec_revision() const { return 0; }
+
+  /// Hint that downstream consumers want frames or have all gone idle.
+  /// Implementations may use this to suspend background tasks (e.g. esp-sr
+  /// feed/fetch) when no consumer reads the output, then resume when a new
+  /// consumer attaches. Must be idempotent and safe to call from any task.
+  /// Default no-op: processors that always run regardless of consumers
+  /// keep working unchanged.
+  virtual void set_processing_active(bool active) { (void) active; }
+
+  /// True when the processor explicitly needs mic frames even without an
+  /// external microphone consumer. Example: AFE VAD may be configured as
+  /// continuous background input, but a VAD toggle alone must not imply boot
+  /// mic ownership. Default false preserves zero-cost idle behavior.
+  virtual bool wants_background_input() const { return false; }
+};
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // ESPHOME_AUDIO_CORE_PROCESSOR_H

--- a/esphome/components/esp_audio_stack/audio_core_ring_buffer_caps.h
+++ b/esphome/components/esp_audio_stack/audio_core_ring_buffer_caps.h
@@ -1,0 +1,244 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "esphome/components/ring_buffer/ring_buffer.h"
+#include "audio_core_log_utils.h"
+
+#include <esp_heap_caps.h>
+#include <esp_memory_utils.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/ringbuf.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <algorithm>
+#include <cstring>
+
+namespace esphome::esp_audio_stack {
+
+/// Ring buffer allocation policy.
+///
+/// ESPHome's stock RingBuffer::create() now supports EXTERNAL_FIRST and
+/// INTERNAL_FIRST preferences. It still does not offer strict placement or
+/// boot-time placement logging, so latency-sensitive audio code cannot prove
+/// whether a hot ring landed in internal RAM.
+///
+/// This helper provides explicit, verifiable placement:
+///   - INTERNAL: always internal RAM. Use for anything in the audio hot path.
+///   - PREFER_PSRAM: try PSRAM first, fall back to internal. Use for large
+///     non-realtime buffers (protocol, staging) when internal is tight.
+///
+/// At creation time the helper logs name, size, policy, and actual placement
+/// (verified via esp_ptr_internal). This makes memory policy auditable at boot.
+enum class RingBufferPolicy {
+  INTERNAL,
+  PREFER_PSRAM,
+};
+
+/// ESPHome ring_buffer::RingBuffer with caller-controlled storage capabilities.
+///
+/// Keep the concrete type in our ownership model: ESPHome's RingBuffer
+/// destructor is not virtual, so deleting a derived buffer through
+/// std::unique_ptr<RingBuffer> would be undefined behaviour even though the
+/// derived object has no additional fields.
+class CapsRingBuffer : public ring_buffer::RingBuffer {
+ public:
+  ~CapsRingBuffer();
+
+  bool install(size_t len, uint32_t caps, RingbufferType_t type = RINGBUF_TYPE_BYTEBUF);
+  const void *probe_storage() const { return this->storage_; }
+
+  size_t read(void *data, size_t len, TickType_t ticks_to_wait = 0);
+  size_t write(const void *data, size_t len);
+  size_t write_without_replacement(const void *data, size_t len, TickType_t ticks_to_wait = 0,
+                                   bool write_partial = true);
+  BaseType_t reset();
+
+ protected:
+  bool discard_bytes_(size_t discard_bytes);
+
+ private:
+  bool is_nosplit_() const { return this->type_ == RINGBUF_TYPE_NOSPLIT; }
+  RingbufferType_t type_{RINGBUF_TYPE_BYTEBUF};
+};
+
+using RingBufferPtr = std::unique_ptr<CapsRingBuffer>;
+
+/// Create a ring buffer with an explicit memory-placement policy.
+///
+/// @param len    capacity in bytes
+/// @param policy placement policy
+/// @param name   identifier for boot-time placement log (must outlive the call)
+/// @return owned pointer, or nullptr on allocation failure
+RingBufferPtr create_ring_buffer(size_t len, RingBufferPolicy policy, const char *name);
+RingBufferPtr create_nosplit_ring_buffer(size_t len, RingBufferPolicy policy, const char *name);
+
+/// Convenience: force internal RAM. Use for audio hot-path ring buffers.
+inline RingBufferPtr create_internal(size_t len, const char *name) {
+  return create_ring_buffer(len, RingBufferPolicy::INTERNAL, name);
+}
+
+/// Convenience: prefer PSRAM with internal fallback. Use for non-realtime buffers.
+inline RingBufferPtr create_prefer_psram(size_t len, const char *name) {
+  return create_ring_buffer(len, RingBufferPolicy::PREFER_PSRAM, name);
+}
+
+inline RingBufferPtr create_nosplit_internal(size_t len, const char *name) {
+  return create_nosplit_ring_buffer(len, RingBufferPolicy::INTERNAL, name);
+}
+
+inline RingBufferPtr create_nosplit_prefer_psram(size_t len, const char *name) {
+  return create_nosplit_ring_buffer(len, RingBufferPolicy::PREFER_PSRAM, name);
+}
+
+namespace detail {
+
+inline const char *policy_str(RingBufferPolicy p) {
+  switch (p) {
+    case RingBufferPolicy::INTERNAL:
+      return "internal";
+    case RingBufferPolicy::PREFER_PSRAM:
+      return "prefer_psram";
+  }
+  return "?";
+}
+
+}  // namespace detail
+
+inline CapsRingBuffer::~CapsRingBuffer() {
+  if (this->handle_ != nullptr) {
+    vRingbufferDelete(this->handle_);
+    heap_caps_free(this->storage_);
+    this->handle_ = nullptr;
+    this->storage_ = nullptr;
+    this->size_ = 0;
+  }
+}
+
+inline bool CapsRingBuffer::install(size_t len, uint32_t caps, RingbufferType_t type) {
+  uint8_t *mem = static_cast<uint8_t *>(heap_caps_malloc(len, caps));
+  if (mem == nullptr)
+    return false;
+  this->storage_ = mem;
+  this->size_ = len;
+  this->type_ = type;
+  this->handle_ = xRingbufferCreateStatic(len, type, mem, &this->structure_);
+  if (this->handle_ == nullptr) {
+    heap_caps_free(mem);
+    this->storage_ = nullptr;
+    this->size_ = 0;
+    this->type_ = RINGBUF_TYPE_BYTEBUF;
+    return false;
+  }
+  return true;
+}
+
+inline size_t CapsRingBuffer::read(void *data, size_t len, TickType_t ticks_to_wait) {
+  if (!this->is_nosplit_())
+    return ring_buffer::RingBuffer::read(data, len, ticks_to_wait);
+
+  size_t item_len = 0;
+  void *item = xRingbufferReceive(this->handle_, &item_len, ticks_to_wait);
+  if (item == nullptr)
+    return 0;
+
+  const size_t copied = std::min(item_len, len);
+  std::memcpy(data, item, copied);
+  vRingbufferReturnItem(this->handle_, item);
+  return copied;
+}
+
+inline size_t CapsRingBuffer::write(const void *data, size_t len) {
+  if (!this->is_nosplit_())
+    return ring_buffer::RingBuffer::write(data, len);
+
+  while (this->free() < len) {
+    if (!this->discard_bytes_(len - this->free()))
+      break;
+  }
+  return this->write_without_replacement(data, len, 0, false);
+}
+
+inline size_t CapsRingBuffer::write_without_replacement(const void *data, size_t len, TickType_t ticks_to_wait,
+                                                        bool write_partial) {
+  if (!this->is_nosplit_())
+    return ring_buffer::RingBuffer::write_without_replacement(data, len, ticks_to_wait, write_partial);
+
+  if (xRingbufferSend(this->handle_, data, len, ticks_to_wait))
+    return len;
+  return 0;
+}
+
+inline BaseType_t CapsRingBuffer::reset() {
+  if (!this->is_nosplit_())
+    return ring_buffer::RingBuffer::reset();
+
+  while (true) {
+    size_t item_len = 0;
+    void *item = xRingbufferReceive(this->handle_, &item_len, 0);
+    if (item == nullptr)
+      return pdPASS;
+    vRingbufferReturnItem(this->handle_, item);
+  }
+}
+
+inline bool CapsRingBuffer::discard_bytes_(size_t discard_bytes) {
+  if (!this->is_nosplit_())
+    return ring_buffer::RingBuffer::discard_bytes_(discard_bytes);
+
+  size_t discarded = 0;
+  while (discarded < discard_bytes) {
+    size_t item_len = 0;
+    void *item = xRingbufferReceive(this->handle_, &item_len, 0);
+    if (item == nullptr)
+      break;
+    discarded += item_len;
+    vRingbufferReturnItem(this->handle_, item);
+  }
+  return discarded >= discard_bytes;
+}
+
+inline RingBufferPtr create_ring_buffer_with_type(size_t len, RingBufferPolicy policy, const char *name,
+                                                  RingbufferType_t type) {
+  auto rb = std::make_unique<CapsRingBuffer>();
+
+  bool ok = false;
+  switch (policy) {
+    case RingBufferPolicy::INTERNAL:
+      ok = rb->install(len, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT, type);
+      break;
+    case RingBufferPolicy::PREFER_PSRAM:
+      ok = rb->install(len, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT, type);
+      if (!ok)
+        ok = rb->install(len, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT, type);
+      break;
+  }
+
+  if (!ok) {
+    log_error("ring_buffer_caps", "ringbuffer '%s': alloc %u bytes FAILED (policy=%s)", name,
+              static_cast<unsigned>(len), detail::policy_str(policy));
+    return nullptr;
+  }
+
+  const void *storage = rb->probe_storage();
+  const char *placement = esp_ptr_internal(storage) ? "internal" : "psram";
+  log_info("ring_buffer_caps", "ringbuffer '%s': size=%u policy=%s type=%s placement=%s", name,
+           static_cast<unsigned>(len), detail::policy_str(policy), type == RINGBUF_TYPE_NOSPLIT ? "nosplit" : "bytebuf",
+           placement);
+
+  return rb;
+}
+
+inline RingBufferPtr create_ring_buffer(size_t len, RingBufferPolicy policy, const char *name) {
+  return create_ring_buffer_with_type(len, policy, name, RINGBUF_TYPE_BYTEBUF);
+}
+
+inline RingBufferPtr create_nosplit_ring_buffer(size_t len, RingBufferPolicy policy, const char *name) {
+  return create_ring_buffer_with_type(len, policy, name, RINGBUF_TYPE_NOSPLIT);
+}
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/audio_core_scoped_lock.h
+++ b/esphome/components/esp_audio_stack/audio_core_scoped_lock.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+namespace esphome::esp_audio_stack {
+
+/// RAII guard around a FreeRTOS mutex / counting semaphore handle, with an
+/// optional acquire timeout.
+///
+/// Why this exists: ESPHome ships `esphome::Mutex` + `esphome::LockGuard`,
+/// but `LockGuard` always acquires with `portMAX_DELAY`. Our audio paths
+/// need bounded waits (e.g. 2 ms in the AEC reference path) so they can
+/// gracefully skip a frame instead of stalling the audio task. ScopedLock
+/// covers both cases:
+///  - Default constructor (no timeout) blocks until the handle is taken,
+///    matching `LockGuard` semantics.
+///  - With a `timeout_ticks` argument it returns immediately on timeout
+///    and the caller checks success via the bool conversion / `is_locked()`.
+///
+/// Usage:
+/// \code
+///   esp_audio_stack::ScopedLock lock(this->spk_ref_mutex_, pdMS_TO_TICKS(2));
+///   if (lock) {
+///     // protected section, auto-released on scope exit
+///   }
+/// \endcode
+class ScopedLock {
+ public:
+  /// Take the handle with `portMAX_DELAY`. Behaves like esphome::LockGuard.
+  explicit ScopedLock(SemaphoreHandle_t handle)
+      : handle_(handle), locked_(handle != nullptr && xSemaphoreTake(handle, portMAX_DELAY) == pdTRUE) {}
+
+  /// Take the handle with the given FreeRTOS tick timeout. On timeout the
+  /// guard is constructed but `locked_` stays false; destructor is a noop.
+  ScopedLock(SemaphoreHandle_t handle, TickType_t timeout_ticks)
+      : handle_(handle), locked_(handle != nullptr && xSemaphoreTake(handle, timeout_ticks) == pdTRUE) {}
+
+  ~ScopedLock() {
+    if (this->locked_)
+      xSemaphoreGive(this->handle_);
+  }
+
+  ScopedLock(const ScopedLock &) = delete;
+  ScopedLock &operator=(const ScopedLock &) = delete;
+  ScopedLock(ScopedLock &&) = delete;
+  ScopedLock &operator=(ScopedLock &&) = delete;
+
+  /// Returns true if the handle was successfully taken.
+  explicit operator bool() const { return this->locked_; }
+  bool is_locked() const { return this->locked_; }
+
+ private:
+  SemaphoreHandle_t handle_;
+  bool locked_;
+};
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/audio_core_task_utils.h
+++ b/esphome/components/esp_audio_stack/audio_core_task_utils.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "esphome/core/helpers.h"
+#include "audio_core_log_utils.h"
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+namespace esphome::esp_audio_stack {
+
+/// Pin a FreeRTOS task to a core, with optional static stack from PSRAM.
+///
+/// Two creation paths are folded into one call so callers do not have to
+/// repeat the if/else. Both paths log the failure reason via the provided
+/// `log_tag`.
+///
+///  - `psram_stack=true`: allocate `stack_bytes` worth of StackType_t storage
+///    from PSRAM, then call xTaskCreateStaticPinnedToCore.
+///    On allocation failure, returns false without touching the task system.
+///    On success, *stack_out holds the allocated stack pointer.
+///
+///  - `psram_stack=false`: classic xTaskCreatePinnedToCore with FreeRTOS
+///    managing the stack on the internal heap. *stack_out stays nullptr.
+///
+/// `tcb_out` and `stack_out` are only touched when `psram_stack=true`.
+/// `handle_out` is always set (to the new handle, or to nullptr on failure).
+///
+/// Returns true if the task is alive and pinned. Returns false if either the
+/// stack allocation or the task creation failed; in that case the caller
+/// stays responsible for any other resources it allocated for the task.
+inline bool start_pinned_task(TaskFunction_t fn, const char *name, uint32_t stack_bytes, void *param, UBaseType_t prio,
+                              BaseType_t core, bool psram_stack, const char *log_tag, TaskHandle_t *handle_out,
+                              StaticTask_t *tcb_out, StackType_t **stack_out) {
+  *handle_out = nullptr;
+  const uint32_t stack_words = (stack_bytes + sizeof(StackType_t) - 1) / sizeof(StackType_t);
+  if (psram_stack) {
+    *stack_out = nullptr;
+    RAMAllocator<StackType_t> alloc(RAMAllocator<StackType_t>::ALLOC_EXTERNAL);
+    *stack_out = alloc.allocate(stack_words);
+    if (*stack_out == nullptr) {
+      log_error(log_tag, "Failed to allocate PSRAM stack for %s task", name);
+      return false;
+    }
+    *handle_out = xTaskCreateStaticPinnedToCore(fn, name, stack_bytes, param, prio, *stack_out, tcb_out, core);
+  } else {
+    BaseType_t ok = xTaskCreatePinnedToCore(fn, name, stack_bytes, param, prio, handle_out, core);
+    if (ok != pdPASS) {
+      *handle_out = nullptr;
+    }
+  }
+  if (*handle_out == nullptr) {
+    log_error(log_tag, "Failed to create %s task", name);
+    if (psram_stack && *stack_out != nullptr) {
+      RAMAllocator<StackType_t> alloc(RAMAllocator<StackType_t>::ALLOC_EXTERNAL);
+      alloc.deallocate(*stack_out, stack_words);
+      *stack_out = nullptr;
+    }
+    return false;
+  }
+  return true;
+}
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/audio_effects_rate_converter.cpp
+++ b/esphome/components/esp_audio_stack/audio_effects_rate_converter.cpp
@@ -1,0 +1,546 @@
+#include "esp_audio_stack.h"
+
+#ifdef USE_ESP32
+
+#include <algorithm>
+#include <cstring>
+
+#if __has_include(<esp_ae_bit_cvt.h>) && __has_include(<esp_ae_data_weaver.h>) && __has_include(<esp_ae_rate_cvt.h>)
+#include <esp_ae_bit_cvt.h>
+#include <esp_ae_data_weaver.h>
+#include <esp_ae_rate_cvt.h>
+#endif
+#include <esp_heap_caps.h>
+#include <esp_log.h>
+
+namespace esphome::esp_audio_stack {
+
+#if __has_include(<esp_ae_bit_cvt.h>) && __has_include(<esp_ae_data_weaver.h>) && __has_include(<esp_ae_rate_cvt.h>)
+
+static const char *const TAG = "i2s_ae_fx";
+
+namespace {
+constexpr uint8_t MAX_DEINTLV_CH = 8;
+
+int16_t *alloc_internal(size_t count, const char *who) {
+  auto *p = static_cast<int16_t *>(heap_caps_malloc(count * sizeof(int16_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+  if (p == nullptr) {
+    ESP_LOGE(who, "audio effects buffer alloc failed: %u bytes, %u internal free, %u largest",
+             static_cast<unsigned>(count * sizeof(int16_t)),
+             static_cast<unsigned>(heap_caps_get_free_size(MALLOC_CAP_INTERNAL)),
+             static_cast<unsigned>(heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL)));
+  }
+  return p;
+}
+
+bool ensure_buffer(int16_t *&ptr, size_t &cap, size_t needed, const char *who) {
+  if (cap >= needed)
+    return true;
+  if (ptr != nullptr)
+    heap_caps_free(ptr);
+  ptr = alloc_internal(needed, who);
+  cap = ptr != nullptr ? needed : 0;
+  return ptr != nullptr;
+}
+
+class BitCvtHandle {
+ public:
+  ~BitCvtHandle() { this->close_handle_(); }
+
+  void init(uint32_t sample_rate, uint8_t channel, uint8_t src_bits, uint8_t dest_bits) {
+    if (this->sample_rate_ == sample_rate && this->channel_ == channel && this->src_bits_ == src_bits &&
+        this->dest_bits_ == dest_bits) {
+      return;
+    }
+    this->sample_rate_ = sample_rate;
+    this->channel_ = channel;
+    this->src_bits_ = src_bits;
+    this->dest_bits_ = dest_bits;
+    this->close_handle_();
+  }
+
+  bool ready() {
+    if (this->src_bits_ == this->dest_bits_)
+      return true;
+    if (this->handle_ != nullptr)
+      return true;
+    if (this->sample_rate_ == 0 || this->channel_ == 0 || this->src_bits_ == 0 || this->dest_bits_ == 0) {
+      ESP_LOGE(TAG, "invalid esp_ae_bit_cvt config: rate=%u ch=%u src=%u dest=%u",
+               static_cast<unsigned>(this->sample_rate_), static_cast<unsigned>(this->channel_),
+               static_cast<unsigned>(this->src_bits_), static_cast<unsigned>(this->dest_bits_));
+      return false;
+    }
+
+    esp_ae_bit_cvt_cfg_t cfg{};
+    cfg.sample_rate = this->sample_rate_;
+    cfg.channel = this->channel_;
+    cfg.src_bits = this->src_bits_;
+    cfg.dest_bits = this->dest_bits_;
+    const esp_ae_err_t err = esp_ae_bit_cvt_open(&cfg, &this->handle_);
+    if (err == ESP_AE_ERR_OK && this->handle_ != nullptr)
+      return true;
+
+    ESP_LOGE(TAG, "esp_ae_bit_cvt_open failed: err=%d rate=%u ch=%u src=%u dest=%u", static_cast<int>(err),
+             static_cast<unsigned>(this->sample_rate_), static_cast<unsigned>(this->channel_),
+             static_cast<unsigned>(this->src_bits_), static_cast<unsigned>(this->dest_bits_));
+    return false;
+  }
+
+  bool process(const void *in, uint32_t sample_num, void *out, const char *scope) {
+    if (this->src_bits_ == this->dest_bits_) {
+      const size_t bytes = static_cast<size_t>(sample_num) * this->channel_ * (this->src_bits_ >> 3);
+      if (in != out)
+        memcpy(out, in, bytes);
+      return true;
+    }
+    if (!this->ready())
+      return false;
+    const esp_ae_err_t err = esp_ae_bit_cvt_process(this->handle_, sample_num, const_cast<void *>(in), out);
+    if (err == ESP_AE_ERR_OK)
+      return true;
+    ESP_LOGE(TAG, "esp_ae_bit_cvt %s failed: err=%d samples=%u ch=%u src=%u dest=%u", scope, static_cast<int>(err),
+             static_cast<unsigned>(sample_num), static_cast<unsigned>(this->channel_),
+             static_cast<unsigned>(this->src_bits_), static_cast<unsigned>(this->dest_bits_));
+    return false;
+  }
+
+ private:
+  void close_handle_() {
+    if (this->handle_ != nullptr) {
+      esp_ae_bit_cvt_close(this->handle_);
+      this->handle_ = nullptr;
+    }
+  }
+
+  uint32_t sample_rate_{0};
+  uint8_t channel_{0};
+  uint8_t src_bits_{0};
+  uint8_t dest_bits_{0};
+  esp_ae_bit_cvt_handle_t handle_{nullptr};
+};
+
+[[maybe_unused]] bool distribute_channels(int16_t *const *ch, uint8_t nch, size_t count, int16_t *mic_interleaved,
+                                          int16_t *mic_mono, int16_t *ref_out, uint8_t num_mic_ch) {
+  if (nch == 0 || ch[0] == nullptr)
+    return false;
+  if (mic_mono != nullptr)
+    memcpy(mic_mono, ch[0], count * sizeof(int16_t));
+
+  if (num_mic_ch >= 2 && nch >= 2) {
+    if (mic_interleaved != nullptr) {
+      esp_ae_sample_t mic_in[2] = {ch[0], ch[1]};
+      const esp_ae_err_t err = esp_ae_intlv_process(2, 16, static_cast<uint32_t>(count), mic_in, mic_interleaved);
+      if (err != ESP_AE_ERR_OK) {
+        ESP_LOGE(TAG, "esp_ae_intlv_process mic failed: err=%d samples=%u", static_cast<int>(err),
+                 static_cast<unsigned>(count));
+        return false;
+      }
+    }
+    if (ref_out != nullptr && nch >= 3)
+      memcpy(ref_out, ch[2], count * sizeof(int16_t));
+  } else if (ref_out != nullptr && nch >= 2) {
+    memcpy(ref_out, ch[1], count * sizeof(int16_t));
+  }
+  return true;
+}
+
+class RateCvtHandle {
+ public:
+  ~RateCvtHandle() { this->close_handle_(); }
+
+  void init(uint32_t ratio, uint32_t src_rate, uint32_t dest_rate, uint8_t channels, uint8_t complexity,
+            uint8_t perf_type) {
+    this->ratio_ = ratio;
+    this->src_rate_ = src_rate;
+    this->dest_rate_ = dest_rate;
+    this->channels_ = channels;
+    this->complexity_ = std::min<uint8_t>(std::max<uint8_t>(complexity, 1), 3);
+    this->perf_type_ = perf_type == 0 ? ESP_AE_RATE_CVT_PERF_TYPE_MEMORY : ESP_AE_RATE_CVT_PERF_TYPE_SPEED;
+    this->close_handle_();
+  }
+
+  void reset() { this->close_handle_(); }
+  bool passthrough() const { return this->ratio_ <= 1; }
+
+  bool ready() {
+    if (this->passthrough())
+      return true;
+    if (this->handle_ != nullptr)
+      return true;
+    if (this->src_rate_ == 0 || this->dest_rate_ == 0 || this->src_rate_ == this->dest_rate_ || this->channels_ == 0) {
+      ESP_LOGE(TAG, "invalid esp_ae_rate_cvt config: src=%u dest=%u ch=%u", static_cast<unsigned>(this->src_rate_),
+               static_cast<unsigned>(this->dest_rate_), static_cast<unsigned>(this->channels_));
+      return false;
+    }
+
+    esp_ae_rate_cvt_cfg_t cfg{};
+    cfg.src_rate = this->src_rate_;
+    cfg.dest_rate = this->dest_rate_;
+    cfg.channel = this->channels_;
+    cfg.bits_per_sample = 16;
+    cfg.complexity = this->complexity_;
+    cfg.perf_type = this->perf_type_;
+    const esp_ae_err_t err = esp_ae_rate_cvt_open(&cfg, &this->handle_);
+    if (err == ESP_AE_ERR_OK && this->handle_ != nullptr)
+      return true;
+
+    ESP_LOGE(TAG, "esp_ae_rate_cvt_open failed: err=%d src=%u dest=%u ch=%u", static_cast<int>(err),
+             static_cast<unsigned>(this->src_rate_), static_cast<unsigned>(this->dest_rate_),
+             static_cast<unsigned>(this->channels_));
+    return false;
+  }
+
+  bool process(int16_t *in, size_t in_count, int16_t *out, size_t expected_out, const char *scope) {
+    if (!this->ready())
+      return false;
+    uint32_t out_samples = static_cast<uint32_t>(expected_out);
+    const esp_ae_err_t err =
+        esp_ae_rate_cvt_process(this->handle_, in, static_cast<uint32_t>(in_count), out, &out_samples);
+    return this->check_(scope, err, out_samples, expected_out);
+  }
+
+  bool process_deintlv(int16_t **in, size_t in_count, int16_t **out, size_t expected_out, const char *scope) {
+    if (!this->ready())
+      return false;
+    esp_ae_sample_t in_args[MAX_RATE_CVT_CHANNELS]{};
+    esp_ae_sample_t out_args[MAX_RATE_CVT_CHANNELS]{};
+    for (uint8_t i = 0; i < this->channels_; i++) {
+      in_args[i] = in[i];
+      out_args[i] = out[i];
+    }
+    uint32_t out_samples = static_cast<uint32_t>(expected_out);
+    const esp_ae_err_t err = esp_ae_rate_cvt_deintlv_process(this->handle_, in_args, static_cast<uint32_t>(in_count),
+                                                             out_args, &out_samples);
+    return this->check_(scope, err, out_samples, expected_out);
+  }
+
+ private:
+  bool check_(const char *scope, esp_ae_err_t err, uint32_t actual, size_t expected) {
+    // This wrapper intentionally supports exact integer decimation only.
+    // CONFIG_SCHEMA rejects non-integer sample_rate/output_sample_rate pairs.
+    // If non-integer SRC is ever allowed, this check must be redesigned to
+    // propagate variable out_samples through every downstream consumer.
+    if (err == ESP_AE_ERR_OK && actual == expected)
+      return true;
+    ESP_LOGE(TAG, "esp_ae_rate_cvt %s failed/misaligned: err=%d out=%u expected=%u ch=%u", scope, static_cast<int>(err),
+             static_cast<unsigned>(actual), static_cast<unsigned>(expected), static_cast<unsigned>(this->channels_));
+    return false;
+  }
+
+  void close_handle_() {
+    if (this->handle_ != nullptr) {
+      esp_ae_rate_cvt_close(this->handle_);
+      this->handle_ = nullptr;
+    }
+  }
+
+  uint32_t ratio_{1};
+  uint32_t src_rate_{0};
+  uint32_t dest_rate_{0};
+  uint8_t channels_{0};
+  uint8_t complexity_{3};
+  esp_ae_rate_cvt_perf_type_t perf_type_{ESP_AE_RATE_CVT_PERF_TYPE_SPEED};
+  esp_ae_rate_cvt_handle_t handle_{nullptr};
+};
+}  // namespace
+
+#if defined(USE_ESP_AUDIO_STACK_MONO_RX) || defined(USE_ESP_AUDIO_STACK_MONO_REF)
+class AudioEffectsRateConverterImpl {
+ public:
+  ~AudioEffectsRateConverterImpl() {
+    if (this->scratch_ != nullptr)
+      heap_caps_free(this->scratch_);
+  }
+
+  void init(uint32_t ratio, uint32_t src_rate, uint32_t dest_rate, uint8_t complexity, uint8_t perf_type) {
+    this->ratio_ = ratio;
+    this->src_rate_ = src_rate;
+    this->dest_rate_ = dest_rate;
+    this->rate_cvt_.init(ratio, src_rate, dest_rate, 1, complexity, perf_type);
+    this->bit_cvt_.init(src_rate, 1, 32, 16);
+  }
+
+  void reset() { this->rate_cvt_.reset(); }
+
+  bool prepare(size_t in_count, bool source_32bit) {
+    if (source_32bit) {
+      this->bit_cvt_.init(this->src_rate_, 1, 32, 16);
+      if (!this->bit_cvt_.ready())
+        return false;
+    }
+    if (this->ratio_ <= 1)
+      return true;
+    return ensure_buffer(this->scratch_, this->scratch_cap_, in_count, "RateCvt") && this->rate_cvt_.ready();
+  }
+
+  bool process(const int16_t *in, int16_t *out, size_t in_count) {
+    if (this->ratio_ <= 1) {
+      memcpy(out, in, in_count * sizeof(int16_t));
+      return true;
+    }
+    const size_t out_count = in_count / this->ratio_;
+    return this->rate_cvt_.process(const_cast<int16_t *>(in), in_count, out, out_count, "mono");
+  }
+
+  bool process_strided(const int16_t *in, int16_t *out, size_t out_count, size_t stride, size_t offset) {
+    if (stride != 1 || offset != 0) {
+      ESP_LOGE(TAG, "mono strided 16-bit conversion now requires Espressif data-weaver path; got stride=%u offset=%u",
+               static_cast<unsigned>(stride), static_cast<unsigned>(offset));
+      return false;
+    }
+    return this->process(in, out, out_count * this->ratio_);
+  }
+
+  bool process_strided_32(const int32_t *in, int16_t *out, size_t out_count, size_t stride, size_t offset) {
+    if (stride != 1 || offset != 0) {
+      ESP_LOGE(TAG, "mono strided 32-bit conversion now requires Espressif data-weaver path; got stride=%u offset=%u",
+               static_cast<unsigned>(stride), static_cast<unsigned>(offset));
+      return false;
+    }
+    const size_t in_count = out_count * this->ratio_;
+    this->bit_cvt_.init(this->src_rate_, 1, 32, 16);
+    if (this->ratio_ <= 1) {
+      return this->bit_cvt_.process(in, static_cast<uint32_t>(in_count), out, "mono32");
+    }
+    if (!ensure_buffer(this->scratch_, this->scratch_cap_, in_count, "RateCvt"))
+      return false;
+    if (!this->bit_cvt_.process(in, static_cast<uint32_t>(in_count), this->scratch_, "mono32"))
+      return false;
+    return this->process(this->scratch_, out, in_count);
+  }
+
+ private:
+  uint32_t ratio_{1};
+  uint32_t src_rate_{0};
+  uint32_t dest_rate_{0};
+  RateCvtHandle rate_cvt_;
+  BitCvtHandle bit_cvt_;
+  int16_t *scratch_{nullptr};
+  size_t scratch_cap_{0};
+};
+#endif
+
+#ifdef USE_ESP_AUDIO_STACK_MULTI_RX
+class MultiChannelAudioEffectsRateConverterImpl {
+ public:
+  ~MultiChannelAudioEffectsRateConverterImpl() {
+    for (uint8_t i = 0; i < MAX_RATE_CVT_CHANNELS; i++) {
+      if (this->out_ch_[i] != nullptr)
+        heap_caps_free(this->out_ch_[i]);
+    }
+    for (uint8_t i = 0; i < MAX_DEINTLV_CH; i++) {
+      if (this->deintlv_ch_[i] != nullptr)
+        heap_caps_free(this->deintlv_ch_[i]);
+    }
+    if (this->bit_scratch_ != nullptr)
+      heap_caps_free(this->bit_scratch_);
+  }
+
+  void init(uint32_t ratio, uint8_t num_channels, uint32_t src_rate, uint32_t dest_rate, uint8_t complexity,
+            uint8_t perf_type) {
+    this->ratio_ = ratio;
+    this->src_rate_ = src_rate;
+    this->dest_rate_ = dest_rate;
+    this->channels_ = std::min<uint8_t>(num_channels, MAX_RATE_CVT_CHANNELS);
+    this->rate_cvt_.init(ratio, src_rate, dest_rate, this->channels_, complexity, perf_type);
+  }
+
+  void reset() { this->rate_cvt_.reset(); }
+
+  bool prepare(size_t in_count, size_t out_count, uint8_t num_channels, uint8_t source_channels, bool source_32bit) {
+    const uint8_t nch = std::min<uint8_t>(num_channels, MAX_RATE_CVT_CHANNELS);
+    const uint8_t deintlv_channels = source_32bit ? source_channels : nch;
+    if (!this->ensure_deintlv_buffers_(deintlv_channels, in_count))
+      return false;
+    if (source_32bit && !this->ensure_bit_conversion_(source_channels, in_count))
+      return false;
+    if (this->ratio_ <= 1)
+      return true;
+    return this->ensure_output_buffers_(nch, out_count) && this->rate_cvt_.ready();
+  }
+
+  bool process_multi(const int16_t *in, size_t out_count, size_t stride, const uint8_t *offsets,
+                     int16_t *mic_interleaved, int16_t *mic_mono, int16_t *ref_out, uint8_t num_mic_ch) {
+    return this->process_multi_t_(in, out_count, stride, offsets, mic_interleaved, mic_mono, ref_out, num_mic_ch,
+                                  false);
+  }
+
+  bool process_multi_32(const int32_t *in, size_t out_count, size_t stride, const uint8_t *offsets,
+                        int16_t *mic_interleaved, int16_t *mic_mono, int16_t *ref_out, uint8_t num_mic_ch) {
+    return this->process_multi_t_(in, out_count, stride, offsets, mic_interleaved, mic_mono, ref_out, num_mic_ch, true);
+  }
+
+ private:
+  template<typename T>
+  bool process_multi_t_(const T *in, size_t out_count, size_t stride, const uint8_t *offsets, int16_t *mic_interleaved,
+                        int16_t *mic_mono, int16_t *ref_out, uint8_t num_mic_ch, bool source_32bit) {
+    const size_t in_count = out_count * this->ratio_;
+    if (!this->deinterleave_selected_(in, in_count, stride, offsets, source_32bit))
+      return false;
+
+    int16_t *selected[MAX_RATE_CVT_CHANNELS]{};
+    for (uint8_t c = 0; c < this->channels_; c++) {
+      selected[c] = source_32bit ? this->deintlv_ch_[offsets[c]] : this->deintlv_ch_[c];
+    }
+
+    if (this->ratio_ <= 1) {
+      return distribute_channels(selected, this->channels_, out_count, mic_interleaved, mic_mono, ref_out, num_mic_ch);
+    }
+
+    if (!this->ensure_output_buffers_(this->channels_, out_count))
+      return false;
+    if (!this->rate_cvt_.process_deintlv(selected, in_count, this->out_ch_, out_count, "multi"))
+      return false;
+    return distribute_channels(this->out_ch_, this->channels_, out_count, mic_interleaved, mic_mono, ref_out,
+                               num_mic_ch);
+  }
+
+  template<typename T>
+  bool deinterleave_selected_(const T *in, size_t in_count, size_t stride, const uint8_t *offsets, bool source_32bit) {
+    if (stride == 0 || stride > MAX_DEINTLV_CH) {
+      ESP_LOGE(TAG, "unsupported source channel count for esp_ae_deintlv: %u", static_cast<unsigned>(stride));
+      return false;
+    }
+    for (uint8_t c = 0; c < this->channels_; c++) {
+      if (offsets[c] >= stride) {
+        ESP_LOGE(TAG, "channel offset %u outside source channel count %u", static_cast<unsigned>(offsets[c]),
+                 static_cast<unsigned>(stride));
+        return false;
+      }
+    }
+    const void *deintlv_input = in;
+    if (source_32bit) {
+      if (!this->ensure_deintlv_buffers_(static_cast<uint8_t>(stride), in_count))
+        return false;
+      if (!this->ensure_bit_conversion_(static_cast<uint8_t>(stride), in_count))
+        return false;
+      if (!this->bit_cvt_.process(in, static_cast<uint32_t>(in_count), this->bit_scratch_, "multi32"))
+        return false;
+      deintlv_input = this->bit_scratch_;
+    } else {
+      return this->extract_selected_channels_(static_cast<const int16_t *>(deintlv_input), in_count, stride, offsets);
+    }
+
+    esp_ae_sample_t out_args[MAX_DEINTLV_CH]{};
+    for (uint8_t c = 0; c < stride; c++) {
+      out_args[c] = this->deintlv_ch_[c];
+    }
+    const esp_ae_err_t err = esp_ae_deintlv_process(static_cast<uint8_t>(stride), 16, static_cast<uint32_t>(in_count),
+                                                    const_cast<void *>(deintlv_input), out_args);
+    if (err == ESP_AE_ERR_OK)
+      return true;
+    ESP_LOGE(TAG, "esp_ae_deintlv_process failed: err=%d samples=%u ch=%u", static_cast<int>(err),
+             static_cast<unsigned>(in_count), static_cast<unsigned>(stride));
+    return false;
+  }
+
+  bool extract_selected_channels_(const int16_t *in, size_t in_count, size_t stride, const uint8_t *offsets) {
+    if (!this->ensure_deintlv_buffers_(this->channels_, in_count))
+      return false;
+    for (uint8_t c = 0; c < this->channels_; c++) {
+      int16_t *out = this->deintlv_ch_[c];
+      const size_t offset = offsets[c];
+      for (size_t i = 0; i < in_count; i++) {
+        out[i] = in[i * stride + offset];
+      }
+    }
+    return true;
+  }
+
+  bool ensure_bit_conversion_(uint8_t source_channels, size_t in_count) {
+    const size_t sample_slots = in_count * source_channels;
+    if (!ensure_buffer(this->bit_scratch_, this->bit_scratch_cap_, sample_slots, "AEBitCvt"))
+      return false;
+    this->bit_cvt_.init(this->src_rate_, source_channels, 32, 16);
+    return this->bit_cvt_.ready();
+  }
+
+  bool ensure_deintlv_buffers_(uint8_t source_channels, size_t in_count) {
+    if (source_channels == 0 || source_channels > MAX_DEINTLV_CH)
+      return false;
+    for (uint8_t c = 0; c < source_channels; c++) {
+      if (!ensure_buffer(this->deintlv_ch_[c], this->deintlv_cap_[c], in_count, "AEDeintlv"))
+        return false;
+    }
+    return true;
+  }
+
+  bool ensure_output_buffers_(uint8_t channels, size_t out_count) {
+    for (uint8_t c = 0; c < channels; c++) {
+      if (!ensure_buffer(this->out_ch_[c], this->out_cap_[c], out_count, "MCRateCvt"))
+        return false;
+    }
+    return true;
+  }
+
+  uint32_t ratio_{1};
+  uint32_t src_rate_{0};
+  uint32_t dest_rate_{0};
+  uint8_t channels_{0};
+  RateCvtHandle rate_cvt_;
+  BitCvtHandle bit_cvt_;
+  int16_t *deintlv_ch_[MAX_DEINTLV_CH]{};
+  size_t deintlv_cap_[MAX_DEINTLV_CH]{};
+  int16_t *out_ch_[MAX_RATE_CVT_CHANNELS]{};
+  size_t out_cap_[MAX_RATE_CVT_CHANNELS]{};
+  int16_t *bit_scratch_{nullptr};
+  size_t bit_scratch_cap_{0};
+};
+#endif
+
+#if defined(USE_ESP_AUDIO_STACK_MONO_RX) || defined(USE_ESP_AUDIO_STACK_MONO_REF)
+AudioEffectsRateConverter::AudioEffectsRateConverter() : impl_(std::make_unique<AudioEffectsRateConverterImpl>()) {}
+AudioEffectsRateConverter::~AudioEffectsRateConverter() = default;
+void AudioEffectsRateConverter::init(uint32_t ratio, uint32_t src_rate, uint32_t dest_rate, uint8_t complexity,
+                                     uint8_t perf_type) {
+  this->impl_->init(ratio, src_rate, dest_rate, complexity, perf_type);
+}
+void AudioEffectsRateConverter::reset() { this->impl_->reset(); }
+bool AudioEffectsRateConverter::prepare(size_t in_count, bool source_32bit) {
+  return this->impl_->prepare(in_count, source_32bit);
+}
+bool AudioEffectsRateConverter::process(const int16_t *in, int16_t *out, size_t in_count) {
+  return this->impl_->process(in, out, in_count);
+}
+bool AudioEffectsRateConverter::process_strided(const int16_t *in, int16_t *out, size_t out_count, size_t stride,
+                                                size_t offset) {
+  return this->impl_->process_strided(in, out, out_count, stride, offset);
+}
+bool AudioEffectsRateConverter::process_strided_32(const int32_t *in, int16_t *out, size_t out_count, size_t stride,
+                                                   size_t offset) {
+  return this->impl_->process_strided_32(in, out, out_count, stride, offset);
+}
+#endif
+
+#ifdef USE_ESP_AUDIO_STACK_MULTI_RX
+MultiChannelAudioEffectsRateConverter::MultiChannelAudioEffectsRateConverter()
+    : impl_(std::make_unique<MultiChannelAudioEffectsRateConverterImpl>()) {}
+MultiChannelAudioEffectsRateConverter::~MultiChannelAudioEffectsRateConverter() = default;
+void MultiChannelAudioEffectsRateConverter::init(uint32_t ratio, uint8_t num_channels, uint32_t src_rate,
+                                                 uint32_t dest_rate, uint8_t complexity, uint8_t perf_type) {
+  this->impl_->init(ratio, num_channels, src_rate, dest_rate, complexity, perf_type);
+}
+void MultiChannelAudioEffectsRateConverter::reset() { this->impl_->reset(); }
+bool MultiChannelAudioEffectsRateConverter::prepare(size_t in_count, size_t out_count, uint8_t num_channels,
+                                                    uint8_t source_channels, bool source_32bit) {
+  return this->impl_->prepare(in_count, out_count, num_channels, source_channels, source_32bit);
+}
+bool MultiChannelAudioEffectsRateConverter::process_multi(const int16_t *in, size_t out_count, size_t in_stride,
+                                                          const uint8_t *channel_offsets, int16_t *mic_interleaved,
+                                                          int16_t *mic_mono, int16_t *ref_out, uint8_t num_mic_ch) {
+  return this->impl_->process_multi(in, out_count, in_stride, channel_offsets, mic_interleaved, mic_mono, ref_out,
+                                    num_mic_ch);
+}
+bool MultiChannelAudioEffectsRateConverter::process_multi_32(const int32_t *in, size_t out_count, size_t in_stride,
+                                                             const uint8_t *channel_offsets, int16_t *mic_interleaved,
+                                                             int16_t *mic_mono, int16_t *ref_out, uint8_t num_mic_ch) {
+  return this->impl_->process_multi_32(in, out_count, in_stride, channel_offsets, mic_interleaved, mic_mono, ref_out,
+                                       num_mic_ch);
+}
+#endif
+
+#endif  // esp-audio-libs headers available
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/audio_pipeline.cpp
+++ b/esphome/components/esp_audio_stack/audio_pipeline.cpp
@@ -1,0 +1,1748 @@
+#include "esp_audio_stack.h"
+
+#ifdef USE_ESP32
+
+#if __has_include(<esp_ae_alc.h>) && __has_include(<esp_ae_ch_cvt.h>) && __has_include(<gain.h>)
+#include <esp_err.h>
+#include <esp_ae_alc.h>
+#include <esp_ae_ch_cvt.h>
+#include <esp_timer.h>
+#include <esp_heap_caps.h>
+#include <gain.h>
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+#if __has_include(<esp_ae_bit_cvt.h>)
+#include <esp_ae_bit_cvt.h>
+#endif
+#endif
+#if defined(USE_ESP_AUDIO_STACK_TDM_BUS) || defined(USE_ESP_AUDIO_STACK_STEREO_TX)
+#if __has_include(<esp_ae_data_weaver.h>)
+#include <esp_ae_data_weaver.h>
+#endif
+#endif
+#endif
+#include <algorithm>
+#include <cstring>
+
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+#ifdef USE_AUDIO_PROCESSOR
+#include "audio_core_processor.h"
+#endif
+#include "audio_core_log_utils.h"
+#include "audio_core_audio_utils.h"
+#ifdef USE_ESP_AUDIO_STACK_RING_REF
+#include "audio_core_ring_buffer_caps.h"
+#endif
+
+namespace esphome::esp_audio_stack {
+
+#if __has_include(<esp_ae_alc.h>) && __has_include(<esp_ae_ch_cvt.h>) && __has_include(<gain.h>)
+
+static const char *const TAG = "audio_stack";
+
+// Default frame size when no AudioProcessor is attached.
+static const size_t DEFAULT_FRAME_SIZE = 256;
+static constexpr size_t AUDIO_BUFFER_ALIGN = 16;
+
+static inline bool alloc_i16_buffer(int16_t **buffer, size_t *buffer_bytes, size_t bytes, uint32_t caps, bool aligned) {
+  if (bytes == 0) {
+    return true;
+  }
+  *buffer = static_cast<int16_t *>(aligned ? heap_caps_aligned_alloc(AUDIO_BUFFER_ALIGN, bytes, caps)
+                                           : heap_caps_malloc(bytes, caps));
+  if (*buffer == nullptr) {
+    return false;
+  }
+  if (buffer_bytes != nullptr) {
+    *buffer_bytes = bytes;
+  }
+  return true;
+}
+
+static inline void free_i16_buffer(int16_t **buffer, size_t *buffer_bytes = nullptr) {
+  if (*buffer != nullptr) {
+    heap_caps_free(*buffer);
+    *buffer = nullptr;
+  }
+  if (buffer_bytes != nullptr) {
+    *buffer_bytes = 0;
+  }
+}
+
+size_t ESPAudioStack::get_mic_callback_buffer_size() const {
+  // ESPHome microphone callbacks are copied from the realtime audio task, so
+  // the backing vector must already cover later processor frame_spec bumps.
+  // GMF AFE on P4/S3 can publish 1024-sample output frames after setup.
+  size_t samples = std::max<size_t>(DEFAULT_FRAME_SIZE, 1024);
+#ifdef USE_AUDIO_PROCESSOR
+  const esp_audio_stack::FrameSpec default_spec{};
+  samples = std::max(samples, std::max(default_spec.input_samples, default_spec.output_samples));
+  if (this->processor_ != nullptr) {
+    const auto spec = this->processor_->frame_spec();
+    if (spec.input_samples > 0) {
+      samples = std::max(samples, spec.input_samples);
+    }
+    if (spec.output_samples > 0) {
+      samples = std::max(samples, spec.output_samples);
+    }
+  }
+#endif
+  return samples * sizeof(int16_t);
+}
+
+void ESPAudioStack::release_audio_buffers_() {
+  free_i16_buffer(&this->prealloc_rx_buffer_, &this->prealloc_rx_buffer_bytes_);
+  free_i16_buffer(&this->prealloc_mic_buffer_, &this->prealloc_mic_buffer_bytes_);
+  free_i16_buffer(&this->prealloc_processor_mic_buffer_, &this->prealloc_processor_mic_buffer_bytes_);
+  free_i16_buffer(&this->prealloc_spk_buffer_, &this->prealloc_spk_buffer_bytes_);
+  free_i16_buffer(&this->prealloc_spk_ref_buffer_, &this->prealloc_spk_ref_buffer_bytes_);
+  free_i16_buffer(&this->prealloc_tx_ref_mono_buffer_, &this->prealloc_tx_ref_mono_buffer_bytes_);
+  free_i16_buffer(&this->prealloc_aec_output_, &this->prealloc_aec_output_bytes_);
+  free_i16_buffer(&this->prealloc_tx_clock_buffer_, &this->prealloc_tx_clock_buffer_bytes_);
+  if (this->mic_alc_handle_ != nullptr) {
+    esp_ae_alc_close(static_cast<esp_ae_alc_handle_t>(this->mic_alc_handle_));
+    this->mic_alc_handle_ = nullptr;
+    this->mic_alc_gain_db_ = 0;
+  }
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+  free_i16_buffer(&this->prealloc_tdm_tx_buffer_, &this->prealloc_tdm_tx_buffer_bytes_);
+  free_i16_buffer(&this->prealloc_tx_silence_buffer_, &this->prealloc_tx_silence_buffer_bytes_);
+#endif
+#ifdef USE_ESP_AUDIO_STACK_STEREO_TX
+  free_i16_buffer(&this->prealloc_tx_interleave_buffer_, &this->prealloc_tx_interleave_buffer_bytes_);
+#endif
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+  free_i16_buffer(&this->prealloc_tx_32_buffer_, &this->prealloc_tx_32_buffer_bytes_);
+  if (this->tx_bit_cvt_handle_ != nullptr) {
+    esp_ae_bit_cvt_close(static_cast<esp_ae_bit_cvt_handle_t>(this->tx_bit_cvt_handle_));
+    this->tx_bit_cvt_handle_ = nullptr;
+    this->tx_bit_cvt_channels_ = 0;
+  }
+#endif
+#if defined(USE_ESP_AUDIO_STACK_STEREO_TX) && defined(USE_ESP_AUDIO_STACK_MONO_REF)
+  if (this->tx_ref_ch_cvt_handle_ != nullptr) {
+    esp_ae_ch_cvt_close(static_cast<esp_ae_ch_cvt_handle_t>(this->tx_ref_ch_cvt_handle_));
+    this->tx_ref_ch_cvt_handle_ = nullptr;
+  }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+  free_i16_buffer(&this->direct_aec_ref_);
+  this->direct_aec_ref_valid_ = false;
+#endif
+#ifdef USE_ESP_AUDIO_STACK_RING_REF
+  this->aec_ref_ring_buffer_.reset();
+#endif
+
+  this->audio_buffers_allocated_ = false;
+}
+
+bool ESPAudioStack::allocate_audio_buffers_(AudioTaskCtx &ctx) {
+  const uint32_t buf_caps =
+      this->buffers_in_psram_ ? (MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) : (MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+
+  // Worst-case processor mic channels: 2 if dual-mic TDM is available, else 1.
+  // Allocating for 2ch unconditionally when dual-mic is possible lets the task
+  // flip between MR (1 mic) and MMR (2 mic) without reallocating on reconfigure.
+  const uint8_t worst_mic_ch = (this->tdm_second_mic_slot_ >= 0) ? 2 : 1;
+  bool processor_buffers_needed = false;
+#ifdef USE_AUDIO_PROCESSOR
+  // Allocate for the processor once its frame shape is known, even if AFE
+  // feed/fetch workers are still parked. This moves heap pressure out of the
+  // first media/call activation without starting I2S or esp-sr work.
+  processor_buffers_needed = this->processor_ != nullptr && ctx.processor_spec_loaded;
+#endif
+  const size_t rx_bytes = ctx.rx_frame_bytes;
+  const size_t mic_bytes = ctx.mic_separate ? ctx.input_frame_bytes : 0;
+  const size_t processor_mic_bytes =
+      (processor_buffers_needed && worst_mic_ch > 1) ? ctx.input_frame_bytes * worst_mic_ch : 0;
+  const size_t spk_bytes = ctx.speaker_frame_bytes;
+  const size_t tx_ref_mono_bytes = (processor_buffers_needed && !ctx.use_tdm_bus && ctx.speaker_channels > 1 &&
+                                    !ctx.use_stereo_aec_ref && !ctx.use_tdm_ref)
+                                       ? ctx.bus_frame_bytes
+                                       : 0;
+  const size_t spk_ref_bytes =
+      (ctx.use_stereo_aec_ref || ctx.use_tdm_ref || processor_buffers_needed) ? ctx.input_frame_bytes : 0;
+  const size_t aec_output_bytes = processor_buffers_needed ? ctx.output_frame_bytes : 0;
+  size_t tdm_tx_bytes = 0;
+  size_t tx_silence_bytes = 0;
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+  tdm_tx_bytes = ctx.use_tdm_bus ? ctx.bus_frame_size * ctx.tdm_total_slots * ctx.i2s_bps : 0;
+  tx_silence_bytes = ctx.use_tdm_bus ? ctx.bus_frame_bytes : 0;
+#endif
+  size_t tx_interleave_bytes = 0;
+#ifdef USE_ESP_AUDIO_STACK_STEREO_TX
+  tx_interleave_bytes = (!ctx.use_tdm_bus && ctx.num_ch > 1 && ctx.speaker_channels == 1)
+                            ? ctx.bus_frame_size * ctx.num_ch * sizeof(int16_t)
+                            : 0;
+#endif
+  const size_t tx_clock_bytes = ctx.use_tdm_bus ? tdm_tx_bytes : ctx.bus_frame_size * ctx.num_ch * ctx.i2s_bps;
+  size_t tx_32_bytes = 0;
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+  tx_32_bytes = ctx.i2s_bps == 4 ? (ctx.use_tdm_bus ? tdm_tx_bytes : ctx.bus_frame_size * ctx.num_ch * ctx.i2s_bps) : 0;
+#endif
+
+  auto prepare_rate_converters = [&]() -> bool {
+    bool ready = true;
+    bool rx_prepared = false;
+#ifdef USE_ESP_AUDIO_STACK_MULTI_RX
+    if (ctx.use_tdm_bus || ctx.use_stereo_aec_ref) {
+      ready = this->rx_rate_converter_.prepare(ctx.bus_frame_size, ctx.input_frame_size, ctx.rx_rate_converter_channels,
+                                               ctx.use_tdm_bus ? ctx.tdm_total_slots : 2, ctx.i2s_bps == 4);
+      rx_prepared = true;
+    }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_MONO_RX
+    if (!rx_prepared && (ctx.ratio > 1 || ctx.i2s_bps == 4)) {
+      // Mono RX uses esp_audio_effects for both rate and bit-depth conversion.
+      ready = this->mic_rate_converter_.prepare(ctx.bus_frame_size, ctx.i2s_bps == 4);
+      rx_prepared = true;
+    }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+    (void) rx_prepared;
+    if (ready && processor_buffers_needed && !ctx.use_stereo_aec_ref && !ctx.use_tdm_ref) {
+      // No-codec / software-reference AEC converts the TX speaker frame into
+      // direct_aec_ref_. Keep that converter hot before speaker playback starts.
+      ready = this->play_ref_rate_converter_.prepare(ctx.bus_frame_size);
+    }
+#if defined(USE_ESP_AUDIO_STACK_STEREO_TX)
+    if (ready && tx_ref_mono_bytes > 0 && this->tx_ref_ch_cvt_handle_ == nullptr) {
+      esp_ae_ch_cvt_cfg_t cfg{};
+      cfg.sample_rate = this->sample_rate_;
+      cfg.bits_per_sample = 16;
+      cfg.src_ch = ctx.speaker_channels;
+      cfg.dest_ch = 1;
+      cfg.weight = nullptr;
+      cfg.weight_len = 0;
+      esp_ae_ch_cvt_handle_t handle = nullptr;
+      const esp_ae_err_t err = esp_ae_ch_cvt_open(&cfg, &handle);
+      if (err != ESP_AE_ERR_OK || handle == nullptr) {
+        ESP_LOGE(TAG, "esp_ae_ch_cvt_open TX ref failed: err=%d ch=%u", static_cast<int>(err),
+                 (unsigned) ctx.speaker_channels);
+        ready = false;
+      } else {
+        this->tx_ref_ch_cvt_handle_ = handle;
+      }
+    }
+#endif
+#else
+    (void) rx_prepared;
+#endif
+    return ready;
+  };
+
+  if (this->audio_buffers_allocated_) {
+    const bool fits =
+        this->prealloc_rx_buffer_ != nullptr && this->prealloc_rx_buffer_bytes_ >= rx_bytes &&
+        (!ctx.mic_separate ||
+         (this->prealloc_mic_buffer_ != nullptr && this->prealloc_mic_buffer_bytes_ >= mic_bytes)) &&
+        (processor_mic_bytes == 0 || (this->prealloc_processor_mic_buffer_ != nullptr &&
+                                      this->prealloc_processor_mic_buffer_bytes_ >= processor_mic_bytes)) &&
+        this->prealloc_spk_buffer_ != nullptr && this->prealloc_spk_buffer_bytes_ >= spk_bytes &&
+        (spk_ref_bytes == 0 ||
+         (this->prealloc_spk_ref_buffer_ != nullptr && this->prealloc_spk_ref_buffer_bytes_ >= spk_ref_bytes)) &&
+        (tx_ref_mono_bytes == 0 || (this->prealloc_tx_ref_mono_buffer_ != nullptr &&
+                                    this->prealloc_tx_ref_mono_buffer_bytes_ >= tx_ref_mono_bytes)) &&
+        (aec_output_bytes == 0 ||
+         (this->prealloc_aec_output_ != nullptr && this->prealloc_aec_output_bytes_ >= aec_output_bytes))
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+        && (tdm_tx_bytes == 0 ||
+            (this->prealloc_tdm_tx_buffer_ != nullptr && this->prealloc_tdm_tx_buffer_bytes_ >= tdm_tx_bytes)) &&
+        (tx_silence_bytes == 0 ||
+         (this->prealloc_tx_silence_buffer_ != nullptr && this->prealloc_tx_silence_buffer_bytes_ >= tx_silence_bytes))
+#endif
+#ifdef USE_ESP_AUDIO_STACK_STEREO_TX
+        && (tx_interleave_bytes == 0 || (this->prealloc_tx_interleave_buffer_ != nullptr &&
+                                         this->prealloc_tx_interleave_buffer_bytes_ >= tx_interleave_bytes))
+#endif
+        && (this->prealloc_tx_clock_buffer_ != nullptr && this->prealloc_tx_clock_buffer_bytes_ >= tx_clock_bytes)
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+        && (tx_32_bytes == 0 ||
+            (this->prealloc_tx_32_buffer_ != nullptr && this->prealloc_tx_32_buffer_bytes_ >= tx_32_bytes))
+#endif
+        ;
+    if (fits) {
+      if (!prepare_rate_converters()) {
+        this->release_audio_buffers_();
+        return false;
+      }
+      return true;
+    }
+    ESP_LOGI(TAG, "Audio buffer shape changed; reallocating buffers");
+    this->release_audio_buffers_();
+  }
+
+  alloc_i16_buffer(&this->prealloc_rx_buffer_, &this->prealloc_rx_buffer_bytes_, rx_bytes, buf_caps, false);
+
+  if (ctx.mic_separate) {
+    alloc_i16_buffer(&this->prealloc_mic_buffer_, &this->prealloc_mic_buffer_bytes_, mic_bytes, buf_caps, true);
+  }
+
+  if (processor_mic_bytes > 0) {
+    alloc_i16_buffer(&this->prealloc_processor_mic_buffer_, &this->prealloc_processor_mic_buffer_bytes_,
+                     processor_mic_bytes, buf_caps, true);
+  }
+
+  alloc_i16_buffer(&this->prealloc_spk_buffer_, &this->prealloc_spk_buffer_bytes_, spk_bytes, buf_caps, false);
+
+  if (ctx.use_stereo_aec_ref || ctx.use_tdm_ref) {
+    alloc_i16_buffer(&this->prealloc_spk_ref_buffer_, &this->prealloc_spk_ref_buffer_bytes_, spk_ref_bytes, buf_caps,
+                     true);
+  }
+
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+  if (ctx.use_tdm_bus) {
+    alloc_i16_buffer(&this->prealloc_tdm_tx_buffer_, &this->prealloc_tdm_tx_buffer_bytes_, tdm_tx_bytes, buf_caps,
+                     false);
+    alloc_i16_buffer(&this->prealloc_tx_silence_buffer_, &this->prealloc_tx_silence_buffer_bytes_, tx_silence_bytes,
+                     buf_caps, true);
+    if (this->prealloc_tx_silence_buffer_ != nullptr) {
+      memset(this->prealloc_tx_silence_buffer_, 0, tx_silence_bytes);
+    }
+  }
+#endif
+
+  if (tx_ref_mono_bytes > 0) {
+    alloc_i16_buffer(&this->prealloc_tx_ref_mono_buffer_, &this->prealloc_tx_ref_mono_buffer_bytes_, tx_ref_mono_bytes,
+                     buf_caps, true);
+  }
+
+#ifdef USE_ESP_AUDIO_STACK_STEREO_TX
+  if (tx_interleave_bytes > 0) {
+    alloc_i16_buffer(&this->prealloc_tx_interleave_buffer_, &this->prealloc_tx_interleave_buffer_bytes_,
+                     tx_interleave_bytes, buf_caps, true);
+  }
+#endif
+
+  alloc_i16_buffer(&this->prealloc_tx_clock_buffer_, &this->prealloc_tx_clock_buffer_bytes_, tx_clock_bytes, buf_caps,
+                   false);
+  if (this->prealloc_tx_clock_buffer_ != nullptr) {
+    memset(this->prealloc_tx_clock_buffer_, 0, tx_clock_bytes);
+  }
+
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+  if (tx_32_bytes > 0) {
+    alloc_i16_buffer(&this->prealloc_tx_32_buffer_, &this->prealloc_tx_32_buffer_bytes_, tx_32_bytes, buf_caps, false);
+  }
+#endif
+
+#ifdef USE_AUDIO_PROCESSOR
+  if (processor_buffers_needed) {
+    if (!this->prealloc_spk_ref_buffer_ && !ctx.use_tdm_ref) {
+      alloc_i16_buffer(&this->prealloc_spk_ref_buffer_, &this->prealloc_spk_ref_buffer_bytes_, spk_ref_bytes, buf_caps,
+                       true);
+    }
+    alloc_i16_buffer(&this->prealloc_aec_output_, &this->prealloc_aec_output_bytes_, aec_output_bytes, buf_caps, true);
+
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+    // direct_aec_ref_ stores the converted TX reference at the processor rate.
+    // Sized to ctx.input_frame_bytes: the AEC reference is the signal that
+    // enters the DSP alongside the mic, so it lives on the input side of the
+    // processor (AudioProcessor::process expects in_ref of input_samples len).
+    // The TX-side rate converter writes input_frame_size samples here per frame.
+    // Honours buffers_in_psram_ alongside the rest.
+    if (!this->direct_aec_ref_ && !ctx.use_stereo_aec_ref && !ctx.use_tdm_ref) {
+      alloc_i16_buffer(&this->direct_aec_ref_, nullptr, ctx.input_frame_bytes, buf_caps, true);
+      if (this->direct_aec_ref_ != nullptr) {
+        memset(this->direct_aec_ref_, 0, ctx.input_frame_bytes);
+      }
+    }
+
+    // AEC reference ring buffer (Espressif/ADF TYPE2-style, no-codec setups).
+#ifdef USE_ESP_AUDIO_STACK_RING_REF
+    if (!ctx.use_stereo_aec_ref && !ctx.use_tdm_ref && !this->aec_ref_ring_buffer_) {
+      // Sized at the processor rate (post-rate-conversion), not the bus rate, since
+      // we now convert on the TX side before storing. Items pushed are
+      // input_frame_bytes (one AEC reference frame) each.
+      const uint32_t output_rate = this->sample_rate_ / ctx.ratio;
+      size_t rb_bytes = (output_rate * this->aec_ref_buffer_ms_ / 1000) * sizeof(int16_t);
+      if (rb_bytes < ctx.input_frame_bytes * 4)
+        rb_bytes = ctx.input_frame_bytes * 4;
+      // Placement YAML-controlled: internal saves ~13.6 us/frame on Core 0 (R+W ~1 KB each),
+      // PSRAM saves ~3-5 KB internal RAM (set aec_ref_ring_in_psram).
+      this->aec_ref_ring_buffer_ = this->aec_ref_ring_in_psram_ ? create_prefer_psram(rb_bytes, "audio_stack.aec_ref")
+                                                                : create_internal(rb_bytes, "audio_stack.aec_ref");
+      if (!this->aec_ref_ring_buffer_) {
+        this->release_audio_buffers_();
+        return false;
+      }
+      ESP_LOGI(TAG, "AEC reference: ring_buffer (%zu bytes, %ums capacity)", rb_bytes,
+               (unsigned) this->aec_ref_buffer_ms_);
+    }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_PREVIOUS_FRAME_REF
+    if (!ctx.use_stereo_aec_ref && !ctx.use_tdm_ref) {
+      ESP_LOGI(TAG, "AEC reference: previous_frame");
+    }
+#endif
+#endif
+  }
+#endif
+
+  // Validate required allocations
+  if (!this->prealloc_rx_buffer_ || !this->prealloc_spk_buffer_) {
+    this->release_audio_buffers_();
+    return false;
+  }
+  if (ctx.mic_separate && !this->prealloc_mic_buffer_) {
+    this->release_audio_buffers_();
+    return false;
+  }
+  if (processor_mic_bytes > 0 && !this->prealloc_processor_mic_buffer_) {
+    this->release_audio_buffers_();
+    return false;
+  }
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+  if (ctx.use_tdm_bus && !this->prealloc_tdm_tx_buffer_) {
+    this->release_audio_buffers_();
+    return false;
+  }
+  if (ctx.use_tdm_bus && !this->prealloc_tx_silence_buffer_) {
+    this->release_audio_buffers_();
+    return false;
+  }
+#endif
+  if (tx_ref_mono_bytes > 0 && !this->prealloc_tx_ref_mono_buffer_) {
+    this->release_audio_buffers_();
+    return false;
+  }
+#ifdef USE_ESP_AUDIO_STACK_STEREO_TX
+  if (tx_interleave_bytes > 0 && !this->prealloc_tx_interleave_buffer_) {
+    this->release_audio_buffers_();
+    return false;
+  }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+  if (tx_32_bytes > 0 && !this->prealloc_tx_32_buffer_) {
+    this->release_audio_buffers_();
+    return false;
+  }
+#endif
+#ifdef USE_AUDIO_PROCESSOR
+  if (processor_buffers_needed) {
+    if (!this->prealloc_aec_output_) {
+      this->release_audio_buffers_();
+      return false;
+    }
+    if ((ctx.use_stereo_aec_ref || ctx.use_tdm_ref) && !this->prealloc_spk_ref_buffer_) {
+      this->release_audio_buffers_();
+      return false;
+    }
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+    // Mono AEC depends on direct_aec_ref_ as both the TX-side rate-conversion scratch
+    // and the previous-frame store. If it failed to allocate, the AEC would
+    // silently run with a zero reference (TX writer is null-gated, ring writer
+    // too, fill_mono falls through to zero-fill) and stay degraded until reboot,
+    // because audio_buffers_allocated_ latches true on success. Fail-closed.
+    if (!ctx.use_stereo_aec_ref && !ctx.use_tdm_ref && !this->direct_aec_ref_) {
+      ESP_LOGE(TAG, "Mono AEC reference buffer allocation failed (%zu bytes)", ctx.input_frame_bytes);
+      this->release_audio_buffers_();
+      return false;
+    }
+    if (!ctx.use_tdm_bus && ctx.speaker_channels > 1 && !ctx.use_stereo_aec_ref && !ctx.use_tdm_ref &&
+        !this->prealloc_tx_ref_mono_buffer_) {
+      ESP_LOGE(TAG, "Stereo TX mono reference buffer allocation failed (%zu bytes)", ctx.bus_frame_bytes);
+      this->release_audio_buffers_();
+      return false;
+    }
+#endif
+  }
+#endif
+
+  if (!prepare_rate_converters()) {
+    this->release_audio_buffers_();
+    return false;
+  }
+
+  this->audio_buffers_allocated_ = true;
+  return true;
+}
+
+void ESPAudioStack::audio_task(void *param) {
+  ESPAudioStack *self = static_cast<ESPAudioStack *>(param);
+  self->audio_task_();
+  vTaskDelete(nullptr);
+}
+
+void ESPAudioStack::audio_task_() {
+  // Component lifetime is process-wide (no destructor in ESPHome), so
+  // this task lives forever; stop()/start() just toggle audio_stack_running_
+  // to park/wake the inner session loop.
+  while (true) {
+    this->audio_task_idle_.store(true, std::memory_order_relaxed);
+    TaskHandle_t waiter = this->audio_state_waiter_.load(std::memory_order_acquire);
+    if (waiter != nullptr) {
+      xTaskNotifyGive(waiter);
+    }
+    if (this->prealloc_requested_.exchange(false, std::memory_order_acq_rel)) {
+      this->preallocate_audio_buffers_from_task_();
+    }
+    this->service_speaker_reset_();
+    if (!this->audio_stack_running_.load(std::memory_order_relaxed)) {
+      ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+      continue;
+    }
+    this->audio_task_idle_.store(false, std::memory_order_relaxed);
+    waiter = this->audio_state_waiter_.load(std::memory_order_acquire);
+    if (waiter != nullptr) {
+      xTaskNotifyGive(waiter);
+    }
+
+    // Run one audio session. Returns on stop() (audio_stack_running_ cleared) or on
+    // processor frame_spec change (session restarts in the next outer iter).
+    this->audio_session_();
+  }
+}
+
+bool ESPAudioStack::prepare_audio_context_(AudioTaskCtx &ctx, bool require_processor_spec, bool log_context) {
+  ctx.ratio = this->rate_conversion_ratio_;
+  ctx.i2s_bps = (this->bits_per_sample_ > 16) ? 4 : 2;
+  ctx.num_ch = this->num_channels_;
+  ctx.speaker_channels = this->get_speaker_channels();
+  ctx.use_stereo_aec_ref = this->use_stereo_aec_ref_;
+  ctx.rx_slot_mode_stereo = this->rx_slot_mode_stereo_;
+  ctx.use_tdm_bus = this->use_tdm_bus_;
+  ctx.use_tdm_ref = this->use_tdm_ref_;
+  ctx.ref_channel_right = this->ref_channel_right_;
+  ctx.correct_dc_offset = this->correct_dc_offset_;
+  ctx.tdm_total_slots = this->tdm_total_slots_;
+  ctx.tdm_mic_slot = this->tdm_mic_slot_;
+  ctx.tdm_second_mic_slot = this->tdm_second_mic_slot_;
+  ctx.tdm_ref_slot = this->tdm_ref_slot_;
+  ctx.tdm_tx_slot = this->tdm_tx_slot_;
+
+  if (log_context) {
+    ESP_LOGI(TAG, "Audio task started (stereo=%s, tdm=%s, rate_conversion=%ux)", ctx.use_stereo_aec_ref ? "YES" : "no",
+             ctx.use_tdm_bus ? (ctx.use_tdm_ref ? "YES/ref" : "YES/mic") : "no", (unsigned) ctx.ratio);
+  }
+
+  // Determine frame sizes: processors may consume and produce different frame lengths.
+  ctx.input_frame_size = DEFAULT_FRAME_SIZE;
+  ctx.output_frame_size = DEFAULT_FRAME_SIZE;
+#ifdef USE_AUDIO_PROCESSOR
+  if (this->processor_ != nullptr) {
+    ctx.processor_spec_revision = this->processor_->frame_spec_revision();
+    auto spec = this->processor_->frame_spec();
+    if (spec.input_samples > 0 && spec.output_samples > 0) {
+      ctx.input_frame_size = spec.input_samples;
+      ctx.output_frame_size = spec.output_samples;
+      ctx.processor_mic_channels = std::max<uint8_t>(1, spec.mic_channels);
+      ctx.processor_spec_loaded = true;
+      uint32_t out_rate = this->get_output_sample_rate();
+      if (log_context) {
+        ESP_LOGI(TAG, "Processor: input=%u, output=%u samples, mic_ch=%u (%ums @ %uHz), revision=%u",
+                 (unsigned) ctx.input_frame_size, (unsigned) ctx.output_frame_size,
+                 (unsigned) ctx.processor_mic_channels, (unsigned) (ctx.input_frame_size * 1000 / out_rate),
+                 (unsigned) out_rate, (unsigned) ctx.processor_spec_revision);
+      }
+    } else if (require_processor_spec) {
+      return false;
+    }
+  }
+#endif
+
+#ifdef USE_ESP_AUDIO_STACK_MULTI_RX
+  // Init multi-channel RX rate converter now that we know channel count
+  if (ctx.use_tdm_bus || ctx.use_stereo_aec_ref || ctx.rx_slot_mode_stereo) {
+    ctx.rx_rate_converter_channels =
+        ctx.use_tdm_bus ? (ctx.processor_mic_channels > 1 ? 2 : 1) + (ctx.use_tdm_ref ? 1 : 0)
+                        : (ctx.use_stereo_aec_ref ? 2 : 1);  // stereo ref: mic + ref; stereo mic: selected mic only
+    this->rx_rate_converter_.init(ctx.ratio, ctx.rx_rate_converter_channels, this->sample_rate_,
+                                  this->get_output_sample_rate(), this->rate_cvt_complexity_,
+                                  this->rate_cvt_perf_type_);
+  }
+#endif
+
+  // ── Frame sizing ──
+  ctx.bus_frame_size = ctx.input_frame_size * ctx.ratio;
+  ctx.input_frame_bytes = ctx.input_frame_size * sizeof(int16_t);
+  ctx.output_frame_bytes = ctx.output_frame_size * sizeof(int16_t);
+  ctx.bus_frame_bytes = ctx.bus_frame_size * sizeof(int16_t);
+  ctx.speaker_frame_bytes = ctx.bus_frame_bytes * ctx.speaker_channels;
+  if (ctx.use_tdm_bus) {
+    ctx.rx_frame_bytes = ctx.bus_frame_size * ctx.tdm_total_slots * ctx.i2s_bps;
+  } else if (ctx.use_stereo_aec_ref || ctx.rx_slot_mode_stereo) {
+    ctx.rx_frame_bytes = ctx.bus_frame_size * 2 * ctx.i2s_bps;
+  } else {
+    ctx.rx_frame_bytes = ctx.bus_frame_size * ctx.i2s_bps;
+  }
+  ctx.mic_separate =
+      (ctx.ratio > 1) || ctx.use_stereo_aec_ref || ctx.rx_slot_mode_stereo || ctx.use_tdm_bus || (ctx.i2s_bps == 4);
+  if (ctx.use_tdm_bus) {
+    ctx.rx_path_kind = RxPathKind::TDM;
+  } else if (ctx.use_stereo_aec_ref) {
+    ctx.rx_path_kind = RxPathKind::STEREO_REF;
+  } else if (ctx.rx_slot_mode_stereo) {
+    ctx.rx_path_kind = RxPathKind::STEREO_SLOT;
+  } else if (ctx.ratio > 1 || ctx.i2s_bps == 4) {
+    ctx.rx_path_kind = RxPathKind::MONO_EFFECTS;
+  } else {
+    ctx.rx_path_kind = RxPathKind::PASSTHROUGH;
+  }
+  return true;
+}
+
+void ESPAudioStack::preallocate_audio_buffers_from_task_() {
+  if (this->audio_buffers_allocated_) {
+    this->prealloc_attempted_.store(true, std::memory_order_release);
+    return;
+  }
+  if (this->prealloc_attempted_.exchange(true, std::memory_order_acq_rel)) {
+    return;
+  }
+
+  AudioTaskCtx ctx{};
+  if (!this->prepare_audio_context_(ctx, true, false)) {
+    this->prealloc_attempted_.store(false, std::memory_order_release);
+    return;
+  }
+  if (this->allocate_audio_buffers_(ctx)) {
+    ESP_LOGI(TAG, "Audio buffers preallocated (rx=%uB, spk=%uB, processor=%s)",
+             (unsigned) this->prealloc_rx_buffer_bytes_, (unsigned) this->prealloc_spk_buffer_bytes_,
+             ctx.processor_spec_loaded ? "yes" : "no");
+    this->log_memory_snapshot_("after_audio_buffer_prealloc");
+  } else {
+    ESP_LOGE(TAG, "Audio buffer preallocation failed; refusing cold-path allocation");
+    this->has_i2s_error_.store(true, std::memory_order_relaxed);
+  }
+}
+
+void ESPAudioStack::audio_session_() {
+  AudioTaskCtx ctx{};
+  // Telemetry compute paths gated on log level: when ESPHOME_LOG_LEVEL is
+  // below DEBUG the entire block is stripped, leaving zero runtime cost
+  // (no per-frame counters, no processor_->telemetry() call, no heap probes).
+#if defined(USE_ESP_AUDIO_STACK_TELEMETRY) && ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+  uint32_t t_frame_count = 0;
+  uint32_t t_spk_underruns = 0;
+#ifdef USE_AUDIO_PROCESSOR
+  ProcessorTelemetry prev_processor_telem{};
+#endif
+#endif
+
+  // ── Populate invariants and frame sizing ──
+  if (!this->prepare_audio_context_(ctx, false, true)) {
+    this->has_i2s_error_.store(true, std::memory_order_relaxed);
+    this->audio_stack_running_.store(false, std::memory_order_relaxed);
+    this->speaker_running_.store(false, std::memory_order_relaxed);
+    return;
+  }
+
+  // ── Buffer setup ──
+  // Working buffers are owned by the component and pre-allocated worst-case
+  // on first task entry (see allocate_audio_buffers_). Subsequent restarts
+  // (frame_spec change, feature toggle) reuse the same pointers without any
+  // heap_caps_alloc calls, eliminating SPIRAM fragmentation that previously
+  // caused "Failed to allocate AEC output buffer" after a few reconfigures.
+
+  auto alloc_fail = [this](const char *what) {
+    ESP_LOGE(TAG, "Failed to allocate %s", what);
+    this->has_i2s_error_.store(true, std::memory_order_relaxed);
+    this->audio_stack_running_.store(false, std::memory_order_relaxed);
+    this->speaker_running_.store(false, std::memory_order_relaxed);
+  };
+
+  if (ctx.processor_mic_channels > 2) {
+    alloc_fail("unsupported processor mic channel count");
+    ESP_LOGD(TAG, "Audio session ended");
+    return;
+  }
+  if (ctx.processor_mic_channels > 1 && !ctx.use_tdm_bus) {
+    alloc_fail("dual-mic processor requires TDM microphone slots");
+    ESP_LOGD(TAG, "Audio session ended");
+    return;
+  }
+  if (ctx.processor_mic_channels > 1 && ctx.tdm_second_mic_slot < 0) {
+    alloc_fail("dual-mic processor requires tdm_mic_slots with two slots");
+    ESP_LOGD(TAG, "Audio session ended");
+    return;
+  }
+
+  if (!this->audio_buffers_allocated_) {
+    alloc_fail("audio buffers (not preallocated)");
+    ESP_LOGD(TAG, "Audio session ended");
+    return;
+  }
+  if (!this->allocate_audio_buffers_(ctx)) {
+    alloc_fail("audio buffers (prepared shape invalid)");
+    ESP_LOGD(TAG, "Audio session ended");
+    return;
+  }
+
+  ctx.rx_buffer = this->prealloc_rx_buffer_;
+  ctx.mic_buffer = ctx.mic_separate ? this->prealloc_mic_buffer_ : ctx.rx_buffer;
+  if (ctx.processor_mic_channels > 1) {
+    ctx.processor_mic_buffer = this->prealloc_processor_mic_buffer_;
+  }
+  ctx.spk_buffer = this->prealloc_spk_buffer_;
+  ctx.spk_ref_buffer = this->prealloc_spk_ref_buffer_;
+  ctx.tx_ref_mono_buffer = this->prealloc_tx_ref_mono_buffer_;
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+  ctx.tdm_tx_buffer = this->prealloc_tdm_tx_buffer_;
+  ctx.tx_silence_buffer = this->prealloc_tx_silence_buffer_;
+#endif
+#ifdef USE_ESP_AUDIO_STACK_STEREO_TX
+  ctx.tx_interleave_buffer = this->prealloc_tx_interleave_buffer_;
+#endif
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+  ctx.tx_32_buffer = this->prealloc_tx_32_buffer_;
+#endif
+  ctx.aec_output = this->prealloc_aec_output_;
+  ctx.tx_clock_buffer = this->prealloc_tx_clock_buffer_;
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+  if (ctx.use_tdm_bus) {
+    ctx.tdm_tx_frame_bytes = ctx.bus_frame_size * ctx.tdm_total_slots * ctx.i2s_bps;
+  }
+#endif
+
+#if defined(USE_ESP_AUDIO_STACK_TELEMETRY) && ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+  ESP_LOGD(TAG, "Heap after audio init: internal=%u, PSRAM=%u", (unsigned) heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+           (unsigned) heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+#endif
+
+  // ── Main loop ──
+  while (this->audio_stack_running_.load(std::memory_order_relaxed)) {
+    // Service ring buffer operations requested by main thread
+    this->service_speaker_reset_();
+    this->drain_tx_completion_events_();
+    // Reset per-frame state
+    ctx.output_buffer = nullptr;
+    ctx.current_output_frame_size = ctx.input_frame_size;
+    ctx.current_output_frame_bytes = ctx.input_frame_bytes;
+    ctx.speaker_underrun = false;
+#ifdef USE_ESP_AUDIO_STACK_TDM_REF_DIAGNOSTIC
+    ctx.previous_speaker_got = ctx.speaker_got;
+    ctx.previous_speaker_dbfs = ctx.current_speaker_dbfs;
+    ctx.current_speaker_dbfs = -120.0f;
+#endif
+    ctx.speaker_got = 0;
+
+    // Snapshot atomic state for this frame (avoids repeated .load() in sample loops)
+    ctx.input_gain_q31 = this->input_gain_q31_.load(std::memory_order_relaxed);
+    ctx.input_gain_boost = this->input_gain_boost_.load(std::memory_order_relaxed);
+    ctx.mic_gain_q31 = this->mic_gain_q31_.load(std::memory_order_relaxed);
+    ctx.mic_gain_boost_db = this->mic_gain_boost_db_.load(std::memory_order_relaxed);
+    ctx.hot_output_volume_q31 = this->hot_output_volume_q31_.load(std::memory_order_relaxed);
+    ctx.speaker_running = this->speaker_running_.load(std::memory_order_relaxed);
+    ctx.speaker_paused = this->speaker_paused_.load(std::memory_order_relaxed);
+    ctx.mic_running = this->has_mic_consumers_.load(std::memory_order_relaxed);
+    this->update_runtime_audio_flags_(ctx);
+
+    ctx.processor_enabled = this->processor_enabled_.load(std::memory_order_relaxed);
+#ifdef USE_AUDIO_PROCESSOR
+    ctx.processor_ready = ctx.processor_enabled && this->processor_ != nullptr && this->processor_->is_initialized();
+#endif
+    ctx.now_ms = millis();
+
+    if (ctx.need_rx_processing) {
+      this->process_rx_path_(ctx);
+    } else if (ctx.need_rx_drain) {
+      this->drain_rx_minimal_(ctx);
+    }
+
+    if (ctx.need_rx_processing) {
+      this->process_aec_and_callbacks_(ctx);
+    }
+    if (ctx.clock_only_tx) {
+      this->process_tx_clock_only_(ctx);
+    } else if (ctx.need_tx_audio) {
+      this->process_tx_path_(ctx);
+    }
+
+#ifdef USE_AUDIO_PROCESSOR
+    // Frame_spec change, for example an AFE mode or graph rebuild: exit this session
+    // so the outer audio_task_ wrapper can re-enter audio_session_ with a
+    // fresh ctx. Preallocated buffers are already worst-case sized, so the
+    // restart does not touch the heap.
+    if (this->processor_ != nullptr) {
+      uint32_t rev = this->processor_->frame_spec_revision();
+      bool ready = this->processor_->is_initialized();
+      if (ready && !ctx.processor_spec_loaded) {
+        ESP_LOGI(TAG, "Processor frame_spec became available (rev %u), restarting session", (unsigned) rev);
+        break;
+      }
+      if (ready && rev != ctx.processor_spec_revision) {
+        ESP_LOGI(TAG, "Processor frame_spec changed (rev %u -> %u), restarting session",
+                 (unsigned) ctx.processor_spec_revision, (unsigned) rev);
+        break;
+      }
+      if (!ready) {
+        ctx.processor_spec_revision = rev;
+      }
+    }
+#endif
+
+#if defined(USE_ESP_AUDIO_STACK_TELEMETRY) && ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+    {
+      // Lightweight per-frame cycle snapshot (only when telemetry: true AND
+      // log level >= DEBUG: otherwise this block is stripped at compile time
+      // so the loop pays zero runtime cost in production builds).
+      // t_frame_count and t_spk_underruns declared before the loop (reset on task restart)
+      t_spk_underruns += ctx.speaker_underrun ? 1 : 0;
+      t_frame_count++;
+      if (t_frame_count >= this->telemetry_log_interval_frames_) {
+        ESP_LOGD(TAG, "Perf[%u frames]: spk_underrun=%u, heap_int=%u, heap_ps=%u", (unsigned) t_frame_count,
+                 (unsigned) t_spk_underruns, (unsigned) heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+                 (unsigned) heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+#ifdef USE_AUDIO_PROCESSOR
+        if (this->processor_ != nullptr) {
+          ProcessorTelemetry telem = this->processor_->telemetry();
+          const uint32_t audio_stack_high_water = uxTaskGetStackHighWaterMark(nullptr) * sizeof(StackType_t);
+          auto delta_u32 = [](uint32_t current, uint32_t previous) -> uint32_t {
+            return current >= previous ? (current - previous) : current;
+          };
+          ESP_LOGD(
+              TAG,
+              "AFE[%u]: +glitch=%u +in_drop=%u +feed_ok=%u +feed_rej=%u "
+              "+fetch_ok=%u +fetch_to=%u +out_drop=%u rb=%.0f%% "
+              "q(feed=%u pk=%u, fetch=%u pk=%u)",
+              (unsigned) telem.frame_count, (unsigned) delta_u32(telem.glitch_count, prev_processor_telem.glitch_count),
+              (unsigned) delta_u32(telem.input_ring_drop, prev_processor_telem.input_ring_drop),
+              (unsigned) delta_u32(telem.feed_ok, prev_processor_telem.feed_ok),
+              (unsigned) delta_u32(telem.feed_rejected, prev_processor_telem.feed_rejected),
+              (unsigned) delta_u32(telem.fetch_ok, prev_processor_telem.fetch_ok),
+              (unsigned) delta_u32(telem.fetch_timeout, prev_processor_telem.fetch_timeout),
+              (unsigned) delta_u32(telem.output_ring_drop, prev_processor_telem.output_ring_drop),
+              telem.ringbuf_free_pct * 100.0f, (unsigned) telem.feed_queue_frames, (unsigned) telem.feed_queue_peak,
+              (unsigned) telem.fetch_queue_frames, (unsigned) telem.fetch_queue_peak);
+          ESP_LOGD(TAG,
+                   "AFE timing: proc last/max=%u/%uus feed last/max=%u/%uus "
+                   "fetch last/max=%u/%uus stackB audio=%u",
+                   (unsigned) telem.process_us_last, (unsigned) telem.process_us_max, (unsigned) telem.feed_us_last,
+                   (unsigned) telem.feed_us_max, (unsigned) telem.fetch_us_last, (unsigned) telem.fetch_us_max,
+                   (unsigned) audio_stack_high_water);
+          prev_processor_telem = telem;
+        }
+#endif
+        t_frame_count = 0;
+        t_spk_underruns = 0;
+      }
+    }
+#endif
+
+    // vTaskDelay(1) yields to lower-priority tasks too, so IDLE
+    // gets to run and feed the task watchdog. taskYIELD() only cedes to
+    // same- or higher-priority tasks; with this audio loop pinned at
+    // prio 19 above lwIP=18, IDLE0 would never run on Core 0 and TWDT
+    // would trip. The blocking codec/I2S read above usually parks the task
+    // long enough for IDLE to run, but the fast path (return with
+    // data immediately available) needs an explicit cooperative point.
+    vTaskDelay(1);
+  }
+
+  // Buffers live on as component-owned preallocations; nothing to free here.
+  // Returning from audio_session_ hands control back to the outer wrapper,
+  // which either parks the task (stop) or re-enters with fresh ctx
+  // (frame_spec change).
+  ESP_LOGD(TAG, "Audio session ended");
+}
+
+void ESPAudioStack::update_runtime_audio_flags_(AudioTaskCtx &ctx) {
+  ctx.any_tdm_slot_level_sensor_enabled = this->any_tdm_slot_level_sensor_enabled_.load(std::memory_order_relaxed);
+  ctx.need_rx_processing = this->rx_handle_ != nullptr && (ctx.mic_running || ctx.any_tdm_slot_level_sensor_enabled);
+  // If RX is enabled but nobody needs the decoded mic surface, still drain the
+  // driver/codec queue so DMA does not build backpressure while speaker-only
+  // playback is active.
+  ctx.need_rx_drain = this->rx_handle_ != nullptr && !ctx.need_rx_processing;
+  ctx.need_tx_audio = this->tx_handle_ != nullptr && ctx.speaker_running && !ctx.speaker_paused;
+  // ESP-IDF full-duplex shares clock signals; keep TX moving whenever the
+  // stack owns TX, even if the frame is just silence for RX clocking.
+  ctx.need_tx_clock = this->tx_handle_ != nullptr;
+  ctx.clock_only_tx = ctx.need_tx_clock && !ctx.need_tx_audio;
+}
+
+void ESPAudioStack::drain_rx_minimal_(AudioTaskCtx &ctx) {
+  if (!this->read_rx_frame_(ctx, "drain"))
+    return;
+}
+
+bool ESPAudioStack::read_rx_frame_(AudioTaskCtx &ctx, const char *label) {
+  if (!this->rx_handle_ || ctx.rx_buffer == nullptr)
+    return false;
+
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  const bool read_ok = this->codec_backend_.read(ctx.rx_buffer, ctx.rx_frame_bytes);
+  const bool io_closed = !this->codec_backend_.is_open();
+#else
+  size_t bytes_read = 0;
+  const esp_err_t read_err =
+      i2s_channel_read(this->rx_handle_, ctx.rx_buffer, ctx.rx_frame_bytes, &bytes_read, portMAX_DELAY);
+  const bool read_ok = read_err == ESP_OK && bytes_read == ctx.rx_frame_bytes;
+  const bool io_closed = read_err == ESP_ERR_INVALID_STATE;
+#endif
+  if (!read_ok && io_closed) {
+    if (this->audio_stack_running_.load(std::memory_order_relaxed)) {
+      if (++ctx.invalid_state_errors > 100) {
+        ESP_LOGE(TAG, "Persistent I2S RX INVALID_STATE during %s (%d) - channel corrupted", label,
+                 ctx.invalid_state_errors);
+        this->has_i2s_error_.store(true, std::memory_order_relaxed);
+        this->audio_stack_running_.store(false, std::memory_order_relaxed);
+      }
+    }
+    return false;
+  }
+  if (!read_ok) {
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+    LOG_W_THROTTLED("Codec RX %s read failed", label);
+#else
+    LOG_W_THROTTLED("I2S %s read failed: err=%s bytes=%u/%u", label, esp_err_to_name(read_err),
+                    static_cast<unsigned>(bytes_read), static_cast<unsigned>(ctx.rx_frame_bytes));
+#endif
+    if (++ctx.consecutive_i2s_errors > 100) {
+      ESP_LOGE(TAG, "Persistent I2S %s read errors (%d)", label, ctx.consecutive_i2s_errors);
+      this->has_i2s_error_.store(true, std::memory_order_relaxed);
+      this->audio_stack_running_.store(false, std::memory_order_relaxed);
+    }
+    return false;
+  }
+  ctx.consecutive_i2s_errors = 0;
+  ctx.invalid_state_errors = 0;
+  return true;
+}
+
+void ESPAudioStack::fail_audio_session_(const char *stage) {
+  ESP_LOGE(TAG, "%s failed; stopping audio session", stage);
+  this->has_i2s_error_.store(true, std::memory_order_relaxed);
+  this->audio_stack_running_.store(false, std::memory_order_relaxed);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// RX PATH: I2S read -> deinterleave/rate-convert -> mic_buffer + spk_ref_buffer
+// ════════════════════════════════════════════════════════════════════════════
+void ESPAudioStack::process_rx_path_(AudioTaskCtx &ctx) {
+  if (!this->read_rx_frame_(ctx, "audio"))
+    return;
+
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+  if (ctx.use_tdm_bus && ctx.any_tdm_slot_level_sensor_enabled) {
+    this->update_tdm_slot_levels_(ctx);
+  }
+#endif
+
+  ctx.output_buffer = ctx.mic_buffer;  // Default: no AEC processing
+  ctx.processor_input = ctx.mic_buffer;
+  if (!this->convert_rx_frame_(ctx)) {
+    return;
+  }
+  this->apply_input_conditioning_(ctx);
+}
+
+bool ESPAudioStack::convert_rx_frame_(AudioTaskCtx &ctx) {
+  switch (ctx.rx_path_kind) {
+    case RxPathKind::PASSTHROUGH:
+      return this->process_rx_passthrough_(ctx);
+    case RxPathKind::MONO_EFFECTS:
+      return this->process_rx_mono_effects_(ctx);
+    case RxPathKind::STEREO_SLOT:
+      return this->process_rx_stereo_slot_(ctx);
+    case RxPathKind::STEREO_REF:
+      return this->process_rx_stereo_ref_(ctx);
+    case RxPathKind::TDM:
+      return this->process_rx_tdm_(ctx);
+  }
+  return false;
+}
+
+bool ESPAudioStack::process_rx_passthrough_(AudioTaskCtx &ctx) {
+  (void) ctx;
+  return true;
+}
+
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
+bool ESPAudioStack::process_rx_tdm_(AudioTaskCtx &ctx) {
+  const uint8_t ts = ctx.tdm_total_slots;
+  const bool dual_mic = ctx.processor_mic_channels > 1 && ctx.tdm_second_mic_slot >= 0;
+  uint8_t ch_offsets[MAX_RATE_CVT_CHANNELS];
+  uint8_t num_mic_ch = dual_mic ? 2 : 1;
+  uint8_t selected_channels = 0;
+  if (dual_mic) {
+    ch_offsets[selected_channels++] = ctx.tdm_mic_slot;
+    ch_offsets[selected_channels++] = static_cast<uint8_t>(ctx.tdm_second_mic_slot);
+  } else {
+    ch_offsets[selected_channels++] = ctx.tdm_mic_slot;
+  }
+  if (ctx.use_tdm_ref) {
+    ch_offsets[selected_channels++] = ctx.tdm_ref_slot;
+  }
+  if (selected_channels != ctx.rx_rate_converter_channels) {
+    this->fail_audio_session_("TDM RX channel map");
+    return false;
+  }
+  int16_t *ref_out = ctx.use_tdm_ref ? ctx.spk_ref_buffer : nullptr;
+  const bool ok = ctx.i2s_bps == 4
+                      ? this->rx_rate_converter_.process_multi_32(
+                            reinterpret_cast<const int32_t *>(ctx.rx_buffer), ctx.input_frame_size, ts, ch_offsets,
+                            dual_mic ? ctx.processor_mic_buffer : nullptr, ctx.mic_buffer, ref_out, num_mic_ch)
+                      : this->rx_rate_converter_.process_multi(ctx.rx_buffer, ctx.input_frame_size, ts, ch_offsets,
+                                                               dual_mic ? ctx.processor_mic_buffer : nullptr,
+                                                               ctx.mic_buffer, ref_out, num_mic_ch);
+  if (!ok) {
+    this->fail_audio_session_("TDM RX audio-effects conversion");
+    return false;
+  }
+  if (dual_mic) {
+    ctx.processor_input = ctx.processor_mic_buffer;
+  }
+  return true;
+}
+#else
+bool ESPAudioStack::process_rx_tdm_(AudioTaskCtx &ctx) {
+  (void) ctx;
+  this->fail_audio_session_("TDM RX unsupported");
+  return false;
+}
+#endif
+
+#ifdef USE_ESP_AUDIO_STACK_STEREO_REF
+bool ESPAudioStack::process_rx_stereo_ref_(AudioTaskCtx &ctx) {
+  const uint8_t mi = ctx.ref_channel_right ? 0 : 1;
+  const uint8_t ri = ctx.ref_channel_right ? 1 : 0;
+  uint8_t ch_offsets[2] = {mi, ri};
+  const bool ok = ctx.i2s_bps == 4
+                      ? this->rx_rate_converter_.process_multi_32(reinterpret_cast<const int32_t *>(ctx.rx_buffer),
+                                                                  ctx.input_frame_size, 2, ch_offsets, nullptr,
+                                                                  ctx.mic_buffer, ctx.spk_ref_buffer, 1)
+                      : this->rx_rate_converter_.process_multi(ctx.rx_buffer, ctx.input_frame_size, 2, ch_offsets,
+                                                               nullptr, ctx.mic_buffer, ctx.spk_ref_buffer, 1);
+  if (!ok) {
+    this->fail_audio_session_("stereo RX audio-effects conversion");
+    return false;
+  }
+  return true;
+}
+#else
+bool ESPAudioStack::process_rx_stereo_ref_(AudioTaskCtx &ctx) {
+  (void) ctx;
+  this->fail_audio_session_("stereo RX reference unsupported");
+  return false;
+}
+#endif
+
+#ifdef USE_ESP_AUDIO_STACK_MULTI_RX
+bool ESPAudioStack::process_rx_stereo_slot_(AudioTaskCtx &ctx) {
+  const uint8_t mic_offset = this->mic_channel_right_ ? 1 : 0;
+  uint8_t ch_offsets[1] = {mic_offset};
+  const bool ok = ctx.i2s_bps == 4
+                      ? this->rx_rate_converter_.process_multi_32(reinterpret_cast<const int32_t *>(ctx.rx_buffer),
+                                                                  ctx.input_frame_size, 2, ch_offsets, nullptr,
+                                                                  ctx.mic_buffer, nullptr, 1)
+                      : this->rx_rate_converter_.process_multi(ctx.rx_buffer, ctx.input_frame_size, 2, ch_offsets,
+                                                               nullptr, ctx.mic_buffer, nullptr, 1);
+  if (!ok) {
+    this->fail_audio_session_(ctx.i2s_bps == 4 ? "stereo mic RX 32-bit audio-effects conversion"
+                                               : "stereo mic RX audio-effects conversion");
+    return false;
+  }
+  return true;
+}
+#else
+bool ESPAudioStack::process_rx_stereo_slot_(AudioTaskCtx &ctx) {
+  (void) ctx;
+  this->fail_audio_session_("stereo mic RX unsupported");
+  return false;
+}
+#endif
+
+#ifdef USE_ESP_AUDIO_STACK_MONO_RX
+bool ESPAudioStack::process_rx_mono_effects_(AudioTaskCtx &ctx) {
+  bool ok = true;
+  if (ctx.i2s_bps == 4) {
+    ok = this->mic_rate_converter_.process_strided_32(reinterpret_cast<const int32_t *>(ctx.rx_buffer), ctx.mic_buffer,
+                                                      ctx.input_frame_size, 1, 0);
+  } else if (ctx.ratio > 1) {
+    ok = this->mic_rate_converter_.process(ctx.rx_buffer, ctx.mic_buffer, ctx.bus_frame_size);
+  }
+  if (!ok) {
+    this->fail_audio_session_(ctx.i2s_bps == 4 ? "mono RX 32-bit audio-effects conversion" : "mono RX rate conversion");
+    return false;
+  }
+  return true;
+}
+#else
+bool ESPAudioStack::process_rx_mono_effects_(AudioTaskCtx &ctx) {
+  (void) ctx;
+  this->fail_audio_session_("mono RX audio-effects unsupported");
+  return false;
+}
+#endif
+
+void ESPAudioStack::apply_input_conditioning_(AudioTaskCtx &ctx) {
+  // Fused loop: DC offset + input gain staging in one pass when DC or positive
+  // boost is needed. Pure input attenuation uses esp-audio-libs Q31 below.
+  // For dual-mic: mic1 is in mic_buffer, mic2 is in processor_mic_buffer[i*2+1]
+  // (both filled by the multi-channel rate converter). Apply DC+input gain on both, update in-place.
+  // When neither DC nor input gain is needed, processor_mic_buffer (dual_mic case)
+  // is left as-is: the multi-channel rate converter has already produced correct values for both mics.
+  const bool do_dc = ctx.correct_dc_offset;
+  const bool do_input_gain_q31 = ctx.input_gain_q31 != INT32_MAX;
+  const bool do_input_gain_boost = ctx.input_gain_boost != 1.0f;
+  const bool dual_mic = ctx.processor_mic_channels > 1 && ctx.processor_mic_buffer != nullptr;
+
+  if (do_dc || do_input_gain_boost) {
+    const float boost = ctx.input_gain_boost;
+    for (size_t i = 0; i < ctx.input_frame_size; i++) {
+      int16_t s1 = ctx.mic_buffer[i];
+
+      if (do_dc) {
+        s1 = this->dc_primary_.process(s1);
+      }
+      if (do_input_gain_boost) {
+        s1 = scale_sample(s1, boost);
+      }
+      ctx.mic_buffer[i] = s1;
+
+      if (dual_mic) {
+        // mic2 already in processor_mic_buffer interleaved by multi-channel rate conversion.
+        int16_t s2 = ctx.processor_mic_buffer[i * 2 + 1];
+        if (do_dc) {
+          s2 = this->dc_secondary_.process(s2);
+        }
+        if (do_input_gain_boost) {
+          s2 = scale_sample(s2, boost);
+        }
+        // Update both mic1 and mic2 in the interleaved buffer
+        ctx.processor_mic_buffer[i * 2] = s1;
+        ctx.processor_mic_buffer[i * 2 + 1] = s2;
+      }
+    }
+  }
+
+  if (do_input_gain_q31) {
+    auto *mic_bytes = reinterpret_cast<uint8_t *>(ctx.mic_buffer);
+    if (ctx.input_gain_q31 == 0) {
+      memset(mic_bytes, 0, ctx.input_frame_size * sizeof(int16_t));
+    } else {
+      esp_audio_libs::gain::apply(mic_bytes, mic_bytes, ctx.input_gain_q31, ctx.input_frame_size, sizeof(int16_t));
+    }
+    if (dual_mic) {
+      auto *processor_bytes = reinterpret_cast<uint8_t *>(ctx.processor_mic_buffer);
+      const size_t processor_bytes_len = ctx.input_frame_size * ctx.processor_mic_channels * sizeof(int16_t);
+      if (ctx.input_gain_q31 == 0) {
+        memset(processor_bytes, 0, processor_bytes_len);
+      } else {
+        esp_audio_libs::gain::apply(processor_bytes, processor_bytes, ctx.input_gain_q31,
+                                    ctx.input_frame_size * ctx.processor_mic_channels, sizeof(int16_t));
+      }
+    }
+  }
+  // dual_mic with no DC/input gain: processor_mic_buffer already correct from the rate converter.
+}
+
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+void ESPAudioStack::update_tdm_slot_levels_(const AudioTaskCtx &ctx) {
+  uint8_t enabled_slots[8];
+  size_t enabled_count = 0;
+  const uint8_t slot_limit = std::min<uint8_t>(ctx.tdm_total_slots, 8);
+  for (uint8_t slot = 0; slot < slot_limit; slot++) {
+    if (this->tdm_slot_level_sensor_enabled_[slot]) {
+      enabled_slots[enabled_count++] = slot;
+    }
+  }
+  if (enabled_count == 0) {
+    return;
+  }
+
+  // Probe only every ~256 ms at 16 kHz / 512-sample cadence to keep overhead low.
+  this->tdm_slot_level_divider_++;
+  if (this->tdm_slot_level_divider_ < 8) {
+    return;
+  }
+  this->tdm_slot_level_divider_ = 0;
+
+  const size_t frame_samples = ctx.bus_frame_size;
+  const size_t slot_stride = ctx.tdm_total_slots;
+  for (size_t i = 0; i < enabled_count; i++) {
+    uint8_t slot = enabled_slots[i];
+    float dbfs;
+    if (ctx.i2s_bps == 4) {
+      // 32-bit mode: rx_buffer stays native; esp_audio_effects handles bit conversion later.
+      auto *src32 = reinterpret_cast<const int32_t *>(ctx.rx_buffer);
+      dbfs = compute_rms_dbfs_i32_top16(src32 + slot, frame_samples, slot_stride);
+    } else {
+      dbfs = compute_rms_dbfs_i16(ctx.rx_buffer + slot, frame_samples, slot_stride);
+    }
+    this->tdm_slot_level_dbfs_[slot].store(dbfs, std::memory_order_relaxed);
+  }
+}
+#endif
+
+#ifdef USE_AUDIO_PROCESSOR
+void ESPAudioStack::run_processor_(AudioTaskCtx &ctx) {
+  this->processor_->process(ctx.processor_input, ctx.spk_ref_buffer, ctx.aec_output, ctx.processor_mic_channels);
+  ctx.output_buffer = ctx.aec_output;
+  ctx.current_output_frame_size = ctx.output_frame_size;
+  ctx.current_output_frame_bytes = ctx.output_frame_bytes;
+}
+#endif
+
+// ════════════════════════════════════════════════════════════════════════════
+// AEC/AFE + CALLBACKS: processing → gain → post-processor callbacks
+// ════════════════════════════════════════════════════════════════════════════
+bool ESPAudioStack::can_dispatch_mic_frame_(const AudioTaskCtx &ctx) const {
+  return this->rx_handle_ != nullptr && ctx.output_buffer != nullptr && ctx.mic_running;
+}
+
+void ESPAudioStack::process_aec_and_callbacks_(AudioTaskCtx &ctx) {
+  if (!this->can_dispatch_mic_frame_(ctx))
+    return;
+
+#ifdef USE_AUDIO_PROCESSOR
+  if (ctx.processor_enabled && (!ctx.processor_ready || ctx.spk_ref_buffer == nullptr || ctx.aec_output == nullptr)) {
+    // Processor configured but unavailable: fail closed. Production consumers
+    // must never receive implicit raw mic audio from a configured processor
+    // path during init, teardown, reinit, or allocation failure.
+    if (ctx.aec_output != nullptr) {
+      memset(ctx.aec_output, 0, ctx.output_frame_bytes);
+      ctx.output_buffer = ctx.aec_output;
+      ctx.current_output_frame_size = ctx.output_frame_size;
+      ctx.current_output_frame_bytes = ctx.output_frame_bytes;
+    } else {
+      memset(ctx.output_buffer, 0, ctx.current_output_frame_bytes);
+    }
+  } else {
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_REF)
+    if (ctx.use_tdm_ref && ctx.processor_ready && ctx.spk_ref_buffer != nullptr && ctx.aec_output != nullptr) {
+      // TDM: hardware-synced reference, no speaker gating needed.
+#ifdef USE_ESP_AUDIO_STACK_TDM_REF_DIAGNOSTIC
+      // Health monitor for slot-map bring-up. Kept out of production builds:
+      // it computes speaker/reference RMS during playback and carries verbose
+      // diagnostic strings that are not part of the normal audio path.
+      constexpr float kRefSilenceThresholdDbfs = -60.0f;
+      constexpr float kSpeakerActiveThresholdDbfs = -55.0f;
+      constexpr uint32_t kRefSilenceWarnFrames = 100;  // ~3.2s @ 32ms frames
+      const bool spk_frame_has_audio =
+          ctx.previous_speaker_got == ctx.bus_frame_bytes && ctx.previous_speaker_dbfs > kSpeakerActiveThresholdDbfs;
+      if (spk_frame_has_audio) {
+        const float ref_dbfs = compute_rms_dbfs_i16(ctx.spk_ref_buffer, ctx.input_frame_size, 1);
+        auto log_tdm_ref_monitor = [&](const char *label, uint32_t silent_frames) {
+          float raw_slot_dbfs[4] = {-120.0f, -120.0f, -120.0f, -120.0f};
+          const uint8_t raw_slot_count = std::min<uint8_t>(ctx.tdm_total_slots, 4);
+          for (uint8_t slot = 0; slot < raw_slot_count; slot++) {
+            if (ctx.i2s_bps == 4) {
+              auto *src32 = reinterpret_cast<const int32_t *>(ctx.rx_buffer);
+              raw_slot_dbfs[slot] = compute_rms_dbfs_i32_top16(src32 + slot, ctx.bus_frame_size, ctx.tdm_total_slots);
+            } else {
+              raw_slot_dbfs[slot] = compute_rms_dbfs_i16(ctx.rx_buffer + slot, ctx.bus_frame_size, ctx.tdm_total_slots);
+            }
+          }
+          ESP_LOGW(TAG,
+                   "%s: post_ref=%.1f dBFS silent_frames=%u "
+                   "raw_slots=[0:%.1f 1:%.1f 2:%.1f 3:%.1f] "
+                   "mic_slots=[%u,%d] ref_slot=%u prev_speaker=%.1f dBFS (%u/%u)",
+                   label, ref_dbfs, (unsigned) silent_frames, raw_slot_dbfs[0], raw_slot_dbfs[1], raw_slot_dbfs[2],
+                   raw_slot_dbfs[3], (unsigned) ctx.tdm_mic_slot, (int) ctx.tdm_second_mic_slot,
+                   (unsigned) ctx.tdm_ref_slot, ctx.previous_speaker_dbfs, (unsigned) ctx.previous_speaker_got,
+                   (unsigned) ctx.bus_frame_bytes);
+        };
+        if (!ctx.tdm_ref_active_monitor_logged) {
+          log_tdm_ref_monitor("TDM ref active frame", 0);
+          ctx.tdm_ref_active_monitor_logged = true;
+        }
+        if (ref_dbfs < kRefSilenceThresholdDbfs) {
+          uint32_t n = this->tdm_ref_silent_frames_.fetch_add(1, std::memory_order_relaxed) + 1;
+          if (n == kRefSilenceWarnFrames) {
+            log_tdm_ref_monitor("TDM ref monitor", n);
+          }
+        } else {
+          this->tdm_ref_silent_frames_.store(0, std::memory_order_relaxed);
+        }
+      } else {
+        this->tdm_ref_silent_frames_.store(0, std::memory_order_relaxed);
+      }
+#endif
+      this->run_processor_(ctx);
+    }
+#endif
+#if defined(USE_ESP_AUDIO_STACK_STEREO_REF) || defined(USE_ESP_AUDIO_STACK_MONO_REF)
+    if (!ctx.use_tdm_ref && ctx.processor_ready && ctx.spk_ref_buffer != nullptr && ctx.aec_output != nullptr) {
+      // Mono mode: get AEC reference (direct from TX or ring buffer).
+      // Reference is post-volume PCM, no additional scaling (Espressif TYPE2 pattern).
+      // When playback is idle, fill_mono_aec_reference_() zero-fills the ref and
+      // we still call the processor. That keeps MWW/VA/call components on the processed
+      // surface instead of silently switching to raw mic audio.
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+      if (!ctx.use_stereo_aec_ref) {
+        this->fill_mono_aec_reference_(ctx);
+      }
+#endif
+      // Stereo mode: spk_ref_buffer already filled from deinterleave. No extra scaling.
+      // TDM mode: spk_ref_buffer filled from TDM deinterleave. No extra scaling.
+
+      this->run_processor_(ctx);
+    }
+#endif
+  }
+#endif
+
+  this->apply_post_processor_gain_(ctx);
+  this->dispatch_mic_callbacks_(ctx);
+}
+
+void ESPAudioStack::apply_post_processor_gain_(AudioTaskCtx &ctx) {
+  if (ctx.output_buffer == nullptr)
+    return;
+
+  if (ctx.mic_gain_q31 != INT32_MAX) {
+    auto *output_bytes = reinterpret_cast<uint8_t *>(ctx.output_buffer);
+    if (ctx.mic_gain_q31 == 0) {
+      memset(output_bytes, 0, ctx.current_output_frame_bytes);
+    } else {
+      esp_audio_libs::gain::apply(output_bytes, output_bytes, ctx.mic_gain_q31, ctx.current_output_frame_size,
+                                  sizeof(int16_t));
+    }
+  }
+  if (ctx.mic_gain_boost_db > 0) {
+    this->apply_mic_alc_gain_(ctx.output_buffer, ctx.current_output_frame_size, ctx.mic_gain_boost_db);
+  }
+}
+
+void ESPAudioStack::dispatch_mic_callbacks_(const AudioTaskCtx &ctx) {
+  if (!ctx.mic_running || ctx.output_buffer == nullptr)
+    return;
+
+  for (size_t i = 0; i < this->mic_callback_count_; i++) {
+    const auto &slot = this->mic_callbacks_[i];
+    if (slot.fn != nullptr) {
+      slot.fn(slot.ctx, (const uint8_t *) ctx.output_buffer, ctx.current_output_frame_bytes);
+    }
+  }
+}
+
+bool ESPAudioStack::apply_mic_alc_gain_(int16_t *samples, size_t sample_count, int8_t gain_db) {
+  if (samples == nullptr || sample_count == 0 || gain_db <= 0) {
+    return true;
+  }
+  if (this->mic_alc_handle_ == nullptr || this->mic_alc_gain_db_ != gain_db) {
+    if (this->mic_alc_handle_ != nullptr) {
+      esp_ae_alc_close(static_cast<esp_ae_alc_handle_t>(this->mic_alc_handle_));
+      this->mic_alc_handle_ = nullptr;
+      this->mic_alc_gain_db_ = 0;
+    }
+    esp_ae_alc_cfg_t cfg{};
+    cfg.sample_rate = this->get_output_sample_rate();
+    cfg.channel = 1;
+    cfg.bits_per_sample = 16;
+    esp_ae_alc_handle_t handle = nullptr;
+    const esp_ae_err_t open_err = esp_ae_alc_open(&cfg, &handle);
+    if (open_err != ESP_AE_ERR_OK || handle == nullptr) {
+      ESP_LOGE(TAG, "esp_ae_alc_open mic gain failed: err=%d rate=%u gain=%d", static_cast<int>(open_err),
+               static_cast<unsigned>(cfg.sample_rate), static_cast<int>(gain_db));
+      return false;
+    }
+    const esp_ae_err_t gain_err = esp_ae_alc_set_gain(handle, 0, gain_db);
+    if (gain_err != ESP_AE_ERR_OK) {
+      ESP_LOGE(TAG, "esp_ae_alc_set_gain mic failed: err=%d gain=%d", static_cast<int>(gain_err),
+               static_cast<int>(gain_db));
+      esp_ae_alc_close(handle);
+      return false;
+    }
+    this->mic_alc_handle_ = handle;
+    this->mic_alc_gain_db_ = gain_db;
+  }
+
+  const esp_ae_err_t err = esp_ae_alc_process(static_cast<esp_ae_alc_handle_t>(this->mic_alc_handle_),
+                                              static_cast<uint32_t>(sample_count), samples, samples);
+  if (err == ESP_AE_ERR_OK) {
+    return true;
+  }
+  ESP_LOGE(TAG, "esp_ae_alc_process mic failed: err=%d samples=%u gain=%d", static_cast<int>(err),
+           static_cast<unsigned>(sample_count), static_cast<int>(gain_db));
+  return false;
+}
+
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+void ESPAudioStack::fill_mono_aec_reference_(AudioTaskCtx &ctx) {
+  // The reference source holds already converted samples at the processor rate
+  // (rate conversion happens once on the TX side in process_tx_path_).
+  // The reference is the input side of the processor, so the unit is
+  // input_frame_bytes (matches AudioProcessor::process expecting in_ref of
+  // input_samples length).
+  const size_t ref_bytes = ctx.input_frame_bytes;
+#ifdef USE_ESP_AUDIO_STACK_RING_REF
+  if (this->aec_ref_ring_buffer_) {
+    if (this->aec_ref_ring_buffer_->available() >= ref_bytes) {
+      this->aec_ref_ring_buffer_->read(ctx.spk_ref_buffer, ref_bytes, 0);
+      return;
+    }
+  }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_PREVIOUS_FRAME_REF
+  if (this->direct_aec_ref_ != nullptr && this->direct_aec_ref_valid_) {
+    memcpy(ctx.spk_ref_buffer, this->direct_aec_ref_, ref_bytes);
+    return;
+  }
+#endif
+
+  // No reference available: zero-fill so the processor still owns the output
+  // surface instead of switching to raw mic audio.
+  memset(ctx.spk_ref_buffer, 0, ref_bytes);
+}
+#endif
+
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+bool ESPAudioStack::tx_bit_cvt_16_to_32_(uint8_t channels, const void *in, uint32_t sample_num, void *out) {
+  if (channels == 0 || in == nullptr || out == nullptr) {
+    ESP_LOGE(TAG, "invalid TX bit conversion args");
+    return false;
+  }
+  if (this->tx_bit_cvt_handle_ != nullptr && this->tx_bit_cvt_channels_ != channels) {
+    esp_ae_bit_cvt_close(static_cast<esp_ae_bit_cvt_handle_t>(this->tx_bit_cvt_handle_));
+    this->tx_bit_cvt_handle_ = nullptr;
+    this->tx_bit_cvt_channels_ = 0;
+  }
+  if (this->tx_bit_cvt_handle_ == nullptr) {
+    esp_ae_bit_cvt_cfg_t cfg{};
+    cfg.sample_rate = this->sample_rate_;
+    cfg.channel = channels;
+    cfg.src_bits = 16;
+    cfg.dest_bits = 32;
+    esp_ae_bit_cvt_handle_t handle = nullptr;
+    const esp_ae_err_t err = esp_ae_bit_cvt_open(&cfg, &handle);
+    if (err != ESP_AE_ERR_OK || handle == nullptr) {
+      ESP_LOGE(TAG, "esp_ae_bit_cvt_open TX failed: err=%d ch=%u", static_cast<int>(err),
+               static_cast<unsigned>(channels));
+      return false;
+    }
+    this->tx_bit_cvt_handle_ = handle;
+    this->tx_bit_cvt_channels_ = channels;
+  }
+
+  const esp_ae_err_t err = esp_ae_bit_cvt_process(static_cast<esp_ae_bit_cvt_handle_t>(this->tx_bit_cvt_handle_),
+                                                  sample_num, const_cast<void *>(in), out);
+  if (err == ESP_AE_ERR_OK)
+    return true;
+  ESP_LOGE(TAG, "esp_ae_bit_cvt_process TX failed: err=%d samples=%u ch=%u", static_cast<int>(err),
+           static_cast<unsigned>(sample_num), static_cast<unsigned>(channels));
+  return false;
+}
+#endif
+
+bool ESPAudioStack::format_tx_frame_(AudioTaskCtx &ctx, void **tx_data, size_t *tx_bytes) {
+  const uint8_t tx_channels = ctx.use_tdm_bus ? ctx.tdm_total_slots : ctx.num_ch;
+  int16_t *formatted16 = ctx.spk_buffer;
+  bool tx_formatted = false;
+
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
+  if (ctx.use_tdm_bus) {
+    if (ctx.tdm_tx_buffer == nullptr || ctx.tx_silence_buffer == nullptr || tx_channels == 0 || tx_channels > 8) {
+      ESP_LOGE(TAG, "missing TDM TX audio-effects buffers");
+      return false;
+    }
+    esp_ae_sample_t slot_samples[8]{};
+    for (uint8_t slot = 0; slot < tx_channels; slot++) {
+      slot_samples[slot] = ctx.tx_silence_buffer;
+    }
+    if (ctx.tdm_tx_slot >= tx_channels) {
+      ESP_LOGE(TAG, "tdm_tx_slot %u out of range for %u slots", (unsigned) ctx.tdm_tx_slot, (unsigned) tx_channels);
+      return false;
+    }
+    slot_samples[ctx.tdm_tx_slot] = ctx.spk_buffer;
+    const esp_ae_err_t err = esp_ae_intlv_process(tx_channels, 16, static_cast<uint32_t>(ctx.bus_frame_size),
+                                                  slot_samples, ctx.tdm_tx_buffer);
+    if (err != ESP_AE_ERR_OK) {
+      ESP_LOGE(TAG, "esp_ae_intlv_process TDM TX failed: err=%d", static_cast<int>(err));
+      return false;
+    }
+    formatted16 = ctx.tdm_tx_buffer;
+    tx_formatted = true;
+  }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_STEREO_TX
+  if (!tx_formatted && ctx.num_ch == 2) {
+    if (ctx.speaker_channels == 2) {
+      // ESPHome speaker streams provide standard interleaved L/R PCM when the
+      // speaker declares two channels. IDF STD stereo TX expects that same
+      // layout, so no mono duplication or de/interleave step is needed here.
+      formatted16 = ctx.spk_buffer;
+    } else {
+      if (ctx.tx_interleave_buffer == nullptr) {
+        ESP_LOGE(TAG, "missing stereo TX audio-effects buffer");
+        return false;
+      }
+      esp_ae_sample_t stereo_samples[2] = {ctx.spk_buffer, ctx.spk_buffer};
+      const esp_ae_err_t err = esp_ae_intlv_process(2, 16, static_cast<uint32_t>(ctx.bus_frame_size), stereo_samples,
+                                                    ctx.tx_interleave_buffer);
+      if (err != ESP_AE_ERR_OK) {
+        ESP_LOGE(TAG, "esp_ae_intlv_process stereo TX failed: err=%d", static_cast<int>(err));
+        return false;
+      }
+      formatted16 = ctx.tx_interleave_buffer;
+    }
+    tx_formatted = true;
+  }
+#else
+  (void) tx_formatted;
+#endif
+
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+  if (ctx.i2s_bps == 4) {
+    if (ctx.tx_32_buffer == nullptr) {
+      ESP_LOGE(TAG, "missing TX 32-bit audio-effects buffer");
+      return false;
+    }
+    if (!this->tx_bit_cvt_16_to_32_(tx_channels, formatted16, static_cast<uint32_t>(ctx.bus_frame_size),
+                                    ctx.tx_32_buffer)) {
+      return false;
+    }
+    *tx_data = ctx.tx_32_buffer;
+    *tx_bytes = ctx.bus_frame_size * tx_channels * sizeof(int32_t);
+    return true;
+  }
+#endif
+
+  *tx_data = formatted16;
+  *tx_bytes = ctx.bus_frame_size * tx_channels * sizeof(int16_t);
+  return true;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// TX PATH: ring buffer read → volume → Espressif format conversion → I2S write
+// ════════════════════════════════════════════════════════════════════════════
+bool ESPAudioStack::write_tx_frame_(AudioTaskCtx &ctx, void *tx_data, size_t tx_bytes) {
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  const bool write_ok = this->codec_backend_.write(tx_data, tx_bytes);
+  const bool io_closed = !this->codec_backend_.is_open();
+#else
+  size_t bytes_written = 0;
+  const esp_err_t write_err = i2s_channel_write(this->tx_handle_, tx_data, tx_bytes, &bytes_written, portMAX_DELAY);
+  const bool write_ok = write_err == ESP_OK && bytes_written == tx_bytes;
+  const bool io_closed = write_err == ESP_ERR_INVALID_STATE;
+#endif
+  if (!write_ok && io_closed) {
+    if (this->audio_stack_running_.load(std::memory_order_relaxed)) {
+      if (++ctx.invalid_state_errors > 100) {
+        ESP_LOGE(TAG, "Persistent I2S TX INVALID_STATE (%d) - channel corrupted", ctx.invalid_state_errors);
+        this->has_i2s_error_.store(true, std::memory_order_relaxed);
+        this->audio_stack_running_.store(false, std::memory_order_relaxed);
+      }
+    }
+    return false;
+  }
+  if (!write_ok) {
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+    LOG_W_THROTTLED("Codec TX write failed");
+#else
+    LOG_W_THROTTLED("I2S write failed: err=%s bytes=%u/%u", esp_err_to_name(write_err),
+                    static_cast<unsigned>(bytes_written), static_cast<unsigned>(tx_bytes));
+#endif
+    if (++ctx.consecutive_i2s_errors > 100) {
+      ESP_LOGE(TAG, "Persistent I2S write errors (%d)", ctx.consecutive_i2s_errors);
+      this->has_i2s_error_.store(true, std::memory_order_relaxed);
+      this->audio_stack_running_.store(false, std::memory_order_relaxed);
+    }
+    return false;
+  }
+
+  ctx.consecutive_i2s_errors = 0;
+  ctx.invalid_state_errors = 0;
+  return true;
+}
+
+bool ESPAudioStack::write_tx_dma_blocks_(AudioTaskCtx &ctx, void *tx_data, size_t tx_bytes, size_t real_speaker_bytes) {
+  if (tx_data == nullptr || tx_bytes == 0) {
+    return false;
+  }
+  if (this->tx_completion_dma_buffer_bytes_ == 0 || this->tx_completion_dma_frames_ == 0) {
+    ESP_LOGE(TAG, "TX DMA completion tracking is not initialized");
+    this->has_i2s_error_.store(true, std::memory_order_relaxed);
+    this->audio_stack_running_.store(false, std::memory_order_relaxed);
+    return false;
+  }
+  if (tx_bytes % this->tx_completion_dma_buffer_bytes_ != 0) {
+    ESP_LOGE(TAG,
+             "TX frame (%u bytes) is not aligned to DMA buffer (%u bytes); "
+             "speaker playback callbacks cannot stay in lockstep",
+             (unsigned) tx_bytes, (unsigned) this->tx_completion_dma_buffer_bytes_);
+    this->has_i2s_error_.store(true, std::memory_order_relaxed);
+    this->audio_stack_running_.store(false, std::memory_order_relaxed);
+    return false;
+  }
+
+  const size_t public_frame_bytes = sizeof(int16_t) * static_cast<size_t>(ctx.speaker_channels);
+  uint32_t remaining_real_frames =
+      public_frame_bytes > 0 ? static_cast<uint32_t>(real_speaker_bytes / public_frame_bytes) : 0;
+  auto *bytes = static_cast<uint8_t *>(tx_data);
+
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  for (size_t offset = 0; offset < tx_bytes; offset += this->tx_completion_dma_buffer_bytes_) {
+    const uint32_t real_frames = std::min(remaining_real_frames, this->tx_completion_dma_frames_);
+    TxCompletionRecord record{};
+    record.real_frames = real_frames;
+    record.trailing_silence_frames = real_frames > 0 ? this->tx_completion_dma_frames_ - real_frames : 0;
+    if (!this->queue_tx_completion_record_(record)) {
+      return false;
+    }
+    remaining_real_frames -= real_frames;
+  }
+  return this->write_tx_frame_(ctx, tx_data, tx_bytes);
+#else
+  for (size_t offset = 0; offset < tx_bytes; offset += this->tx_completion_dma_buffer_bytes_) {
+    const uint32_t real_frames = std::min(remaining_real_frames, this->tx_completion_dma_frames_);
+    TxCompletionRecord record{};
+    record.real_frames = real_frames;
+    record.trailing_silence_frames = real_frames > 0 ? this->tx_completion_dma_frames_ - real_frames : 0;
+    if (!this->queue_tx_completion_record_(record)) {
+      return false;
+    }
+    if (!this->write_tx_frame_(ctx, bytes + offset, this->tx_completion_dma_buffer_bytes_)) {
+      return false;
+    }
+    remaining_real_frames -= real_frames;
+  }
+  return true;
+#endif
+}
+
+void ESPAudioStack::process_tx_clock_only_(AudioTaskCtx &ctx) {
+  if (!this->tx_handle_ || ctx.tx_clock_buffer == nullptr)
+    return;
+
+  const size_t tx_bytes = ctx.use_tdm_bus ? ctx.tdm_tx_frame_bytes : ctx.bus_frame_size * ctx.num_ch * ctx.i2s_bps;
+  ctx.speaker_got = 0;
+  ctx.speaker_underrun = false;
+#ifdef USE_ESP_AUDIO_STACK_TDM_REF_DIAGNOSTIC
+  ctx.current_speaker_dbfs = -120.0f;
+#endif
+  // Clock-only TX keeps full-duplex RX/I2S clocks alive while no speaker
+  // audio is playing. It contains no public speaker frames, but the I2S ISR
+  // still emits TX completion events, so queue zero-frame records to keep the
+  // completion stream in lockstep without notifying speaker consumers.
+  this->write_tx_dma_blocks_(ctx, ctx.tx_clock_buffer, tx_bytes, 0);
+}
+
+void ESPAudioStack::process_tx_path_(AudioTaskCtx &ctx) {
+  if (!this->tx_handle_)
+    return;
+
+  if (ctx.speaker_running && !ctx.speaker_paused) {
+    ctx.speaker_got = this->speaker_buffer_->read((void *) ctx.spk_buffer, ctx.speaker_frame_bytes, 0);
+    size_t got = ctx.speaker_got;
+    // Treat partial frames as underrun too (the frame is padded with zero below
+    // and must not be used as AEC reference, otherwise the AEC adaptive filter
+    // sees a half-real / half-silent signal and fails to correlate with the mic).
+    ctx.speaker_underrun = got < ctx.speaker_frame_bytes;
+
+    if (got > 0) {
+      // Hot-path output volume is cached as Q31 when the volume changes, so
+      // the audio task does not spend every frame converting float -> fixed.
+      auto *spk_bytes = reinterpret_cast<uint8_t *>(ctx.spk_buffer);
+      if (ctx.hot_output_volume_q31 == 0) {
+        memset(spk_bytes, 0, got);
+      } else if (ctx.hot_output_volume_q31 != INT32_MAX) {
+        const size_t got_samples = got / sizeof(int16_t);
+        esp_audio_libs::gain::apply(spk_bytes, spk_bytes, ctx.hot_output_volume_q31, got_samples, sizeof(int16_t));
+      }
+      if (got < ctx.speaker_frame_bytes) {
+        memset(((uint8_t *) ctx.spk_buffer) + got, 0, ctx.speaker_frame_bytes - got);
+      }
+#ifdef USE_ESP_AUDIO_STACK_TDM_REF_DIAGNOSTIC
+      ctx.current_speaker_dbfs = compute_rms_dbfs_i16(ctx.spk_buffer, ctx.bus_frame_size, 1);
+#endif
+    } else {
+      memset(ctx.spk_buffer, 0, ctx.speaker_frame_bytes);
+#ifdef USE_ESP_AUDIO_STACK_TDM_REF_DIAGNOSTIC
+      ctx.current_speaker_dbfs = -120.0f;
+#endif
+    }
+  } else {
+    // Paused speaker output must not drain speaker_buffer_: ESPHome speaker
+    // pause means processing incoming audio is suspended, not consumed as
+    // silent playback.
+    memset(ctx.spk_buffer, 0, ctx.speaker_frame_bytes);
+    ctx.speaker_got = 0;
+#ifdef USE_ESP_AUDIO_STACK_TDM_REF_DIAGNOSTIC
+    ctx.current_speaker_dbfs = -120.0f;
+#endif
+  }
+
+  // Save post-volume TX data as AEC reference (skip if processor is off).
+  // The reference is converted to the processor rate HERE, on the TX side, so
+  // downstream storage and consumer reads happen at the smaller output size.
+  // Two safety properties of this gating:
+  //   1) Decimation only runs on a complete frame (speaker_got == speaker_frame_bytes),
+  //      otherwise the converter state would absorb zero-padding and pollute the
+  //      next valid frame's reference for ~32 samples.
+  //   2) Skipping the save on a short read keeps the last good reference, same
+  //      as the prior implementation.
+#ifdef USE_AUDIO_PROCESSOR
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+  const bool full_frame = ctx.speaker_running && !ctx.speaker_paused && ctx.speaker_got == ctx.speaker_frame_bytes;
+  const int16_t *ref_source = ctx.spk_buffer;
+#ifdef USE_ESP_AUDIO_STACK_STEREO_TX
+  if (full_frame && !ctx.use_tdm_bus && ctx.speaker_channels > 1) {
+    if (ctx.tx_ref_mono_buffer == nullptr || this->tx_ref_ch_cvt_handle_ == nullptr) {
+      ESP_LOGE(TAG, "missing stereo TX mono reference converter");
+      this->has_i2s_error_.store(true, std::memory_order_relaxed);
+      this->audio_stack_running_.store(false, std::memory_order_relaxed);
+      return;
+    }
+    const esp_ae_err_t err =
+        esp_ae_ch_cvt_process(static_cast<esp_ae_ch_cvt_handle_t>(this->tx_ref_ch_cvt_handle_),
+                              static_cast<uint32_t>(ctx.bus_frame_size), ctx.spk_buffer, ctx.tx_ref_mono_buffer);
+    if (err != ESP_AE_ERR_OK) {
+      ESP_LOGE(TAG, "esp_ae_ch_cvt_process TX ref failed: err=%d", static_cast<int>(err));
+      this->has_i2s_error_.store(true, std::memory_order_relaxed);
+      this->audio_stack_running_.store(false, std::memory_order_relaxed);
+      return;
+    }
+    ref_source = ctx.tx_ref_mono_buffer;
+  }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_RING_REF
+  if (this->aec_ref_ring_buffer_ && ctx.processor_enabled) {
+    if (full_frame && this->direct_aec_ref_ != nullptr) {
+      // Decimate TX -> processor rate into direct_aec_ref_ scratch, then push
+      // the converted frame into the ring. direct_aec_ref_ is sized for
+      // input_frame_bytes by allocate_audio_buffers_() (the converter writes
+      // bus_frame_size / ratio = input_frame_size samples).
+      if (!this->play_ref_rate_converter_.process(ref_source, this->direct_aec_ref_, ctx.bus_frame_size)) {
+        ESP_LOGE(TAG, "TX AEC reference rate conversion failed; stopping audio session");
+        this->has_i2s_error_.store(true, std::memory_order_relaxed);
+        this->audio_stack_running_.store(false, std::memory_order_relaxed);
+        return;
+      }
+      const size_t ref_bytes = ctx.input_frame_bytes;
+      // ESPHome RingBuffer::write() already drops oldest data on overflow
+      // (discard_bytes_ + write_without_replacement), which is the right
+      // backpressure here: keep the most recent reference window for AEC.
+      this->aec_ref_ring_buffer_->write((void *) this->direct_aec_ref_, ref_bytes);
+    }
+  }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_PREVIOUS_FRAME_REF
+  if (this->direct_aec_ref_ != nullptr && ctx.processor_enabled) {
+    // Previous frame mode: convert TX once and keep the result for the next
+    // AEC iteration. Only on a full frame, otherwise we keep the last good
+    // direct_aec_ref_ to avoid feeding a zero-padded reference.
+    if (full_frame) {
+      if (!this->play_ref_rate_converter_.process(ref_source, this->direct_aec_ref_, ctx.bus_frame_size)) {
+        ESP_LOGE(TAG, "TX AEC reference rate conversion failed; stopping audio session");
+        this->has_i2s_error_.store(true, std::memory_order_relaxed);
+        this->audio_stack_running_.store(false, std::memory_order_relaxed);
+        return;
+      }
+      this->direct_aec_ref_valid_ = true;
+    }
+  }
+#endif
+#endif
+#endif
+
+  void *tx_data;
+  size_t tx_bytes;
+  if (!this->format_tx_frame_(ctx, &tx_data, &tx_bytes)) {
+    ESP_LOGE(TAG, "TX audio-effects format conversion failed; stopping audio session");
+    this->has_i2s_error_.store(true, std::memory_order_relaxed);
+    this->audio_stack_running_.store(false, std::memory_order_relaxed);
+    return;
+  }
+
+  this->write_tx_dma_blocks_(ctx, tx_data, tx_bytes, ctx.speaker_got);
+}
+
+#endif  // esp-audio-libs headers available
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/codec_dev_backend.cpp
+++ b/esphome/components/esp_audio_stack/codec_dev_backend.cpp
@@ -1,0 +1,609 @@
+#include "esphome/core/defines.h"
+
+#if defined(USE_ESP32) && defined(USE_ESP_AUDIO_STACK_HARDWARE_CODEC)
+
+#include "codec_dev_backend.h"
+
+#include <audio_codec_ctrl_if.h>
+#include <audio_codec_data_if.h>
+#include <audio_codec_if.h>
+#ifdef USE_ESP_AUDIO_STACK_CODEC_ES7210
+#include <es7210_adc.h>
+#endif
+#ifdef USE_ESP_AUDIO_STACK_CODEC_ES8311
+#include <es8311_codec.h>
+#endif
+#ifdef USE_ESP_AUDIO_STACK_CODEC_ES8374
+#include <es8374_codec.h>
+#endif
+#ifdef USE_ESP_AUDIO_STACK_CODEC_ES8388
+#include <es8388_codec.h>
+#endif
+#ifdef USE_ESP_AUDIO_STACK_CODEC_ES8389
+#include <es8389_codec.h>
+#endif
+#include <esp_codec_dev_types.h>
+#include <freertos/FreeRTOS.h>
+
+#ifdef USE_I2C
+#include "esphome/components/i2c/i2c_bus.h"
+#endif
+#include "esphome/core/log.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+
+namespace esphome::esp_audio_stack {
+
+static const char *const TAG = "i2s_codec_dev";
+
+namespace {
+
+#ifdef USE_I2C
+struct EsphomeI2cCtrl {
+  audio_codec_ctrl_if_t base;
+  i2c::I2CBus *bus;
+  uint8_t address;
+  bool open;
+};
+
+static int ctrl_open(const audio_codec_ctrl_if_t *ctrl, void *cfg, int cfg_size) {
+  (void) cfg;
+  (void) cfg_size;
+  if (ctrl == nullptr) {
+    return ESP_CODEC_DEV_INVALID_ARG;
+  }
+  auto *self = reinterpret_cast<EsphomeI2cCtrl *>(const_cast<audio_codec_ctrl_if_t *>(ctrl));
+  self->open = self->bus != nullptr;
+  return self->open ? ESP_CODEC_DEV_OK : ESP_CODEC_DEV_INVALID_ARG;
+}
+
+static bool ctrl_is_open(const audio_codec_ctrl_if_t *ctrl) {
+  if (ctrl == nullptr) {
+    return false;
+  }
+  auto *self = reinterpret_cast<EsphomeI2cCtrl *>(const_cast<audio_codec_ctrl_if_t *>(ctrl));
+  return self->open;
+}
+
+static bool encode_reg(int reg, int reg_len, uint8_t *out) {
+  if (out == nullptr || reg_len < 1 || reg_len > 2) {
+    return false;
+  }
+  if (reg_len == 2) {
+    out[0] = static_cast<uint8_t>((reg >> 8) & 0xFF);
+    out[1] = static_cast<uint8_t>(reg & 0xFF);
+  } else {
+    out[0] = static_cast<uint8_t>(reg & 0xFF);
+  }
+  return true;
+}
+
+static int ctrl_read_reg(const audio_codec_ctrl_if_t *ctrl, int reg, int reg_len, void *data, int data_len) {
+  if (ctrl == nullptr || data == nullptr || data_len <= 0) {
+    return ESP_CODEC_DEV_INVALID_ARG;
+  }
+  auto *self = reinterpret_cast<EsphomeI2cCtrl *>(const_cast<audio_codec_ctrl_if_t *>(ctrl));
+  if (!self->open || self->bus == nullptr) {
+    return ESP_CODEC_DEV_WRONG_STATE;
+  }
+  uint8_t reg_buf[2]{};
+  if (!encode_reg(reg, reg_len, reg_buf)) {
+    return ESP_CODEC_DEV_INVALID_ARG;
+  }
+  auto result = self->bus->write_readv(self->address, reg_buf, reg_len, static_cast<uint8_t *>(data), data_len);
+  return result == i2c::NO_ERROR ? ESP_CODEC_DEV_OK : ESP_CODEC_DEV_READ_FAIL;
+}
+
+static int ctrl_write_reg(const audio_codec_ctrl_if_t *ctrl, int reg, int reg_len, void *data, int data_len) {
+  if (ctrl == nullptr || data == nullptr || data_len < 0) {
+    return ESP_CODEC_DEV_INVALID_ARG;
+  }
+  auto *self = reinterpret_cast<EsphomeI2cCtrl *>(const_cast<audio_codec_ctrl_if_t *>(ctrl));
+  if (!self->open || self->bus == nullptr) {
+    return ESP_CODEC_DEV_WRONG_STATE;
+  }
+  if (reg_len < 1 || reg_len > 2 || data_len > 8) {
+    return ESP_CODEC_DEV_NOT_SUPPORT;
+  }
+  uint8_t write_buf[10]{};
+  if (!encode_reg(reg, reg_len, write_buf)) {
+    return ESP_CODEC_DEV_INVALID_ARG;
+  }
+  memcpy(write_buf + reg_len, data, data_len);
+  auto result = self->bus->write_readv(self->address, write_buf, reg_len + data_len, nullptr, 0);
+  return result == i2c::NO_ERROR ? ESP_CODEC_DEV_OK : ESP_CODEC_DEV_WRITE_FAIL;
+}
+
+static int ctrl_close(const audio_codec_ctrl_if_t *ctrl) {
+  if (ctrl == nullptr) {
+    return ESP_CODEC_DEV_INVALID_ARG;
+  }
+  auto *self = reinterpret_cast<EsphomeI2cCtrl *>(const_cast<audio_codec_ctrl_if_t *>(ctrl));
+  self->open = false;
+  return ESP_CODEC_DEV_OK;
+}
+#endif  // USE_I2C
+
+}  // namespace
+
+CodecDevBackend::~CodecDevBackend() { this->teardown(); }
+
+const audio_codec_ctrl_if_t *CodecDevBackend::new_i2c_ctrl_(uint8_t address) {
+#ifdef USE_I2C
+  if (this->i2c_bus_ == nullptr) {
+    ESP_LOGE(TAG, "Codec I2C bus is not configured");
+    return nullptr;
+  }
+  auto *ctrl = static_cast<EsphomeI2cCtrl *>(calloc(1, sizeof(EsphomeI2cCtrl)));
+  if (ctrl == nullptr) {
+    return nullptr;
+  }
+  ctrl->base.open = ctrl_open;
+  ctrl->base.is_open = ctrl_is_open;
+  ctrl->base.read_reg = ctrl_read_reg;
+  ctrl->base.write_reg = ctrl_write_reg;
+  ctrl->base.close = ctrl_close;
+  ctrl->bus = this->i2c_bus_;
+  ctrl->address = address;
+  // Espressif's audio_codec_new_i2c_ctrl() returns an already-open control
+  // interface; ES7210/ES8311 constructors check that before creating codecs.
+  ctrl->open = true;
+  return &ctrl->base;
+#else
+  (void) address;
+  ESP_LOGE(TAG, "Codec I2C support is not compiled in");
+  return nullptr;
+#endif
+}
+
+esp_codec_dev_sample_info_t CodecDevBackend::make_sample_info_(const SampleConfig &config) {
+  return {
+      .bits_per_sample = config.bits_per_sample,
+      .channel = config.channels,
+      .channel_mask = config.channel_mask,
+      .sample_rate = config.sample_rate,
+      .mclk_multiple = static_cast<int>(config.mclk_multiple),
+  };
+}
+
+const char *CodecDevBackend::codec_kind_name_(CodecKind kind) {
+  switch (kind) {
+    case CodecKind::ES8311:
+      return "ES8311";
+    case CodecKind::ES8388:
+      return "ES8388";
+    case CodecKind::ES8374:
+      return "ES8374";
+    case CodecKind::ES8389:
+      return "ES8389";
+    default:
+      return "none";
+  }
+}
+
+const char *CodecDevBackend::input_codec_name() const {
+  if (this->es7210_.enabled) {
+    return "ES7210";
+  }
+  if (this->input_codec_.enabled) {
+    return codec_kind_name_(this->input_codec_.kind);
+  }
+  return "none";
+}
+
+const char *CodecDevBackend::output_codec_name() const {
+  return this->output_codec_.enabled ? codec_kind_name_(this->output_codec_.kind) : "none";
+}
+
+const audio_codec_if_t *CodecDevBackend::new_generic_codec_(const GenericCodecConfig &config, bool input,
+                                                            uint16_t mclk_div, const audio_codec_ctrl_if_t **ctrl) {
+  if (!config.enabled || ctrl == nullptr) {
+    return nullptr;
+  }
+  *ctrl = this->new_i2c_ctrl_(config.address);
+  if (*ctrl == nullptr) {
+    return nullptr;
+  }
+  const auto mode = input ? ESP_CODEC_DEV_WORK_MODE_ADC : ESP_CODEC_DEV_WORK_MODE_DAC;
+  switch (config.kind) {
+#ifdef USE_ESP_AUDIO_STACK_CODEC_ES8311
+    case CodecKind::ES8311: {
+      es8311_codec_cfg_t cfg = {};
+      cfg.ctrl_if = *ctrl;
+      cfg.gpio_if = nullptr;
+      cfg.codec_mode = mode;
+      cfg.pa_pin = -1;
+      cfg.master_mode = false;
+      cfg.use_mclk = config.use_mclk;
+      cfg.no_dac_ref = config.no_dac_ref;
+      cfg.mclk_div = mclk_div;
+      return es8311_codec_new(&cfg);
+    }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_CODEC_ES8388
+    case CodecKind::ES8388: {
+      es8388_codec_cfg_t cfg = {};
+      cfg.ctrl_if = *ctrl;
+      cfg.gpio_if = nullptr;
+      cfg.codec_mode = mode;
+      cfg.pa_pin = -1;
+      cfg.master_mode = false;
+      return es8388_codec_new(&cfg);
+    }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_CODEC_ES8374
+    case CodecKind::ES8374: {
+      es8374_codec_cfg_t cfg = {};
+      cfg.ctrl_if = *ctrl;
+      cfg.gpio_if = nullptr;
+      cfg.codec_mode = mode;
+      cfg.pa_pin = -1;
+      cfg.master_mode = false;
+      return es8374_codec_new(&cfg);
+    }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_CODEC_ES8389
+    case CodecKind::ES8389: {
+      es8389_codec_cfg_t cfg = {};
+      cfg.ctrl_if = *ctrl;
+      cfg.gpio_if = nullptr;
+      cfg.codec_mode = mode;
+      cfg.pa_pin = -1;
+      cfg.master_mode = false;
+      cfg.use_mclk = config.use_mclk;
+      cfg.digital_mic = false;
+      cfg.invert_mclk = false;
+      cfg.invert_sclk = false;
+      cfg.no_dac_ref = config.no_dac_ref;
+      cfg.mclk_div = mclk_div;
+      return es8389_codec_new(&cfg);
+    }
+#endif
+    default:
+      ESP_LOGE(TAG, "Unsupported codec kind: %u", static_cast<unsigned>(config.kind));
+      return nullptr;
+  }
+}
+
+bool CodecDevBackend::setup(uint8_t tx_i2s_port, uint8_t rx_i2s_port, i2s_chan_handle_t tx_handle,
+                            i2s_chan_handle_t rx_handle, i2s_clock_src_t clk_src, uint32_t mclk_multiple) {
+  this->teardown();
+  const uint16_t codec_mclk_div = mclk_multiple == 0 ? 256 : static_cast<uint16_t>(mclk_multiple);
+
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  const bool shared_i2s_data = tx_i2s_port == rx_i2s_port;
+  if (shared_i2s_data) {
+    audio_codec_i2s_cfg_t i2s_cfg = {
+        .port = tx_i2s_port,
+        .rx_handle = rx_handle,
+        .tx_handle = tx_handle,
+        .clk_src = static_cast<int>(clk_src),
+    };
+    this->tx_data_if_ = audio_codec_new_i2s_data(&i2s_cfg);
+    if (this->tx_data_if_ == nullptr) {
+      ESP_LOGE(TAG, "Failed to create shared esp_codec_dev I2S data interface");
+      return false;
+    }
+    this->rx_data_if_ = this->tx_data_if_;
+  } else {
+    if (rx_handle != nullptr) {
+      audio_codec_i2s_cfg_t rx_i2s_cfg = {
+          .port = rx_i2s_port,
+          .rx_handle = rx_handle,
+          .tx_handle = nullptr,
+          .clk_src = static_cast<int>(clk_src),
+      };
+      this->rx_data_if_ = audio_codec_new_i2s_data(&rx_i2s_cfg);
+      if (this->rx_data_if_ == nullptr) {
+        ESP_LOGE(TAG, "Failed to create RX esp_codec_dev I2S data interface");
+        return false;
+      }
+    }
+    if (tx_handle != nullptr) {
+      audio_codec_i2s_cfg_t tx_i2s_cfg = {
+          .port = tx_i2s_port,
+          .rx_handle = nullptr,
+          .tx_handle = tx_handle,
+          .clk_src = static_cast<int>(clk_src),
+      };
+      this->tx_data_if_ = audio_codec_new_i2s_data(&tx_i2s_cfg);
+      if (this->tx_data_if_ == nullptr) {
+        ESP_LOGE(TAG, "Failed to create TX esp_codec_dev I2S data interface");
+        return false;
+      }
+    }
+  }
+#else
+  audio_codec_i2s_cfg_t i2s_cfg = {
+      .port = tx_i2s_port,
+      .rx_handle = rx_handle,
+      .tx_handle = tx_handle,
+      .clk_src = static_cast<int>(clk_src),
+  };
+  this->data_if_ = audio_codec_new_i2s_data(&i2s_cfg);
+  if (this->data_if_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create esp_codec_dev I2S data interface");
+    return false;
+  }
+#endif
+
+  if (rx_handle != nullptr && this->es7210_.enabled) {
+#ifdef USE_ESP_AUDIO_STACK_CODEC_ES7210
+    this->es7210_ctrl_ = this->new_i2c_ctrl_(this->es7210_.address);
+    if (this->es7210_ctrl_ == nullptr) {
+      return false;
+    }
+    es7210_codec_cfg_t cfg = {};
+    cfg.ctrl_if = this->es7210_ctrl_;
+    cfg.master_mode = false;
+    cfg.mic_selected = this->es7210_.mic_selected;
+    cfg.mclk_div = codec_mclk_div;
+    this->rx_codec_if_ = es7210_codec_new(&cfg);
+    if (this->rx_codec_if_ == nullptr) {
+      ESP_LOGE(TAG, "Failed to create ES7210 codec interface");
+      return false;
+    }
+#else
+    ESP_LOGE(TAG, "ES7210 codec support was not compiled in");
+    return false;
+#endif
+  } else if (rx_handle != nullptr && this->input_codec_.enabled) {
+    this->rx_codec_if_ = this->new_generic_codec_(this->input_codec_, true, codec_mclk_div, &this->input_codec_ctrl_);
+    if (this->rx_codec_if_ == nullptr) {
+      ESP_LOGE(TAG, "Failed to create %s ADC codec interface", this->input_codec_name());
+      return false;
+    }
+  }
+
+  if (tx_handle != nullptr && this->output_codec_.enabled) {
+    this->tx_codec_if_ =
+        this->new_generic_codec_(this->output_codec_, false, codec_mclk_div, &this->output_codec_ctrl_);
+    if (this->tx_codec_if_ == nullptr) {
+      ESP_LOGE(TAG, "Failed to create %s DAC codec interface", this->output_codec_name());
+      return false;
+    }
+  }
+
+  if (rx_handle != nullptr) {
+    esp_codec_dev_cfg_t rx_cfg = {
+        .dev_type = ESP_CODEC_DEV_TYPE_IN,
+        .codec_if = this->rx_codec_if_,
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+        .data_if = this->rx_data_if_,
+#else
+        .data_if = this->data_if_,
+#endif
+    };
+    this->rx_dev_ = esp_codec_dev_new(&rx_cfg);
+    if (this->rx_dev_ == nullptr) {
+      ESP_LOGE(TAG, "Failed to create esp_codec_dev RX device");
+      return false;
+    }
+  }
+
+  if (tx_handle != nullptr) {
+    esp_codec_dev_cfg_t tx_cfg = {
+        .dev_type = ESP_CODEC_DEV_TYPE_OUT,
+        .codec_if = this->tx_codec_if_,
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+        .data_if = this->tx_data_if_,
+#else
+        .data_if = this->data_if_,
+#endif
+    };
+    this->tx_dev_ = esp_codec_dev_new(&tx_cfg);
+    if (this->tx_dev_ == nullptr) {
+      ESP_LOGE(TAG, "Failed to create esp_codec_dev TX device");
+      return false;
+    }
+  }
+
+  this->prepared_ = true;
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  ESP_LOGI(TAG, "esp_codec_dev backend ready (rx_codec=%s, tx_codec=%s, data_if=%s)", this->input_codec_name(),
+           this->output_codec_name(), shared_i2s_data ? "shared" : "split");
+#else
+  ESP_LOGI(TAG, "esp_codec_dev backend ready (rx_codec=%s, tx_codec=%s)", this->input_codec_name(),
+           this->output_codec_name());
+#endif
+  return true;
+}
+
+bool CodecDevBackend::open(const SampleConfig *tx_config, const SampleConfig *rx_config) {
+  if (!this->prepared_) {
+    return false;
+  }
+  if (this->open_) {
+    return true;
+  }
+
+  // Match Espressif's TDM codec-dev tests: bring up playback first, then record,
+  // so the TX side has configured the shared clock before RX starts consuming it.
+  if (this->tx_dev_ != nullptr && tx_config != nullptr) {
+    auto fs = make_sample_info_(*tx_config);
+    int ret = esp_codec_dev_open(this->tx_dev_, &fs);
+    if (ret != ESP_CODEC_DEV_OK) {
+      ESP_LOGE(TAG, "Failed to open TX codec device: %d", ret);
+      return false;
+    }
+    this->apply_output_volume_curve_();
+  }
+  if (this->rx_dev_ != nullptr && rx_config != nullptr) {
+    auto fs = make_sample_info_(*rx_config);
+    int ret = esp_codec_dev_open(this->rx_dev_, &fs);
+    if (ret != ESP_CODEC_DEV_OK) {
+      ESP_LOGE(TAG, "Failed to open RX codec device: %d", ret);
+      if (this->tx_dev_ != nullptr) {
+        esp_codec_dev_close(this->tx_dev_);
+      }
+      return false;
+    }
+    if (this->es7210_.enabled) {
+      this->set_input_gain(this->es7210_.input_gain_db);
+      if (this->es7210_.has_ref_channel_gain) {
+        this->set_input_channel_gain(this->es7210_.ref_channel, this->es7210_.ref_channel_gain_db);
+      }
+    } else if (this->input_codec_.enabled) {
+      this->set_input_gain(this->input_codec_.input_gain_db);
+    }
+  }
+  this->open_ = true;
+  return true;
+}
+
+void CodecDevBackend::close() {
+  if (!this->open_) {
+    return;
+  }
+  if (this->rx_dev_ != nullptr) {
+    esp_codec_dev_close(this->rx_dev_);
+  }
+  if (this->tx_dev_ != nullptr) {
+    esp_codec_dev_close(this->tx_dev_);
+  }
+  this->open_ = false;
+}
+
+bool CodecDevBackend::read(void *data, size_t len) {
+  if (this->rx_dev_ == nullptr || data == nullptr || len == 0) {
+    return false;
+  }
+  const int ret = esp_codec_dev_read(this->rx_dev_, data, static_cast<int>(len));
+  if (ret != ESP_CODEC_DEV_OK) {
+    return false;
+  }
+  return true;
+}
+
+bool CodecDevBackend::write(void *data, size_t len) {
+  if (this->tx_dev_ == nullptr || data == nullptr || len == 0) {
+    return false;
+  }
+  const int ret = esp_codec_dev_write(this->tx_dev_, data, static_cast<int>(len));
+  if (ret != ESP_CODEC_DEV_OK) {
+    return false;
+  }
+  return true;
+}
+
+void CodecDevBackend::set_output_volume(float volume) {
+  if (this->tx_dev_ == nullptr) {
+    return;
+  }
+  if (!(volume > 0.0f)) {
+    volume = 0.0f;
+  } else if (volume > 1.0f) {
+    volume = 1.0f;
+  }
+  esp_codec_dev_set_out_vol(this->tx_dev_, static_cast<int>(volume * 100.0f + 0.5f));
+}
+
+void CodecDevBackend::set_output_volume_curve(float min_db) {
+  if (!std::isfinite(min_db)) {
+    return;
+  }
+  if (min_db < -96.0f)
+    min_db = -96.0f;
+  if (min_db > 0.0f)
+    min_db = 0.0f;
+  this->output_volume_min_db_ = min_db;
+  this->output_volume_curve_configured_ = true;
+  this->apply_output_volume_curve_();
+}
+
+void CodecDevBackend::apply_output_volume_curve_() {
+  if (!this->output_volume_curve_configured_ || this->tx_dev_ == nullptr || !this->output_codec_.enabled) {
+    return;
+  }
+  esp_codec_dev_vol_map_t vol_map[2] = {
+      {.vol = 1, .db_value = this->output_volume_min_db_},
+      {.vol = 100, .db_value = 0.0f},
+  };
+  esp_codec_dev_vol_curve_t curve = {
+      .vol_map = vol_map,
+      .count = 2,
+  };
+  const int ret = esp_codec_dev_set_vol_curve(this->tx_dev_, &curve);
+  if (ret != ESP_CODEC_DEV_OK) {
+    ESP_LOGW(TAG, "Failed to set codec output volume curve: %d", ret);
+  }
+}
+
+void CodecDevBackend::set_output_mute(bool mute) {
+  if (this->tx_dev_ != nullptr) {
+    esp_codec_dev_set_out_mute(this->tx_dev_, mute);
+  }
+}
+
+void CodecDevBackend::set_input_gain(float gain_db) {
+  if (this->rx_dev_ != nullptr) {
+    esp_codec_dev_set_in_gain(this->rx_dev_, gain_db);
+  }
+}
+
+void CodecDevBackend::set_input_channel_gain(uint8_t channel, float gain_db) {
+  if (this->rx_dev_ != nullptr && channel < 16) {
+    esp_codec_dev_set_in_channel_gain(this->rx_dev_, ESP_CODEC_DEV_MAKE_CHANNEL_MASK(channel), gain_db);
+  }
+}
+
+void CodecDevBackend::destroy_codecs_() {
+  if (this->rx_codec_if_ != nullptr) {
+    audio_codec_delete_codec_if(this->rx_codec_if_);
+    this->rx_codec_if_ = nullptr;
+  }
+  if (this->tx_codec_if_ != nullptr) {
+    audio_codec_delete_codec_if(this->tx_codec_if_);
+    this->tx_codec_if_ = nullptr;
+  }
+  if (this->es7210_ctrl_ != nullptr) {
+    audio_codec_delete_ctrl_if(this->es7210_ctrl_);
+    this->es7210_ctrl_ = nullptr;
+  }
+  if (this->input_codec_ctrl_ != nullptr) {
+    audio_codec_delete_ctrl_if(this->input_codec_ctrl_);
+    this->input_codec_ctrl_ = nullptr;
+  }
+  if (this->output_codec_ctrl_ != nullptr) {
+    audio_codec_delete_ctrl_if(this->output_codec_ctrl_);
+    this->output_codec_ctrl_ = nullptr;
+  }
+}
+
+void CodecDevBackend::teardown() {
+  this->close();
+  if (this->rx_dev_ != nullptr) {
+    esp_codec_dev_delete(this->rx_dev_);
+    this->rx_dev_ = nullptr;
+  }
+  if (this->tx_dev_ != nullptr) {
+    esp_codec_dev_delete(this->tx_dev_);
+    this->tx_dev_ = nullptr;
+  }
+  this->destroy_codecs_();
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  const audio_codec_data_if_t *rx_data_if = this->rx_data_if_;
+  const audio_codec_data_if_t *tx_data_if = this->tx_data_if_;
+  if (rx_data_if != nullptr) {
+    audio_codec_delete_data_if(this->rx_data_if_);
+    this->rx_data_if_ = nullptr;
+  }
+  if (tx_data_if != nullptr && tx_data_if != rx_data_if) {
+    audio_codec_delete_data_if(this->tx_data_if_);
+  }
+  this->tx_data_if_ = nullptr;
+#else
+  if (this->data_if_ != nullptr) {
+    audio_codec_delete_data_if(this->data_if_);
+    this->data_if_ = nullptr;
+  }
+#endif
+  this->prepared_ = false;
+  this->open_ = false;
+}
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32 && USE_ESP_AUDIO_STACK_HARDWARE_CODEC

--- a/esphome/components/esp_audio_stack/codec_dev_backend.h
+++ b/esphome/components/esp_audio_stack/codec_dev_backend.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#if defined(USE_ESP32) && defined(USE_ESP_AUDIO_STACK_HARDWARE_CODEC)
+
+#include <driver/i2s_types.h>
+#include <esp_codec_dev.h>
+#include <esp_codec_dev_defaults.h>
+#include <hal/i2s_types.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace esphome {
+namespace i2c {
+class I2CBus;
+}  // namespace i2c
+}  // namespace esphome
+
+namespace esphome::esp_audio_stack {
+
+class CodecDevBackend {
+ public:
+  enum class CodecKind : uint8_t {
+    NONE = 0,
+    ES8311,
+    ES8388,
+    ES8374,
+    ES8389,
+  };
+
+  struct Es7210Config {
+    bool enabled{false};
+    uint8_t address{0x40};
+    uint8_t mic_selected{0x0F};
+    float input_gain_db{30.0f};
+    bool has_ref_channel_gain{false};
+    uint8_t ref_channel{1};
+    float ref_channel_gain_db{0.0f};
+  };
+
+  struct GenericCodecConfig {
+    bool enabled{false};
+    CodecKind kind{CodecKind::NONE};
+    uint8_t address{0x18};
+    bool use_mclk{true};
+    bool no_dac_ref{true};
+    float input_gain_db{24.0f};
+  };
+
+  struct SampleConfig {
+    uint32_t sample_rate{16000};
+    uint8_t bits_per_sample{16};
+    uint8_t channels{2};
+    uint16_t channel_mask{0x0003};
+    uint32_t mclk_multiple{256};
+  };
+
+  CodecDevBackend() = default;
+  ~CodecDevBackend();
+
+  CodecDevBackend(const CodecDevBackend &) = delete;
+  CodecDevBackend &operator=(const CodecDevBackend &) = delete;
+
+  void set_i2c_bus(i2c::I2CBus *bus) { this->i2c_bus_ = bus; }
+  void set_es7210_config(const Es7210Config &config) { this->es7210_ = config; }
+  void set_input_codec_config(const GenericCodecConfig &config) { this->input_codec_ = config; }
+  void set_output_codec_config(const GenericCodecConfig &config) { this->output_codec_ = config; }
+
+  bool setup(uint8_t tx_i2s_port, uint8_t rx_i2s_port, i2s_chan_handle_t tx_handle, i2s_chan_handle_t rx_handle,
+             i2s_clock_src_t clk_src, uint32_t mclk_multiple);
+  bool open(const SampleConfig *tx_config, const SampleConfig *rx_config);
+  void close();
+  void teardown();
+
+  bool read(void *data, size_t len);
+  bool write(void *data, size_t len);
+
+  void set_output_volume(float volume);
+  void set_output_volume_curve(float min_db);
+  void set_output_mute(bool mute);
+  void set_input_gain(float gain_db);
+  void set_input_channel_gain(uint8_t channel, float gain_db);
+
+  bool has_tx() const { return this->tx_dev_ != nullptr; }
+  bool has_rx() const { return this->rx_dev_ != nullptr; }
+  bool is_open() const { return this->open_; }
+  bool has_output_codec() const { return this->output_codec_.enabled; }
+  bool has_input_codec() const { return this->es7210_.enabled || this->input_codec_.enabled; }
+  const char *input_codec_name() const;
+  const char *output_codec_name() const;
+
+ private:
+  static const char *codec_kind_name_(CodecKind kind);
+  static esp_codec_dev_sample_info_t make_sample_info_(const SampleConfig &config);
+
+  const audio_codec_ctrl_if_t *new_i2c_ctrl_(uint8_t address);
+  void apply_output_volume_curve_();
+  const audio_codec_if_t *new_generic_codec_(const GenericCodecConfig &config, bool input, uint16_t mclk_div,
+                                             const audio_codec_ctrl_if_t **ctrl);
+  void destroy_codecs_();
+
+  i2c::I2CBus *i2c_bus_{nullptr};
+  Es7210Config es7210_{};
+  GenericCodecConfig input_codec_{};
+  GenericCodecConfig output_codec_{};
+
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  const audio_codec_data_if_t *rx_data_if_{nullptr};
+  const audio_codec_data_if_t *tx_data_if_{nullptr};
+#else
+  const audio_codec_data_if_t *data_if_{nullptr};
+#endif
+  const audio_codec_ctrl_if_t *es7210_ctrl_{nullptr};
+  const audio_codec_ctrl_if_t *input_codec_ctrl_{nullptr};
+  const audio_codec_ctrl_if_t *output_codec_ctrl_{nullptr};
+  const audio_codec_if_t *rx_codec_if_{nullptr};
+  const audio_codec_if_t *tx_codec_if_{nullptr};
+  esp_codec_dev_handle_t rx_dev_{nullptr};
+  esp_codec_dev_handle_t tx_dev_{nullptr};
+  bool output_volume_curve_configured_{false};
+  float output_volume_min_db_{-49.0f};
+
+  bool prepared_{false};
+  bool open_{false};
+};
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32 && USE_ESP_AUDIO_STACK_HARDWARE_CODEC

--- a/esphome/components/esp_audio_stack/esp_audio_stack.cpp
+++ b/esphome/components/esp_audio_stack/esp_audio_stack.cpp
@@ -1,0 +1,1647 @@
+#include "esp_audio_stack.h"
+
+#ifdef USE_ESP32
+
+#include <driver/i2s_common.h>
+#include <esp_heap_caps.h>
+#include <esp_idf_version.h>
+#include <esp_timer.h>
+#include <gain.h>
+#include <algorithm>
+#include <climits>
+#include <cmath>
+#include <cstring>
+
+#include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+#include "audio_core_processor.h"
+#include "audio_core_ring_buffer_caps.h"
+#include "audio_core_scoped_lock.h"
+#include "audio_core_task_utils.h"
+
+namespace esphome::esp_audio_stack {
+
+static const char *const TAG = "audio_stack";
+
+// Audio parameters
+// IDF default I2S channel config uses 6 descriptors. Keep the old ESPHome
+// duplex latency policy while using the official esp_driver_i2s API directly:
+// one descriptor carries ~10 ms of audio, clamped to the 4092-byte DMA limit.
+constexpr size_t DMA_BUFFER_COUNT = 6;
+constexpr uint32_t DMA_BUFFER_DURATION_MS = 10;
+// Minimum speaker buffer for very small configured durations. The default comes
+// from the speaker platform schema (`buffer_duration: 500ms`) to match native
+// ESPHome I2S speaker semantics.
+constexpr size_t SPEAKER_BUFFER_MIN_BYTES = 2048;
+
+namespace {
+constexpr float SOFTWARE_VOLUME_MIN_DB = -49.0f;
+
+float sanitize_volume_min_db(float db) {
+  if (!std::isfinite(db))
+    return SOFTWARE_VOLUME_MIN_DB;
+  if (db < -96.0f)
+    return -96.0f;
+  if (db > 0.0f)
+    return 0.0f;
+  return db;
+}
+
+int32_t volume_factor_to_q31(float volume, float min_db = SOFTWARE_VOLUME_MIN_DB) {
+  if (!(volume > 0.0f))
+    return 0;
+  if (volume >= 1.0f)
+    return INT32_MAX;
+  return esp_audio_libs::gain::db_to_q31(remap<float, float>(volume, 0.0f, 1.0f, sanitize_volume_min_db(min_db), 0.0f));
+}
+
+int32_t attenuation_factor_to_q31(float gain) {
+  if (!(gain > 0.0f))
+    return 0;
+  if (gain >= 1.0f)
+    return INT32_MAX;
+  return esp_audio_libs::gain::db_to_q31(20.0f * std::log10(gain));
+}
+
+int8_t gain_factor_to_positive_db(float gain) {
+  if (!(gain > 1.0f))
+    return 0;
+  const int32_t db = static_cast<int32_t>(std::lround(20.0f * std::log10(gain)));
+  if (db <= 0)
+    return 0;
+  if (db > 30)
+    return 30;
+  return static_cast<int8_t>(db);
+}
+
+[[maybe_unused]] int32_t multiply_q31(int32_t a, int32_t b) {
+  if (a <= 0 || b <= 0)
+    return 0;
+  const int64_t value = (static_cast<int64_t>(a) * static_cast<int64_t>(b) + (1LL << 30)) >> 31;
+  return value >= INT32_MAX ? INT32_MAX : static_cast<int32_t>(value);
+}
+
+uint32_t largest_divisor_at_most(uint32_t value, uint32_t limit, uint32_t minimum) {
+  if (value == 0 || limit == 0)
+    return 0;
+  uint32_t candidate = std::min(value, limit);
+  while (candidate > minimum) {
+    if (value % candidate == 0)
+      return candidate;
+    candidate--;
+  }
+  return value % minimum == 0 && minimum <= limit ? minimum : std::min(value, limit);
+}
+
+float sanitize_gain_factor(float gain) {
+  if (!std::isfinite(gain) || gain <= 0.0f) {
+    return 0.0f;
+  }
+  // YAML exposes input gain up to 32x and mic_gain_db +30 dB maps to
+  // ~31.6x. Clamp direct C++ callers to the same practical envelope.
+  return gain > 32.0f ? 32.0f : gain;
+}
+}  // namespace
+
+void ESPAudioStack::set_mic_gain(float gain) {
+  gain = sanitize_gain_factor(gain);
+  this->mic_gain_.store(gain, std::memory_order_relaxed);
+  this->mic_gain_q31_.store(attenuation_factor_to_q31(gain), std::memory_order_relaxed);
+  this->mic_gain_boost_db_.store(gain_factor_to_positive_db(gain), std::memory_order_relaxed);
+}
+
+void ESPAudioStack::set_input_gain(float gain) {
+  gain = sanitize_gain_factor(gain);
+  this->input_gain_.store(gain, std::memory_order_relaxed);
+  this->input_gain_q31_.store(attenuation_factor_to_q31(gain), std::memory_order_relaxed);
+  this->input_gain_boost_.store(gain > 1.0f ? gain : 1.0f, std::memory_order_relaxed);
+}
+
+void ESPAudioStack::set_master_volume_min_db(float db) {
+  db = sanitize_volume_min_db(db);
+  const float previous = this->master_volume_min_db_;
+  this->master_volume_min_db_ = db;
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  this->codec_backend_.set_output_volume_curve(db);
+#endif
+  if (previous != db)
+    this->set_master_volume(this->master_volume_linear_.load(std::memory_order_relaxed));
+}
+
+void ESPAudioStack::set_master_volume(float volume) {
+  if (!(volume > 0.0f)) {
+    volume = 0.0f;
+  } else if (volume > 1.0f) {
+    volume = 1.0f;
+  }
+  this->master_volume_linear_.store(volume, std::memory_order_relaxed);
+  const int32_t q31 = volume_factor_to_q31(volume, this->master_volume_min_db_);
+  const int32_t previous = this->master_volume_q31_.exchange(q31, std::memory_order_relaxed);
+  if (previous != q31)
+    this->update_hot_output_volume_();
+}
+
+void ESPAudioStack::set_master_volume_q31(int32_t q31) {
+  if (q31 < 0)
+    q31 = 0;
+  this->master_volume_linear_.store(static_cast<float>(q31) / static_cast<float>(INT32_MAX), std::memory_order_relaxed);
+  const int32_t previous = this->master_volume_q31_.exchange(q31, std::memory_order_relaxed);
+  if (previous != q31)
+    this->update_hot_output_volume_();
+}
+
+void ESPAudioStack::set_output_volume(float volume) {
+  if (!(volume > 0.0f)) {
+    volume = 0.0f;
+  } else if (volume > 1.0f) {
+    volume = 1.0f;
+  }
+  this->set_output_volume_q31(volume_factor_to_q31(volume));
+}
+
+void ESPAudioStack::set_output_volume_q31(int32_t q31) {
+  if (q31 < 0)
+    q31 = 0;
+  const int32_t previous = this->output_volume_q31_.exchange(q31, std::memory_order_relaxed);
+  if (previous != q31)
+    this->update_hot_output_volume_();
+}
+
+void ESPAudioStack::update_hot_output_volume_() {
+  const int32_t output_q31 = this->output_volume_q31_.load(std::memory_order_relaxed);
+  const int32_t master_q31 = this->master_volume_q31_.load(std::memory_order_relaxed);
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_OUTPUT_CODEC
+  const bool hardware_master = true;
+  const float public_master = this->master_volume_linear_.load(std::memory_order_relaxed);
+  const int32_t combined_q31 = output_q31;
+#else
+  const bool hardware_master = false;
+  const float public_master = static_cast<float>(master_q31) / static_cast<float>(INT32_MAX);
+  const int32_t combined_q31 = multiply_q31(output_q31, master_q31);
+#endif
+  const float linear = static_cast<float>(combined_q31) / static_cast<float>(INT32_MAX);
+  this->master_volume_public_.store(public_master, std::memory_order_relaxed);
+  const int32_t previous = this->hot_output_volume_q31_.exchange(combined_q31, std::memory_order_relaxed);
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  if (hardware_master) {
+    this->codec_backend_.set_output_volume(public_master);
+  }
+#endif
+  if (previous != combined_q31) {
+    ESP_LOGD(TAG, "Master volume: output_q31=%d master_q31=%d hot_q31=%d linear=%.3f hw_master=%s previous_q31=%d",
+             output_q31, master_q31, combined_q31, linear, hardware_master ? "yes" : "no", previous);
+  }
+}
+
+const char *ESPAudioStack::runtime_state_to_string(AudioStackRuntimeState state) {
+  switch (state) {
+    case AudioStackRuntimeState::IDLE:
+      return "idle";
+    case AudioStackRuntimeState::MIC:
+      return "mic";
+    case AudioStackRuntimeState::SPEAKER:
+      return "speaker";
+    case AudioStackRuntimeState::DUPLEX:
+      return "duplex";
+  }
+  return "unknown";
+}
+
+AudioStackRuntimeState ESPAudioStack::compute_runtime_state_() const {
+  const bool mic = this->has_mic_consumers_.load(std::memory_order_relaxed);
+  const bool speaker = this->speaker_running_.load(std::memory_order_relaxed);
+  if (mic && speaker)
+    return AudioStackRuntimeState::DUPLEX;
+  if (mic)
+    return AudioStackRuntimeState::MIC;
+  if (speaker)
+    return AudioStackRuntimeState::SPEAKER;
+  return AudioStackRuntimeState::IDLE;
+}
+
+void ESPAudioStack::update_runtime_state_() {
+  const auto next = this->compute_runtime_state_();
+  const auto next_raw = static_cast<uint8_t>(next);
+  const auto prev_raw = this->runtime_state_.exchange(next_raw, std::memory_order_relaxed);
+  if (prev_raw == next_raw)
+    return;
+  const char *state = runtime_state_to_string(next);
+  ESP_LOGD(TAG, "Runtime state: %s", state);
+  this->state_trigger_.trigger(std::string(state));
+}
+
+const char *ESPAudioStack::i2s_hardware_state_to_string(I2SHardwareState state) {
+  switch (state) {
+    case I2SHardwareState::UNPREPARED:
+      return "unprepared";
+    case I2SHardwareState::PREPARING:
+      return "preparing";
+    case I2SHardwareState::READY:
+      return "ready";
+    case I2SHardwareState::RUNNING:
+      return "running";
+    case I2SHardwareState::STOPPING:
+      return "stopping";
+    case I2SHardwareState::ERROR:
+      return "error";
+  }
+  return "unknown";
+}
+
+void ESPAudioStack::set_i2s_hardware_state_(I2SHardwareState state) {
+  const auto next_raw = static_cast<uint8_t>(state);
+  const auto prev_raw = this->i2s_hardware_state_.exchange(next_raw, std::memory_order_relaxed);
+  if (prev_raw != next_raw) {
+    ESP_LOGD(TAG, "I2S hardware state: %s", i2s_hardware_state_to_string(state));
+  }
+}
+
+void ESPAudioStack::service_speaker_reset_() {
+  if (!this->request_speaker_reset_.exchange(false, std::memory_order_relaxed)) {
+    return;
+  }
+  if (this->speaker_buffer_) {
+    this->speaker_buffer_->reset();
+  }
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+  this->direct_aec_ref_valid_ = false;
+#endif
+#ifdef USE_ESP_AUDIO_STACK_RING_REF
+  if (this->aec_ref_ring_buffer_) {
+    this->aec_ref_ring_buffer_->reset();
+  }
+#endif
+}
+
+void ESPAudioStack::log_memory_snapshot_(const char *label) const {
+  ESP_LOGI(TAG, "Memory[%s]: internal_free=%u largest_internal=%u dma_free=%u largest_dma=%u psram_free=%u", label,
+           (unsigned) heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+           (unsigned) heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
+           (unsigned) heap_caps_get_free_size(MALLOC_CAP_DMA),
+           (unsigned) heap_caps_get_largest_free_block(MALLOC_CAP_DMA),
+           (unsigned) heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+}
+
+// Helper: get MCLK multiple enum from integer value
+static i2s_mclk_multiple_t get_mclk_multiple(uint32_t mult) {
+  switch (mult) {
+    case 128:
+      return I2S_MCLK_MULTIPLE_128;
+    case 384:
+      return I2S_MCLK_MULTIPLE_384;
+    case 512:
+      return I2S_MCLK_MULTIPLE_512;
+    default:
+      return I2S_MCLK_MULTIPLE_256;
+  }
+}
+
+// Helper: get STD slot config for the configured comm format (0=philips, 1=msb, 2=pcm_short, 3=pcm_long)
+// Note: PCM short/long are TDM-only in ESP-IDF; falls back to Philips in STD mode
+static i2s_std_slot_config_t get_std_slot_config(uint8_t fmt, i2s_data_bit_width_t bw, i2s_slot_mode_t mode) {
+  switch (fmt) {
+    case 1:
+      return I2S_STD_MSB_SLOT_DEFAULT_CONFIG(bw, mode);
+    default:
+      return I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(bw, mode);
+  }
+}
+
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
+// Helper: get TDM slot config for the configured comm format
+static i2s_tdm_slot_config_t get_tdm_slot_config(uint8_t fmt, i2s_data_bit_width_t bw, i2s_slot_mode_t mode,
+                                                 i2s_tdm_slot_mask_t mask) {
+  switch (fmt) {
+    case 1:
+      return I2S_TDM_MSB_SLOT_DEFAULT_CONFIG(bw, mode, mask);
+    case 2:
+      return I2S_TDM_PCM_SHORT_SLOT_DEFAULT_CONFIG(bw, mode, mask);
+    case 3:
+      return I2S_TDM_PCM_LONG_SLOT_DEFAULT_CONFIG(bw, mode, mask);
+    default:
+      return I2S_TDM_PHILIPS_SLOT_DEFAULT_CONFIG(bw, mode, mask);
+  }
+}
+#endif  // SOC_I2S_SUPPORTS_TDM
+
+void ESPAudioStack::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up ESP Audio Stack (ESP-IDF I2S + esp_codec_dev backend)...");
+
+  // Mutex for the mic consumer registry. Plain FreeRTOS mutex (used as lock,
+  // not as a counting semaphore); replaces std::mutex to keep the public
+  // header free of <mutex>.
+  this->mic_consumers_mutex_ = xSemaphoreCreateMutex();
+  if (this->mic_consumers_mutex_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create mic_consumers_mutex_");
+    this->mark_failed();
+    return;
+  }
+
+  // Compute rate-conversion ratio. The Espressif audio-effects wrappers are also
+  // used at ratio 1 for 32-bit -> 16-bit conversion, so initialise them
+  // unconditionally.
+  if (this->output_sample_rate_ > 0 && this->output_sample_rate_ != this->sample_rate_) {
+    this->rate_conversion_ratio_ = this->sample_rate_ / this->output_sample_rate_;
+    if (this->rate_conversion_ratio_ * this->output_sample_rate_ != this->sample_rate_) {
+      ESP_LOGE(TAG, "sample_rate (%u) must be an exact multiple of output_sample_rate (%u)",
+               (unsigned) this->sample_rate_, (unsigned) this->output_sample_rate_);
+      this->mark_failed();
+      return;
+    }
+    if (this->rate_conversion_ratio_ > 6) {
+      ESP_LOGE(TAG, "Rate conversion ratio %u exceeds maximum of 6", (unsigned) this->rate_conversion_ratio_);
+      this->mark_failed();
+      return;
+    }
+    ESP_LOGI(TAG, "Multi-rate: bus=%uHz, output=%uHz, ratio=%u", (unsigned) this->sample_rate_,
+             (unsigned) this->output_sample_rate_, (unsigned) this->rate_conversion_ratio_);
+  }
+#ifdef USE_ESP_AUDIO_STACK_MONO_RX
+  this->mic_rate_converter_.init(this->rate_conversion_ratio_, this->sample_rate_, this->get_output_sample_rate(),
+                                 this->rate_cvt_complexity_, this->rate_cvt_perf_type_);
+#endif
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+  this->play_ref_rate_converter_.init(this->rate_conversion_ratio_, this->sample_rate_, this->get_output_sample_rate(),
+                                      this->rate_cvt_complexity_, this->rate_cvt_perf_type_);
+#endif
+  // rx_rate_converter_ is initialized inside audio_session_ once the processor has
+  // reported its frame_spec and we know how many channels the RX stream carries.
+
+  // Speaker ring buffer: stores the public ESPHome speaker stream at bus rate.
+  // Most full-duplex profiles keep this mono even when the physical TX bus is
+  // stereo for codec feedback/reference. Opt-in stereo speakers store
+  // interleaved L/R.
+  // PREFER_PSRAM: staging buffer between API play() and the i2s write path, not
+  // realtime-critical itself (the task drains it at priority 19), so PSRAM is fine.
+  const size_t speaker_bytes_per_second = this->sample_rate_ * sizeof(int16_t) * this->get_speaker_channels();
+  this->speaker_buffer_size_ =
+      std::max<size_t>(SPEAKER_BUFFER_MIN_BYTES,
+                       (speaker_bytes_per_second * static_cast<size_t>(this->speaker_buffer_duration_ms_)) / 1000);
+  this->speaker_buffer_ = create_prefer_psram(this->speaker_buffer_size_, "audio_stack.speaker");
+  if (!this->speaker_buffer_) {
+    ESP_LOGE(TAG, "Failed to create speaker ring buffer (%u bytes)", (unsigned) this->speaker_buffer_size_);
+    this->mark_failed();
+    return;
+  }
+  this->log_memory_snapshot_("after_speaker_ring");
+
+  // AEC reference (mono mode only; stereo/TDM get ref from I2S RX).
+  // direct_aec_ref_ is allocated by allocate_audio_buffers_() once the
+  // processor frame spec is known. Storage matches input_frame_bytes because
+  // AudioProcessor::process consumes in_ref at input_samples length; the TX-side
+  // rate converter writes one input-side reference frame here at the processor rate,
+  // not at the bus rate.
+
+  // Create the permanent audio task during component setup, then park it
+  // until start() flips audio_stack_running_. This reserves the stack/TCB before
+  // Wi-Fi/API/VA/MWW churn can fragment internal RAM, and removes xTaskCreate
+  // from the first wake-word/audio activation path.
+  const BaseType_t core = this->task_core_ >= 0 ? this->task_core_ : tskNO_AFFINITY;
+  if (!start_pinned_task(audio_task, "audio_stack", this->task_stack_size_, this, this->task_priority_, core,
+                         this->audio_task_stack_in_psram_, TAG, &this->audio_task_handle_, &this->audio_task_tcb_,
+                         &this->audio_task_stack_)) {
+    ESP_LOGE(TAG, "Failed to create permanent audio task");
+    this->has_i2s_error_.store(true, std::memory_order_relaxed);
+    this->mark_failed();
+    return;
+  }
+
+  // Reserve the hot-path RX/TX/processor buffers as early as the real frame
+  // shape allows. The allocation itself runs on the parked audio task, so this
+  // does not move heavy heap work into the ESPHome setup thread. If processor
+  // setup has not published a frame_spec yet, loop() will retry.
+  this->request_audio_preallocation_();
+
+  ESP_LOGI(TAG, "ESP Audio Stack ready (speaker_buf=%u bytes, task precreated)", (unsigned) this->speaker_buffer_size_);
+}
+
+void ESPAudioStack::set_processor(AudioProcessor *processor) {
+  this->processor_ = processor;
+  this->processor_enabled_.store(processor != nullptr, std::memory_order_relaxed);
+  // Note: direct_aec_ref_ is allocated later in allocate_audio_buffers_() once
+  // the processor frame spec is known for the current audio session.
+}
+
+void ESPAudioStack::sync_processor_background_consumer_() {
+#ifdef USE_AUDIO_PROCESSOR
+  const bool want_background = this->processor_ != nullptr && this->processor_->wants_background_input();
+  const bool registered = this->processor_background_consumer_registered_.load(std::memory_order_relaxed);
+
+  if (want_background && !registered) {
+    if (this->register_mic_consumer(this)) {
+      this->processor_background_consumer_registered_.store(true, std::memory_order_relaxed);
+      ESP_LOGI(TAG, "Processor background mic consumer registered");
+    }
+  } else if (!want_background && registered) {
+    this->processor_background_consumer_registered_.store(false, std::memory_order_relaxed);
+    this->unregister_mic_consumer(this);
+    ESP_LOGI(TAG, "Processor background mic consumer unregistered");
+  }
+#endif
+}
+
+void ESPAudioStack::request_audio_preallocation_() {
+  if (this->prealloc_attempted_.load(std::memory_order_acquire) ||
+      this->prealloc_requested_.load(std::memory_order_acquire) || this->audio_task_handle_ == nullptr) {
+    return;
+  }
+  bool frame_shape_known = true;
+#ifdef USE_AUDIO_PROCESSOR
+  if (this->processor_ != nullptr) {
+    auto spec = this->processor_->frame_spec();
+    frame_shape_known = spec.input_samples > 0 && spec.output_samples > 0;
+  }
+#endif
+  if (!frame_shape_known) {
+    return;
+  }
+  this->prealloc_requested_.store(true, std::memory_order_release);
+  xTaskNotifyGive(this->audio_task_handle_);
+}
+
+void ESPAudioStack::loop() {
+  this->sync_processor_background_consumer_();
+
+  if (!this->audio_stack_running_.load(std::memory_order_relaxed) &&
+      this->audio_task_idle_.load(std::memory_order_relaxed)) {
+    this->request_audio_preallocation_();
+  }
+
+  // Pick up the deferred I2S release queued by stop(). The task may still be
+  // blocked inside a codec/I2S transfer for the current frame, so delete
+  // channels only after it has parked in the outer wait loop.
+  if (this->teardown_pending_.load(std::memory_order_relaxed) &&
+      this->audio_task_idle_.load(std::memory_order_relaxed)) {
+    this->deinit_i2s_();
+    this->teardown_pending_.store(false, std::memory_order_relaxed);
+    ESP_LOGI(TAG, "Audio stack stopped");
+  }
+}
+
+void ESPAudioStack::dump_config() {
+  ESP_LOGCONFIG(TAG, "ESP Audio Stack:");
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  if (this->dual_i2s_bus_) {
+    ESP_LOGCONFIG(TAG, "  I2S Layout: dual bus");
+    ESP_LOGCONFIG(TAG, "  RX Bus: port=%u LRCLK=%d BCLK=%d MCLK=%d DIN=%d", this->rx_bus_.i2s_num,
+                  this->rx_bus_.lrclk_pin, this->rx_bus_.bclk_pin, this->rx_bus_.mclk_pin, this->rx_bus_.din_pin);
+    ESP_LOGCONFIG(TAG, "  TX Bus: port=%u LRCLK=%d BCLK=%d MCLK=%d DOUT=%d", this->tx_bus_.i2s_num,
+                  this->tx_bus_.lrclk_pin, this->tx_bus_.bclk_pin, this->tx_bus_.mclk_pin, this->tx_bus_.dout_pin);
+  } else {
+    ESP_LOGCONFIG(TAG, "  I2S Layout: shared bus");
+    ESP_LOGCONFIG(TAG, "  LRCLK Pin: %d", this->lrclk_pin_);
+    ESP_LOGCONFIG(TAG, "  BCLK Pin: %d", this->bclk_pin_);
+    ESP_LOGCONFIG(TAG, "  MCLK Pin: %d", this->mclk_pin_);
+    ESP_LOGCONFIG(TAG, "  DIN Pin: %d", this->din_pin_);
+    ESP_LOGCONFIG(TAG, "  DOUT Pin: %d", this->dout_pin_);
+    ESP_LOGCONFIG(TAG, "  I2S Port: %u", this->i2s_num_);
+  }
+#else
+  ESP_LOGCONFIG(TAG, "  I2S Layout: shared bus");
+  ESP_LOGCONFIG(TAG, "  LRCLK Pin: %d", this->lrclk_pin_);
+  ESP_LOGCONFIG(TAG, "  BCLK Pin: %d", this->bclk_pin_);
+  ESP_LOGCONFIG(TAG, "  MCLK Pin: %d", this->mclk_pin_);
+  ESP_LOGCONFIG(TAG, "  DIN Pin: %d", this->din_pin_);
+  ESP_LOGCONFIG(TAG, "  DOUT Pin: %d", this->dout_pin_);
+  ESP_LOGCONFIG(TAG, "  I2S Port: %u", this->i2s_num_);
+#endif
+  ESP_LOGCONFIG(TAG, "  I2S Role: %s", this->i2s_mode_secondary_ ? "secondary (peripheral)" : "primary (master)");
+  ESP_LOGCONFIG(TAG, "  I2S Bus Rate: %u Hz", (unsigned) this->sample_rate_);
+  ESP_LOGCONFIG(TAG, "  I2S Bits Per Sample: %u", this->bits_per_sample_);
+  if (this->slot_bit_width_ > 0) {
+    ESP_LOGCONFIG(TAG, "  Slot Bit Width: %u", this->slot_bit_width_);
+  }
+  ESP_LOGCONFIG(TAG, "  TX Channels: %u (%s)", this->num_channels_, this->num_channels_ == 2 ? "stereo" : "mono");
+  ESP_LOGCONFIG(TAG, "  Speaker Stream Channels: %u", this->get_speaker_channels());
+  ESP_LOGCONFIG(TAG, "  RX Mic Channel: %s", this->mic_channel_right_ ? "RIGHT" : "LEFT");
+  ESP_LOGCONFIG(TAG, "  RX Slot Mode: %s", this->rx_slot_mode_stereo_ ? "stereo" : "mono");
+  static const char *const FMT_NAMES[] = {"Philips", "MSB", "PCM Short", "PCM Long"};
+  ESP_LOGCONFIG(TAG, "  Comm Format: %s", FMT_NAMES[this->i2s_comm_fmt_ & 3]);
+  ESP_LOGCONFIG(TAG, "  MCLK Multiple: %u", (unsigned) this->mclk_multiple_);
+  if (this->use_apll_) {
+    ESP_LOGCONFIG(TAG, "  APLL: enabled");
+  }
+  if (this->correct_dc_offset_) {
+    ESP_LOGCONFIG(TAG, "  DC Offset Correction: enabled");
+  }
+  if (this->rate_conversion_ratio_ > 1) {
+    ESP_LOGCONFIG(TAG, "  Output Rate: %u Hz (rate conversion x%u)", (unsigned) this->get_output_sample_rate(),
+                  (unsigned) this->rate_conversion_ratio_);
+    ESP_LOGCONFIG(TAG, "  Rate Converter: esp_ae_rate_cvt");
+    ESP_LOGCONFIG(TAG, "  Rate Converter Complexity: %u", (unsigned) this->rate_cvt_complexity_);
+    ESP_LOGCONFIG(TAG, "  Rate Converter Perf: %s", this->rate_cvt_perf_type_ == 0 ? "memory" : "speed");
+  }
+  ESP_LOGCONFIG(TAG, "  Speaker Buffer: %u bytes (%u ms)", (unsigned) this->speaker_buffer_size_,
+                (unsigned) this->speaker_buffer_duration_ms_);
+  if (this->use_stereo_aec_ref_) {
+    ESP_LOGCONFIG(TAG, "  Stereo AEC Reference: %s channel", this->ref_channel_right_ ? "RIGHT" : "LEFT");
+  }
+  if (this->use_tdm_bus_) {
+    if (this->tdm_second_mic_slot_ >= 0) {
+      ESP_LOGCONFIG(TAG, "  TDM Reference: %u slots, mic_slots=[%u,%d], ref_slot=%u, tx_slot=%u",
+                    this->tdm_total_slots_, this->tdm_mic_slot_, this->tdm_second_mic_slot_, this->tdm_ref_slot_,
+                    this->tdm_tx_slot_);
+    } else {
+      ESP_LOGCONFIG(TAG, "  TDM Reference: %u slots, mic_slot=%u, ref_slot=%u, tx_slot=%u", this->tdm_total_slots_,
+                    this->tdm_mic_slot_, this->tdm_ref_slot_, this->tdm_tx_slot_);
+    }
+  }
+  ESP_LOGCONFIG(TAG, "  AEC: %s", this->processor_ != nullptr ? "enabled" : "disabled");
+  ESP_LOGCONFIG(TAG, "  Task: priority=%u, core=%d, stack=%u", this->task_priority_, this->task_core_,
+                (unsigned) this->task_stack_size_);
+  ESP_LOGCONFIG(TAG, "  I2S Lifecycle: esp_driver_i2s create on start, delete on idle stop");
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  ESP_LOGCONFIG(TAG, "  Codec Backend: esp_codec_dev direct read/write (input=%s, output=%s)",
+                this->codec_backend_.input_codec_name(), this->codec_backend_.output_codec_name());
+#else
+  ESP_LOGCONFIG(TAG, "  IO Backend: esp_driver_i2s direct read/write (no hardware codec)");
+#endif
+  ESP_LOGCONFIG(TAG, "  I2S Hardware State: %s",
+                i2s_hardware_state_to_string(
+                    static_cast<I2SHardwareState>(this->i2s_hardware_state_.load(std::memory_order_relaxed))));
+#ifdef USE_ESP_AUDIO_STACK_TELEMETRY
+  ESP_LOGCONFIG(TAG, "  Telemetry Log Interval: %u frames", (unsigned) this->telemetry_log_interval_frames_);
+#endif
+}
+
+bool ESPAudioStack::prepare_i2s_channels_() {
+  if (this->tx_handle_ != nullptr || this->rx_handle_ != nullptr) {
+    return true;
+  }
+
+  ESP_LOGCONFIG(TAG, "Preparing I2S channels in full-duplex mode...");
+  this->set_i2s_hardware_state_(I2SHardwareState::PREPARING);
+  this->log_memory_snapshot_("before_i2s_prepare");
+
+  // Map configured bit depth to I2S enum
+  // Note: 24-bit data is stored in 32-bit DMA containers (MSB-aligned)
+  i2s_data_bit_width_t bit_width;
+  switch (this->bits_per_sample_) {
+    case 32:
+      bit_width = I2S_DATA_BIT_WIDTH_32BIT;
+      break;
+    case 24:
+      bit_width = I2S_DATA_BIT_WIDTH_24BIT;
+      break;
+    default:
+      bit_width = I2S_DATA_BIT_WIDTH_16BIT;
+      break;
+  }
+
+  // Slot bit width: auto = match data bit width, or explicit override
+  i2s_slot_bit_width_t slot_bw = I2S_SLOT_BIT_WIDTH_AUTO;
+  if (this->slot_bit_width_ > 0) {
+    switch (this->slot_bit_width_) {
+      case 32:
+        slot_bw = I2S_SLOT_BIT_WIDTH_32BIT;
+        break;
+      case 24:
+        slot_bw = I2S_SLOT_BIT_WIDTH_24BIT;
+        break;
+      case 16:
+        slot_bw = I2S_SLOT_BIT_WIDTH_16BIT;
+        break;
+      default:
+        slot_bw = I2S_SLOT_BIT_WIDTH_AUTO;
+        break;
+    }
+  }
+
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  const bool dual_bus = this->dual_i2s_bus_;
+#else
+  constexpr bool dual_bus = false;
+#endif
+  if (dual_bus && this->use_tdm_bus_) {
+    ESP_LOGE(TAG, "dual I2S bus currently supports standard I2S only; TDM reference requires shared bus");
+    this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+    return false;
+  }
+
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  const uint8_t tx_i2s_num = dual_bus ? this->tx_bus_.i2s_num : this->i2s_num_;
+  const uint8_t rx_i2s_num = dual_bus ? this->rx_bus_.i2s_num : this->i2s_num_;
+  const int tx_mclk_pin = dual_bus ? this->tx_bus_.mclk_pin : this->mclk_pin_;
+  const int tx_bclk_pin = dual_bus ? this->tx_bus_.bclk_pin : this->bclk_pin_;
+  const int tx_lrclk_pin = dual_bus ? this->tx_bus_.lrclk_pin : this->lrclk_pin_;
+  const int tx_dout_pin = dual_bus ? this->tx_bus_.dout_pin : this->dout_pin_;
+  const int rx_mclk_pin = dual_bus ? this->rx_bus_.mclk_pin : this->mclk_pin_;
+  const int rx_bclk_pin = dual_bus ? this->rx_bus_.bclk_pin : this->bclk_pin_;
+  const int rx_lrclk_pin = dual_bus ? this->rx_bus_.lrclk_pin : this->lrclk_pin_;
+  const int rx_din_pin = dual_bus ? this->rx_bus_.din_pin : this->din_pin_;
+#else
+  const uint8_t tx_i2s_num = this->i2s_num_;
+  const uint8_t rx_i2s_num = this->i2s_num_;
+  const int tx_mclk_pin = this->mclk_pin_;
+  const int tx_bclk_pin = this->bclk_pin_;
+  const int tx_lrclk_pin = this->lrclk_pin_;
+  const int tx_dout_pin = this->dout_pin_;
+  const int rx_mclk_pin = this->mclk_pin_;
+  const int rx_bclk_pin = this->bclk_pin_;
+  const int rx_lrclk_pin = this->lrclk_pin_;
+  const int rx_din_pin = this->din_pin_;
+#endif
+  (void) rx_mclk_pin;
+  (void) rx_bclk_pin;
+  (void) rx_lrclk_pin;
+
+  const bool physical_tx = (tx_dout_pin >= 0);
+  const bool need_rx = (rx_din_pin >= 0);
+  // In ESP-IDF full-duplex STD/TDM, TX is the clock owner for RX. Create an
+  // explicit clock-only TX channel even for mic-only configurations so RX has
+  // BCLK/WS and the bus can be fully deleted when the audio task parks.
+  const bool need_tx = physical_tx || need_rx;
+
+  if (!physical_tx && !need_rx) {
+    ESP_LOGE(TAG, "At least one of din_pin or dout_pin must be configured");
+    this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+    return false;
+  }
+
+  // Channel configuration
+  // Clock source: APLL for accurate clocking (ESP32 original only)
+  i2s_clock_src_t clk_src = I2S_CLK_SRC_DEFAULT;
+#ifdef I2S_CLK_SRC_APLL
+  if (this->use_apll_)
+    clk_src = I2S_CLK_SRC_APLL;
+#endif
+  i2s_mclk_multiple_t mclk_mult = get_mclk_multiple(this->mclk_multiple_);
+
+  ESP_LOGD(TAG, "I2S driver config: TX=%s(port %u, physical=%s) RX=%s(port %u)", need_tx ? "yes" : "no", tx_i2s_num,
+           physical_tx ? "yes" : "clock-only", need_rx ? "yes" : "no", rx_i2s_num);
+
+  auto pin_or_nc = [](int pin) -> gpio_num_t { return pin >= 0 ? static_cast<gpio_num_t>(pin) : GPIO_NUM_NC; };
+
+  uint32_t bytes_per_sample = (this->bits_per_sample_ > 16) ? 4 : 2;
+  uint32_t tx_bytes_per_frame = this->num_channels_ * bytes_per_sample;
+  uint32_t rx_bytes_per_frame = tx_bytes_per_frame;
+  if (this->use_stereo_aec_ref_) {
+    rx_bytes_per_frame = 2 * bytes_per_sample;
+  }
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
+  if (this->use_tdm_bus_) {
+    const uint32_t tdm_frame = this->tdm_total_slots_ * bytes_per_sample;
+    tx_bytes_per_frame = tdm_frame;
+    rx_bytes_per_frame = tdm_frame;
+  }
+#endif
+  const uint32_t max_bytes_per_frame = std::max(tx_bytes_per_frame, rx_bytes_per_frame);
+  uint32_t dma_desc_num = this->dma_desc_num_;
+  uint32_t dma_frame_num = this->dma_frame_num_configured_
+                               ? this->dma_frame_num_
+                               : std::max<uint32_t>(64, (this->sample_rate_ * DMA_BUFFER_DURATION_MS) / 1000);
+  uint32_t max_frames = 0;
+  if (max_bytes_per_frame > 0) {
+    max_frames = 4092 / max_bytes_per_frame;
+    if (dma_frame_num > max_frames) {
+      if (this->dma_frame_num_configured_) {
+        ESP_LOGE(TAG, "dma_frame_num %u exceeds IDF DMA descriptor limit (%u frames for %u bytes/frame)",
+                 (unsigned) dma_frame_num, (unsigned) max_frames, (unsigned) max_bytes_per_frame);
+        this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+        return false;
+      }
+      dma_frame_num = max_frames;
+    }
+  }
+  uint32_t logical_tx_frames = 256U * this->rate_conversion_ratio_;
+#ifdef USE_AUDIO_PROCESSOR
+  if (this->processor_ != nullptr) {
+    const auto spec = this->processor_->frame_spec();
+    if (spec.input_samples > 0) {
+      logical_tx_frames = static_cast<uint32_t>(spec.input_samples) * this->rate_conversion_ratio_;
+    }
+  }
+#endif
+  if (logical_tx_frames > 0 && max_frames > 0) {
+    const uint32_t aligned_frames = largest_divisor_at_most(logical_tx_frames, max_frames, 64);
+    if (aligned_frames > 0 && aligned_frames != dma_frame_num) {
+      if (this->dma_frame_num_configured_) {
+        ESP_LOGW(TAG,
+                 "Configured dma_frame_num=%u does not divide audio task TX frame (%u); "
+                 "using %u so speaker playback callbacks stay in DMA lockstep",
+                 (unsigned) dma_frame_num, (unsigned) logical_tx_frames, (unsigned) aligned_frames);
+      } else {
+        ESP_LOGD(TAG, "Aligning TX DMA to audio task frame: frames %u -> %u (logical=%u, max=%u)",
+                 (unsigned) dma_frame_num, (unsigned) aligned_frames, (unsigned) logical_tx_frames,
+                 (unsigned) max_frames);
+      }
+      dma_frame_num = aligned_frames;
+    }
+  }
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
+#ifdef USE_AUDIO_PROCESSOR
+  if (this->use_tdm_bus_ && this->processor_ != nullptr && max_frames > 0) {
+    const auto spec = this->processor_->frame_spec();
+    const uint32_t processor_bus_frames = static_cast<uint32_t>(spec.input_samples) * this->rate_conversion_ratio_;
+    if (processor_bus_frames > 0) {
+      auto ceil_div_u32 = [](uint32_t num, uint32_t den) -> uint32_t { return den == 0 ? 0 : (num + den - 1) / den; };
+      // The audio task reads/writes one processor frame per loop. Keep enough
+      // DMA headroom for that full TDM frame plus margin; otherwise a 1024-sample
+      // AFE quantum can underflow a short DMA queue even though the YAML compiles.
+      // Do not change dma_frame_num here: it has already been selected as a
+      // divisor of the logical TX frame so playback completion records stay in
+      // lockstep with the I2S DMA callbacks.
+      const uint32_t target_total_frames = ceil_div_u32(processor_bus_frames * 5U, 4U);
+      if (target_total_frames > dma_desc_num * dma_frame_num) {
+        const uint32_t old_desc = dma_desc_num;
+        dma_desc_num = std::max(dma_desc_num, ceil_div_u32(target_total_frames, dma_frame_num));
+        if (dma_desc_num > 16) {
+          ESP_LOGE(TAG,
+                   "TDM DMA queue too small for processor frame (%u bus frames, target %u); "
+                   "need %u descriptors of %u frames, max supported is 16",
+                   (unsigned) processor_bus_frames, (unsigned) target_total_frames, (unsigned) dma_desc_num,
+                   (unsigned) dma_frame_num);
+          this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+          return false;
+        }
+        ESP_LOGW(TAG,
+                 "Raised TDM DMA queue for processor frame: desc %u->%u, frames %u "
+                 "(processor=%u bus frames, target=%u)",
+                 (unsigned) old_desc, (unsigned) dma_desc_num, (unsigned) dma_frame_num,
+                 (unsigned) processor_bus_frames, (unsigned) target_total_frames);
+      }
+    }
+  }
+#endif
+#endif
+
+  i2s_chan_config_t chan_cfg =
+      I2S_CHANNEL_DEFAULT_CONFIG(static_cast<i2s_port_t>(dual_bus ? tx_i2s_num : this->i2s_num_),
+                                 this->i2s_mode_secondary_ ? static_cast<i2s_role_t>(1) : I2S_ROLE_MASTER);
+  chan_cfg.dma_desc_num = dma_desc_num;
+  chan_cfg.dma_frame_num = dma_frame_num;
+  chan_cfg.auto_clear = true;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
+  chan_cfg.auto_clear_before_cb = false;
+  chan_cfg.intr_priority = 0;
+#endif
+
+  esp_err_t err = ESP_OK;
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  if (dual_bus) {
+    if (need_tx) {
+      chan_cfg.id = static_cast<i2s_port_t>(tx_i2s_num);
+      err = i2s_new_channel(&chan_cfg, &this->tx_handle_, nullptr);
+      if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to create TX I2S channel on port %u: %s", tx_i2s_num, esp_err_to_name(err));
+        this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+        return false;
+      }
+    }
+    if (need_rx) {
+      chan_cfg.id = static_cast<i2s_port_t>(rx_i2s_num);
+      err = i2s_new_channel(&chan_cfg, nullptr, &this->rx_handle_);
+      if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to create RX I2S channel on port %u: %s", rx_i2s_num, esp_err_to_name(err));
+        this->deinit_i2s_();
+        this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+        return false;
+      }
+    }
+  } else {
+#endif
+    i2s_chan_handle_t *tx_ptr = need_tx ? &this->tx_handle_ : nullptr;
+    i2s_chan_handle_t *rx_ptr = need_rx ? &this->rx_handle_ : nullptr;
+    err = i2s_new_channel(&chan_cfg, tx_ptr, rx_ptr);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to create I2S channel: %s", esp_err_to_name(err));
+      this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+      return false;
+    }
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  }
+#endif
+
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
+  if (this->use_tdm_bus_) {
+    // ── TDM MODE: ES7210 multi-slot RX + ES8311 slot-0 TX ──
+    // STEREO with 4 slots: DMA contains all 4 interleaved slots, BCLK/FS = 64.
+    // ESP-IDF MONO only puts slot 0 in DMA; STEREO gives all active slots.
+    // total_slot is derived from slot_mask (not slot_mode), so BCLK doesn't change.
+    // ES8311 reads/writes slot 0 as standard I2S (first 16 bits after LRCLK edge).
+    // DMA frame = tdm_total_slots × 2 bytes. At 4 slots, 256 frames = 2048 bytes/desc (< 4092 limit).
+    i2s_tdm_slot_mask_t tdm_mask = I2S_TDM_SLOT0;
+    for (int i = 1; i < this->tdm_total_slots_; i++)
+      tdm_mask = static_cast<i2s_tdm_slot_mask_t>(tdm_mask | (I2S_TDM_SLOT0 << i));
+
+    i2s_tdm_config_t tdm_cfg = {
+        .clk_cfg =
+            {
+                .sample_rate_hz = this->sample_rate_,
+                .clk_src = clk_src,
+                .ext_clk_freq_hz = 0,
+                .mclk_multiple = mclk_mult,
+            },
+        .slot_cfg = get_tdm_slot_config(this->i2s_comm_fmt_, bit_width, I2S_SLOT_MODE_STEREO, tdm_mask),
+        .gpio_cfg =
+            {
+                .mclk = pin_or_nc(this->mclk_pin_),
+                .bclk = pin_or_nc(this->bclk_pin_),
+                .ws = pin_or_nc(this->lrclk_pin_),
+                .dout = pin_or_nc(this->dout_pin_),
+                .din = pin_or_nc(this->din_pin_),
+                .invert_flags =
+                    {
+                        .mclk_inv = false,
+                        .bclk_inv = false,
+                        .ws_inv = false,
+                    },
+            },
+    };
+
+    // Apply slot_bit_width override BEFORE init
+    if (slot_bw != I2S_SLOT_BIT_WIDTH_AUTO) {
+      tdm_cfg.slot_cfg.slot_bit_width = slot_bw;
+    }
+
+    if (this->tx_handle_) {
+      err = i2s_channel_init_tdm_mode(this->tx_handle_, &tdm_cfg);
+      if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to init TX TDM channel: %s", esp_err_to_name(err));
+        this->deinit_i2s_();
+        this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+        return false;
+      }
+      ESP_LOGD(TAG, "TX TDM channel initialized");
+    }
+    if (this->rx_handle_) {
+      err = i2s_channel_init_tdm_mode(this->rx_handle_, &tdm_cfg);
+      if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to init RX TDM channel: %s", esp_err_to_name(err));
+        this->deinit_i2s_();
+        this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+        return false;
+      }
+      ESP_LOGD(TAG, "RX TDM channel initialized");
+    }
+
+    if (this->tdm_second_mic_slot_ >= 0) {
+      ESP_LOGD(TAG, "TDM mode: %d slots, mic_slots=[%d,%d], ref_slot=%d, mask=0x%x", this->tdm_total_slots_,
+               this->tdm_mic_slot_, this->tdm_second_mic_slot_, this->tdm_ref_slot_, (unsigned) tdm_mask);
+    } else {
+      ESP_LOGD(TAG, "TDM mode: %d slots, mic_slot=%d, ref_slot=%d, mask=0x%x", this->tdm_total_slots_,
+               this->tdm_mic_slot_, this->tdm_ref_slot_, (unsigned) tdm_mask);
+    }
+  } else
+#endif  // SOC_I2S_SUPPORTS_TDM
+  {
+    // ── STANDARD MODE ──
+    i2s_slot_mode_t tx_slot_mode = (this->num_channels_ == 2) ? I2S_SLOT_MODE_STEREO : I2S_SLOT_MODE_MONO;
+    i2s_std_config_t tx_cfg = {
+        .clk_cfg =
+            {
+                .sample_rate_hz = this->sample_rate_,
+                .clk_src = clk_src,
+                .mclk_multiple = mclk_mult,
+            },
+        .slot_cfg = get_std_slot_config(this->i2s_comm_fmt_, bit_width, tx_slot_mode),
+        .gpio_cfg =
+            {
+                .mclk = pin_or_nc(tx_mclk_pin),
+                .bclk = pin_or_nc(tx_bclk_pin),
+                .ws = pin_or_nc(tx_lrclk_pin),
+                .dout = pin_or_nc(tx_dout_pin),
+                .din = dual_bus ? GPIO_NUM_NC : pin_or_nc(rx_din_pin),
+                .invert_flags =
+                    {
+                        .mclk_inv = false,
+                        .bclk_inv = false,
+                        .ws_inv = false,
+                    },
+            },
+    };
+    tx_cfg.slot_cfg.slot_mask = (this->num_channels_ == 2)
+                                    ? I2S_STD_SLOT_BOTH
+                                    : (this->tx_slot_right_ ? I2S_STD_SLOT_RIGHT : I2S_STD_SLOT_LEFT);
+    // Apply slot_bit_width override
+    if (slot_bw != I2S_SLOT_BIT_WIDTH_AUTO) {
+      tx_cfg.slot_cfg.slot_bit_width = slot_bw;
+    }
+
+    // RX configuration - always independent of TX num_channels
+    i2s_std_config_t rx_cfg = tx_cfg;
+    if (dual_bus) {
+      rx_cfg.gpio_cfg.mclk = pin_or_nc(rx_mclk_pin);
+      rx_cfg.gpio_cfg.bclk = pin_or_nc(rx_bclk_pin);
+      rx_cfg.gpio_cfg.ws = pin_or_nc(rx_lrclk_pin);
+      rx_cfg.gpio_cfg.dout = GPIO_NUM_NC;
+      rx_cfg.gpio_cfg.din = pin_or_nc(rx_din_pin);
+    }
+    if (this->use_stereo_aec_ref_ || this->rx_slot_mode_stereo_) {
+      rx_cfg.slot_cfg = get_std_slot_config(this->i2s_comm_fmt_, bit_width, I2S_SLOT_MODE_STEREO);
+      rx_cfg.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
+      ESP_LOGD(TAG, "RX configured as STEREO (%s)", this->use_stereo_aec_ref_ ? "AEC reference" : "mic channel select");
+    } else {
+      rx_cfg.slot_cfg = get_std_slot_config(this->i2s_comm_fmt_, bit_width, I2S_SLOT_MODE_MONO);
+      rx_cfg.slot_cfg.slot_mask = this->mic_channel_right_ ? I2S_STD_SLOT_RIGHT : I2S_STD_SLOT_LEFT;
+    }
+    // Apply slot_bit_width override to RX
+    if (slot_bw != I2S_SLOT_BIT_WIDTH_AUTO) {
+      rx_cfg.slot_cfg.slot_bit_width = slot_bw;
+    }
+
+    if (this->tx_handle_) {
+      err = i2s_channel_init_std_mode(this->tx_handle_, &tx_cfg);
+      if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to init TX I2S channel: %s", esp_err_to_name(err));
+        this->deinit_i2s_();
+        this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+        return false;
+      }
+      ESP_LOGD(TAG, "TX channel initialized");
+    }
+
+    if (this->rx_handle_) {
+      err = i2s_channel_init_std_mode(this->rx_handle_, &rx_cfg);
+      if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to init RX I2S channel: %s", esp_err_to_name(err));
+        this->deinit_i2s_();
+        this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+        return false;
+      }
+      ESP_LOGD(TAG, "RX channel initialized (%s)", this->use_stereo_aec_ref_ ? "stereo" : "mono");
+    }
+  }
+
+  this->set_i2s_hardware_state_(I2SHardwareState::READY);
+  this->tx_completion_dma_frames_ = need_tx ? dma_frame_num : 0;
+  this->tx_completion_bytes_per_frame_ = need_tx ? tx_bytes_per_frame : 0;
+  this->tx_completion_dma_buffer_bytes_ =
+      need_tx ? static_cast<size_t>(dma_frame_num) * static_cast<size_t>(tx_bytes_per_frame) : 0;
+  this->tx_completion_queue_size_ = need_tx ? static_cast<size_t>(dma_desc_num) * 2U : 0;
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  if (!this->setup_codec_backend_(clk_src)) {
+    ESP_LOGE(TAG, "Failed to prepare esp_codec_dev backend");
+    this->deinit_i2s_();
+    this->set_i2s_hardware_state_(I2SHardwareState::ERROR);
+    return false;
+  }
+#endif
+  this->log_memory_snapshot_("after_i2s_prepare");
+  ESP_LOGI(TAG, "ESP audio stack I2S prepared through esp_driver_i2s (%s, dma_desc=%u, dma_frames=%u)",
+           this->use_tdm_bus_ ? "TDM" : "standard", static_cast<unsigned>(dma_desc_num),
+           static_cast<unsigned>(dma_frame_num));
+  return true;
+}
+
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+CodecDevBackend::SampleConfig ESPAudioStack::make_tx_sample_config_() const {
+  CodecDevBackend::SampleConfig cfg;
+  cfg.sample_rate = this->sample_rate_;
+  cfg.bits_per_sample = this->bits_per_sample_;
+  cfg.mclk_multiple = this->mclk_multiple_;
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
+  if (this->use_tdm_bus_) {
+    cfg.channels = this->tdm_total_slots_;
+    cfg.channel_mask = 0;
+    for (uint8_t i = 0; i < this->tdm_total_slots_; i++) {
+      cfg.channel_mask |= ESP_CODEC_DEV_MAKE_CHANNEL_MASK(i);
+    }
+    return cfg;
+  }
+#endif
+  if (this->num_channels_ == 2) {
+    cfg.channels = 2;
+    cfg.channel_mask = ESP_CODEC_DEV_MAKE_CHANNEL_MASK(0) | ESP_CODEC_DEV_MAKE_CHANNEL_MASK(1);
+  } else {
+    cfg.channels = 2;
+    cfg.channel_mask = ESP_CODEC_DEV_MAKE_CHANNEL_MASK(this->tx_slot_right_ ? 1 : 0);
+  }
+  return cfg;
+}
+
+CodecDevBackend::SampleConfig ESPAudioStack::make_rx_sample_config_() const {
+  CodecDevBackend::SampleConfig cfg;
+  cfg.sample_rate = this->sample_rate_;
+  cfg.bits_per_sample = this->bits_per_sample_;
+  cfg.mclk_multiple = this->mclk_multiple_;
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
+  if (this->use_tdm_bus_) {
+    cfg.channels = this->tdm_total_slots_;
+    cfg.channel_mask = 0;
+    for (uint8_t i = 0; i < this->tdm_total_slots_; i++) {
+      cfg.channel_mask |= ESP_CODEC_DEV_MAKE_CHANNEL_MASK(i);
+    }
+    return cfg;
+  }
+#endif
+  if (this->use_stereo_aec_ref_) {
+    cfg.channels = 2;
+    cfg.channel_mask = ESP_CODEC_DEV_MAKE_CHANNEL_MASK(0) | ESP_CODEC_DEV_MAKE_CHANNEL_MASK(1);
+  } else {
+    cfg.channels = 2;
+    cfg.channel_mask = ESP_CODEC_DEV_MAKE_CHANNEL_MASK(this->mic_channel_right_ ? 1 : 0);
+  }
+  return cfg;
+}
+
+bool ESPAudioStack::setup_codec_backend_(i2s_clock_src_t clk_src) {
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  const uint8_t tx_i2s_num = this->dual_i2s_bus_ ? this->tx_bus_.i2s_num : this->i2s_num_;
+  const uint8_t rx_i2s_num = this->dual_i2s_bus_ ? this->rx_bus_.i2s_num : this->i2s_num_;
+#else
+  const uint8_t tx_i2s_num = this->i2s_num_;
+  const uint8_t rx_i2s_num = this->i2s_num_;
+#endif
+  return this->codec_backend_.setup(tx_i2s_num, rx_i2s_num, this->tx_handle_, this->rx_handle_, clk_src,
+                                    this->mclk_multiple_);
+}
+#endif
+
+bool ESPAudioStack::enable_i2s_channels_() {
+  auto state = static_cast<I2SHardwareState>(this->i2s_hardware_state_.load(std::memory_order_relaxed));
+  if (state == I2SHardwareState::RUNNING) {
+    return true;
+  }
+  if (state == I2SHardwareState::ERROR) {
+    ESP_LOGE(TAG, "Cannot enable I2S from error state");
+    return false;
+  }
+  if (!this->prepare_i2s_channels_()) {
+    return false;
+  }
+
+  if (this->tx_handle_ != nullptr) {
+    if (!this->prepare_tx_completion_tracking_()) {
+      this->deinit_i2s_();
+      return false;
+    }
+    const i2s_event_callbacks_t callbacks = {.on_sent = ESPAudioStack::tx_on_sent_callback};
+    const esp_err_t cb_err = i2s_channel_register_event_callback(this->tx_handle_, &callbacks, this);
+    if (cb_err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to register TX completion callback: %s", esp_err_to_name(cb_err));
+      this->deinit_i2s_();
+      return false;
+    }
+  }
+
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  if (!this->prime_tx_completion_records_(false)) {
+    this->deinit_i2s_();
+    return false;
+  }
+  auto tx_cfg = this->make_tx_sample_config_();
+  auto rx_cfg = this->make_rx_sample_config_();
+  if (!this->codec_backend_.open(this->tx_handle_ ? &tx_cfg : nullptr, this->rx_handle_ ? &rx_cfg : nullptr)) {
+    ESP_LOGE(TAG, "Failed to open esp_codec_dev backend");
+    this->deinit_i2s_();
+    return false;
+  }
+  this->codec_backend_.set_output_volume(this->master_volume_linear_.load(std::memory_order_relaxed));
+  this->codec_backend_.set_output_mute(false);
+#else
+  if (this->tx_handle_) {
+    if (!this->prime_tx_completion_records_(true)) {
+      this->deinit_i2s_();
+      return false;
+    }
+    esp_err_t err = i2s_channel_enable(this->tx_handle_);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to enable TX I2S channel: %s", esp_err_to_name(err));
+      this->deinit_i2s_();
+      return false;
+    }
+  }
+  if (this->rx_handle_) {
+    esp_err_t err = i2s_channel_enable(this->rx_handle_);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to enable RX I2S channel: %s", esp_err_to_name(err));
+      if (this->tx_handle_) {
+        i2s_channel_disable(this->tx_handle_);
+      }
+      this->deinit_i2s_();
+      return false;
+    }
+  }
+#endif
+  this->set_i2s_hardware_state_(I2SHardwareState::RUNNING);
+  this->log_memory_snapshot_("after_i2s_enable");
+  ESP_LOGI(TAG, "ESP audio stack running (%s)", this->use_tdm_bus_ ? "TDM" : "standard");
+  return true;
+}
+
+bool ESPAudioStack::init_audio_stack_() { return this->enable_i2s_channels_(); }
+
+void ESPAudioStack::close_audio_io_() {
+  auto state = static_cast<I2SHardwareState>(this->i2s_hardware_state_.load(std::memory_order_relaxed));
+  if (state != I2SHardwareState::RUNNING && state != I2SHardwareState::STOPPING) {
+    return;
+  }
+  this->set_i2s_hardware_state_(I2SHardwareState::STOPPING);
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  this->codec_backend_.close();
+#else
+  if (this->rx_handle_) {
+    esp_err_t err = i2s_channel_disable(this->rx_handle_);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+      ESP_LOGW(TAG, "Failed to disable RX I2S channel: %s", esp_err_to_name(err));
+    }
+  }
+  if (this->tx_handle_) {
+    esp_err_t err = i2s_channel_disable(this->tx_handle_);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+      ESP_LOGW(TAG, "Failed to disable TX I2S channel: %s", esp_err_to_name(err));
+    }
+  }
+#endif
+  this->set_i2s_hardware_state_(I2SHardwareState::READY);
+  this->reset_tx_completion_tracking_();
+  this->log_memory_snapshot_("after_i2s_disable");
+}
+
+void ESPAudioStack::deinit_i2s_() {
+  this->close_audio_io_();
+  this->reset_tx_completion_tracking_();
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  this->codec_backend_.teardown();
+#endif
+  if (this->tx_handle_) {
+    i2s_del_channel(this->tx_handle_);
+    this->tx_handle_ = nullptr;
+  }
+  if (this->rx_handle_) {
+    i2s_del_channel(this->rx_handle_);
+    this->rx_handle_ = nullptr;
+  }
+  this->set_i2s_hardware_state_(I2SHardwareState::UNPREPARED);
+  ESP_LOGI(TAG, "I2S deinitialized");
+}
+
+bool IRAM_ATTR ESPAudioStack::tx_on_sent_callback(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx) {
+  auto *self = static_cast<ESPAudioStack *>(user_ctx);
+  if (self == nullptr || self->tx_completion_event_queue_ == nullptr) {
+    return false;
+  }
+  const int64_t now = esp_timer_get_time();
+  BaseType_t need_yield1 = pdFALSE;
+  BaseType_t need_yield2 = pdFALSE;
+  if (xQueueIsQueueFullFromISR(self->tx_completion_event_queue_)) {
+    int64_t dummy = 0;
+    xQueueReceiveFromISR(self->tx_completion_event_queue_, &dummy, &need_yield1);
+    self->tx_completion_desync_ = true;
+  }
+  xQueueSendToBackFromISR(self->tx_completion_event_queue_, &now, &need_yield2);
+  (void) handle;
+  (void) event;
+  return need_yield1 || need_yield2;
+}
+
+bool ESPAudioStack::prepare_tx_completion_tracking_() {
+  if (this->tx_handle_ == nullptr) {
+    return true;
+  }
+  if (this->tx_completion_dma_buffer_bytes_ == 0 || this->tx_completion_queue_size_ == 0) {
+    ESP_LOGE(TAG, "TX completion tracking missing DMA sizing");
+    return false;
+  }
+  if (this->tx_completion_event_queue_ != nullptr) {
+    vQueueDelete(this->tx_completion_event_queue_);
+    this->tx_completion_event_queue_ = nullptr;
+  }
+  if (this->tx_completion_record_queue_ != nullptr) {
+    vQueueDelete(this->tx_completion_record_queue_);
+    this->tx_completion_record_queue_ = nullptr;
+  }
+  this->tx_completion_event_queue_ = xQueueCreate(this->tx_completion_queue_size_, sizeof(int64_t));
+  this->tx_completion_record_queue_ = xQueueCreate(this->tx_completion_queue_size_, sizeof(TxCompletionRecord));
+  if (this->tx_completion_event_queue_ == nullptr || this->tx_completion_record_queue_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to allocate TX completion queues");
+    return false;
+  }
+  if (this->tx_completion_silence_bytes_ < this->tx_completion_dma_buffer_bytes_) {
+    if (this->tx_completion_silence_ != nullptr) {
+      heap_caps_free(this->tx_completion_silence_);
+      this->tx_completion_silence_ = nullptr;
+      this->tx_completion_silence_bytes_ = 0;
+    }
+    this->tx_completion_silence_ = static_cast<uint8_t *>(
+        heap_caps_calloc(1, this->tx_completion_dma_buffer_bytes_, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+    this->tx_completion_silence_bytes_ =
+        this->tx_completion_silence_ != nullptr ? this->tx_completion_dma_buffer_bytes_ : 0;
+  } else if (this->tx_completion_silence_ != nullptr) {
+    memset(this->tx_completion_silence_, 0, this->tx_completion_dma_buffer_bytes_);
+  }
+  if (this->tx_completion_silence_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to allocate TX DMA silence buffer (%u bytes)",
+             (unsigned) this->tx_completion_dma_buffer_bytes_);
+    return false;
+  }
+  this->tx_completion_desync_ = false;
+  this->tx_completion_pending_real_records_.store(0, std::memory_order_release);
+  return true;
+}
+
+bool ESPAudioStack::prime_tx_completion_records_(bool preload_dma) {
+  if (this->tx_handle_ == nullptr) {
+    return true;
+  }
+  const size_t desc_count = this->tx_completion_queue_size_ / 2U;
+  for (size_t i = 0; i < desc_count; i++) {
+    if (preload_dma) {
+      size_t loaded = 0;
+      const esp_err_t err = i2s_channel_preload_data(this->tx_handle_, this->tx_completion_silence_,
+                                                     this->tx_completion_dma_buffer_bytes_, &loaded);
+      if (err != ESP_OK || loaded != this->tx_completion_dma_buffer_bytes_) {
+        ESP_LOGE(TAG, "Failed to preload TX DMA silence %u/%u: %s loaded=%u", (unsigned) (i + 1U),
+                 (unsigned) desc_count, esp_err_to_name(err), (unsigned) loaded);
+        return false;
+      }
+    }
+    TxCompletionRecord zero{};
+    if (xQueueSend(this->tx_completion_record_queue_, &zero, 0) != pdTRUE) {
+      ESP_LOGE(TAG, "Failed to queue TX priming completion record");
+      return false;
+    }
+  }
+  return true;
+}
+
+void ESPAudioStack::reset_tx_completion_tracking_() {
+  this->tx_completion_desync_ = false;
+  this->tx_completion_pending_real_records_.store(0, std::memory_order_release);
+  if (this->tx_completion_event_queue_ != nullptr) {
+    xQueueReset(this->tx_completion_event_queue_);
+  }
+  if (this->tx_completion_record_queue_ != nullptr) {
+    xQueueReset(this->tx_completion_record_queue_);
+  }
+}
+
+void ESPAudioStack::dispatch_speaker_output_callbacks_(uint32_t frames, int64_t timestamp) {
+  for (size_t i = 0; i < this->speaker_output_callback_count_; i++) {
+    const auto &slot = this->speaker_output_callbacks_[i];
+    if (slot.fn != nullptr) {
+      slot.fn(slot.ctx, frames, timestamp);
+    }
+  }
+}
+
+void ESPAudioStack::drain_tx_completion_events_() {
+  if (this->tx_completion_event_queue_ == nullptr || this->tx_completion_record_queue_ == nullptr) {
+    return;
+  }
+  if (this->tx_completion_desync_) {
+    ESP_LOGE(TAG, "TX completion event queue overflowed; stopping audio stack to restore lockstep");
+    this->has_i2s_error_.store(true, std::memory_order_relaxed);
+    this->audio_stack_running_.store(false, std::memory_order_relaxed);
+    return;
+  }
+  int64_t timestamp = 0;
+  while (xQueueReceive(this->tx_completion_event_queue_, &timestamp, 0) == pdTRUE) {
+    TxCompletionRecord record{};
+    if (xQueueReceive(this->tx_completion_record_queue_, &record, 0) != pdTRUE) {
+      if (this->tx_completion_pending_real_records_.load(std::memory_order_acquire) == 0) {
+        // esp_codec_dev_open()/I2S channel reconfiguration can emit initial TX
+        // completion callbacks before the audio task has queued clock-only or
+        // speaker records. With no real speaker frames pending, those callbacks
+        // are driver priming noise and must not stop the full-duplex mic path.
+        continue;
+      }
+      ESP_LOGE(TAG, "TX completion event without matching write record; stopping audio stack");
+      this->has_i2s_error_.store(true, std::memory_order_relaxed);
+      this->audio_stack_running_.store(false, std::memory_order_relaxed);
+      return;
+    }
+    if (record.real_frames == 0) {
+      continue;
+    }
+    if (this->tx_completion_pending_real_records_.load(std::memory_order_acquire) > 0) {
+      this->tx_completion_pending_real_records_.fetch_sub(1, std::memory_order_acq_rel);
+    }
+    if (this->speaker_output_callback_count_ == 0) {
+      continue;
+    }
+    const int64_t adjusted_timestamp = timestamp - static_cast<int64_t>(record.trailing_silence_frames) * 1000000LL /
+                                                       static_cast<int64_t>(this->sample_rate_);
+    this->dispatch_speaker_output_callbacks_(record.real_frames, adjusted_timestamp);
+  }
+}
+
+bool ESPAudioStack::queue_tx_completion_record_(const TxCompletionRecord &record) {
+  if (this->tx_completion_record_queue_ == nullptr) {
+    return true;
+  }
+  if (xQueueSend(this->tx_completion_record_queue_, &record, 0) != pdTRUE) {
+    ESP_LOGE(TAG, "TX completion record queue full; stopping audio stack");
+    this->has_i2s_error_.store(true, std::memory_order_relaxed);
+    this->audio_stack_running_.store(false, std::memory_order_relaxed);
+    return false;
+  }
+  if (record.real_frames > 0) {
+    this->tx_completion_pending_real_records_.fetch_add(1, std::memory_order_acq_rel);
+  }
+  return true;
+}
+
+bool ESPAudioStack::wait_audio_task_state_(bool idle, uint32_t timeout_ms) {
+  if (this->audio_task_idle_.load(std::memory_order_relaxed) == idle) {
+    return true;
+  }
+  TaskHandle_t waiter = xTaskGetCurrentTaskHandle();
+  ulTaskNotifyTake(pdTRUE, 0);
+  this->audio_state_waiter_.store(waiter, std::memory_order_release);
+  if (this->audio_task_idle_.load(std::memory_order_relaxed) == idle) {
+    this->audio_state_waiter_.store(nullptr, std::memory_order_release);
+    return true;
+  }
+  const bool ok = ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(timeout_ms)) > 0 ||
+                  this->audio_task_idle_.load(std::memory_order_relaxed) == idle;
+  this->audio_state_waiter_.store(nullptr, std::memory_order_release);
+  return ok;
+}
+
+void ESPAudioStack::start() {
+  if (this->audio_stack_running_.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  // Complete any deferred close from the previous session before reopening.
+  // Reusing codec/I2S handles that the audio task has already parked during a
+  // stop/start call cycle can leave TX in a half-closed state on the next
+  // playback or an active call.
+  if (this->teardown_pending_.load(std::memory_order_relaxed)) {
+    if (this->wait_audio_task_idle_(250)) {
+      this->deinit_i2s_();
+      this->teardown_pending_.store(false, std::memory_order_relaxed);
+      ESP_LOGI(TAG, "Completed pending audio stack teardown before restart");
+    } else {
+      ESP_LOGW(TAG, "Audio stack restart refused while teardown is still pending");
+      return;
+    }
+  }
+
+  ESP_LOGI(TAG, "Starting audio stack...");
+
+  // setup() normally pre-creates the task. Manually constructed test instances
+  // can still enter through start(), so create the task here if needed.
+  if (this->audio_task_handle_ == nullptr) {
+    const BaseType_t core = this->task_core_ >= 0 ? this->task_core_ : tskNO_AFFINITY;
+    if (!start_pinned_task(audio_task, "audio_stack", this->task_stack_size_, this, this->task_priority_, core,
+                           this->audio_task_stack_in_psram_, TAG, &this->audio_task_handle_, &this->audio_task_tcb_,
+                           &this->audio_task_stack_)) {
+      this->has_i2s_error_.store(true, std::memory_order_relaxed);
+      return;
+    }
+  }
+
+  // I2S allocation happens here, not in setup(): start() owns both driver
+  // channel creation and codec open while stop() tears the bus back down.
+  this->request_audio_preallocation_();
+  if (!this->enable_i2s_channels_()) {
+    ESP_LOGE(TAG, "Failed to start I2S");
+    return;
+  }
+
+  this->has_i2s_error_.store(false, std::memory_order_relaxed);
+  // start_speaker()/stop_speaker() own speaker_running_. A mic-only start
+  // still writes silence to TX to keep the full-duplex bus clocked, but it must not
+  // make the component look like active playback; otherwise the last mic
+  // consumer leaving would fail to park the pipeline.
+
+  // Wake the permanent audio task (created once in setup()).
+  this->audio_stack_running_.store(true, std::memory_order_relaxed);
+  if (this->audio_task_handle_ != nullptr) {
+    xTaskNotifyGive(this->audio_task_handle_);
+  }
+
+#ifdef USE_AUDIO_PROCESSOR
+  if (this->use_stereo_aec_ref_) {
+    ESP_LOGD(TAG, "ES8311 digital feedback - reference is sample-aligned");
+  }
+  if (this->use_tdm_ref_) {
+    ESP_LOGD(TAG, "TDM hardware reference - slot %u is echo ref", this->tdm_ref_slot_);
+  }
+  if (this->processor_ != nullptr && this->has_mic_consumers_.load(std::memory_order_relaxed)) {
+    this->wait_audio_task_active_(50);
+    this->processor_->set_processing_active(true);
+  }
+#endif
+
+  this->start_trigger_.trigger();
+  ESP_LOGI(TAG, "Audio stack started");
+}
+
+void ESPAudioStack::stop() {
+  if (!this->audio_stack_running_.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  ESP_LOGI(TAG, "Stopping audio stack (deferred)");
+
+  // Consumers stay registered across stop()/start() so the mic path is
+  // reconnected automatically after an internal restart (frame_spec change).
+  if (this->speaker_running_.exchange(false, std::memory_order_relaxed)) {
+    this->speaker_idle_trigger_.trigger();
+    this->update_runtime_state_();
+  }
+#ifdef USE_AUDIO_PROCESSOR
+  if (this->processor_ != nullptr) {
+    this->processor_->set_processing_active(false);
+  }
+#endif
+  this->audio_stack_running_.store(false, std::memory_order_relaxed);
+  this->idle_trigger_.trigger();
+
+  // Defer I2S deletion to loop(): polling audio_task_idle_ here would block
+  // the main task for up to 600 ms (often >60 ms), starving network/UI/LVGL.
+  // loop() picks this up on the next tick once the audio task has parked.
+  this->teardown_pending_.store(true, std::memory_order_relaxed);
+}
+
+bool ESPAudioStack::stop_and_wait(uint32_t timeout_ms) {
+  this->stop();
+
+  if (!this->wait_audio_task_idle_(timeout_ms)) {
+    ESP_LOGW(TAG, "Timed out waiting for audio task to stop before maintenance");
+    return false;
+  }
+
+  if (this->teardown_pending_.load(std::memory_order_relaxed)) {
+    this->deinit_i2s_();
+    this->teardown_pending_.store(false, std::memory_order_relaxed);
+    ESP_LOGI(TAG, "Audio stack stopped synchronously");
+  }
+  return true;
+}
+
+bool ESPAudioStack::register_mic_consumer(void *token) {
+  bool needs_start = false;
+  size_t count_after = 0;
+  bool first_consumer = false;
+  bool full = false;
+  if (this->mic_consumers_mutex_ == nullptr)
+    return false;
+  {
+    ScopedLock lock(this->mic_consumers_mutex_);
+    // Already registered?
+    for (size_t i = 0; i < this->mic_consumer_count_; i++) {
+      if (this->mic_consumers_[i] == token)
+        return true;
+    }
+    if (this->mic_consumer_count_ >= MAX_LISTENERS) {
+      full = true;
+    } else {
+      first_consumer = (this->mic_consumer_count_ == 0);
+      this->mic_consumers_[this->mic_consumer_count_++] = token;
+      count_after = this->mic_consumer_count_;
+      this->has_mic_consumers_.store(true, std::memory_order_relaxed);
+      needs_start = !this->audio_stack_running_.load(std::memory_order_relaxed);
+    }
+  }
+  if (full) {
+    ESP_LOGW(TAG, "Mic consumer registry full (max=%u), refusing token=%p", (unsigned) MAX_LISTENERS, token);
+    return false;
+  }
+  if (first_consumer) {
+    ESP_LOGI(TAG, "Mic consumer registered (token=%p), mic path active (consumers=%zu)", token, count_after);
+    this->mic_start_trigger_.trigger();
+    // If the stack is already running, wake the processor immediately. If this
+    // consumer is also starting the stack, start() will wake the audio task
+    // first and then enable the processor so AFE has input frames available.
+#ifdef USE_AUDIO_PROCESSOR
+    if (!needs_start && this->processor_ != nullptr) {
+      this->processor_->set_processing_active(true);
+    }
+#endif
+  } else {
+    ESP_LOGD(TAG, "Mic consumer registered (token=%p, consumers=%zu)", token, count_after);
+  }
+  if (needs_start) {
+    this->start();
+  }
+  if (first_consumer) {
+    this->update_runtime_state_();
+  }
+  return true;
+}
+
+void ESPAudioStack::unregister_mic_consumer(void *token) {
+  size_t count_after = 0;
+  bool removed = false;
+  bool last_consumer_gone = false;
+  if (this->mic_consumers_mutex_ == nullptr)
+    return;
+  {
+    ScopedLock lock(this->mic_consumers_mutex_);
+    for (size_t i = 0; i < this->mic_consumer_count_; i++) {
+      if (this->mic_consumers_[i] == token) {
+        // Swap-and-pop: order in the array is not meaningful, swap with last.
+        this->mic_consumers_[i] = this->mic_consumers_[this->mic_consumer_count_ - 1];
+        this->mic_consumers_[this->mic_consumer_count_ - 1] = nullptr;
+        this->mic_consumer_count_--;
+        removed = true;
+        break;
+      }
+    }
+    count_after = this->mic_consumer_count_;
+    last_consumer_gone = removed && this->mic_consumer_count_ == 0;
+    this->has_mic_consumers_.store(this->mic_consumer_count_ != 0, std::memory_order_relaxed);
+  }
+  if (!removed) {
+    return;
+  }
+  if (last_consumer_gone) {
+    ESP_LOGI(TAG, "Last mic consumer removed (token=%p), mic path idle", token);
+    this->mic_idle_trigger_.trigger();
+    // Tell the audio processor it can suspend background work until a new
+    // consumer arrives. Without this hint esp_afe's GMF pipeline/task (and
+    // the esp-sr internal worker on Core 1) keep cycling on every frame
+    // even when nobody is listening, which on spotpear-ball-v2 was monopolising
+    // CPU1 long enough to trip the loopTask 30s watchdog on HA restart.
+#ifdef USE_AUDIO_PROCESSOR
+    if (this->processor_ != nullptr) {
+      this->processor_->set_processing_active(false);
+    }
+#endif
+    // If no playback either, park the audio task and delete I2S channels once
+    // the task is idle.
+    if (!this->speaker_running_.load(std::memory_order_relaxed)) {
+      ESP_LOGI(TAG, "Audio stack going idle (no consumers, no playback)");
+      this->stop();
+    }
+    this->update_runtime_state_();
+  } else {
+    ESP_LOGD(TAG, "Mic consumer unregistered (token=%p, consumers=%zu)", token, count_after);
+  }
+}
+
+void ESPAudioStack::start_speaker() {
+  if (!this->audio_stack_running_.load(std::memory_order_relaxed)) {
+    this->start();
+  }
+  if (!this->audio_stack_running_.load(std::memory_order_relaxed)) {
+    ESP_LOGW(TAG, "Speaker start refused: audio stack did not enter RUNNING");
+    return;
+  }
+  if (!this->speaker_running_.load(std::memory_order_relaxed)) {
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+    this->direct_aec_ref_valid_ = false;
+#endif
+#ifdef USE_ESP_AUDIO_STACK_TDM_REF_DIAGNOSTIC
+    this->tdm_ref_silent_frames_.store(0, std::memory_order_relaxed);
+#endif
+  }
+  if (!this->speaker_running_.exchange(true, std::memory_order_relaxed)) {
+    this->speaker_start_trigger_.trigger();
+    this->update_runtime_state_();
+  }
+}
+
+void ESPAudioStack::stop_speaker() {
+  if (this->speaker_running_.exchange(false, std::memory_order_relaxed)) {
+    this->speaker_idle_trigger_.trigger();
+    this->update_runtime_state_();
+  }
+  // Request audio task to reset ring buffers (avoids concurrent access).
+  this->request_speaker_reset_.store(true, std::memory_order_relaxed);
+  // If no mic consumers either, tear down the audio stack pipeline. This signals
+  // the audio processor (e.g. AFE) it can suspend its workers and parks the
+  // audio task; channels stay configured for fast wake on the next start.
+  if (!this->has_mic_consumers_.load(std::memory_order_relaxed)) {
+    ESP_LOGI(TAG, "Audio stack going idle (speaker stopped, no mic consumers)");
+#ifdef USE_AUDIO_PROCESSOR
+    if (this->processor_ != nullptr) {
+      this->processor_->set_processing_active(false);
+    }
+#endif
+    this->stop();
+  }
+}
+
+size_t ESPAudioStack::play(const uint8_t *data, size_t len, TickType_t ticks_to_wait) {
+  if (!this->speaker_buffer_) {
+    return 0;
+  }
+
+  // Data arrives at bus rate (e.g. 48kHz from mixer/resampler). Partial writes
+  // are allowed because upstream ESPHome sources retry unwritten tails, but a
+  // partial must never split an interleaved PCM frame.
+  const size_t frame_bytes = sizeof(int16_t) * static_cast<size_t>(this->get_speaker_channels());
+  if (frame_bytes == 0) {
+    return 0;
+  }
+  const size_t aligned_len = len - (len % frame_bytes);
+  if (aligned_len == 0) {
+    return 0;
+  }
+  size_t written = this->speaker_buffer_->write_without_replacement((void *) data, aligned_len, ticks_to_wait, false);
+
+  if (written > 0) {
+    this->last_speaker_audio_ms_.store(millis(), std::memory_order_relaxed);
+  }
+  return written;
+}
+
+size_t ESPAudioStack::get_speaker_buffer_available() const {
+  if (!this->speaker_buffer_)
+    return 0;
+  return this->speaker_buffer_->available();
+}
+
+size_t ESPAudioStack::get_speaker_buffer_size() const { return this->speaker_buffer_size_; }
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/esp_audio_stack.h
+++ b/esphome/components/esp_audio_stack/esp_audio_stack.h
@@ -1,0 +1,904 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "audio_core_audio_utils.h"
+#include "audio_core_ring_buffer_caps.h"
+#include "audio_core_scoped_lock.h"
+#include "audio_core_task_utils.h"
+
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+#include "codec_dev_backend.h"
+#endif
+
+#include <driver/i2s_std.h>
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
+#include <driver/i2s_tdm.h>
+#endif
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+#include <freertos/task.h>
+
+#include <esp_heap_caps.h>
+#include <esp_log.h>
+#include <freertos/semphr.h>
+
+#include <atomic>
+#include <climits>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "audio_core_processor.h"
+
+namespace esphome::esp_audio_stack {
+
+// Maximum listener count for microphone/speaker reference counting
+static constexpr UBaseType_t MAX_LISTENERS = 16;
+
+// Callback type for mic data: receives the public post-processor PCM stream
+// (pointer + length, zero-copy). Raw/pre-processor taps are diagnostic-only and
+// must not feed MWW, VA or call TX.
+// IMPORTANT: Callbacks are invoked from the audio task (high priority, Core 0).
+// They MUST NOT block, allocate memory, do network I/O, or hold locks.
+// Target completion: <1ms to avoid I2S DMA underruns.
+using MicDataCallback = void (*)(void *ctx, const uint8_t *data, size_t len);
+// Callback type for speaker output: reports frames played and timestamp (for mixer pending_playback tracking).
+// Same real-time constraints as MicDataCallback apply.
+using SpeakerOutputCallback = void (*)(void *ctx, uint32_t frames, int64_t timestamp);
+
+struct MicCallbackSlot {
+  MicDataCallback fn{nullptr};
+  void *ctx{nullptr};
+};
+
+struct SpeakerOutputCallbackSlot {
+  SpeakerOutputCallback fn{nullptr};
+  void *ctx{nullptr};
+};
+
+enum class AudioStackRuntimeState : uint8_t {
+  IDLE = 0,
+  MIC = 1,
+  SPEAKER = 2,
+  DUPLEX = 3,
+};
+
+enum class I2SHardwareState : uint8_t {
+  UNPREPARED = 0,
+  PREPARING = 1,
+  READY = 2,
+  RUNNING = 3,
+  STOPPING = 4,
+  ERROR = 5,
+};
+
+enum class RxPathKind : uint8_t {
+  PASSTHROUGH = 0,
+  MONO_EFFECTS = 1,
+  STEREO_SLOT = 2,
+  STEREO_REF = 3,
+  TDM = 4,
+};
+
+static constexpr uint8_t MAX_RATE_CVT_CHANNELS = 3;
+
+// Forward declarations for Pimpl.
+class AudioEffectsRateConverterImpl;
+class MultiChannelAudioEffectsRateConverterImpl;
+
+#if defined(USE_ESP_AUDIO_STACK_MONO_RX) || defined(USE_ESP_AUDIO_STACK_MONO_REF)
+// Sample-rate converter: consumes samples at high rate, produces at low rate.
+// Backed by Espressif esp_ae_rate_cvt from esp_audio_effects.
+class AudioEffectsRateConverter {
+ public:
+  AudioEffectsRateConverter();
+  ~AudioEffectsRateConverter();
+  AudioEffectsRateConverter(const AudioEffectsRateConverter &) = delete;
+  AudioEffectsRateConverter &operator=(const AudioEffectsRateConverter &) = delete;
+
+  void init(uint32_t ratio, uint32_t src_rate = 0, uint32_t dest_rate = 0, uint8_t complexity = 3,
+            uint8_t perf_type = 1);
+  void reset();
+
+  // Contiguous int16 input.
+  bool process(const int16_t *in, int16_t *out, size_t in_count);
+  // Preallocate scratch and open the Espressif converter before the first realtime frame.
+  bool prepare(size_t in_count, bool source_32bit = false);
+  // Strided int16 input: deinterleave into scratch, then rate-convert.
+  bool process_strided(const int16_t *in, int16_t *out, size_t out_count, size_t stride, size_t offset);
+  // Strided int32 input with inline >>16 downshift.
+  bool process_strided_32(const int32_t *in, int16_t *out, size_t out_count, size_t stride, size_t offset);
+
+ private:
+  std::unique_ptr<AudioEffectsRateConverterImpl> impl_;
+};
+#endif
+
+#ifdef USE_ESP_AUDIO_STACK_MULTI_RX
+// Multi-channel sample-rate converter: converts N channels from TDM/stereo
+// rx_buffer in one pass. One esp_ae_rate_cvt handle processes all selected
+// channels so mic/ref latency stays coupled. Max 3 channels (MMR: mic1 + mic2 + ref).
+class MultiChannelAudioEffectsRateConverter {
+ public:
+  MultiChannelAudioEffectsRateConverter();
+  ~MultiChannelAudioEffectsRateConverter();
+  MultiChannelAudioEffectsRateConverter(const MultiChannelAudioEffectsRateConverter &) = delete;
+  MultiChannelAudioEffectsRateConverter &operator=(const MultiChannelAudioEffectsRateConverter &) = delete;
+
+  void init(uint32_t ratio, uint8_t num_channels, uint32_t src_rate = 0, uint32_t dest_rate = 0, uint8_t complexity = 3,
+            uint8_t perf_type = 1);
+  void reset();
+  // Preallocate scratch and per-channel output buffers before the first
+  // realtime TDM/stereo conversion frame.
+  bool prepare(size_t in_count, size_t out_count, uint8_t num_channels, uint8_t source_channels, bool source_32bit);
+
+  // Convert N channels from strided int16 TDM input, producing:
+  //   - mic_interleaved: [mic1, mic2, mic1, mic2, ...] (num_mic_ch interleaved, for AFE)
+  //   - mic_mono: mic1 contiguous (for callbacks/MWW/call components)
+  //   - ref_out: ref contiguous (for AEC, may be nullptr if no ref channel)
+  // channel_offsets: slot indices in TDM frame [mic1_slot, mic2_slot, ref_slot]
+  // num_mic_ch: 1 or 2 (how many of the channels are mic, rest is ref)
+  bool process_multi(const int16_t *in, size_t out_count, size_t in_stride, const uint8_t *channel_offsets,
+                     int16_t *mic_interleaved, int16_t *mic_mono, int16_t *ref_out, uint8_t num_mic_ch);
+  // Same but for 32-bit I2S input with inline >>16 downshift.
+  bool process_multi_32(const int32_t *in, size_t out_count, size_t in_stride, const uint8_t *channel_offsets,
+                        int16_t *mic_interleaved, int16_t *mic_mono, int16_t *ref_out, uint8_t num_mic_ch);
+
+ private:
+  std::unique_ptr<MultiChannelAudioEffectsRateConverterImpl> impl_;
+};
+#endif
+
+/// Full-duplex I2S codec driver.
+///
+/// Extends the upstream i2s_audio pattern with a single shared I2S bus
+/// that carries both mic RX and speaker TX (typical for codec chips
+/// like ES8311 / ES7210). Optionally integrates an AudioProcessor (set
+/// via processor_id) for AEC/NS/AGC/SE on the mic path. The processor
+/// may be EspAec (AEC only) or EspAfe (full pipeline); both are drop-in
+/// AudioProcessor implementations.
+///
+/// Runs a single audio task that pulls I2S RX frames, optionally
+/// converts sample rate with AudioEffectsRateConverter, invokes the processor, and distributes
+/// the result to registered MicDataCallback listeners. Speaker frames
+/// come in via SpeakerOutputCallback and are written to I2S TX.
+class ESPAudioStack : public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  // PROCESSOR (=400) is the ESPHome tier for audio pipeline components;
+  // HARDWARE (=800) is the I2C/SPI bus tier and runs too early. The
+  // companion processors (esp_aec/esp_afe) also use PROCESSOR, so the
+  // component-internal pointers (set_processor) are wired up before any
+  // setup() touches the audio path.
+  float get_setup_priority() const override { return setup_priority::PROCESSOR; }
+
+  // Pin setters
+  void set_lrclk_pin(int pin) { this->lrclk_pin_ = pin; }
+  void set_bclk_pin(int pin) { this->bclk_pin_ = pin; }
+  void set_mclk_pin(int pin) { this->mclk_pin_ = pin; }
+  void set_din_pin(int pin) { this->din_pin_ = pin; }
+  void set_dout_pin(int pin) { this->dout_pin_ = pin; }
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  void configure_rx_bus(uint8_t i2s_num, int lrclk_pin, int bclk_pin, int mclk_pin, int din_pin) {
+    this->rx_bus_.configured = true;
+    this->rx_bus_.i2s_num = i2s_num;
+    this->rx_bus_.lrclk_pin = lrclk_pin;
+    this->rx_bus_.bclk_pin = bclk_pin;
+    this->rx_bus_.mclk_pin = mclk_pin;
+    this->rx_bus_.din_pin = din_pin;
+    this->dual_i2s_bus_ = true;
+  }
+  void configure_tx_bus(uint8_t i2s_num, int lrclk_pin, int bclk_pin, int mclk_pin, int dout_pin) {
+    this->tx_bus_.configured = true;
+    this->tx_bus_.i2s_num = i2s_num;
+    this->tx_bus_.lrclk_pin = lrclk_pin;
+    this->tx_bus_.bclk_pin = bclk_pin;
+    this->tx_bus_.mclk_pin = mclk_pin;
+    this->tx_bus_.dout_pin = dout_pin;
+    this->dual_i2s_bus_ = true;
+  }
+#endif
+  void set_sample_rate(uint32_t rate) { this->sample_rate_ = rate; }
+  void set_output_sample_rate(uint32_t rate) { this->output_sample_rate_ = rate; }
+  void set_bits_per_sample(uint8_t bps) { this->bits_per_sample_ = bps; }
+  uint8_t get_bits_per_sample() const { return this->bits_per_sample_; }
+  void set_correct_dc_offset(bool enabled) { this->correct_dc_offset_ = enabled; }
+  void set_num_channels(uint8_t ch) { this->num_channels_ = ch; }
+  uint8_t get_num_channels() const { return this->num_channels_; }
+  void set_speaker_channels(uint8_t ch) { this->speaker_channels_ = ch; }
+  uint8_t get_speaker_channels() const { return this->use_tdm_bus_ ? 1 : this->speaker_channels_; }
+  void set_i2s_mode_secondary(bool secondary) { this->i2s_mode_secondary_ = secondary; }
+  void set_use_apll(bool use) { this->use_apll_ = use; }
+  void set_i2s_num(uint8_t num) { this->i2s_num_ = num; }
+  void set_mclk_multiple(uint32_t mult) { this->mclk_multiple_ = mult; }
+  void set_i2s_comm_fmt(uint8_t fmt) { this->i2s_comm_fmt_ = fmt; }
+  void set_mic_channel_right(bool right) { this->mic_channel_right_ = right; }
+  void set_rx_slot_mode_stereo(bool stereo) { this->rx_slot_mode_stereo_ = stereo; }
+  void set_tx_slot_right(bool right) { this->tx_slot_right_ = right; }
+  void set_slot_bit_width(uint8_t sbw) { this->slot_bit_width_ = sbw; }
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  void set_codec_i2c_bus(i2c::I2CBus *bus) { this->codec_backend_.set_i2c_bus(bus); }
+  void configure_es7210_codec(uint8_t address, uint8_t mic_selected, float input_gain_db, bool has_ref_channel_gain,
+                              uint8_t ref_channel, float ref_channel_gain_db) {
+    CodecDevBackend::Es7210Config cfg;
+    cfg.enabled = true;
+    cfg.address = address;
+    cfg.mic_selected = mic_selected;
+    cfg.input_gain_db = input_gain_db;
+    cfg.has_ref_channel_gain = has_ref_channel_gain;
+    cfg.ref_channel = ref_channel;
+    cfg.ref_channel_gain_db = ref_channel_gain_db;
+    this->codec_backend_.set_es7210_config(cfg);
+  }
+  void configure_es8311_input_codec(uint8_t address, bool use_mclk, bool no_dac_ref, float input_gain_db) {
+    CodecDevBackend::GenericCodecConfig cfg;
+    cfg.enabled = true;
+    cfg.kind = CodecDevBackend::CodecKind::ES8311;
+    cfg.address = address;
+    cfg.use_mclk = use_mclk;
+    cfg.no_dac_ref = no_dac_ref;
+    cfg.input_gain_db = input_gain_db;
+    this->codec_backend_.set_input_codec_config(cfg);
+  }
+  void configure_input_codec(uint8_t kind, uint8_t address, bool use_mclk, bool no_dac_ref, float input_gain_db) {
+    CodecDevBackend::GenericCodecConfig cfg;
+    cfg.enabled = true;
+    cfg.kind = static_cast<CodecDevBackend::CodecKind>(kind);
+    cfg.address = address;
+    cfg.use_mclk = use_mclk;
+    cfg.no_dac_ref = no_dac_ref;
+    cfg.input_gain_db = input_gain_db;
+    this->codec_backend_.set_input_codec_config(cfg);
+  }
+  void configure_es8311_codec(uint8_t address, bool use_mclk, bool no_dac_ref) {
+    CodecDevBackend::GenericCodecConfig cfg;
+    cfg.enabled = true;
+    cfg.kind = CodecDevBackend::CodecKind::ES8311;
+    cfg.address = address;
+    cfg.use_mclk = use_mclk;
+    cfg.no_dac_ref = no_dac_ref;
+    this->codec_backend_.set_output_codec_config(cfg);
+  }
+  void configure_output_codec(uint8_t kind, uint8_t address, bool use_mclk, bool no_dac_ref) {
+    CodecDevBackend::GenericCodecConfig cfg;
+    cfg.enabled = true;
+    cfg.kind = static_cast<CodecDevBackend::CodecKind>(kind);
+    cfg.address = address;
+    cfg.use_mclk = use_mclk;
+    cfg.no_dac_ref = no_dac_ref;
+    this->codec_backend_.set_output_codec_config(cfg);
+  }
+#endif
+
+  // Optional AEC/AFE processor attachment.
+  void set_processor(AudioProcessor *processor);
+  void set_processor_enabled(bool enabled) { this->processor_enabled_.store(enabled, std::memory_order_relaxed); }
+  bool is_processor_enabled() const { return this->processor_enabled_.load(std::memory_order_relaxed); }
+
+  // Mic gain control. Attenuation uses esp-audio-libs Q31 in the hot path;
+  // positive dB boost uses Espressif esp_ae_alc because Q31 gain cannot
+  // represent amplification above unity.
+  void set_mic_gain(float gain);
+  float get_mic_gain() const { return this->mic_gain_.load(std::memory_order_relaxed); }
+
+  // Input gain before the audio processor, for hot or weak mics.
+  void set_input_gain(float gain);
+  float get_input_gain() const { return this->input_gain_.load(std::memory_order_relaxed); }
+  // Master volume is independent from the speaker abstraction volume used by
+  // ESPHome's media_player. The audio task applies media/speaker volume *
+  // master volume, so HA media volume and the board master control cascade.
+  void set_master_volume_min_db(float db);
+  void set_master_volume(float volume);
+  void set_master_volume_q31(int32_t q31);
+  void set_output_volume(float volume);
+  void set_output_volume_q31(int32_t q31);
+  float get_master_volume() const { return this->master_volume_public_.load(std::memory_order_relaxed); }
+
+  // ES8311 Digital Feedback mode: RX is stereo with L=ADC(mic), R=DAC(ref)
+  void set_use_stereo_aec_reference(bool use) { this->use_stereo_aec_ref_ = use; }
+
+  // Reference channel selection: false=left (default), true=right
+  void set_reference_channel_right(bool right) { this->ref_channel_right_ = right; }
+
+  // TDM bus/reference: TDM bus selects TDM RX/TX slot layout; TDM reference
+  // controls whether the AEC ref comes from the configured TDM slot or from
+  // the software speaker reference path.
+  void set_use_tdm_bus(bool use) { this->use_tdm_bus_ = use; }
+  void set_use_tdm_reference(bool use) { this->use_tdm_ref_ = use; }
+  void set_tdm_total_slots(uint8_t n) { this->tdm_total_slots_ = n; }
+  void set_tdm_mic_slot(uint8_t slot) { this->tdm_mic_slot_ = slot; }
+  void set_secondary_tdm_mic_slot(int8_t slot) { this->tdm_second_mic_slot_ = slot; }
+  void set_tdm_ref_slot(uint8_t slot) { this->tdm_ref_slot_ = slot; }
+  void set_tdm_tx_slot(uint8_t slot) { this->tdm_tx_slot_ = slot; }
+  void set_tdm_slot_level_sensor_enabled(uint8_t slot, bool enabled) {
+    if (slot >= 8)
+      return;
+    this->tdm_slot_level_sensor_enabled_[slot] = enabled;
+    bool any = false;
+    for (bool slot_enabled : this->tdm_slot_level_sensor_enabled_) {
+      any = any || slot_enabled;
+    }
+    this->any_tdm_slot_level_sensor_enabled_.store(any, std::memory_order_relaxed);
+  }
+  float get_tdm_slot_level_dbfs(uint8_t slot) const {
+    if (slot >= 8)
+      return -120.0f;
+    return this->tdm_slot_level_dbfs_[slot].load(std::memory_order_relaxed);
+  }
+
+  // Microphone interface
+  bool add_mic_data_callback(MicDataCallback callback, void *ctx) {
+    if (callback == nullptr)
+      return false;
+    if (this->mic_callback_count_ >= MAX_LISTENERS)
+      return false;
+    this->mic_callbacks_[this->mic_callback_count_++] = MicCallbackSlot{callback, ctx};
+    return true;
+  }
+
+  // Consumer registry: each consumer (a microphone wrapper, call TX path,
+  // etc.) registers an opaque token. The audio task gates mic callbacks on
+  // has_mic_consumers_. Registration survives an internal stop()+start()
+  // sequence (e.g. frame_spec change), so consumers stay connected across
+  // reconfigure without having to re-register. Idempotent per token.
+  bool register_mic_consumer(void *token);
+  void unregister_mic_consumer(void *token);
+  bool is_mic_running() const { return this->has_mic_consumers_.load(std::memory_order_relaxed); }
+
+  // Speaker interface: data arrives at bus rate (from mixer/resampler)
+  size_t play(const uint8_t *data, size_t len, TickType_t ticks_to_wait = portMAX_DELAY);
+  void start_speaker();
+  void stop_speaker();
+  void set_speaker_buffer_duration(uint32_t ms) { this->speaker_buffer_duration_ms_ = ms; }
+  bool is_speaker_running() const { return this->speaker_running_.load(std::memory_order_relaxed); }
+  void set_speaker_paused(bool paused) { this->speaker_paused_.store(paused, std::memory_order_relaxed); }
+  bool is_speaker_paused() const { return this->speaker_paused_.load(std::memory_order_relaxed); }
+
+  // Audio stack lifecycle control
+  void start();  // Start both mic and speaker
+  void stop();   // Stop both
+  bool stop_and_wait(uint32_t timeout_ms = 2000);
+
+  bool is_running() const { return this->audio_stack_running_.load(std::memory_order_relaxed); }
+  bool is_idle() const {
+    return !this->audio_stack_running_.load(std::memory_order_relaxed) &&
+           this->audio_task_idle_.load(std::memory_order_relaxed) &&
+           !this->teardown_pending_.load(std::memory_order_relaxed);
+  }
+  bool has_i2s_error() const { return this->has_i2s_error_.load(std::memory_order_relaxed); }
+  Trigger<> *get_start_trigger() { return &this->start_trigger_; }
+  Trigger<> *get_idle_trigger() { return &this->idle_trigger_; }
+  Trigger<std::string> *get_state_trigger() { return &this->state_trigger_; }
+  Trigger<> *get_mic_start_trigger() { return &this->mic_start_trigger_; }
+  Trigger<> *get_mic_idle_trigger() { return &this->mic_idle_trigger_; }
+  Trigger<> *get_speaker_start_trigger() { return &this->speaker_start_trigger_; }
+  Trigger<> *get_speaker_idle_trigger() { return &this->speaker_idle_trigger_; }
+
+  // Speaker output callback registration (for mixer pending_playback_frames tracking)
+  bool add_speaker_output_callback(SpeakerOutputCallback callback, void *ctx) {
+    if (callback == nullptr)
+      return false;
+    if (this->speaker_output_callback_count_ >= MAX_LISTENERS)
+      return false;
+    this->speaker_output_callbacks_[this->speaker_output_callback_count_++] = SpeakerOutputCallbackSlot{callback, ctx};
+    return true;
+  }
+
+  // Getters for platform wrappers
+  // get_sample_rate() returns the I2S bus rate (used by speaker for audio_stream_info)
+  uint32_t get_sample_rate() const { return this->sample_rate_; }
+  // get_output_sample_rate() returns the converted rate for mic consumers (MWW/AEC/VA/call components)
+  uint32_t get_output_sample_rate() const {
+    return this->output_sample_rate_ > 0 ? this->output_sample_rate_ : this->sample_rate_;
+  }
+  size_t get_mic_callback_buffer_size() const;
+  size_t get_speaker_buffer_available() const;
+  bool has_pending_speaker_output() const {
+    return this->tx_completion_pending_real_records_.load(std::memory_order_acquire) > 0;
+  }
+  size_t get_speaker_buffer_size() const;
+
+  // Task configuration (settable from YAML)
+  void set_task_priority(uint8_t prio) { this->task_priority_ = prio; }
+  void set_task_core(int8_t core) { this->task_core_ = core; }
+  void set_task_stack_size(uint32_t size) { this->task_stack_size_ = size; }
+  void set_dma_desc_num(uint32_t desc_num) { this->dma_desc_num_ = desc_num; }
+  void set_dma_frame_num(uint32_t frame_num) {
+    this->dma_frame_num_ = frame_num;
+    this->dma_frame_num_configured_ = true;
+  }
+  void set_buffers_in_psram(bool psram) { this->buffers_in_psram_ = psram; }
+  void set_audio_task_stack_in_psram(bool psram) { this->audio_task_stack_in_psram_ = psram; }
+#ifdef USE_ESP_AUDIO_STACK_RING_REF
+  void set_aec_ref_buffer_ms(uint32_t ms) { this->aec_ref_buffer_ms_ = ms; }
+#else
+  void set_aec_ref_buffer_ms(uint32_t ms) { (void) ms; }
+#endif
+#ifdef USE_ESP_AUDIO_STACK_RING_REF
+  void set_aec_ref_ring_in_psram(bool psram) { this->aec_ref_ring_in_psram_ = psram; }
+#else
+  void set_aec_ref_ring_in_psram(bool psram) { (void) psram; }
+#endif
+  void set_telemetry_log_interval_frames(uint16_t frames) { this->telemetry_log_interval_frames_ = frames; }
+  void set_rate_cvt_complexity(uint8_t complexity) { this->rate_cvt_complexity_ = complexity; }
+  void set_rate_cvt_perf_type(uint8_t perf_type) { this->rate_cvt_perf_type_ = perf_type; }
+
+ protected:
+  bool init_audio_stack_();
+  bool prepare_i2s_channels_();
+  bool enable_i2s_channels_();
+  void close_audio_io_();
+  void deinit_i2s_();
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  bool setup_codec_backend_(i2s_clock_src_t clk_src);
+  CodecDevBackend::SampleConfig make_tx_sample_config_() const;
+  CodecDevBackend::SampleConfig make_rx_sample_config_() const;
+#endif
+
+  static void audio_task(void *param);
+  // Top-level task entry: outer loop that spawns one audio_session_ per start()/stop()
+  // cycle. Created once in setup(), never destroyed, so subsequent cycles can't trip
+  // a FreeRTOS xTaskCreate race on a lingering TCB.
+  void audio_task_();
+  // One audio session: populate ctx, enter the processing loop, and return when
+  // stop() flips audio_stack_running_ off or the processor's frame_spec changes.
+  void audio_session_();
+  void update_hot_output_volume_();
+
+  // Audio task context: groups all buffers, sizes, and per-frame snapshots
+  // to avoid long parameter lists in the refactored processing functions.
+  struct AudioTaskCtx {
+    // ── Invariants (set once at task start) ──
+    uint32_t ratio{1};
+    uint8_t i2s_bps{2};  // 2 or 4 bytes per I2S sample
+    uint8_t num_ch{1};   // TX channels
+    bool use_stereo_aec_ref{false};
+    bool rx_slot_mode_stereo{false};
+    bool use_tdm_bus{false};
+    bool use_tdm_ref{false};
+    bool ref_channel_right{false};
+    bool correct_dc_offset{false};
+    uint8_t tdm_total_slots{0};
+    uint8_t tdm_mic_slot{0};
+    int8_t tdm_second_mic_slot{-1};
+    uint8_t tdm_ref_slot{0};
+    uint8_t tdm_tx_slot{0};
+    uint8_t speaker_channels{1};
+    uint8_t processor_mic_channels{1};
+    uint32_t processor_spec_revision{0};
+    bool processor_spec_loaded{false};
+    RxPathKind rx_path_kind{RxPathKind::PASSTHROUGH};
+    uint8_t rx_rate_converter_channels{0};
+    bool tdm_ref_active_monitor_logged{false};
+
+    // ── Frame sizing ──
+    size_t input_frame_size{0};
+    size_t output_frame_size{0};
+    size_t bus_frame_size{0};
+    size_t input_frame_bytes{0};
+    size_t output_frame_bytes{0};
+    size_t bus_frame_bytes{0};
+    size_t speaker_frame_bytes{0};
+    size_t rx_frame_bytes{0};
+    size_t tdm_tx_frame_bytes{0};
+
+    // ── Working buffers (heap-allocated, owned by audio_task_) ──
+    // processor_mic_buffer is interleaved when a secondary mic is active
+    // (layout: [mic1[i], mic2[i]] for i in [0, rx_frames)).
+    // Rate conversion reads rx_buffer with a stride, so no separate
+    // deinterleave buffer is kept.
+    int16_t *rx_buffer{nullptr};
+    int16_t *mic_buffer{nullptr};
+    int16_t *processor_mic_buffer{nullptr};
+    int16_t *spk_buffer{nullptr};
+    int16_t *spk_ref_buffer{nullptr};
+    int16_t *tx_ref_mono_buffer{nullptr};
+    int16_t *tdm_tx_buffer{nullptr};
+    int16_t *tx_interleave_buffer{nullptr};
+    int16_t *tx_silence_buffer{nullptr};
+    int16_t *tx_clock_buffer{nullptr};
+    int16_t *tx_32_buffer{nullptr};
+    int16_t *aec_output{nullptr};
+
+    // ── Loop mutable state ──
+    int consecutive_i2s_errors{0};
+    // INVALID_STATE counter: codec/GMF IO can surface invalid state
+    // briefly when stop() disables a channel; counted separately so we
+    // can escalate only when it persists while audio_stack_running_ stays true
+    // (channel corrupted independently of our own teardown).
+    int invalid_state_errors{0};
+    // DC-HPF state lives on the component; the process_rx_path_ loop keeps
+    // converging across audio_session_ restarts (frame_spec changes
+    // would otherwise zero the state and produce ~10 ms of mic gain
+    // transient on every reconfigure).
+    const int16_t *processor_input{nullptr};
+    int16_t *output_buffer{nullptr};  // points to mic_buffer or aec_output
+    size_t current_output_frame_bytes{0};
+    size_t current_output_frame_size{0};
+    bool mic_separate{false};  // true if mic_buffer != rx_buffer
+    bool need_rx_processing{false};
+    bool need_rx_drain{false};
+    bool need_tx_audio{false};
+    bool need_tx_clock{false};
+    bool clock_only_tx{false};
+    bool any_tdm_slot_level_sensor_enabled{false};
+
+    // ── Per-iteration snapshots from atomics ──
+    int8_t mic_gain_boost_db{0};
+    int32_t mic_gain_q31{INT32_MAX};
+    float input_gain_boost{1.0f};
+    int32_t input_gain_q31{INT32_MAX};
+    int32_t hot_output_volume_q31{INT32_MAX};
+    bool processor_enabled{false};
+    bool processor_ready{false};  // cached: enabled && initialized (avoids virtual call per frame)
+    bool speaker_running{false};
+    bool speaker_paused{false};
+    bool speaker_underrun{false};
+#ifdef USE_ESP_AUDIO_STACK_TDM_REF_DIAGNOSTIC
+    size_t previous_speaker_got{0};  // previous TX frame, used to validate captured full-duplex ref
+    float previous_speaker_dbfs{-120.0f};
+    float current_speaker_dbfs{-120.0f};
+#endif
+    size_t speaker_got{0};  // bytes actually read from speaker ring buffer
+    bool mic_running{false};
+    uint32_t now_ms{0};
+  };
+
+  // Refactored audio processing functions (called from audio_task_ main loop)
+  void update_runtime_audio_flags_(AudioTaskCtx &ctx);
+  void process_rx_path_(AudioTaskCtx &ctx);
+  bool read_rx_frame_(AudioTaskCtx &ctx, const char *label);
+  void fail_audio_session_(const char *stage);
+  bool convert_rx_frame_(AudioTaskCtx &ctx);
+  bool process_rx_passthrough_(AudioTaskCtx &ctx);
+  bool process_rx_mono_effects_(AudioTaskCtx &ctx);
+  bool process_rx_stereo_slot_(AudioTaskCtx &ctx);
+  bool process_rx_stereo_ref_(AudioTaskCtx &ctx);
+  bool process_rx_tdm_(AudioTaskCtx &ctx);
+  void apply_input_conditioning_(AudioTaskCtx &ctx);
+  void drain_rx_minimal_(AudioTaskCtx &ctx);
+  void process_aec_and_callbacks_(AudioTaskCtx &ctx);
+  void process_tx_path_(AudioTaskCtx &ctx);
+  void process_tx_clock_only_(AudioTaskCtx &ctx);
+  bool write_tx_frame_(AudioTaskCtx &ctx, void *tx_data, size_t tx_bytes);
+  bool write_tx_dma_blocks_(AudioTaskCtx &ctx, void *tx_data, size_t tx_bytes, size_t real_speaker_bytes);
+  bool can_dispatch_mic_frame_(const AudioTaskCtx &ctx) const;
+  void apply_post_processor_gain_(AudioTaskCtx &ctx);
+  void dispatch_mic_callbacks_(const AudioTaskCtx &ctx);
+  bool apply_mic_alc_gain_(int16_t *samples, size_t sample_count, int8_t gain_db);
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+  void update_tdm_slot_levels_(const AudioTaskCtx &ctx);
+#endif
+  bool format_tx_frame_(AudioTaskCtx &ctx, void **tx_data, size_t *tx_bytes);
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+  bool tx_bit_cvt_16_to_32_(uint8_t channels, const void *in, uint32_t sample_num, void *out);
+#endif
+#ifdef USE_AUDIO_PROCESSOR
+  void run_processor_(AudioTaskCtx &ctx);
+#endif
+  bool wait_audio_task_state_(bool idle, uint32_t timeout_ms);
+  bool wait_audio_task_idle_(uint32_t timeout_ms) { return this->wait_audio_task_state_(true, timeout_ms); }
+  bool wait_audio_task_active_(uint32_t timeout_ms) { return this->wait_audio_task_state_(false, timeout_ms); }
+
+  struct TxCompletionRecord {
+    uint32_t real_frames{0};
+    uint32_t trailing_silence_frames{0};
+  };
+  static bool IRAM_ATTR tx_on_sent_callback(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx);
+  bool prepare_tx_completion_tracking_();
+  bool prime_tx_completion_records_(bool preload_dma);
+  void drain_tx_completion_events_();
+  void reset_tx_completion_tracking_();
+  bool queue_tx_completion_record_(const TxCompletionRecord &record);
+  void dispatch_speaker_output_callbacks_(uint32_t frames, int64_t timestamp);
+
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+  // Fill ctx.spk_ref_buffer for the mono AEC path (ring buffer or previous
+  // frame, zero-filled only when no reference exists). TDM and stereo paths
+  // pre-fill the buffer during RX deinterleave and must not call this.
+  void fill_mono_aec_reference_(AudioTaskCtx &ctx);
+#endif
+
+  // Pre-allocate audio task working buffers as soon as the processor frame
+  // shape is known. Buffers persist across internal stop()+start() cycles so
+  // the task can re-enter without calling heap_caps_alloc, which fragments
+  // SPIRAM over time and causes spurious allocation failures on feature-toggle
+  // sequences.
+  bool prepare_audio_context_(AudioTaskCtx &ctx, bool require_processor_spec, bool log_context);
+  bool allocate_audio_buffers_(AudioTaskCtx &ctx);
+  void request_audio_preallocation_();
+  void preallocate_audio_buffers_from_task_();
+
+  // Pin configuration
+  int lrclk_pin_{-1};
+  int bclk_pin_{-1};
+  int mclk_pin_{-1};
+  int din_pin_{-1};   // Mic data in
+  int dout_pin_{-1};  // Speaker data out
+
+  uint32_t sample_rate_{16000};
+  uint8_t bits_per_sample_{16};        // I2S bus bit depth: 16 or 32
+  bool correct_dc_offset_{false};      // IIR high-pass filter to remove mic DC bias
+  uint8_t num_channels_{1};            // Physical STD TX bus channels: 1 or 2
+  uint8_t speaker_channels_{1};        // Public ESPHome speaker stream channels
+  bool i2s_mode_secondary_{false};     // false = primary controller, true = secondary peripheral
+  bool use_apll_{false};               // Use APLL clock source (ESP32 original only)
+  uint8_t i2s_num_{0};                 // I2S port number (0 or 1)
+  uint32_t mclk_multiple_{256};        // MCLK multiple: 128, 256, 384, or 512
+  uint8_t i2s_comm_fmt_{0};            // 0=philips, 1=msb, 2=pcm_short, 3=pcm_long
+  bool mic_channel_right_{false};      // RX mono slot: false=LEFT, true=RIGHT
+  bool rx_slot_mode_stereo_{false};    // STD RX reads both slots; mic_channel selects one in software
+  bool tx_slot_right_{false};          // TX mono slot: false=LEFT (default), true=RIGHT
+  uint8_t slot_bit_width_{0};          // 0 = auto (match bits_per_sample), or 16/24/32
+  uint32_t output_sample_rate_{0};     // 0 = use sample_rate_ (no rate conversion)
+  uint32_t rate_conversion_ratio_{1};  // sample_rate_ / output_sample_rate_ (computed in setup)
+  uint8_t rate_cvt_complexity_{3};     // esp_ae_rate_cvt complexity, 1..3
+  uint8_t rate_cvt_perf_type_{1};      // esp_ae_rate_cvt perf type: 0=memory, 1=speed
+
+  // Espressif rate converters for mic and software-reference paths.
+#ifdef USE_ESP_AUDIO_STACK_MULTI_RX
+  MultiChannelAudioEffectsRateConverter rx_rate_converter_;  // Multi-channel: TDM/stereo RX path
+#endif
+#ifdef USE_ESP_AUDIO_STACK_MONO_RX
+  AudioEffectsRateConverter mic_rate_converter_;  // Mono RX without TDM/stereo
+#endif
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+  AudioEffectsRateConverter play_ref_rate_converter_;  // Mono mode: bus-rate ref from play() converted in audio_task
+#endif
+
+  // I2S handles managed as a coordinated RX/TX pair
+  i2s_chan_handle_t tx_handle_{nullptr};
+  i2s_chan_handle_t rx_handle_{nullptr};
+#ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
+  CodecDevBackend codec_backend_;
+#endif
+
+#ifdef USE_ESP_AUDIO_STACK_DUAL_BUS
+  struct I2SBusConfig {
+    bool configured{false};
+    uint8_t i2s_num{0};
+    int lrclk_pin{-1};
+    int bclk_pin{-1};
+    int mclk_pin{-1};
+    int din_pin{-1};
+    int dout_pin{-1};
+  };
+  bool dual_i2s_bus_{false};
+  I2SBusConfig rx_bus_;
+  I2SBusConfig tx_bus_;
+#endif
+
+  // State
+  std::atomic<bool> audio_stack_running_{false};
+  // Cached presence flag read by audio_task_ on the hot path; kept in sync
+  // with mic_consumers_ (below) under mic_consumers_mutex_ on register/unregister.
+  std::atomic<bool> has_mic_consumers_{false};
+  // Opaque consumer tokens; registration survives stop()+start() by construction.
+  // Fixed-size array (cap = MAX_LISTENERS = 16) avoids std::vector + std::mutex
+  // in this public header, keeping the include footprint minimal.
+  void *mic_consumers_[MAX_LISTENERS]{};
+  size_t mic_consumer_count_{0};
+  SemaphoreHandle_t mic_consumers_mutex_{nullptr};
+  std::atomic<bool> speaker_running_{false};
+  std::atomic<bool> speaker_paused_{false};
+  std::atomic<uint8_t> runtime_state_{static_cast<uint8_t>(AudioStackRuntimeState::IDLE)};
+  std::atomic<uint8_t> i2s_hardware_state_{static_cast<uint8_t>(I2SHardwareState::UNPREPARED)};
+  Trigger<> start_trigger_;
+  Trigger<> idle_trigger_;
+  Trigger<std::string> state_trigger_;
+  Trigger<> mic_start_trigger_;
+  Trigger<> mic_idle_trigger_;
+  Trigger<> speaker_start_trigger_;
+  Trigger<> speaker_idle_trigger_;
+  // audio_task_idle_: true while the task is parked in its outer wait loop
+  //                   (not owning I2S). Waiters use audio_state_waiter_ instead
+  //                   of polling when maintenance needs a specific task state.
+  std::atomic<bool> audio_task_idle_{true};
+  std::atomic<TaskHandle_t> audio_state_waiter_{nullptr};
+  TaskHandle_t audio_task_handle_{nullptr};
+
+  // Cross-thread buffer operation request (main thread -> audio task, avoids concurrent ring buffer access)
+  std::atomic<bool> request_speaker_reset_{false};
+  std::atomic<bool> prealloc_requested_{false};
+  std::atomic<bool> prealloc_attempted_{false};
+
+  // Deferred I2S release: stop() sets this and returns; loop() deletes the
+  // esp_driver_i2s channels after audio_task_idle_ flips.
+  // Avoids a blocking poll on the main loop during stop_speaker / unregister_mic_consumer.
+  std::atomic<bool> teardown_pending_{false};
+
+  AudioStackRuntimeState compute_runtime_state_() const;
+  static const char *runtime_state_to_string(AudioStackRuntimeState state);
+  void update_runtime_state_();
+  static const char *i2s_hardware_state_to_string(I2SHardwareState state);
+  void set_i2s_hardware_state_(I2SHardwareState state);
+  void log_memory_snapshot_(const char *label) const;
+  void service_speaker_reset_();
+
+#ifdef USE_ESP_AUDIO_STACK_TDM_REF_DIAGNOSTIC
+  // TDM AEC reference health: diagnostic-only counter for slot-map bring-up.
+  std::atomic<uint32_t> tdm_ref_silent_frames_{0};
+#endif
+
+  DcBlockerState dc_primary_;
+  DcBlockerState dc_secondary_;
+
+  // Mic data callbacks
+  MicCallbackSlot mic_callbacks_[MAX_LISTENERS]{};  // Post-processor stream for MWW, VA, call components
+  size_t mic_callback_count_{0};
+
+  // Speaker output callbacks (for mixer pending_playback_frames tracking)
+  SpeakerOutputCallbackSlot speaker_output_callbacks_[MAX_LISTENERS]{};
+  size_t speaker_output_callback_count_{0};
+
+  QueueHandle_t tx_completion_event_queue_{nullptr};
+  QueueHandle_t tx_completion_record_queue_{nullptr};
+  uint8_t *tx_completion_silence_{nullptr};
+  size_t tx_completion_silence_bytes_{0};
+  size_t tx_completion_queue_size_{0};
+  size_t tx_completion_dma_buffer_bytes_{0};
+  uint32_t tx_completion_dma_frames_{0};
+  uint32_t tx_completion_bytes_per_frame_{0};
+  volatile bool tx_completion_desync_{false};
+  std::atomic<uint32_t> tx_completion_pending_real_records_{0};
+
+  // Speaker ring buffer: stores data at bus rate (sample_rate_)
+  RingBufferPtr speaker_buffer_;
+  size_t speaker_buffer_size_{0};  // Actual allocated size (scales with rate_conversion_ratio_)
+  uint32_t speaker_buffer_duration_ms_{500};
+
+  // Optional AEC/AFE processor support.
+  AudioProcessor *processor_{nullptr};
+  std::atomic<bool> processor_enabled_{false};  // Runtime toggle (only enabled when processor_ is set)
+  std::atomic<bool> processor_background_consumer_registered_{false};
+  void sync_processor_background_consumer_();
+#ifdef USE_ESP_AUDIO_STACK_MONO_REF
+  int16_t *direct_aec_ref_{nullptr};  // TX-side converted reference storage/scratch (processor rate)
+  bool direct_aec_ref_valid_{false};  // True after first previous_frame reference has been saved
+#endif
+
+#ifdef USE_ESP_AUDIO_STACK_RING_REF
+  // AEC ring buffer reference (TYPE2-style, for no-codec setups)
+  uint32_t aec_ref_buffer_ms_{80};     // Config: ring buffer size in ms
+  RingBufferPtr aec_ref_ring_buffer_;  // Ring buffer for AEC ref (processor rate, post-volume)
+#endif
+
+  // Gain controls (atomic: written from main loop, read from audio task via snapshot)
+  std::atomic<float> mic_gain_{1.0f};             // Public/debug value, applied AFTER AEC.
+  std::atomic<int32_t> mic_gain_q31_{INT32_MAX};  // Official esp-audio-libs attenuation path.
+  std::atomic<int8_t> mic_gain_boost_db_{0};      // >0 dB via official esp_ae_alc.
+  std::atomic<float> input_gain_{1.0f};           // Public/debug value before the processor.
+  std::atomic<int32_t> input_gain_q31_{INT32_MAX};
+  std::atomic<float> input_gain_boost_{1.0f};
+  std::atomic<float> master_volume_public_{1.0f};          // public/debug master value
+  std::atomic<int32_t> hot_output_volume_q31_{INT32_MAX};  // combined hot-path fixed-point output volume
+  std::atomic<int32_t> output_volume_q31_{INT32_MAX};      // media_player/speaker abstraction volume
+  std::atomic<int32_t> master_volume_q31_{INT32_MAX};      // board master volume
+  std::atomic<float> master_volume_linear_{1.0f};          // unclipped user value for hardware codec volume APIs
+  float master_volume_min_db_{-49.0f};                     // 0..100% master curve floor; 0% remains hard mute
+  void *mic_alc_handle_{nullptr};
+  int8_t mic_alc_gain_db_{0};
+  bool use_stereo_aec_ref_{false};  // ES8311 digital feedback: RX stereo with L=mic, R=ref
+  bool ref_channel_right_{false};   // Which channel is AEC reference: false=L, true=R
+
+  // TDM bus/reference (ES7210 in TDM mode)
+  bool use_tdm_bus_{false};
+  bool use_tdm_ref_{false};
+  uint8_t tdm_total_slots_{4};
+  uint8_t tdm_mic_slot_{0};         // TDM slot index for voice mic
+  int8_t tdm_second_mic_slot_{-1};  // Optional second mic slot for dual-mic AFE
+  uint8_t tdm_ref_slot_{1};         // TDM slot index for AEC reference
+  uint8_t tdm_tx_slot_{0};          // TDM slot index for speaker TX
+  bool tdm_slot_level_sensor_enabled_[8] = {false};
+  std::atomic<bool> any_tdm_slot_level_sensor_enabled_{false};
+  std::atomic<float> tdm_slot_level_dbfs_[8] = {};
+  uint8_t tdm_slot_level_divider_{0};
+
+  // AEC gating: only run echo canceller while speaker has recent real audio.
+  std::atomic<uint32_t> last_speaker_audio_ms_{0};
+  static constexpr uint32_t AEC_ACTIVE_TIMEOUT_MS{250};
+
+  // Task configuration (defaults match ESP-IDF audio best practices)
+  uint8_t task_priority_{19};  // Above lwIP(18), below WiFi(23)
+  int8_t task_core_{0};        // Core 0: canonical Espressif AEC pattern; -1 = unpinned
+  uint32_t task_stack_size_{8192};
+  uint32_t dma_desc_num_{6};
+  uint32_t dma_frame_num_{0};
+  bool dma_frame_num_configured_{false};
+  bool buffers_in_psram_{false};           // Non-DMA buffers in PSRAM (saves ~15KB internal RAM)
+  bool audio_task_stack_in_psram_{false};  // Audio task stack in PSRAM (saves ~8KB internal RAM)
+#ifdef USE_ESP_AUDIO_STACK_RING_REF
+  bool aec_ref_ring_in_psram_{
+      false};  // AEC reference ring in PSRAM (saves ~3-5 KB internal, costs ~13.6 us/frame Core 0)
+#endif
+  StackType_t *audio_task_stack_{nullptr};  // Owned when audio_task_stack_in_psram_ is true
+  StaticTask_t audio_task_tcb_{};           // Static TCB for the permanent audio task
+  uint16_t telemetry_log_interval_frames_{128};
+
+  // Error propagation: set by audio_task_ on persistent I2S failures
+  std::atomic<bool> has_i2s_error_{false};
+
+  // Pre-allocated audio task buffers (owned by component, not by ctx).
+  // Allocated on audio_task_ entry and reused while the current frame shape
+  // fits. Runtime processor reconfigures can grow frame sizes, so
+  // allocate_audio_buffers_ validates the shape and reallocates before the
+  // task touches RX/rate-converter buffers.
+  void release_audio_buffers_();
+  int16_t *prealloc_rx_buffer_{nullptr};
+  int16_t *prealloc_mic_buffer_{nullptr};
+  int16_t *prealloc_processor_mic_buffer_{nullptr};
+  int16_t *prealloc_spk_buffer_{nullptr};
+  int16_t *prealloc_spk_ref_buffer_{nullptr};
+  int16_t *prealloc_tx_ref_mono_buffer_{nullptr};
+  int16_t *prealloc_aec_output_{nullptr};
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+  int16_t *prealloc_tdm_tx_buffer_{nullptr};
+  int16_t *prealloc_tx_silence_buffer_{nullptr};
+#endif
+#ifdef USE_ESP_AUDIO_STACK_STEREO_TX
+  int16_t *prealloc_tx_interleave_buffer_{nullptr};
+#endif
+  int16_t *prealloc_tx_clock_buffer_{nullptr};
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+  int16_t *prealloc_tx_32_buffer_{nullptr};
+#endif
+  size_t prealloc_rx_buffer_bytes_{0};
+  size_t prealloc_mic_buffer_bytes_{0};
+  size_t prealloc_processor_mic_buffer_bytes_{0};
+  size_t prealloc_spk_buffer_bytes_{0};
+  size_t prealloc_spk_ref_buffer_bytes_{0};
+  size_t prealloc_tx_ref_mono_buffer_bytes_{0};
+  size_t prealloc_aec_output_bytes_{0};
+#ifdef USE_ESP_AUDIO_STACK_TDM_BUS
+  size_t prealloc_tdm_tx_buffer_bytes_{0};
+  size_t prealloc_tx_silence_buffer_bytes_{0};
+#endif
+#ifdef USE_ESP_AUDIO_STACK_STEREO_TX
+  size_t prealloc_tx_interleave_buffer_bytes_{0};
+#endif
+  size_t prealloc_tx_clock_buffer_bytes_{0};
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+  size_t prealloc_tx_32_buffer_bytes_{0};
+#endif
+  bool audio_buffers_allocated_{false};
+#if defined(USE_ESP_AUDIO_STACK_STEREO_TX) && defined(USE_ESP_AUDIO_STACK_MONO_REF)
+  void *tx_ref_ch_cvt_handle_{nullptr};
+#endif
+#ifdef USE_ESP_AUDIO_STACK_32BIT
+  void *tx_bit_cvt_handle_{nullptr};
+  uint8_t tx_bit_cvt_channels_{0};
+#endif
+};
+
+// Native actions for YAML automations
+template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<ESPAudioStack> {
+ public:
+  void play(const Ts &...x) override { this->parent_->start(); }
+};
+
+template<typename... Ts> class StopAction : public Action<Ts...>, public Parented<ESPAudioStack> {
+ public:
+  void play(const Ts &...x) override { this->parent_->stop(); }
+};
+
+template<typename... Ts> class StopAndWaitAction : public Action<Ts...>, public Parented<ESPAudioStack> {
+ public:
+  void play(const Ts &...x) override { this->parent_->stop_and_wait(); }
+};
+
+template<typename... Ts> class IsIdleCondition : public Condition<Ts...>, public Parented<ESPAudioStack> {
+ public:
+  bool check(const Ts &...x) override { return this->parent_->is_idle(); }
+};
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/microphone/__init__.py
+++ b/esphome/components/esp_audio_stack/microphone/__init__.py
@@ -1,0 +1,80 @@
+"""ESP Audio Stack Microphone Platform - Wraps full-duplex bus as standard ESPHome microphone"""
+
+import esphome.codegen as cg
+from esphome.components import audio, microphone
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_BITS_PER_SAMPLE,
+    CONF_ID,
+    CONF_NUM_CHANNELS,
+    CONF_SAMPLE_RATE,
+)
+
+from .. import CONF_ESP_AUDIO_STACK_ID, ESPAudioStack, esp_audio_stack_ns
+
+DEPENDENCIES = ["esp_audio_stack"]
+CODEOWNERS = ["@n-IA-hane"]
+
+ESPAudioStackMicrophone = esp_audio_stack_ns.class_(
+    "ESPAudioStackMicrophone",
+    microphone.Microphone,
+    cg.Component,
+    cg.Parented.template(ESPAudioStack),
+)
+
+
+def _set_stream_limits(config):
+    # Mic output is at output_sample_rate (e.g. 16 kHz after rate conversion).
+    # Allow range to cover the standard 16 kHz VA path and supported output rates.
+    audio.set_stream_limits(
+        min_bits_per_sample=16,
+        max_bits_per_sample=16,
+        min_channels=1,
+        max_channels=1,
+        min_sample_rate=8000,
+        max_sample_rate=48000,
+    )(config)
+    return config
+
+
+def _reject_child_audio_overrides(config):
+    """The audio stack microphone format is owned by the shared full-duplex bus.
+
+    `microphone.MICROPHONE_SCHEMA` inherits the generic audio keys, but applying
+    them on the child would be misleading: the C++ stream format is derived from
+    the parent `esp_audio_stack` bus and `output_sample_rate`.
+    """
+    invalid = [
+        key
+        for key in (CONF_SAMPLE_RATE, CONF_BITS_PER_SAMPLE, CONF_NUM_CHANNELS)
+        if key in config
+    ]
+    if invalid:
+        fields = ", ".join(invalid)
+        raise cv.Invalid(
+            f"{fields} must be configured on esp_audio_stack, not on "
+            "microphone.platform: esp_audio_stack. The audio stack microphone "
+            "publishes the parent output stream."
+        )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    microphone.MICROPHONE_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(ESPAudioStackMicrophone),
+            cv.GenerateID(CONF_ESP_AUDIO_STACK_ID): cv.use_id(ESPAudioStack),
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    _reject_child_audio_overrides,
+    _set_stream_limits,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await microphone.register_microphone(var, config)
+
+    parent = await cg.get_variable(config[CONF_ESP_AUDIO_STACK_ID])
+    cg.add(var.set_parent(parent))

--- a/esphome/components/esp_audio_stack/microphone/esp_audio_stack_microphone.cpp
+++ b/esphome/components/esp_audio_stack/microphone/esp_audio_stack_microphone.cpp
@@ -1,0 +1,185 @@
+#include "esp_audio_stack_microphone.h"
+
+#ifdef USE_ESP32
+
+#include <cstring>
+
+#include "esphome/core/log.h"
+#include "../audio_core_log_utils.h"
+
+namespace esphome::esp_audio_stack {
+
+static const char *const TAG = "audio_stack.mic";
+
+void ESPAudioStackMicrophone::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up ESP Audio Stack Microphone...");
+
+  // Counting semaphore for listener refcounting (take to decrement, give
+  // to increment). Initial count == max count == MAX_LISTENERS.
+  this->active_listeners_semaphore_ = xSemaphoreCreateCounting(MAX_LISTENERS, MAX_LISTENERS);
+  if (this->active_listeners_semaphore_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create semaphore");
+    this->mark_failed();
+    return;
+  }
+
+  // Configure audio stream info for 16-bit mono PCM at output rate
+  // When rate conversion is active, mic delivers data at output_sample_rate (e.g. 16 kHz).
+  // AudioStreamInfo constructor: (bits_per_sample, channels, sample_rate)
+  this->audio_stream_info_ = audio::AudioStreamInfo(16, 1, this->parent_->get_output_sample_rate());
+
+  // Pre-allocate callback buffer to avoid heap allocation in the RT audio task.
+  // Do not grow this vector in on_audio_data_(): that callback runs in the
+  // parent audio task.
+  const size_t callback_buffer_bytes = this->parent_->get_mic_callback_buffer_size();
+  this->audio_buffer_.reserve(callback_buffer_bytes);
+  ESP_LOGCONFIG(TAG, "  Callback Buffer: %u bytes", (unsigned) callback_buffer_bytes);
+
+  // Standard microphone output is always post-processor. MWW, VA and
+  // call components all consume the same cleaned stream.
+  if (!this->parent_->add_mic_data_callback(ESPAudioStackMicrophone::mic_data_callback, this)) {
+    ESP_LOGE(TAG, "Failed to register parent mic callback");
+    this->mark_failed();
+  }
+}
+
+void ESPAudioStackMicrophone::dump_config() {
+  ESP_LOGCONFIG(TAG, "ESP Audio Stack Microphone:");
+  ESP_LOGCONFIG(TAG, "  Sample Rate: %u Hz", this->parent_->get_output_sample_rate());
+  ESP_LOGCONFIG(TAG, "  Bits Per Sample: 16");
+  ESP_LOGCONFIG(TAG, "  Channels: 1 (mono)");
+}
+
+void ESPAudioStackMicrophone::start() {
+  if (this->is_failed())
+    return;
+
+  // Take semaphore to register as active listener
+  if (xSemaphoreTake(this->active_listeners_semaphore_, 0) != pdTRUE) {
+    ESP_LOGW(TAG, "No free semaphore slots");
+    return;
+  }
+
+  // Native ESPHome microphone semantics are asynchronous: start() only
+  // registers interest; loop() performs the state transition.
+  this->enable_loop_soon_any_context();
+}
+
+void ESPAudioStackMicrophone::stop() {
+  if (this->is_failed() || this->active_listeners_semaphore_ == nullptr)
+    return;
+
+  if (uxSemaphoreGetCount(this->active_listeners_semaphore_) >= MAX_LISTENERS)
+    return;
+
+  // Give semaphore to unregister as listener. Do this even if loop() has not
+  // transitioned to STATE_RUNNING yet, otherwise start()+immediate stop() leaks
+  // a listener slot and keeps the parent mic path alive.
+  xSemaphoreGive(this->active_listeners_semaphore_);
+
+  if (uxSemaphoreGetCount(this->active_listeners_semaphore_) < MAX_LISTENERS)
+    return;
+
+  if (this->state_ == microphone::STATE_STOPPED) {
+    return;
+  }
+
+  // loop() will process the stop edge; do not block the ESPHome main loop.
+  this->enable_loop_soon_any_context();
+}
+
+void ESPAudioStackMicrophone::mic_data_callback(void *ctx, const uint8_t *data, size_t len) {
+  static_cast<ESPAudioStackMicrophone *>(ctx)->on_audio_data_(data, len);
+}
+
+void ESPAudioStackMicrophone::on_audio_data_(const uint8_t *data, size_t len) {
+  if (this->state_ != microphone::STATE_RUNNING) {
+    return;
+  }
+
+  if (len > this->audio_buffer_.capacity()) {
+    LOG_W_THROTTLED("Mic callback frame too large: %u > %u bytes; dropping", (unsigned) len,
+                    (unsigned) this->audio_buffer_.capacity());
+    return;
+  }
+  this->audio_buffer_.resize(len);
+  const bool muted = this->mute_state_;
+  if (muted) {
+    std::memset(this->audio_buffer_.data(), 0, len);
+  } else {
+    std::memcpy(this->audio_buffer_.data(), data, len);
+  }
+  // ESPHome's base Microphone wrapper allocates a temporary zero vector when
+  // mute_state_ is true. We have already zero-filled the preallocated callback
+  // buffer, so clear the flag only while dispatching to avoid RT-task heap churn.
+  if (muted)
+    this->mute_state_ = false;
+  this->data_callbacks_.call(this->audio_buffer_);
+  if (muted)
+    this->mute_state_ = true;
+}
+
+void ESPAudioStackMicrophone::loop() {
+  // Propagate I2S errors from parent audio task
+  if (this->parent_->has_i2s_error() && !this->status_has_error()) {
+    ESP_LOGE(TAG, "I2S error detected in audio task");
+    this->status_set_error(LOG_STR("I2S read error in audio task"));
+  }
+
+  // Check semaphore count to decide when to start/stop
+  UBaseType_t count = uxSemaphoreGetCount(this->active_listeners_semaphore_);
+
+  // Start the microphone if any semaphores are taken (listeners active)
+  if ((count < MAX_LISTENERS) && (this->state_ == microphone::STATE_STOPPED)) {
+    this->state_ = microphone::STATE_STARTING;
+  }
+
+  // Stop the microphone if all semaphores are returned (no listeners)
+  if ((count == MAX_LISTENERS) && (this->state_ == microphone::STATE_RUNNING)) {
+    this->state_ = microphone::STATE_STOPPING;
+  }
+
+  switch (this->state_) {
+    case microphone::STATE_STARTING:
+      if (this->status_has_error()) {
+        break;
+      }
+      if (uxSemaphoreGetCount(this->active_listeners_semaphore_) >= MAX_LISTENERS) {
+        this->state_ = microphone::STATE_STOPPED;
+        break;
+      }
+      ESP_LOGI(TAG, "Microphone started");
+      if (!this->parent_->register_mic_consumer(this)) {
+        ESP_LOGW(TAG, "Parent audio stack refused mic consumer registration");
+        xSemaphoreGive(this->active_listeners_semaphore_);
+        this->state_ = microphone::STATE_STOPPED;
+        break;
+      }
+      if (!this->parent_->is_running()) {
+        ESP_LOGW(TAG, "Parent audio stack failed to start; aborting microphone start");
+        this->parent_->unregister_mic_consumer(this);
+        xSemaphoreGive(this->active_listeners_semaphore_);
+        this->state_ = microphone::STATE_STOPPED;
+        break;
+      }
+      this->state_ = microphone::STATE_RUNNING;
+      break;
+
+    case microphone::STATE_RUNNING:
+      break;
+
+    case microphone::STATE_STOPPING:
+      ESP_LOGI(TAG, "Microphone stopped");
+      this->parent_->unregister_mic_consumer(this);
+      this->state_ = microphone::STATE_STOPPED;
+      break;
+
+    case microphone::STATE_STOPPED:
+      this->disable_loop();
+      break;
+  }
+}
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/microphone/esp_audio_stack_microphone.h
+++ b/esphome/components/esp_audio_stack/microphone/esp_audio_stack_microphone.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/microphone/microphone.h"
+#include "../esp_audio_stack.h"
+
+#include <vector>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+namespace esphome::esp_audio_stack {
+
+class ESPAudioStackMicrophone : public microphone::Microphone, public Component, public Parented<ESPAudioStack> {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  // microphone::Microphone interface
+  void start() override;
+  void stop() override;
+
+ protected:
+  static void mic_data_callback(void *ctx, const uint8_t *data, size_t len);
+  void on_audio_data_(const uint8_t *data, size_t len);
+
+  std::vector<uint8_t> audio_buffer_;
+
+  // Reference counting for multiple listeners (voice_assistant, wake_word, call components, etc.)
+  SemaphoreHandle_t active_listeners_semaphore_{nullptr};
+};
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/number.h
+++ b/esphome/components/esp_audio_stack/number.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#if defined(USE_ESP32) && defined(USE_NUMBER)
+
+#include "esphome/components/number/number.h"
+#include "esphome/components/speaker/speaker.h"
+#include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
+#include "esp_audio_stack.h"
+#include "audio_core_log_utils.h"
+#include <cmath>
+
+namespace esphome::esp_audio_stack {
+
+class MicGainNumber : public number::Number, public Component {
+ public:
+  void set_parent(ESPAudioStack *parent) { this->parent_ = parent; }
+  void set_min_db(float min_db) { this->min_db_ = min_db; }
+  void set_max_db(float max_db) { this->max_db_ = max_db; }
+
+  void setup() override {
+    float value;
+    this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+    if (this->pref_.load(&value)) {
+      value = clamp_db_(value);
+      this->apply_(value);
+      this->publish_state(value);
+    } else {
+      this->publish_state(this->clamp_db_(0.0f));  // 0 dB = unity gain when allowed
+    }
+  }
+
+  void dump_config() override {
+    log_config("audio_stack.mic_gain", "Mic Gain Number (post-processor dB, range %.1f..%.1f)", this->min_db_,
+               this->max_db_);
+  }
+
+ protected:
+  float clamp_db_(float value) const {
+    if (!std::isfinite(value))
+      return 0.0f;
+    if (value < this->min_db_)
+      return this->min_db_;
+    if (value > this->max_db_)
+      return this->max_db_;
+    return value;
+  }
+
+  void apply_(float value) {
+    if (this->parent_ != nullptr) {
+      float linear = std::pow(10.0f, value / 20.0f);
+      this->parent_->set_mic_gain(linear);
+    }
+  }
+
+  void control(float value) override {
+    if (this->parent_ != nullptr) {
+      value = clamp_db_(value);
+      this->apply_(value);
+      this->publish_state(value);
+      this->pref_.save(&value);
+    }
+  }
+
+  ESPAudioStack *parent_{nullptr};
+  ESPPreferenceObject pref_;
+  float min_db_{-20.0f};
+  float max_db_{30.0f};
+};
+
+class MasterVolumeNumber : public number::Number, public Component {
+ public:
+  void set_parent(ESPAudioStack *parent) { this->parent_ = parent; }
+  void set_speaker(speaker::Speaker *speaker) { this->speaker_ = speaker; }
+
+  void setup() override {
+    float value;
+    this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+    if (this->pref_.load(&value)) {
+      value = clamp_percent(value);
+      this->apply_(value);
+      this->publish_state(value);
+    } else if (this->parent_ != nullptr) {
+      this->publish_state(this->parent_->get_master_volume() * 100.0f);
+    } else if (this->speaker_ != nullptr) {
+      this->publish_state(this->speaker_->get_volume() * 100.0f);
+    }
+  }
+
+  void dump_config() override {
+    log_config("audio_stack.master_volume", "Master Volume Number%s",
+               this->speaker_ != nullptr ? " (speaker-backed)" : "");
+  }
+
+ protected:
+  static float clamp_percent(float value) {
+    if (!std::isfinite(value))
+      return 0.0f;
+    if (value < 0.0f)
+      return 0.0f;
+    if (value > 100.0f)
+      return 100.0f;
+    return value;
+  }
+
+  void apply_(float value) {
+    float volume = value / 100.0f;
+    if (this->parent_ != nullptr) {
+      this->parent_->set_master_volume(volume);
+    } else if (this->speaker_ != nullptr) {
+      this->speaker_->set_volume(volume);
+    }
+  }
+
+  void control(float value) override {
+    if (this->speaker_ != nullptr || this->parent_ != nullptr) {
+      value = clamp_percent(value);
+      this->apply_(value);
+      this->publish_state(value);
+      this->pref_.save(&value);
+    }
+  }
+
+  ESPAudioStack *parent_{nullptr};
+  speaker::Speaker *speaker_{nullptr};
+  ESPPreferenceObject pref_;
+};
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32 && USE_NUMBER

--- a/esphome/components/esp_audio_stack/number.py
+++ b/esphome/components/esp_audio_stack/number.py
@@ -1,0 +1,95 @@
+"""Number platform for ESP Audio Stack - mic gain and Master Volume"""
+
+import esphome.codegen as cg
+from esphome.components import number, speaker
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_MAX_VALUE,
+    CONF_MIC_GAIN,
+    CONF_MIN_VALUE,
+    ENTITY_CATEGORY_CONFIG,
+    UNIT_PERCENT,
+)
+
+from . import CONF_ESP_AUDIO_STACK_ID, ESPAudioStack, esp_audio_stack_ns
+
+CONF_MASTER_VOLUME = "master_volume"
+CONF_SPEAKER_ID = "speaker_id"
+
+# Number classes
+MicGainNumber = esp_audio_stack_ns.class_("MicGainNumber", number.Number, cg.Component)
+MasterVolumeNumber = esp_audio_stack_ns.class_(
+    "MasterVolumeNumber", number.Number, cg.Component
+)
+
+MIC_GAIN_SCHEMA = number.number_schema(
+    MicGainNumber,
+    entity_category=ENTITY_CATEGORY_CONFIG,
+    icon="mdi:microphone",
+).extend(
+    {
+        cv.Optional(CONF_MIN_VALUE, default=-20.0): cv.float_range(min=-20.0, max=30.0),
+        cv.Optional(CONF_MAX_VALUE, default=30.0): cv.float_range(min=-20.0, max=30.0),
+    }
+)
+
+
+def _validate_mic_gain_range(config):
+    if config[CONF_MIN_VALUE] >= config[CONF_MAX_VALUE]:
+        raise cv.Invalid("mic_gain min_value must be lower than max_value")
+    return config
+
+
+MIC_GAIN_SCHEMA = cv.All(MIC_GAIN_SCHEMA, _validate_mic_gain_range)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ESP_AUDIO_STACK_ID): cv.use_id(ESPAudioStack),
+        cv.Optional(CONF_MIC_GAIN): MIC_GAIN_SCHEMA,
+        cv.Optional(CONF_MASTER_VOLUME): number.number_schema(
+            MasterVolumeNumber,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            icon="mdi:volume-high",
+            unit_of_measurement=UNIT_PERCENT,
+        ).extend(
+            {
+                cv.Optional(CONF_SPEAKER_ID): cv.use_id(speaker.Speaker),
+            }
+        ),
+    }
+)
+
+
+async def _setup_mic_gain(config, key, parent):
+    if key in config:
+        conf = config[key]
+        var = await number.new_number(
+            conf,
+            min_value=conf[CONF_MIN_VALUE],
+            max_value=conf[CONF_MAX_VALUE],
+            step=1.0,
+        )
+        await cg.register_component(var, conf)
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_min_db(conf[CONF_MIN_VALUE]))
+        cg.add(var.set_max_db(conf[CONF_MAX_VALUE]))
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ESP_AUDIO_STACK_ID])
+
+    await _setup_mic_gain(config, CONF_MIC_GAIN, parent)
+
+    if CONF_MASTER_VOLUME in config:
+        conf = config[CONF_MASTER_VOLUME]
+        var = await number.new_number(
+            conf,
+            min_value=0.0,
+            max_value=100.0,
+            step=5.0,
+        )
+        await cg.register_component(var, conf)
+        cg.add(var.set_parent(parent))
+        if CONF_SPEAKER_ID in conf:
+            speaker_var = await cg.get_variable(conf[CONF_SPEAKER_ID])
+            cg.add(var.set_speaker(speaker_var))

--- a/esphome/components/esp_audio_stack/sensor.h
+++ b/esphome/components/esp_audio_stack/sensor.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#if defined(USE_ESP32) && defined(USE_SENSOR)
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+#include "esp_audio_stack.h"
+#include "audio_core_log_utils.h"
+
+namespace esphome::esp_audio_stack {
+
+class TdmSlotLevelSensor : public sensor::Sensor, public PollingComponent, public Parented<ESPAudioStack> {
+ public:
+  void set_slot(uint8_t slot) { this->slot_ = slot; }
+
+  void update() override {
+    if (this->parent_ != nullptr) {
+      this->publish_state(this->parent_->get_tdm_slot_level_dbfs(this->slot_));
+    }
+  }
+
+  void dump_config() override {
+    log_config("audio_stack.tdm_slot_sensor", "ESP Audio Stack TDM Slot %u Level Sensor", this->slot_);
+  }
+
+ protected:
+  uint8_t slot_{0};
+};
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32 && USE_SENSOR

--- a/esphome/components/esp_audio_stack/sensor.py
+++ b/esphome/components/esp_audio_stack/sensor.py
@@ -1,0 +1,52 @@
+"""Sensor platform for ESP Audio Stack diagnostics."""
+
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
+
+from . import CONF_ESP_AUDIO_STACK_ID, ESPAudioStack, esp_audio_stack_ns
+
+CONF_SLOT = "slot"
+CONF_TDM_SLOT_LEVELS = "tdm_slot_levels"
+
+TdmSlotLevelSensor = esp_audio_stack_ns.class_(
+    "TdmSlotLevelSensor",
+    sensor.Sensor,
+    cg.PollingComponent,
+    cg.Parented.template(ESPAudioStack),
+)
+
+
+def _slot_level_schema():
+    return (
+        sensor.sensor_schema(
+            TdmSlotLevelSensor,
+            unit_of_measurement="dBFS",
+            accuracy_decimals=1,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            icon="mdi:microphone-message",
+        )
+        .extend(cv.polling_component_schema("500ms"))
+        .extend({cv.Required(CONF_SLOT): cv.int_range(min=0, max=7)})
+    )
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ESP_AUDIO_STACK_ID): cv.use_id(ESPAudioStack),
+        cv.Optional(CONF_TDM_SLOT_LEVELS): cv.ensure_list(_slot_level_schema()),
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ESP_AUDIO_STACK_ID])
+
+    for conf in config.get(CONF_TDM_SLOT_LEVELS, []):
+        slot = conf[CONF_SLOT]
+        cg.add(parent.set_tdm_slot_level_sensor_enabled(slot, True))
+        var = await sensor.new_sensor(conf)
+        await cg.register_component(var, conf)
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_slot(slot))

--- a/esphome/components/esp_audio_stack/speaker/__init__.py
+++ b/esphome/components/esp_audio_stack/speaker/__init__.py
@@ -1,0 +1,81 @@
+"""ESP Audio Stack Speaker Platform - Wraps full-duplex bus as standard ESPHome speaker"""
+
+import esphome.codegen as cg
+from esphome.components import audio, speaker
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_BUFFER_DURATION,
+    CONF_ID,
+    CONF_NEVER,
+    CONF_NUM_CHANNELS,
+    CONF_TIMEOUT,
+)
+
+from .. import CONF_ESP_AUDIO_STACK_ID, ESPAudioStack, esp_audio_stack_ns
+
+DEPENDENCIES = ["esp_audio_stack"]
+CODEOWNERS = ["@n-IA-hane"]
+
+ESPAudioStackSpeaker = esp_audio_stack_ns.class_(
+    "ESPAudioStackSpeaker",
+    speaker.Speaker,
+    cg.Component,
+    cg.Parented.template(ESPAudioStack),
+)
+
+
+def _set_audio_properties(config):
+    """Set default audio properties for mixer/resampler compatibility.
+
+    Note: sample_rate is NOT defaulted here because the speaker operates at bus
+    rate (e.g. 48kHz for ES8311), not a fixed 16kHz. The C++ setup() sets
+    audio_stream_info_ from parent->get_sample_rate() at runtime.
+    """
+    if CONF_NUM_CHANNELS not in config:
+        config[CONF_NUM_CHANNELS] = 1
+    return config
+
+
+def _set_stream_limits(config):
+    # Speaker accepts audio at bus rate (e.g. 48kHz). ResamplerSpeaker handles upsampling
+    audio.set_stream_limits(
+        min_bits_per_sample=16,
+        max_bits_per_sample=16,
+        min_channels=1,
+        max_channels=2,
+        min_sample_rate=8000,
+        max_sample_rate=48000,
+    )(config)
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    speaker.SPEAKER_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(ESPAudioStackSpeaker),
+            cv.GenerateID(CONF_ESP_AUDIO_STACK_ID): cv.use_id(ESPAudioStack),
+            cv.Optional(
+                CONF_BUFFER_DURATION, default="500ms"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_TIMEOUT, default=CONF_NEVER): cv.Any(
+                cv.positive_time_period_milliseconds,
+                cv.one_of(CONF_NEVER, lower=True),
+            ),
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    _set_audio_properties,
+    _set_stream_limits,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    parent = await cg.get_variable(config[CONF_ESP_AUDIO_STACK_ID])
+    cg.add(var.set_parent(parent))
+    cg.add(parent.set_speaker_buffer_duration(config[CONF_BUFFER_DURATION]))
+    if config[CONF_TIMEOUT] != CONF_NEVER:
+        cg.add(var.set_timeout(config[CONF_TIMEOUT]))
+
+    await speaker.register_speaker(var, config)

--- a/esphome/components/esp_audio_stack/speaker/esp_audio_stack_speaker.cpp
+++ b/esphome/components/esp_audio_stack/speaker/esp_audio_stack_speaker.cpp
@@ -1,0 +1,246 @@
+#include "esp_audio_stack_speaker.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+#include <cmath>
+
+namespace esphome::esp_audio_stack {
+
+static const char *const TAG = "audio_stack.spk";
+
+void ESPAudioStackSpeaker::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up ESP Audio Stack Speaker...");
+
+  this->active_listeners_semaphore_ = xSemaphoreCreateCounting(MAX_LISTENERS, MAX_LISTENERS);
+  if (this->active_listeners_semaphore_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create semaphore");
+    this->mark_failed();
+    return;
+  }
+
+  this->audio_stream_info_ =
+      audio::AudioStreamInfo(16, this->parent_->get_speaker_channels(), this->parent_->get_sample_rate());
+
+  // Forward frame-played notifications from I2S audio task to mixer callbacks.
+  // Without this, mixer source speakers can't track pending_playback_frames.
+  if (!this->parent_->add_speaker_output_callback(ESPAudioStackSpeaker::speaker_output_callback, this)) {
+    ESP_LOGE(TAG, "Failed to register parent speaker callback");
+    this->mark_failed();
+  }
+}
+
+void ESPAudioStackSpeaker::dump_config() {
+  ESP_LOGCONFIG(TAG, "ESP Audio Stack Speaker:");
+  ESP_LOGCONFIG(TAG, "  Sample Rate: %u Hz", this->parent_->get_sample_rate());
+  ESP_LOGCONFIG(TAG, "  Bits Per Sample: 16");
+  ESP_LOGCONFIG(TAG, "  Channels: %u", (unsigned) this->parent_->get_speaker_channels());
+  ESP_LOGCONFIG(TAG, "  Buffer Size: %u bytes", (unsigned) this->parent_->get_speaker_buffer_size());
+  if (this->timeout_.has_value()) {
+    ESP_LOGCONFIG(TAG, "  Timeout: %u ms", (unsigned) this->timeout_.value());
+  } else {
+    ESP_LOGCONFIG(TAG, "  Timeout: never");
+  }
+}
+
+void ESPAudioStackSpeaker::start() {
+  if (this->is_failed())
+    return;
+
+  // Clear finishing flag on new stream start
+  this->finishing_ = false;
+  if (this->pause_state_) {
+    this->set_pause_state(false);
+  }
+  this->last_write_ms_ = millis();
+
+  // Idempotent: register listener only once per stream session.
+  bool expected = false;
+  if (!this->listener_registered_.compare_exchange_strong(expected, true, std::memory_order_acq_rel,
+                                                          std::memory_order_relaxed))
+    return;
+
+  if (xSemaphoreTake(this->active_listeners_semaphore_, 0) != pdTRUE) {
+    this->listener_registered_.store(false, std::memory_order_release);
+    ESP_LOGW(TAG, "No free semaphore slots");
+    return;
+  }
+  this->enable_loop_soon_any_context();
+}
+
+void ESPAudioStackSpeaker::stop() {
+  if (this->is_failed())
+    return;
+
+  this->finishing_ = false;
+  if (this->pause_state_) {
+    this->set_pause_state(false);
+  }
+  if (!this->listener_registered_.exchange(false, std::memory_order_acq_rel))
+    return;
+
+  xSemaphoreGive(this->active_listeners_semaphore_);
+  this->enable_loop_soon_any_context();
+}
+
+void ESPAudioStackSpeaker::finish() {
+  // Non-blocking: set flag, loop() will call stop() once buffer is drained
+  if (this->pause_state_) {
+    this->set_pause_state(false);
+  }
+  this->finishing_ = true;
+  this->enable_loop_soon_any_context();
+}
+
+void ESPAudioStackSpeaker::speaker_output_callback(void *ctx, uint32_t frames, int64_t timestamp) {
+  static_cast<ESPAudioStackSpeaker *>(ctx)->audio_output_callback_.call(frames, timestamp);
+}
+
+size_t ESPAudioStackSpeaker::play(const uint8_t *data, size_t length) { return this->play(data, length, 0); }
+
+size_t ESPAudioStackSpeaker::play(const uint8_t *data, size_t length, TickType_t ticks_to_wait) {
+  if (this->is_failed()) {
+    return 0;
+  }
+
+  if (this->state_ != speaker::STATE_RUNNING && this->state_ != speaker::STATE_STARTING) {
+    this->start();
+  }
+
+  if (!this->listener_registered_.load(std::memory_order_acquire)) {
+    return 0;
+  }
+
+  size_t written = this->parent_->play(data, length, ticks_to_wait);
+  if (written > 0) {
+    this->last_write_ms_ = millis();
+  }
+  return written;
+}
+
+bool ESPAudioStackSpeaker::has_buffered_data() const {
+  return this->parent_->get_speaker_buffer_available() > 0 || this->parent_->has_pending_speaker_output();
+}
+
+void ESPAudioStackSpeaker::set_volume(float volume) {
+  if (!std::isfinite(volume) || volume < 0.0f) {
+    volume = 0.0f;
+  } else if (volume > 1.0f) {
+    volume = 1.0f;
+  }
+  this->volume_ = volume;
+
+#ifdef USE_AUDIO_DAC
+  if (this->audio_dac_ != nullptr) {
+    ESP_LOGD(TAG, "Speaker set_volume: %.3f -> audio_dac", volume);
+    if (!this->mute_state_ && volume > 0.0f) {
+      this->audio_dac_->set_mute_off();
+    }
+    this->audio_dac_->set_volume(volume);
+    if (this->mute_state_) {
+      this->audio_dac_->set_mute_on();
+    }
+  } else
+#endif
+  {
+    ESP_LOGD(TAG, "Speaker set_volume: %.3f -> output volume layer", volume);
+    if (this->mute_state_) {
+      this->parent_->set_output_volume_q31(0);
+    } else {
+      this->parent_->set_output_volume(volume);
+    }
+  }
+}
+
+void ESPAudioStackSpeaker::set_mute_state(bool mute_state) {
+  this->mute_state_ = mute_state;
+
+#ifdef USE_AUDIO_DAC
+  if (this->audio_dac_ != nullptr) {
+    ESP_LOGD(TAG, "Speaker mute: %s -> audio_dac", mute_state ? "on" : "off");
+    if (mute_state) {
+      this->audio_dac_->set_mute_on();
+    } else {
+      this->audio_dac_->set_mute_off();
+    }
+  } else
+#endif
+  {
+    ESP_LOGD(TAG, "Speaker mute: %s -> software_q31", mute_state ? "on" : "off");
+    if (mute_state) {
+      this->parent_->set_output_volume_q31(0);
+    } else {
+      this->parent_->set_output_volume(this->volume_);
+    }
+  }
+}
+
+void ESPAudioStackSpeaker::set_pause_state(bool pause_state) {
+  this->pause_state_ = pause_state;
+  this->parent_->set_speaker_paused(pause_state);
+  ESP_LOGD(TAG, "Pause state: %s", pause_state ? "PAUSED" : "PLAYING");
+}
+
+void ESPAudioStackSpeaker::loop() {
+  // Propagate I2S errors from parent audio task
+  if (this->parent_->has_i2s_error() && !this->status_has_error()) {
+    ESP_LOGE(TAG, "I2S error detected in audio task");
+    this->status_set_error(LOG_STR("I2S write error in audio task"));
+  }
+
+  UBaseType_t count = uxSemaphoreGetCount(this->active_listeners_semaphore_);
+
+  if ((count < MAX_LISTENERS) && (this->state_ == speaker::STATE_STOPPED)) {
+    this->state_ = speaker::STATE_STARTING;
+  }
+
+  if ((count == MAX_LISTENERS) && (this->state_ == speaker::STATE_RUNNING)) {
+    this->state_ = speaker::STATE_STOPPING;
+  }
+
+  switch (this->state_) {
+    case speaker::STATE_STARTING:
+      if (this->status_has_error()) {
+        break;
+      }
+      if (uxSemaphoreGetCount(this->active_listeners_semaphore_) == MAX_LISTENERS) {
+        this->state_ = speaker::STATE_STOPPED;
+        break;
+      }
+      this->parent_->start_speaker();
+      if (!this->parent_->is_running()) {
+        ESP_LOGW(TAG, "Parent audio stack failed to start; aborting speaker start");
+        this->stop();
+        this->state_ = speaker::STATE_STOPPED;
+        break;
+      }
+      this->state_ = speaker::STATE_RUNNING;
+      break;
+
+    case speaker::STATE_RUNNING:
+      // Non-blocking finish: drain buffer then stop
+      if (this->finishing_ && !this->has_buffered_data()) {
+        this->finishing_ = false;
+        this->stop();
+      } else if (!this->pause_state_ && this->timeout_.has_value() && !this->has_buffered_data() &&
+                 (millis() - this->last_write_ms_) > this->timeout_.value()) {
+        this->stop();
+      }
+      break;
+
+    case speaker::STATE_STOPPING:
+      this->parent_->stop_speaker();
+      this->state_ = speaker::STATE_STOPPED;
+      break;
+
+    case speaker::STATE_STOPPED:
+      this->disable_loop();
+      break;
+  }
+}
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/speaker/esp_audio_stack_speaker.h
+++ b/esphome/components/esp_audio_stack/speaker/esp_audio_stack_speaker.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/speaker/speaker.h"
+#include "../esp_audio_stack.h"
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+#include <atomic>
+
+namespace esphome::esp_audio_stack {
+
+class ESPAudioStackSpeaker : public speaker::Speaker, public Component, public Parented<ESPAudioStack> {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  // speaker::Speaker interface
+  void start() override;
+  void stop() override;
+  void finish() override;
+
+  size_t play(const uint8_t *data, size_t length) override;
+  size_t play(const uint8_t *data, size_t length, TickType_t ticks_to_wait) override;
+
+  bool has_buffered_data() const override;
+
+  void set_volume(float volume) override;
+  void set_mute_state(bool mute_state) override;
+
+  void set_pause_state(bool pause_state) override;
+  bool get_pause_state() const override { return this->pause_state_; }
+  void set_timeout(uint32_t timeout) { this->timeout_ = timeout; }
+
+ protected:
+  static void speaker_output_callback(void *ctx, uint32_t frames, int64_t timestamp);
+
+  bool pause_state_{false};
+  bool finishing_{false};  // Non-blocking drain: finish() sets flag, loop() handles drain+stop
+  optional<uint32_t> timeout_;
+  uint32_t last_write_ms_{0};
+  // Reference counting for multiple listeners (media_player, voice_assistant, call components, etc.)
+  SemaphoreHandle_t active_listeners_semaphore_{nullptr};
+  // Idempotency guard: prevents multiple xSemaphoreTake per stream session.
+  // Without this, play() calling start() before loop() sets STATE_RUNNING causes
+  // semaphore count to leak (take N times, give 1 time → never reaches MAX_LISTENERS
+  // → speaker never enters STATE_STOPPING → is_playing stays true forever).
+  std::atomic<bool> listener_registered_{false};
+};
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32

--- a/esphome/components/esp_audio_stack/switch.h
+++ b/esphome/components/esp_audio_stack/switch.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#if defined(USE_ESP32) && defined(USE_SWITCH)
+
+#include "esphome/components/switch/switch.h"
+#include "esphome/core/component.h"
+#include "esp_audio_stack.h"
+#include "audio_core_log_utils.h"
+
+namespace esphome::esp_audio_stack {
+
+class AECSwitch : public switch_::Switch, public Component {
+ public:
+  void set_parent(ESPAudioStack *parent) { this->parent_ = parent; }
+
+  void setup() override {
+    if (this->parent_ == nullptr)
+      return;
+
+    auto initial = this->get_initial_state_with_restore_mode();
+    if (initial.has_value()) {
+      this->write_state(*initial);
+    } else {
+      this->publish_state(this->parent_->is_processor_enabled());
+    }
+  }
+
+  void dump_config() override { log_config("audio_stack.aec_switch", "AEC Switch"); }
+
+ protected:
+  void write_state(bool state) override {
+    if (this->parent_ != nullptr) {
+      this->parent_->set_processor_enabled(state);
+      this->publish_state(state);
+    }
+  }
+
+  ESPAudioStack *parent_{nullptr};
+};
+
+}  // namespace esphome::esp_audio_stack
+
+#endif  // USE_ESP32 && USE_SWITCH

--- a/esphome/components/esp_audio_stack/switch.py
+++ b/esphome/components/esp_audio_stack/switch.py
@@ -1,0 +1,34 @@
+"""Switch platform for ESP Audio Stack - AEC enable/disable"""
+
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_CONFIG
+
+from . import CONF_ESP_AUDIO_STACK_ID, ESPAudioStack, esp_audio_stack_ns
+
+CONF_AEC = "aec"
+
+# Switch class
+AECSwitch = esp_audio_stack_ns.class_("AECSwitch", switch.Switch, cg.Component)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ESP_AUDIO_STACK_ID): cv.use_id(ESPAudioStack),
+        cv.Optional(CONF_AEC): switch.switch_schema(
+            AECSwitch,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            icon="mdi:account-voice",
+        ),
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ESP_AUDIO_STACK_ID])
+
+    if CONF_AEC in config:
+        conf = config[CONF_AEC]
+        var = await switch.new_switch(conf)
+        await cg.register_component(var, conf)
+        cg.add(var.set_parent(parent))

--- a/tests/components/esp_audio_stack/.gitignore
+++ b/tests/components/esp_audio_stack/.gitignore
@@ -1,0 +1,5 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml

--- a/tests/components/esp_audio_stack/test.esp32-p4-idf.yaml
+++ b/tests/components/esp_audio_stack/test.esp32-p4-idf.yaml
@@ -1,0 +1,63 @@
+esphome:
+  name: test-esp-audio-stack-p4
+
+esp32:
+  board: esp32-p4_r3-evboard
+  variant: esp32p4
+  flash_size: 32MB
+  cpu_frequency: 360MHz
+  framework:
+    type: esp-idf
+    advanced:
+      enable_idf_experimental_features: true
+
+psram:
+  mode: hex
+  speed: 200MHz
+
+i2c:
+  sda: GPIO47
+  scl: GPIO48
+
+esp_audio_stack:
+  id: audio_stack
+  sample_rate: 48000
+  output_sample_rate: 16000
+  bits_per_sample: 32
+  slot_bit_width: 32
+  i2s_mclk_pin: GPIO5
+  i2s_bclk_pin: GPIO6
+  i2s_lrclk_pin: GPIO7
+  i2s_din_pin: GPIO4
+  i2s_dout_pin: GPIO8
+  codec:
+    input:
+      type: es8311
+    output:
+      type: es8311
+
+microphone:
+  - platform: esp_audio_stack
+    id: stack_mic
+    esp_audio_stack_id: audio_stack
+
+speaker:
+  - platform: esp_audio_stack
+    id: stack_speaker
+    esp_audio_stack_id: audio_stack
+    buffer_duration: 500ms
+
+switch:
+  - platform: esp_audio_stack
+    esp_audio_stack_id: audio_stack
+    aec:
+      name: AEC
+
+number:
+  - platform: esp_audio_stack
+    esp_audio_stack_id: audio_stack
+    mic_gain:
+      name: Mic Gain
+    master_volume:
+      name: Master Volume
+      speaker_id: stack_speaker

--- a/tests/components/esp_audio_stack/test.esp32-s3-idf.yaml
+++ b/tests/components/esp_audio_stack/test.esp32-s3-idf.yaml
@@ -1,0 +1,59 @@
+esphome:
+  name: test-esp-audio-stack
+
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+  speed: 80MHz
+
+i2c:
+  sda: GPIO47
+  scl: GPIO48
+
+esp_audio_stack:
+  id: audio_stack
+  sample_rate: 48000
+  output_sample_rate: 16000
+  bits_per_sample: 32
+  slot_bit_width: 32
+  i2s_mclk_pin: GPIO5
+  i2s_bclk_pin: GPIO6
+  i2s_lrclk_pin: GPIO7
+  i2s_din_pin: GPIO4
+  i2s_dout_pin: GPIO8
+  codec:
+    input:
+      type: es8311
+    output:
+      type: es8311
+
+microphone:
+  - platform: esp_audio_stack
+    id: stack_mic
+    esp_audio_stack_id: audio_stack
+
+speaker:
+  - platform: esp_audio_stack
+    id: stack_speaker
+    esp_audio_stack_id: audio_stack
+    buffer_duration: 500ms
+
+switch:
+  - platform: esp_audio_stack
+    esp_audio_stack_id: audio_stack
+    aec:
+      name: AEC
+
+number:
+  - platform: esp_audio_stack
+    esp_audio_stack_id: audio_stack
+    mic_gain:
+      name: Mic Gain
+    master_volume:
+      name: Master Volume
+      speaker_id: stack_speaker


### PR DESCRIPTION
## Summary

This PR adds `esp_audio_stack`, a reusable ESP32 audio runtime for ESPHome.

`esp_audio_stack` is intended to be a complete audio backend on its own: it can manage microphone capture, speaker playback, buffering, runtime state and diagnostics without requiring an audio processor. When needed, the same backend can also feed optional processing components such as standalone AEC or the full Espressif AFE pipeline.

## What this enables

This component is designed for ESP32 audio devices that need a coordinated audio runtime rather than independent microphone and speaker paths.

It supports:

- full-duplex capture and playback
- single-bus and dual-bus I2S topologies
- standard I2S and TDM capture layouts
- multi-slot TDM input
- microphone plus playback-reference layouts for AEC
- mic + mic + reference layouts used by dual-mic voice devices
- coordinated microphone/speaker start and stop
- reusable runtime state, buffering and diagnostics
- optional integration with AEC and AFE processing components

A key target is modern ESP32 voice hardware where microphone input, speaker output and echo-reference audio need to stay synchronized.

## Architecture

`esp_audio_stack` owns the shared audio transport layer:

- I2S input and output setup
- DMA buffer lifecycle
- optional TDM slot extraction
- microphone frame delivery
- speaker frame submission
- reference frame handling
- runtime start/stop coordination
- memory and task ownership for the audio path

The component can be used directly as an audio backend, or as the source/sink runtime for higher-level processors.

## Relationship with AEC and AFE

AEC and AFE are optional processing layers.

`esp_audio_stack` provides the audio transport and runtime. `esp_aec` and `esp_afe` can attach to it when echo cancellation, dual-mic speech enhancement, VAD, NS or AGC are needed.

This separation lets simple devices use the audio stack alone, while more advanced voice devices can reuse the same backend with processing enabled.

## Validation

Tested locally with:

```text
PYTHONPATH=$PWD python -m esphome config tests/components/esp_audio_stack/test.esp32-p4-idf.yaml
PYTHONPATH=$PWD python -m esphome compile tests/components/esp_audio_stack/test.esp32-p4-idf.yaml
```

Result: ESP32-P4 compile passed.

## Notes

Documentation is not included in this repository PR because ESPHome documentation lives in the separate docs repository. A matching documentation PR should be submitted after the component API is accepted.
