### PR TITLE
[zigbee] Fix merge endpoint

### DIFF
--- a/esphome/components/zigbee/zigbee_ep_esp32.py
+++ b/esphome/components/zigbee/zigbee_ep_esp32.py
@@ -94,66 +94,74 @@ def get_next_ep_num(eps: list[int]) -> int:
     return ep_num
 
 
-def merge_endpoint(
+def compare_clusters(
+    existing_ep: dict[str, Any],
+    ep: dict[str, Any],
+) -> tuple[int, str] | None:
+    existing_clusters = [(cl[CONF_ID], cl[ROLE]) for cl in existing_ep[CONF_CLUSTERS]]
+    for cl in [(cl[CONF_ID], cl[ROLE]) for cl in ep[CONF_CLUSTERS]]:
+        if cl in existing_clusters:
+            return cl
+    return None
+
+
+def merge_endpoints(
     existing_ep: dict[str, Any],
     ep_num: int | None,
     ep: dict[str, Any],
     use_type: bool | None,
-    skip_error: bool,
 ) -> bool:
-    add = True
-    existing_clusters = [(cl[CONF_ID], cl[ROLE]) for cl in existing_ep[CONF_CLUSTERS]]
-    for cl in [(cl[CONF_ID], cl[ROLE]) for cl in ep[CONF_CLUSTERS]]:
-        if cl in existing_clusters:
-            if not skip_error:
-                raise cv.Invalid(
-                    f"Endpoint {ep_num} has more than one cluster with cluster id {cl[0]} and role {cl[1]}."
-                )
-            add = False
-            break
-    if not add:
+    if compare_clusters(existing_ep, ep):
         return False
-    if (
-        use_type
-        and existing_ep.get(CONF_USE_DEVICE_TYPE)
-        and ep.get(DEVICE_TYPE) != existing_ep.get(DEVICE_TYPE)
-    ):
-        if not skip_error:
-            raise cv.Invalid(
-                f"Endpoint {ep_num} has a conflicting device type {existing_ep.get(DEVICE_TYPE, 'CUSTOM_ATTR')} and use_type is set for both."
-            )
-        return False
-    if use_type:
-        existing_ep[CONF_USE_DEVICE_TYPE] = use_type
-        if ep.get(DEVICE_TYPE):
-            existing_ep[DEVICE_TYPE] = ep[DEVICE_TYPE]
-        else:
-            existing_ep.pop(DEVICE_TYPE, None)
-        existing_ep[CONF_CLUSTERS].extend(ep[CONF_CLUSTERS])
-        return True
-    if existing_ep.get(CONF_USE_DEVICE_TYPE):
-        existing_ep[CONF_CLUSTERS].extend(ep[CONF_CLUSTERS])
-        return True
     if (
         ep.get(DEVICE_TYPE)
         and existing_ep.get(DEVICE_TYPE)
-        and ep[DEVICE_TYPE] != existing_ep[DEVICE_TYPE]
+        and ep.get(DEVICE_TYPE) != existing_ep.get(DEVICE_TYPE)
     ):
-        if not skip_error:
-            raise cv.Invalid(
-                f"Endpoint {ep_num} has already a conflicting device type {existing_ep[DEVICE_TYPE]} and use_type is not set for both."
-            )
         return False
+    if (
+        ep.get(DEVICE_TYPE)
+        and not existing_ep.get(DEVICE_TYPE)
+        and existing_ep.get(CONF_USE_DEVICE_TYPE)
+    ):
+        return False
+    if existing_ep.get(DEVICE_TYPE) and not ep.get(DEVICE_TYPE) and use_type:
+        return False
+    if use_type:
+        existing_ep[CONF_USE_DEVICE_TYPE] = use_type
     if ep.get(DEVICE_TYPE):
         existing_ep[DEVICE_TYPE] = ep[DEVICE_TYPE]
     existing_ep[CONF_CLUSTERS].extend(ep[CONF_CLUSTERS])
     return True
 
 
+def validate_endpoints(ep_dict):
+    for num, ep in ep_dict.items():
+        types_dict = ep.get(CONF_USE_DEVICE_TYPE)
+        if not types_dict:
+            continue
+        if len(types_dict) == 1:
+            ep[DEVICE_TYPE] = list(types_dict.keys())[0]
+            del ep[CONF_USE_DEVICE_TYPE]
+            continue
+        types_list = [t[0] for t in types_dict.items() if t[1]]
+        if len(types_list) > 1:
+            raise cv.Invalid(
+                f"There is more than one component with endpoint: {num} and {CONF_USE_DEVICE_TYPE}: True"
+            )
+        if not types_list:
+            raise cv.Invalid(
+                f"Multiple device types on endpoint: {num}. Set {CONF_USE_DEVICE_TYPE}: True on one component."
+            )
+        ep[DEVICE_TYPE] = types_list[0]
+        del ep[CONF_USE_DEVICE_TYPE]
+
+
 def create_ep(router: bool) -> None:
     zb_data = CORE.data.setdefault(KEY_ZIGBEE, {})
     ep_dict: dict[int, dict] = zb_data.setdefault(KEY_ZIGBEE_EP, {})
     ep_list: list[dict] = zb_data.setdefault(KEY_ZIGBEE_EP_NO_NUM, [])
+    validate_endpoints(ep_dict)
     # create dummy endpoint if list is empty
     if not ep_dict and not ep_list:
         ep_type = "CUSTOM_ATTR"
@@ -166,9 +174,7 @@ def create_ep(router: bool) -> None:
         for ep in ep_list:
             added = False
             for existing_ep in ep_list_new:
-                if merge_endpoint(
-                    existing_ep, None, ep, ep.get(CONF_USE_DEVICE_TYPE), True
-                ):
+                if merge_endpoints(existing_ep, None, ep, ep.get(CONF_USE_DEVICE_TYPE)):
                     added = True
                     break
             if not added:
@@ -191,6 +197,8 @@ def create_ep(router: bool) -> None:
 
 def add_ep(ep: dict[str, Any], ep_num: int | None, use_type: bool | None) -> None:
     zb_data = CORE.data.setdefault(KEY_ZIGBEE, {})
+    if use_type is False:
+        ep.pop(DEVICE_TYPE, None)
     if ep_num is None:
         if use_type:
             ep[CONF_USE_DEVICE_TYPE] = use_type
@@ -201,8 +209,19 @@ def add_ep(ep: dict[str, Any], ep_num: int | None, use_type: bool | None) -> Non
         if ep_num in ep_dict:
             # check if the existing endpoint has same clusters
             existing_ep = ep_dict[ep_num]
-            merge_endpoint(existing_ep, ep_num, ep, use_type, False)
+            if cl := compare_clusters(
+                existing_ep,
+                ep,
+            ):
+                raise cv.Invalid(
+                    f"Endpoint {ep_num} has more than one cluster with cluster id {cl[0]} and role {cl[1]}."
+                )
+            if ep.get(DEVICE_TYPE) or use_type:
+                types_dict = existing_ep.setdefault(CONF_USE_DEVICE_TYPE, {})
+                if not types_dict.get(ep.get(DEVICE_TYPE)) or use_type:
+                    types_dict[ep.get(DEVICE_TYPE)] = use_type
+            existing_ep[CONF_CLUSTERS].extend(ep[CONF_CLUSTERS])
         else:
-            if use_type is not None:
-                ep[CONF_USE_DEVICE_TYPE] = use_type
+            if use_type or ep.get(DEVICE_TYPE):
+                ep[CONF_USE_DEVICE_TYPE] = {ep.get(DEVICE_TYPE): use_type}
             ep_dict[ep_num] = ep

--- a/esphome/components/zigbee/zigbee_ep_esp32.py
+++ b/esphome/components/zigbee/zigbee_ep_esp32.py
@@ -97,7 +97,7 @@ def get_next_ep_num(eps: list[int]) -> int:
 def compare_clusters(
     existing_ep: dict[str, Any],
     ep: dict[str, Any],
-) -> tuple[int, str] | None:
+) -> tuple[str | int, str] | None:
     existing_clusters = [(cl[CONF_ID], cl[ROLE]) for cl in existing_ep[CONF_CLUSTERS]]
     for cl in [(cl[CONF_ID], cl[ROLE]) for cl in ep[CONF_CLUSTERS]]:
         if cl in existing_clusters:
