### PR TITLE
[mdns] Fix missing device info TXT records when native API is not enabled

### DIFF
--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -51,25 +51,18 @@ void MDNSComponent::setup_buffers_and_register_(PlatformRegisterFn platform_regi
 #ifdef USE_MDNS_STORE_SERVICES
   get_mac_address_into_buffer(this->mac_address_);
   char *mac_ptr = this->mac_address_;
-#else
-  char mac_address[MAC_ADDRESS_BUFFER_SIZE];
-  get_mac_address_into_buffer(mac_address);
-  char *mac_ptr = mac_address;
-#endif
-#else
-  char *mac_ptr = nullptr;
-#endif
-
-#ifdef USE_API
-#ifdef USE_MDNS_STORE_SERVICES
   format_hex_to(this->config_hash_str_, App.get_config_hash());
   char *cfg_ptr = this->config_hash_str_;
 #else
+  char mac_address[MAC_ADDRESS_BUFFER_SIZE];
   char config_hash_str[CONFIG_HASH_STR_SIZE];
+  get_mac_address_into_buffer(mac_address);
   format_hex_to(config_hash_str, App.get_config_hash());
+  char *mac_ptr = mac_address;
   char *cfg_ptr = config_hash_str;
 #endif
 #else
+  char *mac_ptr = nullptr;
   char *cfg_ptr = nullptr;
 #endif
 
@@ -85,12 +78,12 @@ void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUN
 #ifdef USE_MDNS_DEVICE_INFO_TXT
   MDNS_STATIC_CONST_CHAR(TXT_VERSION, "version");
   MDNS_STATIC_CONST_CHAR(TXT_MAC, "mac");
+  MDNS_STATIC_CONST_CHAR(TXT_CONFIG_HASH, "config_hash");
 #endif
 
 #ifdef USE_API
   MDNS_STATIC_CONST_CHAR(SERVICE_ESPHOMELIB, "_esphomelib");
   MDNS_STATIC_CONST_CHAR(TXT_FRIENDLY_NAME, "friendly_name");
-  MDNS_STATIC_CONST_CHAR(TXT_CONFIG_HASH, "config_hash");
   MDNS_STATIC_CONST_CHAR(TXT_PLATFORM, "platform");
   MDNS_STATIC_CONST_CHAR(TXT_BOARD, "board");
   MDNS_STATIC_CONST_CHAR(TXT_NETWORK, "network");
@@ -226,7 +219,8 @@ void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUN
   // Without the native API there is no _esphomelib service, so publish the
   // device info here for the device builder to discover.
   web_service.txt_records = {{MDNS_STR(TXT_VERSION), MDNS_STR(VALUE_VERSION)},
-                             {MDNS_STR(TXT_MAC), MDNS_STR(mac_address_buf)}};
+                             {MDNS_STR(TXT_MAC), MDNS_STR(mac_address_buf)},
+                             {MDNS_STR(TXT_CONFIG_HASH), MDNS_STR(config_hash_buf)}};
 #endif
 #endif
 
