### PR TITLE
[sendspin] Report accurate paused state in media_player

### DIFF
--- a/esphome/components/sendspin/media_player/sendspin_media_player.cpp
+++ b/esphome/components/sendspin/media_player/sendspin_media_player.cpp
@@ -6,6 +6,9 @@
 #include "esphome/core/log.h"
 
 #include <sendspin/types.h>
+#ifdef USE_SENDSPIN_METADATA
+#include <sendspin/metadata_role.h>
+#endif
 
 #include <algorithm>
 #include <cmath>
@@ -19,26 +22,23 @@ namespace esphome::sendspin_ {
 static const char *const TAG = "sendspin.media_player";
 
 // THREAD CONTEXT: Main loop. The callbacks registered here also fire on the main loop,
-// since SendspinHub dispatches group updates and controller state from client_->loop().
+// since SendspinHub dispatches group updates, controller state, and metadata from client_->loop().
 void SendspinMediaPlayer::setup() {
   // Register for group updates to sync playback state
   this->parent_->add_group_update_callback([this](const sendspin::GroupUpdateObject &group_obj) {
     if (group_obj.playback_state.has_value()) {
-      media_player::MediaPlayerState new_state;
-      switch (group_obj.playback_state.value()) {
-        case sendspin::SendspinPlaybackState::PLAYING:
-          new_state = media_player::MEDIA_PLAYER_STATE_PLAYING;
-          break;
-        case sendspin::SendspinPlaybackState::STOPPED:
-        default:
-          new_state = media_player::MEDIA_PLAYER_STATE_IDLE;
-          break;
+      auto new_group_state = group_obj.playback_state.value();
+#ifdef USE_SENDSPIN_METADATA
+      // A fresh metadata update confirming the new track's speed can lag several seconds behind
+      // this group transition. Starting/resuming playback makes any cached pause signal stale -
+      // assume "playing" until fresh metadata says otherwise, rather than showing a stale PAUSED.
+      if (new_group_state == sendspin::SendspinPlaybackState::PLAYING &&
+          this->group_playback_state_ != sendspin::SendspinPlaybackState::PLAYING) {
+        this->playback_speed_ = 1;
       }
-      if (this->state != new_state) {
-        this->state = new_state;
-        this->publish_state();
-        ESP_LOGD(TAG, "State changed to %s", media_player::media_player_state_to_string(this->state));
-      }
+#endif
+      this->group_playback_state_ = new_group_state;
+      this->update_state_();
     }
   });
 
@@ -52,9 +52,49 @@ void SendspinMediaPlayer::setup() {
     }
   });
 
+#ifdef USE_SENDSPIN_METADATA
+  // Only the metadata role's playback progress carries playback_speed and duration, which is how
+  // a paused track becomes observable; the group update alone reports STOPPED for both a paused
+  // and a genuinely empty/idle group, so it can't tell the two apart on its own.
+  this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+    if (!metadata.progress.has_value())
+      return;
+    uint32_t new_speed = metadata.progress.value().playback_speed;
+    uint32_t new_duration = metadata.progress.value().track_duration;
+    if (new_speed != this->playback_speed_ || new_duration != this->track_duration_ms_) {
+      this->playback_speed_ = new_speed;
+      this->track_duration_ms_ = new_duration;
+      this->update_state_();
+    }
+  });
+#endif
+
   // Publish an initial state
   this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
   this->publish_state();
+}
+
+void SendspinMediaPlayer::update_state_() {
+  media_player::MediaPlayerState new_state = media_player::MEDIA_PLAYER_STATE_IDLE;
+  if (this->group_playback_state_ == sendspin::SendspinPlaybackState::PLAYING) {
+    new_state = media_player::MEDIA_PLAYER_STATE_PLAYING;
+  }
+#ifdef USE_SENDSPIN_METADATA
+  // A paused track keeps a known nonzero duration while its progress is frozen (speed 0); this
+  // overrides the base state above regardless of what the group itself reported, since the group
+  // reports STOPPED both when paused and when genuinely idle/empty. Known limitation: some servers
+  // (e.g. Music Assistant, at least for group/queue playback - see music-assistant/support#5813)
+  // report this same signal for an explicit stop, not just pause, since they don't reset or clear
+  // metadata on stop; such a stop is indistinguishable from pause here and is reported as PAUSED.
+  if (this->playback_speed_ == 0 && this->track_duration_ms_ > 0) {
+    new_state = media_player::MEDIA_PLAYER_STATE_PAUSED;
+  }
+#endif
+  if (this->state != new_state) {
+    this->state = new_state;
+    this->publish_state();
+    ESP_LOGD(TAG, "State changed to %s", media_player::media_player_state_to_string(this->state));
+  }
 }
 
 // THREAD CONTEXT: Main loop (invoked by the media_player framework)

--- a/esphome/components/sendspin/media_player/sendspin_media_player.h
+++ b/esphome/components/sendspin/media_player/sendspin_media_player.h
@@ -7,6 +7,8 @@
 #include "esphome/components/media_player/media_player.h"
 #include "esphome/components/sendspin/sendspin_hub.h"
 
+#include <sendspin/types.h>
+
 namespace esphome::sendspin_ {
 
 class SendspinMediaPlayer final : public SendspinChild, public media_player::MediaPlayer {
@@ -25,8 +27,20 @@ class SendspinMediaPlayer final : public SendspinChild, public media_player::Med
   // Receives commands from HA
   void control(const media_player::MediaPlayerCall &call) override;
 
+  // Recomputes `state` from the last known group playback state and (when the metadata role is
+  // available) playback speed/duration, and publishes if it changed. A group can report PLAYING
+  // while the track itself is paused - the server only surfaces that via metadata's
+  // playback_speed, not the group update, so the two have to be combined here rather than each
+  // setting state independently.
+  void update_state_();
+
   float volume_increment_{0.05f};
   bool muted_{false};
+  sendspin::SendspinPlaybackState group_playback_state_{sendspin::SendspinPlaybackState::STOPPED};
+#ifdef USE_SENDSPIN_METADATA
+  uint32_t playback_speed_{0};
+  uint32_t track_duration_ms_{0};
+#endif
 };
 
 }  // namespace esphome::sendspin_

