### PR TITLE
[usb_uart][lvgl] Fix output truncation and keyboard on_value text

### DIFF
--- a/esphome/components/lvgl/widgets/keyboard.py
+++ b/esphome/components/lvgl/widgets/keyboard.py
@@ -34,7 +34,9 @@ lv_keyboard_t = LvType(
     parents=(KeyProvider, LvCompound),
     largs=[(std_string, "text")],
     has_on_value=True,
-    lvalue=lambda w: literal(f"lv_textarea_get_text({w.obj})"),
+    lvalue=lambda w: literal(
+        f"lv_textarea_get_text(lv_keyboard_get_textarea({w.obj}))"
+    ),
 )
 
 

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -160,7 +160,7 @@ void USBUartChannel::write_array(const uint8_t *data, size_t len) {
     }
     uint16_t chunk_len = std::min(len, UsbOutputChunk::MAX_CHUNK_SIZE);
     memcpy(chunk->data, data, chunk_len);
-    chunk->length = static_cast<uint8_t>(chunk_len);
+    chunk->length = chunk_len;
     // Push always succeeds: pool is sized to queue capacity (SIZE-1), so if
     // allocate() returned non-null, the queue cannot be full.
     this->output_queue_.push(chunk);


### PR DESCRIPTION
# What does this implement/fix?

Two unrelated correctness fixes found while reviewing these components.

**usb_uart** (`usb_uart.cpp`): the output chunk length was assigned with `static_cast<uint8_t>(chunk_len)`, but `UsbOutputChunk::length` is `uint16_t` and `MAX_CHUNK_SIZE == USB_MAX_PACKET_SIZE` is **512 on ESP32-P4 high-speed** USB (64 only on full-speed). Any write with a chunk ≥ 256 bytes had its length truncated mod 256 — a full 512-byte chunk recorded `length = 0`, so the transmit path sent zero bytes while `data`/`len` had already advanced past the whole chunk, silently dropping the output. The field type and the two sibling assignments (`ft23xx.cpp:311`, `usb_uart.cpp:323`) already use the full 16-bit value; this line was the lone truncation.

**lvgl** (`widgets/keyboard.py`): the keyboard `on_value` trigger built its `text` argument with `lv_textarea_get_text(<keyboard>)`. A keyboard is an `lv_buttonmatrix` subclass, not a textarea, so the text was read from a misinterpreted pointer (garbage / possible crash) on every value-changed event for any keyboard using `on_value`. Route through `lv_keyboard_get_textarea()` to read the keyboard's attached textarea before fetching its text.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

The existing `usb_uart` (esp32-s3-idf) and `lvgl` (host, which exercises a keyboard `on_value`) component tests both compile with the fixes.

## Example entry for `config.yaml`:

```yaml
# lvgl keyboard on_value now receives the attached textarea's text
lvgl:
  pages:
    - widgets:
        - keyboard:
            id: kb
            on_value:
              then:
                - logger.log:
                    format: "keyboard value %s"
                    args: [text.c_str()]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).