@@ -241,7 +235,8 @@ void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUN
   fallback_service.proto = MDNS_STR(SERVICE_TCP);
   fallback_service.port = []() -> uint16_t { return USE_WEBSERVER_PORT; };
   fallback_service.txt_records = {{MDNS_STR(TXT_VERSION), MDNS_STR(VALUE_VERSION)},
-                                  {MDNS_STR(TXT_MAC), MDNS_STR(mac_address_buf)}};
+                                  {MDNS_STR(TXT_MAC), MDNS_STR(mac_address_buf)},
+                                  {MDNS_STR(TXT_CONFIG_HASH), MDNS_STR(config_hash_buf)}};
 #endif
 }
 

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -47,22 +47,29 @@ void MDNSComponent::setup_buffers_and_register_(PlatformRegisterFn platform_regi
   auto &services = services_storage;
 #endif
 
-#ifdef USE_API
+#ifdef USE_MDNS_DEVICE_INFO_TXT
 #ifdef USE_MDNS_STORE_SERVICES
   get_mac_address_into_buffer(this->mac_address_);
   char *mac_ptr = this->mac_address_;
-  format_hex_to(this->config_hash_str_, App.get_config_hash());
-  char *cfg_ptr = this->config_hash_str_;
 #else
   char mac_address[MAC_ADDRESS_BUFFER_SIZE];
-  char config_hash_str[CONFIG_HASH_STR_SIZE];
   get_mac_address_into_buffer(mac_address);
-  format_hex_to(config_hash_str, App.get_config_hash());
   char *mac_ptr = mac_address;
-  char *cfg_ptr = config_hash_str;
 #endif
 #else
   char *mac_ptr = nullptr;
+#endif
+
+#ifdef USE_API
+#ifdef USE_MDNS_STORE_SERVICES
+  format_hex_to(this->config_hash_str_, App.get_config_hash());
+  char *cfg_ptr = this->config_hash_str_;
+#else
+  char config_hash_str[CONFIG_HASH_STR_SIZE];
+  format_hex_to(config_hash_str, App.get_config_hash());
+  char *cfg_ptr = config_hash_str;
+#endif
+#else
   char *cfg_ptr = nullptr;
 #endif
 
@@ -75,12 +82,15 @@ void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUN
   // IMPORTANT: The #ifdef blocks below must match COMPONENTS_WITH_MDNS_SERVICES
   // in mdns/__init__.py. If you add a new service here, update both locations.
 
+#ifdef USE_MDNS_DEVICE_INFO_TXT
+  MDNS_STATIC_CONST_CHAR(TXT_VERSION, "version");
+  MDNS_STATIC_CONST_CHAR(TXT_MAC, "mac");
+#endif
+
 #ifdef USE_API
   MDNS_STATIC_CONST_CHAR(SERVICE_ESPHOMELIB, "_esphomelib");
   MDNS_STATIC_CONST_CHAR(TXT_FRIENDLY_NAME, "friendly_name");
-  MDNS_STATIC_CONST_CHAR(TXT_VERSION, "version");
   MDNS_STATIC_CONST_CHAR(TXT_CONFIG_HASH, "config_hash");
-  MDNS_STATIC_CONST_CHAR(TXT_MAC, "mac");
   MDNS_STATIC_CONST_CHAR(TXT_PLATFORM, "platform");
   MDNS_STATIC_CONST_CHAR(TXT_BOARD, "board");
   MDNS_STATIC_CONST_CHAR(TXT_NETWORK, "network");
@@ -212,12 +222,17 @@ void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUN
   web_service.service_type = MDNS_STR(SERVICE_HTTP);
   web_service.proto = MDNS_STR(SERVICE_TCP);
   web_service.port = []() -> uint16_t { return USE_WEBSERVER_PORT; };
+#ifndef USE_API
+  // Without the native API there is no _esphomelib service, so publish the
+  // device info here for the device builder to discover.
+  web_service.txt_records = {{MDNS_STR(TXT_VERSION), MDNS_STR(VALUE_VERSION)},
+                             {MDNS_STR(TXT_MAC), MDNS_STR(mac_address_buf)}};
+#endif
 #endif
 
 #if !defined(USE_API) && !defined(USE_PROMETHEUS) && !defined(USE_SENDSPIN) && !defined(USE_WEBSERVER) && \
     !defined(USE_MDNS_EXTRA_SERVICES)
   MDNS_STATIC_CONST_CHAR(SERVICE_HTTP, "_http");
-  MDNS_STATIC_CONST_CHAR(TXT_VERSION, "version");
 
   // Publish "http" service if not using native API or any other services
   // This is just to have *some* mDNS service so that .local resolution works
@@ -225,7 +240,8 @@ void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUN
   fallback_service.service_type = MDNS_STR(SERVICE_HTTP);
   fallback_service.proto = MDNS_STR(SERVICE_TCP);
   fallback_service.port = []() -> uint16_t { return USE_WEBSERVER_PORT; };
-  fallback_service.txt_records = {{MDNS_STR(TXT_VERSION), MDNS_STR(VALUE_VERSION)}};
+  fallback_service.txt_records = {{MDNS_STR(TXT_VERSION), MDNS_STR(VALUE_VERSION)},
+                                  {MDNS_STR(TXT_MAC), MDNS_STR(mac_address_buf)}};
 #endif
 }
 

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -70,8 +70,8 @@ void MDNSComponent::setup_buffers_and_register_(PlatformRegisterFn platform_regi
   platform_register(this, services);
 }
 
