### PR TITLE
[atc_mithermometer] Make duplicate-packet counter per-instance

### DIFF
--- a/esphome/components/atc_mithermometer/atc_mithermometer.cpp
+++ b/esphome/components/atc_mithermometer/atc_mithermometer.cpp
@@ -65,12 +65,11 @@ optional<ParseResult> ATCMiThermometer::parse_header_(const esp32_ble_tracker::S
     return {};
   }
 
-  static uint8_t last_frame_count = 0;
-  if (last_frame_count == raw[12]) {
-    ESP_LOGVV(TAG, "parse_header(): duplicate data packet received (%hhu).", last_frame_count);
+  if (this->last_frame_count_ == raw[12]) {
+    ESP_LOGVV(TAG, "parse_header(): duplicate data packet received (%hhu).", this->last_frame_count_);
     return {};
   }
-  last_frame_count = raw[12];
+  this->last_frame_count_ = raw[12];
 
   return result;
 }

--- a/esphome/components/atc_mithermometer/atc_mithermometer.h
+++ b/esphome/components/atc_mithermometer/atc_mithermometer.h
@@ -38,6 +38,8 @@ class ATCMiThermometer final : public Component, public esp32_ble_tracker::ESPBT
   sensor::Sensor *battery_voltage_{nullptr};
   sensor::Sensor *signal_strength_{nullptr};
 
+  uint8_t last_frame_count_{0};
+
   optional<ParseResult> parse_header_(const esp32_ble_tracker::ServiceData &service_data);
   bool parse_message_(const std::vector<uint8_t> &message, ParseResult &result);
   bool report_results_(const optional<ParseResult> &result, const char *address);


### PR DESCRIPTION
# What does this implement/fix?

`parse_header_()` suppressed duplicate advertisements using a function-local `static uint8_t last_frame_count`, which is shared across **all** `atc_mithermometer` instances:

```cpp
static uint8_t last_frame_count = 0;
if (last_frame_count == raw[12]) { ... return {}; }
last_frame_count = raw[12];
```

With more than one thermometer configured, one device's frame counter overwrites the shared value, so a genuinely new frame from another device can be dropped as a "duplicate", and real duplicates can slip through. Moved the counter to a per-instance member so each device tracks its own frame count.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

The existing `atc_mithermometer` component test compiles on esp32-idf.

## Example entry for `config.yaml`:

```yaml
# Two or more thermometers previously shared one duplicate-suppression counter
sensor:
  - platform: atc_mithermometer
    mac_address: "A4:C1:38:AA:AA:AA"
    temperature:
      name: "Room 1 Temperature"
  - platform: atc_mithermometer
    mac_address: "A4:C1:38:BB:BB:BB"
    temperature:
      name: "Room 2 Temperature"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).