### PR TITLE
[sendspin] Add on_connect/on_disconnect triggers to the hub

### DIFF
--- a/esphome/components/sendspin/__init__.py
+++ b/esphome/components/sendspin/__init__.py
@@ -7,6 +7,8 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_BUFFER_SIZE,
     CONF_ID,
+    CONF_ON_CONNECT,
+    CONF_ON_DISCONNECT,
     CONF_SAMPLE_RATE,
     CONF_TASK_STACK_IN_PSRAM,
 )
@@ -147,6 +149,10 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(SendspinHub),
             cv.Optional(CONF_TASK_STACK_IN_PSRAM): psram.validate_task_stack_in_psram,
+            cv.Optional(CONF_ON_CONNECT): automation.validate_automation(single=True),
+            cv.Optional(CONF_ON_DISCONNECT): automation.validate_automation(
+                single=True
+            ),
         }
     ),
     cv.only_on_esp32,
@@ -196,6 +202,15 @@ async def to_code(config: ConfigType) -> None:
     if config.get(CONF_TASK_STACK_IN_PSRAM):
         cg.add(var.set_task_stack_in_psram(True))
         psram.request_external_task_stack()
+
+    if on_connect_config := config.get(CONF_ON_CONNECT):
+        await automation.build_automation(
+            var.get_connect_trigger(), [], on_connect_config
+        )
+    if on_disconnect_config := config.get(CONF_ON_DISCONNECT):
+        await automation.build_automation(
+            var.get_disconnect_trigger(), [], on_disconnect_config
+        )
 
     # sendspin-cpp library
     esp32.add_idf_component(name="sendspin/sendspin-cpp", ref="0.6.1")

--- a/esphome/components/sendspin/sendspin_hub.cpp
+++ b/esphome/components/sendspin/sendspin_hub.cpp
@@ -58,7 +58,19 @@ void SendspinHub::setup() {
   }
 }
 
-void SendspinHub::loop() { this->client_->loop(); }
+void SendspinHub::loop() {
+  this->client_->loop();
+  // No push-based "connected" event exists in sendspin-cpp, so poll and edge-detect here.
+  bool is_connected = this->client_->is_connected();
+  if (is_connected != this->was_connected_) {
+    this->was_connected_ = is_connected;
+    if (is_connected) {
+      this->connect_trigger_.trigger();
+    } else {
+      this->disconnect_trigger_.trigger();
+    }
+  }
+}
 
 void SendspinHub::dump_config() {
   char mac_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];

--- a/esphome/components/sendspin/sendspin_hub.h
+++ b/esphome/components/sendspin/sendspin_hub.h
@@ -84,6 +84,11 @@ class SendspinHub final : public Component,
   void loop() override;
   void dump_config() override;
 
+  /// @brief Trigger fired when the client establishes a connection to a Sendspin server.
+  Trigger<> *get_connect_trigger() { return &this->connect_trigger_; }
+  /// @brief Trigger fired when the client loses its connection to a Sendspin server.
+  Trigger<> *get_disconnect_trigger() { return &this->disconnect_trigger_; }
+
   /// @brief Connects the underlying client to the given Sendspin server.
   ///
   /// No-op if the hub's client is not ready (e.g. setup() has not completed).
@@ -209,6 +214,12 @@ class SendspinHub final : public Component,
   CallbackManager<void(const sendspin::GroupUpdateObject &)> group_update_callbacks_{};
 
   bool task_stack_in_psram_{false};
+
+  // sendspin-cpp has no push-based "connected" event, so loop() polls is_connected() and
+  // edge-detects transitions against this to fire connect_trigger_/disconnect_trigger_.
+  Trigger<> connect_trigger_{};
+  Trigger<> disconnect_trigger_{};
+  bool was_connected_{false};
 };
 
 /// @brief Base class for all sendspin subcomponents.

--- a/tests/components/sendspin/common-on-connect.yaml
+++ b/tests/components/sendspin/common-on-connect.yaml
@@ -1,0 +1,8 @@
+<<: !include common.yaml
+sendspin:
+  id: sendspin_hub_id
+  task_stack_in_psram: true
+  on_connect:
+    - logger.log: "Sendspin connected"
+  on_disconnect:
+    - logger.log: "Sendspin disconnected"

--- a/tests/components/sendspin/test-on-connect.esp32-idf.yaml
+++ b/tests/components/sendspin/test-on-connect.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common-on-connect.yaml


### PR DESCRIPTION
# What does this implement/fix?

There was previously no way for YAML automations to detect whether the device has a live connection to a Sendspin server. Client components had to infer it indirectly from side effects (e.g. metadata arriving, a media_player transitioning to `PLAYING`), which handles first boot reasonably but has no way to detect *losing* the connection later (Wi-Fi drop, server restart) - the device just keeps reporting stale state forever with nothing to react to.

`sendspin-cpp`'s `SendspinClient::is_connected()` already exposes what's needed ("true if there is an active connection with completed handshake"), but nothing in `SendspinHub` called it. There's no push-based "connected" event in the library's listener interface, so this has to be polled and edge-detected - the same way ESPHome's own `wifi` component implements its `on_connect`/`on_disconnect` (matched that pattern exactly: `Trigger<>` members + getters on the hub, `automation.build_automation()` wiring in `to_code()`).

```cpp
void SendspinHub::loop() {
  this->client_->loop();
  bool is_connected = this->client_->is_connected();
  if (is_connected != this->was_connected_) {
    this->was_connected_ = is_connected;
    if (is_connected) {
      this->connect_trigger_.trigger();
    } else {
      this->disconnect_trigger_.trigger();
    }
  }
}
```

Verified end-to-end on real hardware (a Sendspin display client against a live Music Assistant server): `on_connect` fired within milliseconds of the library's own "Connection handshake complete" log line on initial connect, and `on_disconnect` fired within milliseconds of "Current connection lost" when the MA server was restarted, with no false triggers during the Wi-Fi association phase before the Sendspin connection itself was established.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6965

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sendspin:
  on_connect:
    - logger.log: "Connected to Sendspin server"
  on_disconnect:
    - logger.log: "Lost connection to Sendspin server"
```

## Checklist:

  - [x] The code change is tested and works locally. (Verified via `script/test_build_components.py -e compile -c sendspin -t esp32-idf --isolate sendspin`, and end-to-end against real hardware - a Sendspin display client running against a live Music Assistant server - confirming both triggers fire correctly on connect and on server restart.)
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). (Added `tests/components/sendspin/test-on-connect.esp32-idf.yaml`, exercising the hub's `on_connect`/`on_disconnect` config with no child roles required.)

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).