### PR TITLE
[zigbee] prevent task watchdog trigger with large configs.

### DIFF
--- a/esphome/components/zigbee/zigbee_attribute_esp32.cpp
+++ b/esphome/components/zigbee/zigbee_attribute_esp32.cpp
@@ -50,25 +50,6 @@ void ZigbeeAttribute::report_(bool has_lock) {
   }
 }
 
-void ZigbeeAttribute::setup_reporting() {
-  ezb_zcl_reporting_info_t reporting_info = ezb_zcl_reporting_info_find(
-      this->endpoint_id_, this->cluster_id_, this->role_, this->attr_id_, EZB_ZCL_STD_MANUF_CODE);
-  if (reporting_info == EZB_ZCL_INVALID_REPORTING_INFO) {
-    ESP_LOGD(TAG, "Could not find reporting info for attribute 0x%04X in cluster 0x%04X in endpoint %u", this->attr_id_,
-             this->cluster_id_, this->endpoint_id_);
-    this->report_enabled = false;
-    this->force_report_ = false;
-  } else {
-    ESP_LOGD(TAG, "Found reporting info for attr 0x%04X in cluster 0x%04X", this->attr_id_, this->cluster_id_);
-    ezb_zcl_attr_variable_t delta = {.u64 = 0};
-    ezb_zcl_reporting_info_update_default_interval(reporting_info, 0, 65000);
-    ezb_zcl_reporting_info_update(reporting_info, 0, 65000, &delta);
-    if (ezb_zcl_reporting_start_attr_report(reporting_info) != EZB_ERR_NONE) {
-      ESP_LOGE(TAG, "Could not start reporting for attribute");
-    }
-  }
-}
-
 void ZigbeeAttribute::set_report(ZigbeeReportT report) {
   this->report_enabled = true;
   if (report == ZigbeeReportT::ZIGBEE_REPORT_FORCE) {

--- a/esphome/components/zigbee/zigbee_attribute_esp32.h
+++ b/esphome/components/zigbee/zigbee_attribute_esp32.h
@@ -42,7 +42,6 @@ class ZigbeeAttribute final : public Component {
         scale_(scale) {}
   void loop() override;
   template<typename T> void add_attr(T value);
-  void setup_reporting();
   template<typename T> void set_attr(const T &value);
   uint8_t attr_type() { return attr_type_; }
   void set_report(ZigbeeReportT report);

--- a/esphome/components/zigbee/zigbee_esp32.cpp
+++ b/esphome/components/zigbee/zigbee_esp32.cpp
@@ -130,8 +130,10 @@ static void zb_action_handler(ezb_zcl_core_action_callback_id_t callback_id, voi
       zb_attribute_handler((ezb_zcl_set_attr_value_message_t *) message);
       break;
     case EZB_ZCL_CORE_DEFAULT_RSP_CB_ID: {
+#ifdef ESPHOME_LOG_HAS_VERBOSE
       ezb_zcl_cmd_default_rsp_message_t *default_rsp = (ezb_zcl_cmd_default_rsp_message_t *) message;
       ESP_LOGV(TAG, "Received ZCL Default Response: 0x%02x", default_rsp->in.status_code);
+#endif
     } break;
     default:
       ESP_LOGD(TAG, "Receive Zigbee action(0x%04x) callback", static_cast<unsigned>(callback_id));
@@ -200,19 +202,25 @@ void ZigbeeComponent::update_basic_cluster_(ezb_af_ep_desc_t ep_desc) {
   ezb_af_endpoint_add_cluster_desc(ep_desc, cluster_desc);
 }
 
-void ZigbeeComponent::register_device() {
+bool ZigbeeComponent::register_device() {
   if (ezb_af_device_desc_register(this->dev_desc_) != EZB_ERR_NONE) {
     ESP_LOGE(TAG, "Could not register the endpoint list");
     this->mark_failed();
-    return;
+    return false;
   }
+  return true;
 }
 
 static void ezb_task(void *pv_parameters) {
-  global_zigbee->register_device();
+  if (!global_zigbee->register_device()) {
+    vTaskDelete(NULL);
+    return;
+  }
   if (esp_zigbee_start(false) != ESP_OK) {
     ESP_LOGE(TAG, "Could not setup Zigbee");
+    global_zigbee->mark_failed();
     vTaskDelete(NULL);
+    return;  // vTaskDelete(NULL) never returns, but keep intent explicit
   }
 
   // Increase priority to 5 to align with openthread or BLE

--- a/esphome/components/zigbee/zigbee_esp32.cpp
+++ b/esphome/components/zigbee/zigbee_esp32.cpp
@@ -53,11 +53,7 @@ bool ZigbeeComponent::app_signal_handler(const ezb_app_signal_t *app_signal) {
   switch (signal_type) {
     case EZB_ZDO_SIGNAL_SKIP_STARTUP:
       ESP_LOGD(TAG, "Zigbee stack initialized");
-      if (ezb_bdb_is_factory_new()) {
-        global_zigbee->defer([]() { global_zigbee->setup_reporting(); });
-      } else {
-        ezb_bdb_start_top_level_commissioning(EZB_BDB_MODE_INITIALIZATION);
-      }
+      ezb_bdb_start_top_level_commissioning(EZB_BDB_MODE_INITIALIZATION);
       break;
     case EZB_BDB_SIGNAL_DEVICE_FIRST_START:
     case EZB_BDB_SIGNAL_DEVICE_REBOOT: {
@@ -133,12 +129,10 @@ static void zb_action_handler(ezb_zcl_core_action_callback_id_t callback_id, voi
     case EZB_ZCL_CORE_SET_ATTR_VALUE_CB_ID:
       zb_attribute_handler((ezb_zcl_set_attr_value_message_t *) message);
       break;
-#ifdef ESPHOME_LOG_HAS_VERBOSE
     case EZB_ZCL_CORE_DEFAULT_RSP_CB_ID: {
       ezb_zcl_cmd_default_rsp_message_t *default_rsp = (ezb_zcl_cmd_default_rsp_message_t *) message;
       ESP_LOGV(TAG, "Received ZCL Default Response: 0x%02x", default_rsp->in.status_code);
     } break;
-#endif
     default:
       ESP_LOGD(TAG, "Receive Zigbee action(0x%04x) callback", static_cast<unsigned>(callback_id));
       break;
@@ -206,21 +200,24 @@ void ZigbeeComponent::update_basic_cluster_(ezb_af_ep_desc_t ep_desc) {
   ezb_af_endpoint_add_cluster_desc(ep_desc, cluster_desc);
 }
 
-void ZigbeeComponent::setup_reporting() {
-  ESP_LOGD(TAG, "Setting up reporting for all attributes");
-  esp_zigbee_lock_acquire(portMAX_DELAY);
-  for (auto &[_, attribute] : this->attributes_) {
-    attribute->setup_reporting();
+void ZigbeeComponent::register_device() {
+  if (ezb_af_device_desc_register(this->dev_desc_) != EZB_ERR_NONE) {
+    ESP_LOGE(TAG, "Could not register the endpoint list");
+    this->mark_failed();
+    return;
   }
-  ezb_bdb_start_top_level_commissioning(EZB_BDB_MODE_INITIALIZATION);
-  esp_zigbee_lock_release();
 }
 
 static void ezb_task(void *pv_parameters) {
+  global_zigbee->register_device();
   if (esp_zigbee_start(false) != ESP_OK) {
     ESP_LOGE(TAG, "Could not setup Zigbee");
     vTaskDelete(NULL);
   }
+
+  // Increase priority to 5 to align with openthread or BLE
+  vTaskPrioritySet(NULL, 5);
+
   esp_zigbee_launch_mainloop();
 
   esp_zigbee_deinit();
@@ -274,12 +271,6 @@ void ZigbeeComponent::setup() {
     return;
   }
 
-  if (ezb_af_device_desc_register(this->dev_desc_) != EZB_ERR_NONE) {
-    ESP_LOGE(TAG, "Could not register the endpoint list");
-    this->mark_failed();
-    return;
-  }
-
   ezb_zcl_core_action_handler_register(zb_action_handler);
 
   if (ezb_bdb_set_primary_channel_set(EZB_PRIMARY_CHANNEL_MASK) != ESP_OK) {
@@ -298,7 +289,8 @@ void ZigbeeComponent::setup() {
   };
   ezb_af_set_node_power_desc(&desc);
 
-  xTaskCreate(ezb_task, "Zigbee_main", 4096, NULL, 24, NULL);
+  // Start the Zigbee task with priority 1 to ensure main loop can still run even if Zigbee is busy
+  xTaskCreate(ezb_task, "Zigbee_main", 4096, NULL, 1, NULL);
   this->disable_loop();  // loop is only needed for processing events, so disable until we join a network
 }
 

--- a/esphome/components/zigbee/zigbee_esp32.h
+++ b/esphome/components/zigbee/zigbee_esp32.h
@@ -42,7 +42,7 @@ class ZigbeeComponent final : public Component {
   void set_basic_cluster(const char *model, const char *manufacturer, uint8_t power_source);
   void add_cluster(uint8_t endpoint_id, uint16_t cluster_id, uint8_t role);
   void create_default_cluster(uint8_t endpoint_id, uint16_t device_id);
-  void setup_reporting();
+  void register_device();
 
   template<typename T>
   void add_attr(ZigbeeAttribute *attr, uint8_t endpoint_id, uint16_t cluster_id, uint8_t role, uint16_t attr_id,

--- a/esphome/components/zigbee/zigbee_esp32.h
+++ b/esphome/components/zigbee/zigbee_esp32.h
@@ -42,7 +42,7 @@ class ZigbeeComponent final : public Component {
   void set_basic_cluster(const char *model, const char *manufacturer, uint8_t power_source);
   void add_cluster(uint8_t endpoint_id, uint16_t cluster_id, uint8_t role);
   void create_default_cluster(uint8_t endpoint_id, uint16_t device_id);
-  void register_device();
+  bool register_device();
 
   template<typename T>
   void add_attr(ZigbeeAttribute *attr, uint8_t endpoint_id, uint16_t cluster_id, uint8_t role, uint16_t attr_id,


### PR DESCRIPTION
# What does this implement/fix?

Move device register into zigbee task and remove setup_reporting. No user facing change.

### Issue 
Configurations with many attributes (>50) trigger task watchdog during setup. Reason is that sdk 2.0 `ezb_af_device_desc_register()` takes very long for configs with many attributes and it keeps the task busy. A secondary issue is that calling `ezb_zcl_reporting_info_find()` many times is also quite slow.

### solution
* Move device register into zigbee task and reduce priority to 1 so it does not block the main task. After registering task priority is increased to 5 which aligns with openthread and ble components.
* Reporting setup is removed completely. As it turns out it is not needed anymore with 2.0 sdk. Default values are fine and in all normal setups the coordinator is overwriting it anyway. Reduces complexity and aligns with nrf52 implementation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
