### PR TITLE
[emc2101] Fix negative external temperatures reported as large positives

### DIFF
--- a/esphome/components/emc2101/emc2101.cpp
+++ b/esphome/components/emc2101/emc2101.cpp
@@ -145,9 +145,9 @@ float Emc2101Component::get_external_temperature() {
     return NAN;
   }
 
-  // join msb and lsb (5 least significant bits are not used)
-  uint16_t raw = (msb << 8 | lsb) >> 5;
-  return raw * 0.125;
+  // join msb and lsb (5 least significant bits are not used); msb is signed, so read as int16_t
+  int16_t raw = static_cast<int16_t>((msb << 8) | lsb) >> 5;
+  return raw * 0.125f;
 }
 
 float Emc2101Component::get_speed() {


### PR DESCRIPTION
# What does this implement/fix?

The EMC2101 external diode temperature is a two's-complement value whose sign lives in the MSB (register 0x01), but `get_external_temperature()` assembled it into a `uint16_t` and treated it as unsigned:

```cpp
uint16_t raw = (msb << 8 | lsb) >> 5;
return raw * 0.125;
```

So any external temperature below 0 °C decoded as a large positive number (e.g. −1 °C reported as ~511 °C). Sign-extend the MSB before the shift so negative temperatures decode correctly:

```cpp
int16_t raw = ((static_cast<int8_t>(msb) << 8) | lsb) >> 5;
return raw * 0.125f;
```

Verified against the datasheet's signed external-diode format: `msb=0xFF, lsb=0x00` → −1.0 °C, `msb=0xFF, lsb=0xE0` → −0.125 °C, and positive readings are unchanged (`0x19` → 25.0 °C). Only manifests below freezing, which is why it went unnoticed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

The existing `emc2101` component test compiles on esp32-idf.

## Example entry for `config.yaml`:

```yaml
# No config change; affects the external temperature reading of the emc2101 sensor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).