### PR TITLE
[deep_sleep] feed watchdog in deep sleep

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_zephyr.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_zephyr.cpp
@@ -1,12 +1,35 @@
 #include "deep_sleep_component.h"
 #ifdef USE_ZEPHYR
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include "esphome/core/wake.h"
 #include <zephyr/sys/poweroff.h>
+#include <algorithm>
 
 namespace esphome::deep_sleep {
 
 static const char *const TAG = "deep_sleep";
+
+// The Zephyr watchdog has a short window (2s, or 10s with Zigbee) and
+// WDT_OPT_PAUSE_IN_SLEEP only pauses it during true hardware sleep — not while a
+// radio thread (e.g. the Zigbee stack) keeps the CPU busy in k_sem_take(). Feed
+// it at least this often while waiting so it does not reset the device.
+static const uint32_t WDT_FEED_INTERVAL_MS = 1000;
+
+static bool wakeable_delay_feed_wdt(uint32_t ms) {
+  while (ms > 0) {
+    const uint32_t step = std::min(ms, WDT_FEED_INTERVAL_MS);
+    esphome::internal::wakeable_delay(step);
+    esphome::arch_feed_wdt();
+    if (esphome::wake_request_take()) {
+      return true;
+    }
+    if (ms != UINT32_MAX) {
+      ms -= step;
+    }
+  }
+  return false;
+}
 
 optional<uint32_t> DeepSleepComponent::get_run_duration_() const { return this->run_duration_; }
 
@@ -15,8 +38,9 @@ void DeepSleepComponent::dump_config_platform_() {}
 bool DeepSleepComponent::prepare_to_sleep_() { return true; }
 
 void DeepSleepComponent::deep_sleep_() {
+  bool woke = false;
   if (this->sleep_duration_.has_value()) {
-    esphome::internal::wakeable_delay(static_cast<uint32_t>(*this->sleep_duration_ / 1000));
+    woke = wakeable_delay_feed_wdt(static_cast<uint32_t>(*this->sleep_duration_ / 1000));
   } else {
 #ifndef USE_ZIGBEE
     // the device can be woken up through one of the following signals:
@@ -29,10 +53,9 @@ void DeepSleepComponent::deep_sleep_() {
     // The system is reset when it wakes up from System OFF mode.
     sys_poweroff();
 #else
-    esphome::internal::wakeable_delay(UINT32_MAX);
+    woke = wakeable_delay_feed_wdt(UINT32_MAX);
 #endif
   }
-  const bool woke = esphome::wake_request_take();
   if (woke) {
     ESP_LOGD(TAG, "Woken up by another thread");
   } else {


### PR DESCRIPTION
# What does this implement/fix?

deep_sleep with sleep_time is reset by watchdog. There is no way to disable watchdog on nrf52840 so it has to be touch in sleeping loop.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
