### PR TITLE
[mipi_rgb] Use dict-style packages in test so it can be batch-grouped

### DIFF
--- a/tests/components/mipi_rgb/test.esp32-s3-idf.yaml
+++ b/tests/components/mipi_rgb/test.esp32-s3-idf.yaml
@@ -1,5 +1,5 @@
 packages:
-  - !include ../../test_build_components/common/i2c/esp32-s3-idf.yaml
+  i2c: !include ../../test_build_components/common/i2c/esp32-s3-idf.yaml
 
 psram:
   mode: octal


### PR DESCRIPTION
# What does this implement/fix?

Converts the `mipi_rgb` test file's i2c include from a list-style package entry to a named dict-style package key. The test-grouping scripts only understand dict-style `packages:`, so with the old list-style form this component was flagged as needing migration and could not be batched with other components sharing the same bus in CI. This change lets it participate in batch grouping, reducing CI build count.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).