-void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services, char *mac_address_buf,
-                                     char *config_hash_buf) {
+void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services,
+                                     const char *mac_address_buf, const char *config_hash_buf) {
   // IMPORTANT: The #ifdef blocks below must match COMPONENTS_WITH_MDNS_SERVICES
   // in mdns/__init__.py. If you add a new service here, update both locations.
 

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -24,6 +24,8 @@
 
 // Device info TXT records (version, mac, config_hash) are published on the _esphomelib service
 // when the native API is enabled, otherwise on the _http service (web_server's or the fallback one).
+// When neither applies (only prometheus, sendspin or user-defined services are configured), no
+// device info records are published and the buffers below are not needed.
 #if defined(USE_API) || defined(USE_WEBSERVER) || \
     (!defined(USE_PROMETHEUS) && !defined(USE_SENDSPIN) && !defined(USE_MDNS_EXTRA_SERVICES))
 #define USE_MDNS_DEVICE_INFO_TXT

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -156,8 +156,8 @@ class MDNSComponent final : public Component
   // RP2040 defers MDNS.begin() until the first IP-up event; this tracks that.
   bool initialized_{false};
 #endif
-  void compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services, char *mac_address_buf,
-                        char *config_hash_buf);
+  void compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services, const char *mac_address_buf,
+                        const char *config_hash_buf);
 };
 
 }  // namespace esphome::mdns

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -22,6 +22,13 @@
 #endif
 #endif
 
