### PR TITLE
[zigbee] add radio power off stats

### DIFF
--- a/esphome/components/zigbee/zigbee_zephyr.cpp
+++ b/esphome/components/zigbee/zigbee_zephyr.cpp
@@ -229,6 +229,7 @@ void ZigbeeComponent::dump_config() {
                 "  Wipe on boot: %s\n"
                 "  Device is joined to the network: %s\n"
                 "  Sleep time: %us\n"
+                "  Radio sleep time: %us\n"
                 "  RX ON when idle: %s\n"
                 "  Current channel: %d\n"
                 "  Current page: %d\n"
@@ -238,9 +239,10 @@ void ZigbeeComponent::dump_config() {
                 "  Short addr: 0x%04X\n"
                 "  Long pan id: 0x%s\n"
                 "  Short pan id: 0x%04X",
-                get_wipe_on_boot(), YESNO(zb_zdo_joined()), this->sleep_time_, YESNO(zb_get_rx_on_when_idle()),
-                zb_get_current_channel(), zb_get_current_page(), zb_get_sleep_threshold(), role(), ieee_addr_buf,
-                zb_get_short_address(), extended_pan_id_buf, zb_get_pan_id());
+                get_wipe_on_boot(), YESNO(zb_zdo_joined()), this->sleep_time_, this->radio_sleep_time_,
+                YESNO(zb_get_rx_on_when_idle()), zb_get_current_channel(), zb_get_current_page(),
+                zb_get_sleep_threshold(), role(), ieee_addr_buf, zb_get_short_address(), extended_pan_id_buf,
+                zb_get_pan_id());
   dump_reporting_();
 }
 
@@ -250,6 +252,13 @@ static void send_attribute_report(zb_bufid_t bufid, zb_uint16_t cmd_id) {
 }
 
 void ZigbeeComponent::force_report() { this->force_report_ = true; }
+
+void ZigbeeComponent::add_radio_sleep_time_ms(uint32_t ms) {
+  this->radio_sleep_remainder_ += ms;
+  uint32_t seconds = this->radio_sleep_remainder_ / 1000;
+  this->radio_sleep_remainder_ -= seconds * 1000;
+  this->radio_sleep_time_ += seconds;
+}
 
 void ZigbeeComponent::loop() {
   if (this->force_report_) {
@@ -326,6 +335,36 @@ zb_ret_t __wrap_zb_zcl_put_reporting_info_from_req(zb_zcl_configure_reporting_re
   zb_ret_t ret = __real_zb_zcl_put_reporting_info_from_req(config_rep_req, attr_addr_info);
   esphome::zigbee::global_zigbee->after_reporting_info(config_rep_req, attr_addr_info);
   return ret;
+}
+
+extern void __real_zb_trans_enter_sleep(void);
+extern void __real_zb_trans_enter_receive(void);
+extern zb_bool_t __real_zb_trans_transmit(zb_uint8_t wait_type, zb_time_t tx_at, zb_uint8_t *tx_buf,
+                                          zb_uint8_t current_channel);
+
+static uint32_t radio_sleep_start_ms = 0;
+
+static void stop_radio_sleep_timer() {
+  if (radio_sleep_start_ms) {
+    esphome::zigbee::global_zigbee->add_radio_sleep_time_ms(esphome::millis() - radio_sleep_start_ms);
+  }
+  radio_sleep_start_ms = 0;
+}
+
+void __wrap_zb_trans_enter_sleep(void) {
+  __real_zb_trans_enter_sleep();
+  radio_sleep_start_ms = esphome::millis();
+}
+
+void __wrap_zb_trans_enter_receive(void) {
+  stop_radio_sleep_timer();
+  __real_zb_trans_enter_receive();
+}
+
+zb_bool_t __wrap_zb_trans_transmit(zb_uint8_t wait_type, zb_time_t tx_at, zb_uint8_t *tx_buf,
+                                   zb_uint8_t current_channel) {
+  stop_radio_sleep_timer();
+  return __real_zb_trans_transmit(wait_type, tx_at, tx_buf, current_channel);
 }
 // NOLINTEND(readability-identifier-naming,bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 }

--- a/esphome/components/zigbee/zigbee_zephyr.h
+++ b/esphome/components/zigbee/zigbee_zephyr.h
@@ -81,6 +81,7 @@ class ZigbeeComponent final : public Component {
   void force_report();
   void loop() override;
   void set_sleepy(bool sleepy) { this->sleepy_ = sleepy; }
+  void add_radio_sleep_time_ms(uint32_t ms);
 
  protected:
   static void zcl_device_cb(zb_bufid_t bufid);
@@ -94,6 +95,8 @@ class ZigbeeComponent final : public Component {
   bool force_report_{false};
   uint32_t sleep_time_{};
   uint32_t sleep_remainder_{};
+  uint32_t radio_sleep_time_{};
+  uint32_t radio_sleep_remainder_{};
   bool sleepy_{};
 };
 

--- a/esphome/components/zigbee/zigbee_zephyr.py
+++ b/esphome/components/zigbee/zigbee_zephyr.py
@@ -117,6 +117,14 @@ async def zephyr_to_code(config: ConfigType) -> "MockObj":
 
     cg.add_build_flag("-Wl,--wrap=zb_zcl_put_reporting_info_from_req")
 
+    # Wrap the transceiver sleep/receive/transmit calls to measure how long the
+    # radio is powered down. The span between a zb_trans_enter_sleep() and the
+    # following zb_trans_enter_receive() or zb_trans_transmit() is time the
+    # radio spent asleep.
+    cg.add_build_flag("-Wl,--wrap=zb_trans_enter_sleep")
+    cg.add_build_flag("-Wl,--wrap=zb_trans_enter_receive")
+    cg.add_build_flag("-Wl,--wrap=zb_trans_transmit")
+
     if CONF_IEEE802154_VENDOR_OUI in config:
         zephyr_add_prj_conf("IEEE802154_VENDOR_OUI_ENABLE", True)
         random_number = config[CONF_IEEE802154_VENDOR_OUI]


### PR DESCRIPTION
# What does this implement/fix?

show how long radio for zigbee on nrf52840 is powered off

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
