### PR TITLE
[ci] Add rp2 clang-tidy environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,6 +504,10 @@ jobs:
             options: --environment nrf52-tidy --grep USE_ZEPHYR --grep USE_NRF52
             cache_sdk_nrf: true
             ignore_errors: false
+          - id: clang-tidy
+            name: Run script/clang-tidy for RP2
+            options: --environment rp2-tidy --grep USE_RP2
+            pio_cache_key: tidyrp2
 
     steps:
       - name: Check out code from GitHub

--- a/esphome/components/debug/debug_rp2.cpp
+++ b/esphome/components/debug/debug_rp2.cpp
@@ -74,7 +74,7 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
   constexpr size_t size = DEVICE_INFO_BUFFER_SIZE;
   char *buf = buffer.data();
 
-  uint32_t cpu_freq = ::rp2040.f_cpu();
+  uint32_t cpu_freq = RP2040::f_cpu();
   ESP_LOGD(TAG, "CPU Frequency: %" PRIu32, cpu_freq);
   pos = buf_append_printf(buf, size, pos, "|CPU Frequency: %" PRIu32, cpu_freq);
 

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -110,10 +110,12 @@ enum class EthernetComponentState : uint8_t {
   CONNECTED,
 };
 
-// Platform-neutral duplex/speed types
+// Platform-neutral duplex/speed types, mirroring the ESP-IDF esp_eth names
 #ifndef USE_ESP32
+// NOLINTBEGIN(readability-identifier-naming)
 enum eth_duplex_t { ETH_DUPLEX_HALF, ETH_DUPLEX_FULL };
 enum eth_speed_t { ETH_SPEED_10M, ETH_SPEED_100M };
