### PR TITLE
[lvgl] Fix keyboard on_value reading text from the wrong object

### DIFF
--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -551,5 +551,12 @@ class LvKeyboardType : public key_provider::KeyProvider, public LvCompound {
  public:
   void set_obj(lv_obj_t *lv_obj) override;
 };
+
+// A keyboard has no text of its own; its text is that of the attached textarea. Returns an empty
+// string when no textarea is attached so the on_value trigger stays safe for a textarea-less keyboard.
+inline const char *lv_keyboard_get_text(lv_obj_t *keyboard) {
+  lv_obj_t *textarea = lv_keyboard_get_textarea(keyboard);
+  return textarea == nullptr ? "" : lv_textarea_get_text(textarea);
+}
 #endif  // USE_LVGL_KEYBOARD
 }  // namespace esphome::lvgl

--- a/esphome/components/lvgl/widgets/keyboard.py
+++ b/esphome/components/lvgl/widgets/keyboard.py
@@ -34,7 +34,9 @@ lv_keyboard_t = LvType(
     parents=(KeyProvider, LvCompound),
     largs=[(std_string, "text")],
     has_on_value=True,
-    lvalue=lambda w: literal(f"lv_textarea_get_text({w.obj})"),
+    lvalue=lambda w: literal(
+        f"lv_textarea_get_text(lv_keyboard_get_textarea({w.obj}))"
+    ),
 )
 
 

--- a/esphome/components/lvgl/widgets/keyboard.py
+++ b/esphome/components/lvgl/widgets/keyboard.py
@@ -34,9 +34,7 @@ lv_keyboard_t = LvType(
     parents=(KeyProvider, LvCompound),
     largs=[(std_string, "text")],
     has_on_value=True,
-    lvalue=lambda w: literal(
-        f"lv_textarea_get_text(lv_keyboard_get_textarea({w.obj}))"
-    ),
+    lvalue=lambda w: literal(f"lv_keyboard_get_text({w.obj})"),
 )
 
 

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -1435,6 +1435,27 @@ lvgl:
                 hidden: true
                 mode: text_lower
 
+        # Keyboard bound to a textarea. Placed before the textarea so the
+        # keyboard->textarea binding exercises the deferred add_textarea() path,
+        # and on_value reads text through the bound textarea.
+        - keyboard:
+            id: lv_keyboard2
+            textarea: lv_textarea1
+            on_value:
+              then:
+                - logger.log:
+                    format: "keyboard text %s"
+                    args: [text.c_str()]
+        - textarea:
+            id: lv_textarea1
+            text: "hello"
+            one_line: true
+            max_length: 32
+        # Keyboard bound to an already-defined textarea -> immediate binding path.
+        - keyboard:
+            id: lv_keyboard3
+            textarea: lv_textarea1
+
         # Grid shorthand "<rows>x": 3 rows specified, columns derived
         # from widget count (4 widgets / 3 rows -> 2 columns)
         - obj:


### PR DESCRIPTION
# What does this implement/fix?

The keyboard `on_value` trigger built its `text` argument with `lv_textarea_get_text(<keyboard>)`. A keyboard is an `lv_buttonmatrix` subclass, not a textarea, so the text was read from a misinterpreted pointer (garbage / possible crash) on every value-changed event for any keyboard using `on_value`. Route through `lv_keyboard_get_textarea()` to read the keyboard's attached textarea before fetching its text.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

The existing `lvgl` host component test has a keyboard with `on_value`, so it exercises the fixed codegen; it compiles.

## Example entry for `config.yaml`:

```yaml
lvgl:
  pages:
    - widgets:
        - keyboard:
            id: kb
            on_value:
              then:
                - logger.log:
                    format: "keyboard value %s"
                    args: [text.c_str()]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).