### PR TITLE
[gsl3670] Fix i2c package variant in esp32-s3-idf test

### DIFF
--- a/tests/components/gsl3670/test.esp32-s3-idf.yaml
+++ b/tests/components/gsl3670/test.esp32-s3-idf.yaml
@@ -1,5 +1,5 @@
 packages:
-  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+  i2c: !include ../../test_build_components/common/i2c/esp32-s3-idf.yaml
   spi: !include ../../test_build_components/common/spi/esp32-s3-idf.yaml
 
 xl9535:

--- a/tests/components/gsl3670/test.esp32-s3-idf.yaml
+++ b/tests/components/gsl3670/test.esp32-s3-idf.yaml
@@ -10,6 +10,9 @@ display:
     id: gsl3670_display
     spi_id: spi_bus
     model: t-display-s3-pro
+    # The model's default DC pin (GPIO9) clashes with the shared i2c bus SCL
+    # pin, so override it onto a free pin for this test.
+    dc_pin: GPIO5
 
 psram:
   mode: quad


### PR DESCRIPTION
# What does this implement/fix?

The `gsl3670` esp32-s3-idf test file included the `esp32-idf` i2c common package instead of the `esp32-s3-idf` one. Both variants declare an i2c bus with `id: i2c_bus`, but at different pins, so when CI batch-groups `gsl3670` with other s3-idf components (e.g. `mipi_rgb`, which correctly uses the s3-idf i2c package) the config merge aborts with a conflicting-bus error. Pointing the test at the matching `esp32-s3-idf` i2c package lets the grouped build merge and validate cleanly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — test-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).