+// NOLINTEND(readability-identifier-naming)
 #endif
 
 class EthernetComponent final : public Component {

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -110,7 +110,7 @@ enum class EthernetComponentState : uint8_t {
   CONNECTED,
 };
 
-// Platform-neutral duplex/speed types, mirroring the ESP-IDF esp_eth names
+// Platform-neutral duplex/speed types
 #ifndef USE_ESP32
 // NOLINTBEGIN(readability-identifier-naming)
 enum eth_duplex_t { ETH_DUPLEX_HALF, ETH_DUPLEX_FULL };

--- a/esphome/components/ethernet/ethernet_component_rp2.cpp
+++ b/esphome/components/ethernet/ethernet_component_rp2.cpp
@@ -187,17 +187,18 @@ void EthernetComponent::loop() {
 }
 
 void EthernetComponent::dump_config() {
-  const char *type_str = "Unknown";
 #if defined(USE_ETHERNET_W5500)
-  type_str = "W5500";
+  const char *type_str = "W5500";
 #elif defined(USE_ETHERNET_W5100)
-  type_str = "W5100";
+  const char *type_str = "W5100";
 #elif defined(USE_ETHERNET_W6100)
-  type_str = "W6100";
+  const char *type_str = "W6100";
 #elif defined(USE_ETHERNET_W6300)
-  type_str = "W6300";
+  const char *type_str = "W6300";
 #elif defined(USE_ETHERNET_ENC28J60)
-  type_str = "ENC28J60";
+  const char *type_str = "ENC28J60";
+#else
+  const char *type_str = "Unknown";
 #endif
 #if defined(USE_ETHERNET_W6300)
   // W6300 uses PIO QSPI with hardcoded pins — SPI pin fields are not used

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "fastled_light.h"
 #include "esphome/core/log.h"

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "fastled_light.h"
 #include "esphome/core/log.h"

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
 
 #include "fastled_light.h"
 #include "esphome/core/log.h"

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#ifdef USE_ARDUINO
+// FastLED is not supported on RP2 (see require_framework_version in fastled_clockless/light.py)
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -1,6 +1,5 @@
 #pragma once
 
-// FastLED is not supported on RP2 (see require_framework_version in fastled_clockless/light.py)
 #if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/component.h"

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"

--- a/esphome/components/midea/ac_adapter.cpp
+++ b/esphome/components/midea/ac_adapter.cpp
@@ -1,4 +1,3 @@
-// MideaUART does not build on RP2 (its manifest excludes the platform)
 #if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/log.h"

--- a/esphome/components/midea/ac_adapter.cpp
+++ b/esphome/components/midea/ac_adapter.cpp
@@ -1,4 +1,5 @@
-#ifdef USE_ARDUINO
+// MideaUART does not build on RP2 (its manifest excludes the platform)
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/log.h"
 #include "ac_adapter.h"

--- a/esphome/components/midea/ac_adapter.cpp
+++ b/esphome/components/midea/ac_adapter.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
 
 #include "esphome/core/log.h"
 #include "ac_adapter.h"

--- a/esphome/components/midea/ac_adapter.cpp
+++ b/esphome/components/midea/ac_adapter.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/log.h"
 #include "ac_adapter.h"

--- a/esphome/components/midea/ac_adapter.h
+++ b/esphome/components/midea/ac_adapter.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#ifdef USE_ARDUINO
+// MideaUART does not build on RP2 (its manifest excludes the platform)
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 // MideaUART
 #include <Appliance/AirConditioner/AirConditioner.h>

--- a/esphome/components/midea/ac_adapter.h
+++ b/esphome/components/midea/ac_adapter.h
@@ -1,6 +1,5 @@
 #pragma once
 
-// MideaUART does not build on RP2 (its manifest excludes the platform)
 #if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 // MideaUART

--- a/esphome/components/midea/ac_adapter.h
+++ b/esphome/components/midea/ac_adapter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 // MideaUART
 #include <Appliance/AirConditioner/AirConditioner.h>

--- a/esphome/components/midea/ac_adapter.h
+++ b/esphome/components/midea/ac_adapter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
 
 // MideaUART
 #include <Appliance/AirConditioner/AirConditioner.h>

--- a/esphome/components/midea/ac_automations.h
+++ b/esphome/components/midea/ac_automations.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/automation.h"
 #include "air_conditioner.h"

--- a/esphome/components/midea/ac_automations.h
+++ b/esphome/components/midea/ac_automations.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
 
 #include "esphome/core/automation.h"
 #include "air_conditioner.h"

--- a/esphome/components/midea/ac_automations.h
+++ b/esphome/components/midea/ac_automations.h
@@ -1,6 +1,5 @@
 #pragma once
 
-// MideaUART does not build on RP2 (its manifest excludes the platform)
 #if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/automation.h"

--- a/esphome/components/midea/ac_automations.h
+++ b/esphome/components/midea/ac_automations.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#ifdef USE_ARDUINO
+// MideaUART does not build on RP2 (its manifest excludes the platform)
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/automation.h"
 #include "air_conditioner.h"

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -1,4 +1,5 @@
-#ifdef USE_ARDUINO
+// MideaUART does not build on RP2 (its manifest excludes the platform)
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -1,4 +1,3 @@
-// MideaUART does not build on RP2 (its manifest excludes the platform)
 #if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 #include "esphome/core/helpers.h"

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#ifdef USE_ARDUINO
+// MideaUART does not build on RP2 (its manifest excludes the platform)
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 // MideaUART
 #include <Appliance/AirConditioner/AirConditioner.h>

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -1,6 +1,5 @@
 #pragma once
 
-// MideaUART does not build on RP2 (its manifest excludes the platform)
 #if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 // MideaUART

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 // MideaUART
 #include <Appliance/AirConditioner/AirConditioner.h>

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
 
 // MideaUART
 #include <Appliance/AirConditioner/AirConditioner.h>

--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 // MideaUART
 #include <Appliance/ApplianceBase.h>

--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
 
 // MideaUART
 #include <Appliance/ApplianceBase.h>

--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -1,6 +1,5 @@
 #pragma once
 
-// MideaUART does not build on RP2 (its manifest excludes the platform)
 #if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 // MideaUART

--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#ifdef USE_ARDUINO
+// MideaUART does not build on RP2 (its manifest excludes the platform)
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 
 // MideaUART
 #include <Appliance/ApplianceBase.h>

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -152,6 +152,13 @@ CONFIG_SCHEMA = cv.All(
     .extend(uart.UART_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA),
     cv.only_with_arduino,
+    cv.require_framework_version(
+        esp8266_arduino=cv.Version(0, 0, 0),
+        esp32_arduino=cv.Version(0, 0, 0),
+        bk72xx_arduino=cv.Version(0, 0, 0),
+        rtl87xx_arduino=cv.Version(0, 0, 0),
+        ln882x_arduino=cv.Version(0, 0, 0),
+    ),
 )
 
 # Actions

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -25,6 +25,11 @@ from esphome.const import (
     ICON_POWER,
     ICON_THERMOMETER,
     ICON_WATER_PERCENT,
+    PLATFORM_BK72XX,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_LN882X,
+    PLATFORM_RTL87XX,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
     UNIT_PERCENT,
@@ -152,12 +157,14 @@ CONFIG_SCHEMA = cv.All(
     .extend(uart.UART_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA),
     cv.only_with_arduino,
-    cv.require_framework_version(
-        esp8266_arduino=cv.Version(0, 0, 0),
-        esp32_arduino=cv.Version(0, 0, 0),
-        bk72xx_arduino=cv.Version(0, 0, 0),
-        rtl87xx_arduino=cv.Version(0, 0, 0),
-        ln882x_arduino=cv.Version(0, 0, 0),
+    cv.only_on(
+        [
+            PLATFORM_ESP32,
+            PLATFORM_ESP8266,
+            PLATFORM_BK72XX,
+            PLATFORM_RTL87XX,
+            PLATFORM_LN882X,
+        ]
     ),
 )
 

--- a/esphome/components/midea/ir_transmitter.h
+++ b/esphome/components/midea/ir_transmitter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 #ifdef USE_REMOTE_TRANSMITTER
 #include "esphome/components/remote_base/midea_protocol.h"
 

--- a/esphome/components/midea/ir_transmitter.h
+++ b/esphome/components/midea/ir_transmitter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !(defined(USE_RP2) && defined(CLANG_TIDY))
 #ifdef USE_REMOTE_TRANSMITTER
 #include "esphome/components/remote_base/midea_protocol.h"
 

--- a/esphome/components/midea/ir_transmitter.h
+++ b/esphome/components/midea/ir_transmitter.h
@@ -1,6 +1,5 @@
 #pragma once
 
-// MideaUART does not build on RP2 (its manifest excludes the platform)
 #if defined(USE_ARDUINO) && !defined(USE_RP2)
 #ifdef USE_REMOTE_TRANSMITTER
 #include "esphome/components/remote_base/midea_protocol.h"

--- a/esphome/components/midea/ir_transmitter.h
+++ b/esphome/components/midea/ir_transmitter.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#ifdef USE_ARDUINO
+// MideaUART does not build on RP2 (its manifest excludes the platform)
+#if defined(USE_ARDUINO) && !defined(USE_RP2)
 #ifdef USE_REMOTE_TRANSMITTER
 #include "esphome/components/remote_base/midea_protocol.h"
 

--- a/esphome/components/rp2/core.h
+++ b/esphome/components/rp2/core.h
@@ -5,6 +5,7 @@
 #include <Arduino.h>
 #include <pico.h>
 
+// NOLINTNEXTLINE(google-runtime-int,readability-identifier-naming,readability-redundant-declaration)
 extern "C" unsigned long ulMainGetRunTimeCounterValue();
 
 namespace esphome::rp2 {}  // namespace esphome::rp2

--- a/esphome/components/rp2/crash_handler.cpp
+++ b/esphome/components/rp2/crash_handler.cpp
@@ -64,7 +64,7 @@ static struct CrashData {
   uint32_t sp;
   uint32_t backtrace[MAX_BACKTRACE];
   uint8_t backtrace_count;
-} s_crash_data __attribute__((section(".noinit")));
+} s_crash_data __attribute__((section(".noinit")));  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 bool crash_handler_has_data() { return s_crash_data.valid; }
 

--- a/esphome/components/rp2/hal.cpp
+++ b/esphome/components/rp2/hal.cpp
@@ -20,8 +20,7 @@ namespace esphome {
 // arch_feed_wdt(), arch_get_cpu_cycle_count() inlined in components/rp2/hal.h.
 void arch_restart() {
   watchdog_reboot(0, 0, 10);
-  while (1) {
-    continue;
+  while (true) {
   }
 }
 

--- a/esphome/components/rp2/hal.h
+++ b/esphome/components/rp2/hal.h
@@ -17,13 +17,13 @@ extern "C" unsigned long micros(void);
 extern "C" unsigned long millis(void);
 // NOLINTEND(google-runtime-int,readability-identifier-naming,readability-redundant-declaration)
 
-// Forward decl from <pico/time.h>.
+// Forward decls from <pico/time.h> and the pico-sdk / FreeRTOS port for the
+// inline arch_* wrappers below.
+// NOLINTBEGIN(google-runtime-int,readability-identifier-naming,readability-redundant-declaration)
 extern "C" uint64_t time_us_64(void);
-
-// Forward decls from pico-sdk / FreeRTOS port for the inline arch_*
-// wrappers below.
 extern "C" void watchdog_update(void);
 extern "C" unsigned long ulMainGetRunTimeCounterValue(void);
+// NOLINTEND(google-runtime-int,readability-identifier-naming,readability-redundant-declaration)
 
 namespace esphome::rp2 {}
 

--- a/esphome/components/rp2/preferences.cpp
+++ b/esphome/components/rp2/preferences.cpp
@@ -26,6 +26,7 @@ static bool s_flash_dirty = false;               // NOLINT(cppcoreguidelines-avo
 // No preference can exceed the total flash storage, so stack buffer covers all cases.
 static constexpr size_t PREF_MAX_BUFFER_SIZE = RP2040_FLASH_STORAGE_SIZE;
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 extern "C" uint8_t _EEPROM_start;
 
 template<class It> uint8_t calculate_crc(It first, It last, uint32_t type) {
@@ -38,9 +39,9 @@ template<class It> uint8_t calculate_crc(It first, It last, uint32_t type) {
 }
 
 bool RP2PreferenceBackend::save(const uint8_t *data, size_t len) {
-  const size_t buffer_size = len + 1;
-  if (buffer_size > PREF_MAX_BUFFER_SIZE)
+  if (len >= PREF_MAX_BUFFER_SIZE)
     return false;
+  const size_t buffer_size = len + 1;
   uint8_t buffer[PREF_MAX_BUFFER_SIZE];
   memcpy(buffer, data, len);
   buffer[len] = calculate_crc(buffer, buffer + len, this->type);
@@ -59,9 +60,9 @@ bool RP2PreferenceBackend::save(const uint8_t *data, size_t len) {
 }
 
 bool RP2PreferenceBackend::load(uint8_t *data, size_t len) {
-  const size_t buffer_size = len + 1;
-  if (buffer_size > PREF_MAX_BUFFER_SIZE)
+  if (len >= PREF_MAX_BUFFER_SIZE)
     return false;
+  const size_t buffer_size = len + 1;
   uint8_t buffer[PREF_MAX_BUFFER_SIZE];
 
   for (size_t i = 0; i < buffer_size; i++) {

--- a/esphome/components/rp2/printf_stubs.cpp
+++ b/esphome/components/rp2/printf_stubs.cpp
@@ -33,8 +33,8 @@ static int write_printf_buffer(FILE *stream, char *buf, int len) {
   if (write_len >= PRINTF_BUFFER_SIZE) {
     fwrite(buf, 1, PRINTF_BUFFER_SIZE - 1, stream);
     // Use fwrite for the message to avoid recursive __wrap_printf call
-    static const char msg[] = "\nprintf buffer overflow\n";
-    fwrite(msg, 1, sizeof(msg) - 1, stream);
+    static const char MSG[] = "\nprintf buffer overflow\n";
+    fwrite(MSG, 1, sizeof(MSG) - 1, stream);
     abort();
   }
   if (fwrite(buf, 1, write_len, stream) < write_len || ferror(stream)) {

--- a/esphome/components/rp2040_ble/rp2040_ble.cpp
+++ b/esphome/components/rp2040_ble/rp2040_ble.cpp
@@ -35,10 +35,10 @@ void RP2040BLE::enable() {
     l2cap_init();
     sm_init();
 
-    this->hci_event_callback_registration_.callback = &RP2040BLE::packet_handler_;
+    this->hci_event_callback_registration_.callback = &RP2040BLE::packet_handler;
     hci_add_event_handler(&this->hci_event_callback_registration_);
 
-    this->sm_event_callback_registration_.callback = &RP2040BLE::packet_handler_;
+    this->sm_event_callback_registration_.callback = &RP2040BLE::packet_handler;
     sm_add_event_handler(&this->sm_event_callback_registration_);
 
     this->btstack_initialized_ = true;
@@ -95,7 +95,7 @@ void RP2040BLE::dump_config() {
 
 float RP2040BLE::get_setup_priority() const { return setup_priority::BLUETOOTH; }
 
-void RP2040BLE::packet_handler_(uint8_t type, uint16_t channel, uint8_t *packet, uint16_t size) {
+void RP2040BLE::packet_handler(uint8_t type, uint16_t channel, uint8_t *packet, uint16_t size) {
   if (global_ble == nullptr) {
     return;
   }

--- a/esphome/components/rp2040_ble/rp2040_ble.h
+++ b/esphome/components/rp2040_ble/rp2040_ble.h
@@ -32,7 +32,7 @@ class RP2040BLE final : public Component {
   void set_enable_on_boot(bool enable_on_boot) { this->enable_on_boot_ = enable_on_boot; }
 
  protected:
-  static void packet_handler_(uint8_t type, uint16_t channel, uint8_t *packet, uint16_t size);
+  static void packet_handler(uint8_t type, uint16_t channel, uint8_t *packet, uint16_t size);
 
   btstack_packet_callback_registration_t hci_event_callback_registration_{};
   btstack_packet_callback_registration_t sm_event_callback_registration_{};

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -14,26 +14,15 @@
 
 namespace esphome::rp2040_pio_led_strip {
 
-static const char *TAG = "rp2040_pio_led_strip";
-
-static uint8_t num_instance_[2] = {0, 0};
-static std::map<Chipset, uint> chipset_offsets_ = {
-    {CHIPSET_WS2812, 0}, {CHIPSET_WS2812B, 0}, {CHIPSET_SK6812, 0}, {CHIPSET_SM16703, 0}, {CHIPSET_CUSTOM, 0},
-};
-static std::map<Chipset, bool> conf_count_ = {
-    {CHIPSET_WS2812, false},  {CHIPSET_WS2812B, false}, {CHIPSET_SK6812, false},
-    {CHIPSET_SM16703, false}, {CHIPSET_CUSTOM, false},
-};
-static bool dma_chan_active_[12];
-static struct semaphore dma_write_complete_sem_[12];
+static const char *const TAG = "rp2040_pio_led_strip";
 
 // DMA interrupt service routine
-void RP2040PIOLEDStripLightOutput::dma_write_complete_handler_() {
+void RP2040PIOLEDStripLightOutput::dma_write_complete_handler() {
   uint32_t channel = dma_hw->ints0;
   for (uint dma_chan = 0; dma_chan < 12; ++dma_chan) {
-    if (RP2040PIOLEDStripLightOutput::dma_chan_active_[dma_chan] && (channel & (1u << dma_chan))) {
-      dma_hw->ints0 = (1u << dma_chan);                                               // Clear the interrupt
-      sem_release(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem_[dma_chan]);  // Handle the interrupt
+    if (RP2040PIOLEDStripLightOutput::dma_chan_active[dma_chan] && (channel & (1u << dma_chan))) {
+      dma_hw->ints0 = (1u << dma_chan);                                              // Clear the interrupt
+      sem_release(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem[dma_chan]);  // Handle the interrupt
     }
   }
 }
@@ -69,22 +58,22 @@ void RP2040PIOLEDStripLightOutput::setup() {
   // but there are only 4 state machines on each PIO so we can only have 4 strips per PIO
   uint offset = 0;
 
-  if (RP2040PIOLEDStripLightOutput::num_instance_[this->pio_ == pio0 ? 0 : 1] >= 4) {
+  if (RP2040PIOLEDStripLightOutput::num_instance[this->pio_ == pio0 ? 0 : 1] >= 4) {
     ESP_LOGE(TAG, "Too many instances of PIO program");
     this->mark_failed();
     return;
   }
   // keep track of how many instances of the PIO program are running on each PIO
-  RP2040PIOLEDStripLightOutput::num_instance_[this->pio_ == pio0 ? 0 : 1]++;
+  RP2040PIOLEDStripLightOutput::num_instance[this->pio_ == pio0 ? 0 : 1]++;
 
   // if there are multiple strips of the same chipset, we can reuse the same PIO program and save space
-  if (this->conf_count_[this->chipset_]) {
-    offset = RP2040PIOLEDStripLightOutput::chipset_offsets_[this->chipset_];
+  if (RP2040PIOLEDStripLightOutput::conf_count[this->chipset_]) {
+    offset = RP2040PIOLEDStripLightOutput::chipset_offsets[this->chipset_];
   } else {
     // Load the assembled program into the PIO and get its location in the PIO's instruction memory and save it
     offset = pio_add_program(this->pio_, this->program_);
-    RP2040PIOLEDStripLightOutput::chipset_offsets_[this->chipset_] = offset;
-    RP2040PIOLEDStripLightOutput::conf_count_[this->chipset_] = true;
+    RP2040PIOLEDStripLightOutput::chipset_offsets[this->chipset_] = offset;
+    RP2040PIOLEDStripLightOutput::conf_count[this->chipset_] = true;
   }
 
   // Configure the state machine's PIO, and start it
@@ -106,7 +95,7 @@ void RP2040PIOLEDStripLightOutput::setup() {
   }
 
   // Mark the DMA channel as active
-  RP2040PIOLEDStripLightOutput::dma_chan_active_[this->dma_chan_] = true;
+  RP2040PIOLEDStripLightOutput::dma_chan_active[this->dma_chan_] = true;
 
   this->dma_config_ = dma_channel_get_default_config(this->dma_chan_);
   channel_config_set_transfer_data_size(
@@ -125,11 +114,11 @@ void RP2040PIOLEDStripLightOutput::setup() {
   );
 
   // Initialize the semaphore for this DMA channel
-  sem_init(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem_[this->dma_chan_], 1, 1);
+  sem_init(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem[this->dma_chan_], 1, 1);
 
-  irq_set_exclusive_handler(DMA_IRQ_0, dma_write_complete_handler_);  // after DMA all data, raise an interrupt
-  dma_channel_set_irq0_enabled(this->dma_chan_, true);                // map DMA channel to interrupt
-  irq_set_enabled(DMA_IRQ_0, true);                                   // enable interrupt
+  irq_set_exclusive_handler(DMA_IRQ_0, dma_write_complete_handler);  // after DMA all data, raise an interrupt
+  dma_channel_set_irq0_enabled(this->dma_chan_, true);               // map DMA channel to interrupt
+  irq_set_enabled(DMA_IRQ_0, true);                                  // enable interrupt
 
   this->init_(this->pio_, this->sm_, offset, this->pin_, this->max_refresh_rate_);
 }
@@ -148,12 +137,12 @@ void RP2040PIOLEDStripLightOutput::write_state(light::LightState *state) {
   }
 
   // the bits are already in the correct order for the pio program so we can just copy the buffer using DMA
-  sem_acquire_blocking(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem_[this->dma_chan_]);
+  sem_acquire_blocking(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem[this->dma_chan_]);
   dma_channel_transfer_from_buffer_now(this->dma_chan_, this->buf_, this->get_buffer_size_());
 }
 
 light::ESPColorView RP2040PIOLEDStripLightOutput::get_view_internal(int32_t index) const {
-  int32_t r = 0, g = 0, b = 0, w = 0;
+  int32_t r = 0, g = 0, b = 0;
   switch (this->rgb_order_) {
     case ORDER_RGB:
       r = 0;

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -95,7 +95,7 @@ class RP2040PIOLEDStripLightOutput final : public light::AddressableLight {
 
   size_t get_buffer_size_() const { return this->num_leds_ * (3 + this->is_rgbw_); }
 
-  static void dma_write_complete_handler_();
+  static void dma_write_complete_handler();
 
   uint8_t *buf_{nullptr};
   uint8_t *effect_data_{nullptr};
@@ -119,11 +119,11 @@ class RP2040PIOLEDStripLightOutput final : public light::AddressableLight {
   init_fn init_;
 
  private:
-  inline static int num_instance_[2];
-  inline static std::map<Chipset, bool> conf_count_;
-  inline static std::map<Chipset, int> chipset_offsets_;
-  inline static bool dma_chan_active_[12];
-  inline static struct semaphore dma_write_complete_sem_[12];
+  inline static int num_instance[2];
+  inline static std::map<Chipset, bool> conf_count;
+  inline static std::map<Chipset, int> chipset_offsets;
+  inline static bool dma_chan_active[12];
+  inline static struct semaphore dma_write_complete_sem[12];
 };
 
 }  // namespace esphome::rp2040_pio_led_strip

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -819,7 +819,7 @@ class WiFiComponent final : public Component {
 
 #ifdef USE_RP2
   static int s_wifi_scan_result(void *env, const cyw43_ev_scan_result_t *result);
-  void wifi_scan_result(void *env, const cyw43_ev_scan_result_t *result);
+  void wifi_scan_result_(void *env, const cyw43_ev_scan_result_t *result);
 #endif
 
 #ifdef USE_LIBRETINY

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -109,10 +109,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   // setup depends on begin() succeeding. beginNoBlock() skips the outer wait loop, saving
   // up to 20 additional seconds of blocking per attempt.
   auto ret = WiFi.beginNoBlock(ap.ssid_.c_str(), ap.password_.c_str());
-  if (ret == WL_IDLE_STATUS)
-    return false;
-
-  return true;
+  return ret != WL_IDLE_STATUS;
 }
 
 bool WiFiComponent::wifi_sta_pre_setup_() { return this->wifi_mode_(true, {}); }
@@ -169,11 +166,11 @@ WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
 }
 
 int WiFiComponent::s_wifi_scan_result(void *env, const cyw43_ev_scan_result_t *result) {
-  global_wifi_component->wifi_scan_result(env, result);
+  global_wifi_component->wifi_scan_result_(env, result);
   return 0;
 }
 
-void WiFiComponent::wifi_scan_result(void *env, const cyw43_ev_scan_result_t *result) {
+void WiFiComponent::wifi_scan_result_(void *env, const cyw43_ev_scan_result_t *result) {
   s_scan_result_count++;
 
   // CYW43 scan results have ssid as a 32-byte buffer that is NOT null-terminated.
@@ -282,7 +279,7 @@ network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
   // Filter out AP interface addresses — addrList includes all lwIP netifs.
   // The AP netif IP lingers even after the AP radio is disabled.
   IPAddress ap_ip = WiFi.softAPIP();
-  for (auto addr : addrList) {
+  for (const auto &addr : addrList) {
     IPAddress ip(addr.ipFromNetifNum());
     if (ip == ap_ip) {
       continue;
@@ -351,12 +348,11 @@ bool WiFiComponent::wifi_loop_() {
 
   // Detect IP address changes (only when connected)
   if (is_connected) {
-    bool has_ip = false;
-    // Check for any IP address (IPv4 or IPv6)
-    for (auto addr : addrList) {
-      has_ip = true;
-      break;
-    }
+    // Check for any IP address (IPv4 or IPv6). The iterator comparison
+    // operators take non-const references, so the temporaries need names.
+    auto addr_it = addrList.begin();
+    auto addr_end = addrList.end();
+    bool has_ip = addr_it != addr_end;
 
     if (has_ip && !s_sta_had_ip) {
       // Just got IP address

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -6,7 +6,17 @@ import esphome.codegen as cg
 from esphome.components import time
 from esphome.components.esp32 import CORE, add_idf_sdkconfig_option
 import esphome.config_validation as cv
-from esphome.const import CONF_ADDRESS, CONF_ID, CONF_REBOOT_TIMEOUT, CONF_TIME_ID
+from esphome.const import (
+    CONF_ADDRESS,
+    CONF_ID,
+    CONF_REBOOT_TIMEOUT,
+    CONF_TIME_ID,
+    PLATFORM_BK72XX,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_LN882X,
+    PLATFORM_RTL87XX,
+)
 from esphome.core import TimePeriod
 
 CONF_NETMASK = "netmask"
@@ -57,30 +67,41 @@ def _cidr_network(value):
     return value
 
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(Wireguard),
-        cv.GenerateID(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
-        cv.Required(CONF_ADDRESS): cv.ipv4address,
-        cv.Optional(CONF_NETMASK, default="255.255.255.255"): cv.ipv4address,
-        cv.Required(CONF_PRIVATE_KEY): _wireguard_key,
-        cv.Required(CONF_PEER_ENDPOINT): cv.string,
-        cv.Required(CONF_PEER_PUBLIC_KEY): _wireguard_key,
-        cv.Optional(CONF_PEER_PORT, default=51820): cv.port,
-        cv.Optional(CONF_PEER_PRESHARED_KEY): _wireguard_key,
-        cv.Optional(CONF_PEER_ALLOWED_IPS, default=["0.0.0.0/0"]): cv.ensure_list(
-            _cidr_network
-        ),
-        cv.Optional(CONF_PEER_PERSISTENT_KEEPALIVE, default="0s"): cv.All(
-            cv.positive_time_period_seconds,
-            cv.Range(max=TimePeriod(seconds=65535)),
-        ),
-        cv.Optional(
-            CONF_REBOOT_TIMEOUT, default="15min"
-        ): cv.positive_time_period_milliseconds,
-        cv.Optional(CONF_REQUIRE_CONNECTION_TO_PROCEED, default=False): cv.boolean,
-    }
-).extend(cv.polling_component_schema("10s"))
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Wireguard),
+            cv.GenerateID(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
+            cv.Required(CONF_ADDRESS): cv.ipv4address,
+            cv.Optional(CONF_NETMASK, default="255.255.255.255"): cv.ipv4address,
+            cv.Required(CONF_PRIVATE_KEY): _wireguard_key,
+            cv.Required(CONF_PEER_ENDPOINT): cv.string,
+            cv.Required(CONF_PEER_PUBLIC_KEY): _wireguard_key,
+            cv.Optional(CONF_PEER_PORT, default=51820): cv.port,
+            cv.Optional(CONF_PEER_PRESHARED_KEY): _wireguard_key,
+            cv.Optional(CONF_PEER_ALLOWED_IPS, default=["0.0.0.0/0"]): cv.ensure_list(
+                _cidr_network
+            ),
+            cv.Optional(CONF_PEER_PERSISTENT_KEEPALIVE, default="0s"): cv.All(
+                cv.positive_time_period_seconds,
+                cv.Range(max=TimePeriod(seconds=65535)),
+            ),
+            cv.Optional(
+                CONF_REBOOT_TIMEOUT, default="15min"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_REQUIRE_CONNECTION_TO_PROCEED, default=False): cv.boolean,
+        }
+    ).extend(cv.polling_component_schema("10s")),
+    cv.only_on(
+        [
+            PLATFORM_ESP32,
+            PLATFORM_ESP8266,
+            PLATFORM_BK72XX,
+            PLATFORM_RTL87XX,
+            PLATFORM_LN882X,
+        ]
+    ),
+)
 
 
 async def to_code(config):

--- a/esphome/components/wled/wled_light_effect.h
+++ b/esphome/components/wled/wled_light_effect.h
@@ -8,7 +8,15 @@
 #include <vector>
 #include <memory>
 
+#ifdef USE_RP2
+// arduino-pico's UDP lives in the arduino namespace
+namespace arduino {
 class UDP;
+}  // namespace arduino
+using arduino::UDP;  // NOLINT(google-global-names-in-headers)
+#else
+class UDP;
+#endif
 
 namespace esphome::wled {
 

--- a/esphome/components/wled/wled_light_effect.h
+++ b/esphome/components/wled/wled_light_effect.h
@@ -9,7 +9,6 @@
 #include <memory>
 
 #ifdef USE_RP2
-// arduino-pico's UDP lives in the arduino namespace
 namespace arduino {
 class UDP;
 }  // namespace arduino

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -205,8 +205,11 @@
 #define MAX_API_CONNECTIONS 6
 #define USE_MD5
 #define USE_SHA256
+#ifndef USE_RP2  // no MQTT backend or esp_wireguard library on RP2
 #define USE_MQTT
 #define USE_MQTT_COVER_JSON
+#define USE_WIREGUARD
+#endif
 #define USE_RTTTL_FINISHED_PLAYBACK_CALLBACK
 #define USE_RUNTIME_IMAGE_BMP
 #define USE_RUNTIME_IMAGE_PNG
@@ -219,7 +222,6 @@
 #define USE_WIFI
 #define USE_WIFI_AP
 #define USE_WIFI_MANUAL_IP
-#define USE_WIREGUARD
 #endif
 
 // Arduino-specific feature flags
@@ -429,6 +431,11 @@
 #ifndef USE_ETHERNET_SPI
 #define USE_ETHERNET_SPI
 #endif
+#define USE_ETHERNET_W5500
+#define USE_WIFI_IP_STATE_LISTENERS
+#define ESPHOME_WIFI_IP_STATE_LISTENERS 2
+#define USE_ETHERNET_IP_STATE_LISTENERS
+#define ESPHOME_ETHERNET_IP_STATE_LISTENERS 2
 #endif
 
 #ifdef USE_LIBRETINY

--- a/esphome/core/wake/wake_rp2.cpp
+++ b/esphome/core/wake/wake_rp2.cpp
@@ -20,7 +20,7 @@ volatile bool g_main_loop_woke = false;
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static volatile bool s_delay_expired = false;
 
-static int64_t alarm_callback_(alarm_id_t id, void *user_data) {
+static int64_t alarm_callback(alarm_id_t id, void *user_data) {
   (void) id;
   (void) user_data;
   s_delay_expired = true;
@@ -43,7 +43,7 @@ void wakeable_delay(uint32_t ms) {
     return;
   }
   s_delay_expired = false;
-  alarm_id_t alarm = add_alarm_in_ms(ms, alarm_callback_, nullptr, true);
+  alarm_id_t alarm = add_alarm_in_ms(ms, alarm_callback, nullptr, true);
   if (alarm <= 0) {
     delay(ms);
     return;

--- a/platformio.ini
+++ b/platformio.ini
@@ -214,8 +214,19 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ayushsharma82/RPAsyncTCP@1.3.2        ; async_tcp
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
+    WiFi                                  ; wifi (arduino-pico built-in)
+    lwIP_CYW43                            ; wifi (arduino-pico built-in, WiFi dependency)
+    HTTPClient                            ; http_request (arduino-pico built-in)
+    Updater                               ; ota (arduino-pico built-in)
+    MD5Builder                            ; md5 (arduino-pico built-in)
+    LEAmDNS                               ; mdns (arduino-pico built-in)
+    lwIP_w5500                            ; ethernet (arduino-pico built-in)
+    lwIP-Ethernet                         ; ethernet (arduino-pico built-in, lwIP_w5500/lwIP_CYW43 dependency)
+    WebServer                             ; web_server_base (arduino-pico built-in, ESPAsyncWebServer dependency)
+    http-parser                           ; web_server_base (arduino-pico built-in, ESPAsyncWebServer dependency)
 build_flags =
     ${common:arduino.build_flags}
+    -DUSE_RP2
     -DUSE_RP2040
     -DUSE_RP2040_FRAMEWORK_ARDUINO
 build_unflags =
@@ -507,6 +518,17 @@ board = rpipico
 build_flags =
     ${common:rp2040-arduino.build_flags}
     ${flags:runtime.build_flags}
+build_unflags =
+    ${common.build_unflags}
+
+[env:rp2-tidy]
+extends = common:rp2040-arduino
+; The W variant so the cyw43 / WiFi library paths are part of the idedata.
+board = rpipicow
+build_flags =
+    ${common:rp2040-arduino.build_flags}
+    ${flags:clangtidy.build_flags}
+    -DPIO_FRAMEWORK_ARDUINO_ENABLE_BLUETOOTH
 build_unflags =
     ${common.build_unflags}
 

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -99,6 +99,10 @@ def clang_options(idedata, environment):
             "-DCLANG_TIDY",
             # (esp-idf) Fix __once_callable in some libstdc++ headers
             "-D_GLIBCXX_HAVE_TLS",
+            # suppress warning about attribute cannot be applied to type
+            # https://github.com/esp8266/Arduino/pull/8258
+            # also keeps deprecation diagnostics consistent across environments
+            "-Ddeprecated(x)=",
         ]
     )
 
@@ -124,9 +128,6 @@ def clang_options(idedata, environment):
                 # this next one is also needed with upstream pgmspace.h
                 # suppress warning about identifier naming in expansion of this macro
                 "-DPSTRN(s, n)=(s)",
-                # suppress warning about attribute cannot be applied to type
-                # https://github.com/esp8266/Arduino/pull/8258
-                "-Ddeprecated(x)=",
             ]
         )
 

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -29,7 +29,7 @@ from helpers import (
 )
 
 
-def clang_options(idedata):
+def clang_options(idedata, environment):
     cmd = []
 
     # extract target architecture from triplet in g++ filename
@@ -95,29 +95,40 @@ def clang_options(idedata):
         [
             # disable built-in include directories from the host
             "-nostdinc",
-            # replace pgmspace.h, as it uses GNU extensions clang doesn't support
-            # https://github.com/earlephilhower/newlib-xtensa/pull/18
-            "-D_PGMSPACE_H_",
-            "-Dpgm_read_byte(s)=(*(const uint8_t *)(s))",
-            "-Dpgm_read_byte_near(s)=(*(const uint8_t *)(s))",
-            "-Dpgm_read_word(s)=(*(const uint16_t *)(s))",
-            "-Dpgm_read_dword(s)=(*(const uint32_t *)(s))",
-            "-Dpgm_read_ptr(s)=(*(const void *const *)(s))",
-            "-DPROGMEM=",
-            "-DPGM_P=const char *",
-            "-DPSTR(s)=(s)",
-            # this next one is also needed with upstream pgmspace.h
-            # suppress warning about identifier naming in expansion of this macro
-            "-DPSTRN(s, n)=(s)",
-            # suppress warning about attribute cannot be applied to type
-            # https://github.com/esp8266/Arduino/pull/8258
-            "-Ddeprecated(x)=",
             # allow to condition code on the presence of clang-tidy
             "-DCLANG_TIDY",
             # (esp-idf) Fix __once_callable in some libstdc++ headers
             "-D_GLIBCXX_HAVE_TLS",
         ]
     )
+
+    if environment.startswith("rp2"):
+        # clang's ARM backend doesn't know GCC's long_call attribute (IRAM_ATTR)
+        cmd.append("-Wno-unknown-attributes")
+    else:
+        # replace pgmspace.h, as it uses GNU extensions clang doesn't support
+        # https://github.com/earlephilhower/newlib-xtensa/pull/18
+        # arduino-pico ships clang-parseable pgmspace inline functions, so the
+        # replacements are skipped there (they clash with those definitions).
+        cmd.extend(
+            [
+                "-D_PGMSPACE_H_",
+                "-Dpgm_read_byte(s)=(*(const uint8_t *)(s))",
+                "-Dpgm_read_byte_near(s)=(*(const uint8_t *)(s))",
+                "-Dpgm_read_word(s)=(*(const uint16_t *)(s))",
+                "-Dpgm_read_dword(s)=(*(const uint32_t *)(s))",
+                "-Dpgm_read_ptr(s)=(*(const void *const *)(s))",
+                "-DPROGMEM=",
+                "-DPGM_P=const char *",
+                "-DPSTR(s)=(s)",
+                # this next one is also needed with upstream pgmspace.h
+                # suppress warning about identifier naming in expansion of this macro
+                "-DPSTRN(s, n)=(s)",
+                # suppress warning about attribute cannot be applied to type
+                # https://github.com/esp8266/Arduino/pull/8258
+                "-Ddeprecated(x)=",
+            ]
+        )
 
     # Copy compiler flags, dropping: ones clang doesn't understand; -Werror*
     # (clang-tidy enforces .clang-tidy's WarningsAsErrors, and a build -Werror
@@ -207,6 +218,15 @@ def run_tidy(executable, args, options, tmpdir, path_queue, lock, failed_files):
         if sys.stdout.isatty():
             invocation.append("--use-color")
 
+        if args.environment.startswith("rp2"):
+            # MMIO peripheral access on bare-metal RP2 is all fixed-address.
+            # bugprone-pointer-arithmetic-on-polymorphic-object (and its
+            # cert-ctr56-cpp alias) crashes clang-tidy 22 with infinite matcher
+            # recursion on lvgl_esphome.h under the RP2 defines.
+            invocation.append(
+                "--checks=-clang-analyzer-core.FixedAddressDereference,"
+                "-bugprone-pointer-arithmetic-on-polymorphic-object,-cert-ctr56-cpp"
+            )
         invocation.append(f"--header-filter={Path(basepath).resolve()}/.*")
         invocation.append(str(Path(path).resolve()))
         invocation.append("--")
@@ -351,7 +371,7 @@ def main():
 
     # Load idedata and options only if we have files to check
     idedata = load_idedata(args.environment)
-    options = clang_options(idedata)
+    options = clang_options(idedata, args.environment)
 
     tmpdir = None
     if args.fix:


### PR DESCRIPTION
# What does this implement/fix?

Adds an `rp2-tidy` clang-tidy environment and CI job, closing the static-analysis gap for the rp2 platform: roughly 80 files guarded by `USE_RP2` have never been analyzed (comparable in size to the nRF52/Zephyr set that gained a tidy env in #17364). The job follows the esp8266/nrf52 pattern: `--environment rp2-tidy --grep USE_RP2`, PlatformIO-managed toolchain with a `tidyrp2` cache key.

## Environment

- `platformio.ini`: new `[env:rp2-tidy]` on `rpipicow` (the W variant so the cyw43/WiFi paths are in the idedata) with bluetooth enabled for btstack. With `lib_ldf_mode = off` every library must be explicit, so the arduino-pico built-ins used by rp2 code are added to `common:rp2040-arduino` lib_deps (WiFi, HTTPClient, Updater, MD5Builder, LEAmDNS, lwIP w5500/Ethernet, WebServer, http-parser). Also adds the canonical `-DUSE_RP2` next to the legacy `-DUSE_RP2040` alias.
- `script/clang-tidy`: on rp2, skip the esp8266 pgmspace macro replacements (arduino-pico ships clang-parseable inline versions that they clash with), suppress the unknown `long_call` attribute (`IRAM_ATTR`), and disable two checks: `clang-analyzer-core.FixedAddressDereference` (MMIO register access on bare metal is fixed-address by design) and `bugprone-pointer-arithmetic-on-polymorphic-object`/`cert-ctr56-cpp` (crashes clang-tidy 22 with infinite matcher recursion on `lvgl_esphome.h` under rp2 defines).
- `defines.h`: mirror real rp2 codegen (`USE_ETHERNET_W5500`, WiFi/Ethernet IP state listener defines) and exclude `USE_MQTT`/`USE_WIREGUARD`, which have no rp2 backend/library.
- fastled and midea headers are excluded on rp2: their libraries cannot build there (FastLED has no rp2 framework entry; MideaUART's manifest excludes the platform and its headers hard-error on arduino-pico). A failing library include degrades the AST and produces false clang-tidy findings in unrelated headers, so these must be excluded rather than left broken.

## Findings fixed

- `wled`: the global `class UDP;` forward declaration is ambiguous against arduino-pico's `arduino::UDP` — wled currently does not compile on rp2. Fixed with a namespaced forward declaration.
- `rp2040_pio_led_strip`: removed dead file-scope statics duplicating the class members; static members/method renamed per naming convention; removed unused variable.
- `rp2/preferences.cpp`: length guard now rejects `len >= PREF_MAX_BUFFER_SIZE` before computing `len + 1` (a `SIZE_MAX` length would previously pass the check).
- `wifi_component_pico_w.cpp`: boolean simplifications, const-ref loop variable, replaced a loop-with-break emptiness check; `wifi_scan_result` → `wifi_scan_result_` (protected method naming, rp2-only section).
- Naming fixes across rp2 platform files (`packet_handler`, `alarm_callback`, `MSG`, `TAG`), `while (true)` cleanup, and NOLINTs for external linker/SDK symbols (`_EEPROM_start`, `ulMainGetRunTimeCounterValue`), the `.noinit` crash scratch, and the intentionally IDF-mirroring `eth_duplex_t`/`eth_speed_t` enum names.

Full scan is clean locally: 43 rp2 cpp files + the all-headers TU, zero findings. The esp8266 all-headers TU was re-run as a regression check and is also clean.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — CI/static-analysis change, no user-facing configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).