--- a/tests/components/sendspin/common-media_player-paused.yaml
+++ b/tests/components/sendspin/common-media_player-paused.yaml
@@ -1,0 +1,10 @@
+<<: !include common.yaml
+
+media_player:
+  - platform: sendspin
+    id: media_player_id
+
+sensor:
+  - platform: sendspin
+    name: "Sendspin Track Progress"
+    type: track_progress

--- a/tests/components/sendspin/test-media_player-paused.esp32-idf.yaml
+++ b/tests/components/sendspin/test-media_player-paused.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common-media_player-paused.yaml


### PR DESCRIPTION
# What does this implement/fix?

The `sendspin` media_player only looks at the group's `playback_state`, which the protocol only reports as `PLAYING` or `STOPPED` - there is no `PAUSED` value at that level. As a result, pausing a track (while the group/session stays active) was reported as `playing`, never `paused`, even though `MediaPlayerState::MEDIA_PLAYER_STATE_PAUSED` and the generic `on_pause` automation trigger already exist in the base `media_player` component and just weren't being used here.

The actual pause signal exists one layer down: the metadata role's playback progress carries a `playback_speed` field (0 when paused). This is also according to the [sendspin protocol](https://www.sendspin-audio.com/spec/#metadata-messages) that defines paused as `playback_speed == 0`:
> playback_speed: integer - playback speed multiplier * 1000 (e.g., 1000 = normal speed, 1500 = 1.5x speed, 500 = 0.5x speed, 0 = paused)

This PR combines the group's `playback_state` with the metadata role's `playback_speed`/`track_duration` (when the metadata role is enabled on the same hub) to report a real `paused` state instead of `playing`:
- A group reporting `PLAYING` with `playback_speed == 0` is paused (the group is active, the track just isn't advancing).
- A group reporting `STOPPED` with a known nonzero `track_duration` is also paused - the group-level state alone can't distinguish "paused" from "genuinely stopped/empty" (both report `STOPPED`), but a paused track still has a track loaded (known duration), while a truly empty group doesn't.
- A group transitioning to `PLAYING` treats any previously cached pause signal as stale until fresh metadata confirms it, since metadata can lag the group's own state transition by several seconds on resume (observed directly on real hardware - see Known limitations).

When the metadata role isn't configured (a controller-only setup), behavior is unchanged from before - there's no way to observe pausing without it, so it still reports `playing`.

## Known limitations

This has been verified end-to-end on real hardware (a Sendspin display client against a Music Assistant server). A few things surfaced during that testing worth being explicit about:

- **This IS NOT workaround for a temporary bug - Music Assistant, as the reference sendspin server implementation,  documents never sending `paused` at all, permanently.** Music Assistant's own docs state this explicitly ([Specification Compliance and Deviations](https://www.music-assistant.io/player-support/sendspin/#specification-compliance-and-deviations)): *"the `paused` playback_state is never used - only `playing` and `stopped` are sent to clients."* Verified directly on the wire too (via a small bare-metadata-client debug script): a real pause reports group `playback_state: "stopped"`, identical to what a genuine stop reports. So the client-side speed+duration disambiguation this PR adds is durably necessary for interoperating with Music Assistant specifically, at least until they fix this limitation on the server side.
- **A corollary: Music Assistant's Sendspin Server Reference implementations `stop` and `pause` end up indistinguishable from this client's perspective.** Per the sendspin spec, `pause` keeps the current position while `stop` resets it to the beginning - but tracing Music Assistant's `sendspin` provider (`player.py`'s `stop()`), it sets `current_media = None`, which *should* trigger a clean metadata clear (title/artist/duration all reset), but real captured traces show metadata does not clear on a group-level stop - the group's last-known track duration/position just freezes, identically to a real pause. This PR reports `PAUSED` for both, which is still a strict improvement over the prior behavior (which reported neither correctly - see below), and is not a regression: if/when a server clears metadata properly on stop (as this component already handles: duration reads back 0/unknown, falling through to `IDLE`), this will resolve itself with no further client-side changes needed.

None of the above changes the fact that the *previous* behavior (reporting `playing` or `idle` for an actually-paused track) was strictly worse for the common case (a real pause via any controller-role client) - this PR fixes that case unconditionally, and only the ambiguous Music-Assistant-group-stop case remains an open, server-side question.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6964

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sendspin:

media_player:
  - platform: sendspin
    name: "Sendspin Group"

# The metadata role is what makes paused vs. playing observable at all;
# any of these (or a text_sensor: platform: sendspin entry) is enough to enable it.
sensor:
  - platform: sendspin
    name: "Sendspin Track Progress"
    type: track_progress
```

## Checklist:

  - [x] The code change is tested and works locally. (Verified via `script/test_build_components.py -e compile -c sendspin -t esp32-idf --isolate sendspin`, and end-to-end against real hardware - a Sendspin display client running against a live Music Assistant server - confirming PLAYING/PAUSED/resume transitions behave correctly, including the resume-stale-signal guard described above.)
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). (Added `tests/components/sendspin/test-media_player-paused.esp32-idf.yaml`, combining `media_player` with a metadata sensor so CI actually compiles the new code path; the existing `test-media_player` variant continues to cover the metadata-less path.)

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).