### PR TITLE
[mcp4461] Fix wiper increment/decrement write length

### DIFF
--- a/esphome/components/mcp4461/mcp4461.cpp
+++ b/esphome/components/mcp4461/mcp4461.cpp
@@ -342,7 +342,7 @@ bool Mcp4461Component::increase_wiper_(Mcp4461WiperIdx wiper) {
   ESP_LOGV(TAG, "Increasing wiper %u", wiper_idx);
   uint8_t addr = this->get_wiper_address_(wiper_idx);
   uint8_t reg = addr | static_cast<uint8_t>(Mcp4461Commands::INCREMENT);
-  auto err = this->write(&this->address_, reg);
+  auto err = this->write(&reg, 1);
   if (err != i2c::ERROR_OK) {
     this->error_code_ = MCP4461_STATUS_I2C_ERROR;
     this->status_set_warning();
@@ -373,7 +373,7 @@ bool Mcp4461Component::decrease_wiper_(Mcp4461WiperIdx wiper) {
   ESP_LOGV(TAG, "Decreasing wiper %u", wiper_idx);
   uint8_t addr = this->get_wiper_address_(wiper_idx);
   uint8_t reg = addr | static_cast<uint8_t>(Mcp4461Commands::DECREMENT);
-  auto err = this->write(&this->address_, reg);
+  auto err = this->write(&reg, 1);
   if (err != i2c::ERROR_OK) {
     this->error_code_ = MCP4461_STATUS_I2C_ERROR;
     this->status_set_warning();


### PR DESCRIPTION
# What does this implement/fix?

`increase_wiper_` / `decrease_wiper_` called `this->write(&this->address_, reg)`, but the I2C `write()` signature is `write(const uint8_t *data, size_t len)`. So the command byte `reg` was passed as the **length** and the payload pointer was `&this->address_`.

The result on every wiper increment/decrement:
- `reg` is `wiper_address | INCREMENT/DECREMENT`, i.e. 4–120 depending on the wiper, so the transaction sent that many payload bytes instead of one.
- The first byte sent was `address_` (the device's own I2C address value), not the intended command.
- The remaining bytes were read from memory past the single-byte `address_` member — an out-of-bounds read of adjacent object memory, put on the wire as garbage.
- The intended command byte `reg` was never transmitted; it only determined how many garbage bytes to send.

So the increment/decrement actions never actually worked, and each call also over-read the object. Send the single command byte instead.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

The existing `mcp4461` component test (esp32-idf) compiles with the fix.

## Example entry for `config.yaml`:

```yaml
# No config change; affects mcp4461.increase_wiper / decrease_wiper actions
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).