### PR TITLE
Add epaper_spi trigger_full_update action

### DIFF
--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -235,3 +235,27 @@ async def to_code(config):
     )
     if transform_str:
         cg.add(var.set_transform(RawExpression(transform_str)))
+
+
+# Automation
+from esphome import automation
+
+EPaperSPITriggerFullUpdateAction = epaper_spi_ns.class_(
+    "EPaperSPITriggerFullUpdateAction", automation.Action
+)
+
+
+@automation.register_action(
+    "display.epaper_spi.trigger_full_update",
+    EPaperSPITriggerFullUpdateAction,
+    automation.maybe_simple_id(
+        {
+            cv.Required(CONF_ID): cv.use_id(EPaperBase),
+        }
+    ),
+    synchronous=True,
+)
+async def epaper_spi_trigger_full_update_to_code(config, action_id, template_arg, args):
+    display_var = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, display_var)
+    return var

--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -61,6 +61,7 @@ class EPaperBase : public Display,
     this->update_effective_transform_();
   }
   void set_full_update_every(uint8_t full_update_every) { this->full_update_every_ = full_update_every; }
+  void trigger_full_update() { this->update_count_ = 0; }
   void dump_config() override;
 
   void command(uint8_t value);

--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -4,6 +4,7 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/split_buffer/split_buffer.h"
 #include "esphome/core/component.h"
+#include "esphome/core/automation.h"
 
 namespace esphome::epaper_spi {
 using namespace display;
@@ -61,7 +62,7 @@ class EPaperBase : public Display,
     this->update_effective_transform_();
   }
   void set_full_update_every(uint8_t full_update_every) { this->full_update_every_ = full_update_every; }
-  void trigger_full_update() { this->update_count_ = 0; }
+  void set_update_count(uint8_t update_count) { this->update_count_ = update_count; }
   void dump_config() override;
 
   void command(uint8_t value);
@@ -202,6 +203,19 @@ class EPaperBase : public Display,
   EPaperState state_{EPaperState::IDLE};
   uint32_t reset_duration_{10};
   uint8_t full_update_every_{1};
+};
+
+template<typename... Ts> class EPaperSPITriggerFullUpdateAction : public Action<Ts...> {
+ public:
+  explicit EPaperSPITriggerFullUpdateAction(EPaperBase *display) : display_(display) {}
+
+ protected:
+  void play(const Ts &...x) override {
+    this->display_->set_update_count(0);
+    this->display_->update();
+  }
+
+  EPaperBase *display_;
 };
 
 }  // namespace esphome::epaper_spi

--- a/tests/components/epaper_spi/test.esp32-s3-idf.yaml
+++ b/tests/components/epaper_spi/test.esp32-s3-idf.yaml
@@ -3,6 +3,7 @@ packages:
 
 display:
   - platform: epaper_spi
+    id: test_display
     spi_id: spi_bus
     model: spectra-e6
     dimensions:
@@ -232,3 +233,8 @@ display:
       it.filled_rectangle(0, 0, it.get_width(), it.get_height(), Color::WHITE);
       it.circle(it.get_width() / 2, it.get_height() / 2, 100, Color::BLACK);
       it.circle(it.get_width() / 2, it.get_height() / 2, 60, Color(255, 0, 0));
+
+script:
+  - id: test_script
+    then:
+      - display.epaper_spi.trigger_full_update: test_display


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a public `set_update_count(uint8_t count)` method and a native `display.epaper_spi.trigger_full_update` action to the `epaper_spi` component, allowing users to manually force a full update / refresh cycle (by resetting the internal update counter to `0`) directly from YAML configurations (e.g. inside `on_page_change` triggers).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
- none

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**
- esphome/esphome.io#6981

## Test Environment

- [x] ESP32 (Tested on Waveshare 7.50inv2p display)
- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
display:
  - platform: epaper_spi
    id: my_display
    full_update_every: 30
    on_page_change:
      then:
        - display.epaper_spi.trigger_full_update: my_display
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (added configuration validation test coverage to `test.esp32-s3-idf.yaml`).
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