@@ -107,7 +107,6 @@ def compare_clusters(
 
 def merge_endpoints(
     existing_ep: dict[str, Any],
-    ep_num: int | None,
     ep: dict[str, Any],
     use_type: bool | None,
 ) -> bool:
@@ -135,7 +134,7 @@ def merge_endpoints(
     return True
 
 
-def validate_endpoints(ep_dict):
+def validate_endpoints(ep_dict: dict[int, dict]) -> None:
     for num, ep in ep_dict.items():
         types_dict = ep.get(CONF_USE_DEVICE_TYPE)
         if not types_dict:
@@ -174,7 +173,7 @@ def create_ep(router: bool) -> None:
         for ep in ep_list:
             added = False
             for existing_ep in ep_list_new:
-                if merge_endpoints(existing_ep, None, ep, ep.get(CONF_USE_DEVICE_TYPE)):
+                if merge_endpoints(existing_ep, ep, ep.get(CONF_USE_DEVICE_TYPE)):
                     added = True
                     break
             if not added:

--- a/tests/components/zigbee/common_esp32.yaml
+++ b/tests/components/zigbee/common_esp32.yaml
@@ -5,6 +5,7 @@ binary_sensor:
   - platform: template
     name: "Garage Door Open 10"
     report: "default"
+    use_device_type: false
   - platform: template
     name: "Garage Door Open 12"
     report: "force"


### PR DESCRIPTION
# What does this implement/fix?

Fix some issues in the endpoint merging logic and handle explicit `use_device_type: false`.

Testing with #17388 revealed some flaws in the merging logic:
* A config with three components with device type and the last one setting `use_device_type: true` throws validation error because each component is validated individually and the first two are not compatible without the third -> move to final validate.
* Unnumbered components with `use_device_type: true` should not overwrite any other device types
* `use_device_type: false` should always remove the device type of the component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6961

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
