### PR TITLE
[mipi_rgb] Test in isolation to avoid bus/pin merge conflicts

### DIFF
--- a/script/analyze_component_buses.py
+++ b/script/analyze_component_buses.py
@@ -90,6 +90,7 @@ ISOLATED_COMPONENTS = {
     "openthread_info": "Conflicts with wifi: used by most components",
     "matrix_keypad": "Needs isolation due to keypad",
     "microphone": "Defines PDM microphone requiring I2S port 0 - conflicts with micro_wake_word PDM mic when merged",
+    "mipi_rgb": "RGB display occupies many GPIOs (including ones used by the shared i2c bus) that conflict when merged with other bus components",
     "modbus_controller": "Defines multiple modbus buses for testing client/server functionality - conflicts with package modbus bus",
     "neopixelbus": "RMT type conflict with ESP32 Arduino/ESP-IDF headers (enum vs struct rmt_channel_t)",
     "packages": "cannot merge packages",


### PR DESCRIPTION
# What does this implement/fix?

CI component grouping intermittently fails on the esp32-s3-idf batch with:

```
ID i2c_bus redefined! Check i2c->0->id.
```

(e.g. https://github.com/esphome/esphome/actions/runs/29209762908/job/86695443714 on the 2026.7.0b2 bump, in the group `gsl3670, mixer, resampler, sound_level, mipi_rgb`).

**Cause:** the `mipi_rgb` display test drives a parallel RGB panel that occupies many GPIOs — for `WAVESHARE-5-1024X600` that includes GPIO17 — plus an i2c bus for `ch422g`. When it gets grouped with another i2c component, the two can't share a single i2c bus:

- `gsl3670` uses `common/i2c/esp32-idf.yaml` (scl 16 / sda 17), because its SPI already uses GPIO9, so it can't use the s3 i2c pins.
- `mipi_rgb` uses `common/i2c/esp32-s3-idf.yaml` (scl 9 / sda 8), because its RGB data lines use GPIO17, so it can't use sda 17.

There is no shared i2c package that satisfies both, so they cannot be merged into one grouped config. It only surfaced now because grouping is dynamic and the release bump marked nearly everything changed, batching `gsl3670` and `mipi_rgb` together; it reproduces on plain `dev`.

**Fix:** add `mipi_rgb` to `ISOLATED_COMPONENTS` so it is validated individually (the same mechanism used for `lvgl`, `modbus_controller`, etc.). With this, the batch groups the remaining components and tests `mipi_rgb` on its own — verified locally: `2 passed, 0 failed`, with `> [GROUPED: gsl3670, mixer, resampler, sound_level]` and `> [mipi_rgb] [test]` separated.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Verified locally with `script/test_build_components.py -c gsl3670,mipi_rgb,mixer,resampler,sound_level -t esp32-s3-idf -e config` (2 passed, mipi_rgb isolated).

## Example entry for `config.yaml`:

```yaml
# CI-only change; no user-facing configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).