+// Device info TXT records (version, mac) are published on the _esphomelib service when the
+// native API is enabled, otherwise on the _http service (web_server's or the fallback one).
+#if defined(USE_API) || defined(USE_WEBSERVER) || \
+    (!defined(USE_PROMETHEUS) && !defined(USE_SENDSPIN) && !defined(USE_MDNS_EXTRA_SERVICES))
+#define USE_MDNS_DEVICE_INFO_TXT
+#endif
+
 namespace esphome::mdns {
 
 // Helper struct that identifies strings that may be stored in flash storage (similar to LogString)
@@ -136,9 +143,11 @@ class MDNSComponent final : public Component
   StaticVector<std::string, MDNS_DYNAMIC_TXT_COUNT> dynamic_txt_values_;
 #endif
 
-#if defined(USE_API) && defined(USE_MDNS_STORE_SERVICES)
+#if defined(USE_MDNS_DEVICE_INFO_TXT) && defined(USE_MDNS_STORE_SERVICES)
   /// Fixed buffer for MAC address (only needed when services are stored)
   char mac_address_[MAC_ADDRESS_BUFFER_SIZE];
+#endif
+#if defined(USE_API) && defined(USE_MDNS_STORE_SERVICES)
   /// Fixed buffer for config hash hex string (only needed when services are stored)
   char config_hash_str_[CONFIG_HASH_STR_SIZE];
 #endif

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -22,8 +22,8 @@
 #endif
 #endif
 
-// Device info TXT records (version, mac) are published on the _esphomelib service when the
-// native API is enabled, otherwise on the _http service (web_server's or the fallback one).
+// Device info TXT records (version, mac, config_hash) are published on the _esphomelib service
+// when the native API is enabled, otherwise on the _http service (web_server's or the fallback one).
 #if defined(USE_API) || defined(USE_WEBSERVER) || \
     (!defined(USE_PROMETHEUS) && !defined(USE_SENDSPIN) && !defined(USE_MDNS_EXTRA_SERVICES))
 #define USE_MDNS_DEVICE_INFO_TXT
@@ -146,8 +146,6 @@ class MDNSComponent final : public Component
 #if defined(USE_MDNS_DEVICE_INFO_TXT) && defined(USE_MDNS_STORE_SERVICES)
   /// Fixed buffer for MAC address (only needed when services are stored)
   char mac_address_[MAC_ADDRESS_BUFFER_SIZE];
-#endif
-#if defined(USE_API) && defined(USE_MDNS_STORE_SERVICES)
   /// Fixed buffer for config hash hex string (only needed when services are stored)
   char config_hash_str_[CONFIG_HASH_STR_SIZE];
 #endif

--- a/esphome/components/mdns/mdns_host.cpp
+++ b/esphome/components/mdns/mdns_host.cpp
@@ -15,13 +15,10 @@ void MDNSComponent::setup() {
 #ifdef USE_MDNS_DEVICE_INFO_TXT
   get_mac_address_into_buffer(this->mac_address_);
   char *mac_ptr = this->mac_address_;
-#else
-  char *mac_ptr = nullptr;
-#endif
-#ifdef USE_API
   format_hex_to(this->config_hash_str_, App.get_config_hash());
   char *cfg_ptr = this->config_hash_str_;
 #else
+  char *mac_ptr = nullptr;
   char *cfg_ptr = nullptr;
 #endif
   this->compile_records_(this->services_, mac_ptr, cfg_ptr);

--- a/esphome/components/mdns/mdns_host.cpp
+++ b/esphome/components/mdns/mdns_host.cpp
@@ -12,13 +12,16 @@ namespace esphome::mdns {
 
 void MDNSComponent::setup() {
 #ifdef USE_MDNS_STORE_SERVICES
-#ifdef USE_API
+#ifdef USE_MDNS_DEVICE_INFO_TXT
   get_mac_address_into_buffer(this->mac_address_);
   char *mac_ptr = this->mac_address_;
+#else
+  char *mac_ptr = nullptr;
+#endif
+#ifdef USE_API
   format_hex_to(this->config_hash_str_, App.get_config_hash());
   char *cfg_ptr = this->config_hash_str_;
 #else
-  char *mac_ptr = nullptr;
   char *cfg_ptr = nullptr;
 #endif
   this->compile_records_(this->services_, mac_ptr, cfg_ptr);

--- a/tests/components/mdns/test-fallback.esp32-idf.yaml
+++ b/tests/components/mdns/test-fallback.esp32-idf.yaml
@@ -1,0 +1,7 @@
+# No api, web_server or extra services so the fallback _http service
+# (with version and mac TXT records) is compiled.
+wifi:
+  ssid: MySSID
+  password: password1
+
+mdns:

--- a/tests/components/mdns/test-fallback.esp32-idf.yaml
+++ b/tests/components/mdns/test-fallback.esp32-idf.yaml
@@ -1,5 +1,5 @@
 # No api, web_server or extra services so the fallback _http service
-# (with version and mac TXT records) is compiled.
+# (with version, mac and config_hash TXT records) is compiled.
 wifi:
   ssid: MySSID
   password: password1

--- a/tests/components/mdns/test-webserver-no-api.esp32-idf.yaml
+++ b/tests/components/mdns/test-webserver-no-api.esp32-idf.yaml
@@ -1,0 +1,9 @@
+# web_server without the native api so the version, mac and config_hash
+# TXT records are attached to the web_server _http service.
+wifi:
+  ssid: MySSID
+  password: password1
+
+web_server:
+
+mdns:


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug where adding `web_server` to a config without the native API dropped the `version` TXT record from mDNS; the fallback `_http` service carried `version`, but `web_server` suppresses the fallback and its own `_http` service had no TXT records at all, so the record silently disappeared.

While fixing that, the `_http` service now gets parity with what matters for discovery: `version`, `mac` and `config_hash` are always published when the API is not part of the config, whether the service comes from `web_server` or the fallback. This lets the device builder identify non API devices and show their version; see https://github.com/orgs/esphome/discussions/3763

Configs with the API keep publishing everything on `_esphomelib` as before.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/orgs/esphome/discussions/3763

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# A config without the native api now publishes version and mac via mDNS
mqtt:
  broker: 10.0.0.2

mdns:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
