### PR TITLE
[spi] Software quad and octal SPI on classic ESP32

### DIFF
--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -15,7 +15,6 @@ from esphome.components.esp32 import (
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
-    only_on_variant,
 )
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
@@ -30,6 +29,7 @@ from esphome.const import (
     CONF_MOSI_PIN,
     CONF_NUMBER,
     CONF_SPI_ID,
+    CONF_TYPE,
     KEY_CORE,
     KEY_TARGET_PLATFORM,
     KEY_VARIANT,
@@ -267,6 +267,12 @@ def validate_hw_pins(spi, index=-1):
 
 def get_hw_spi(config, available):
     """Get an available hardware spi interface suitable for this config"""
+    if config[CONF_TYPE] == TYPE_OCTAL and get_target_variant() not in [
+        VARIANT_ESP32P4,
+        VARIANT_ESP32S2,
+        VARIANT_ESP32S3,
+    ]:
+        return None
     matching = list(filter(lambda idx: validate_hw_pins(config, idx), available))
     if len(matching) != 0:
         return matching[0]
@@ -306,12 +312,22 @@ def validate_spi_config(config):
             if index is not None:
                 spi[CONF_INTERFACE_INDEX] = index
                 available.remove(index)
+            else:
+                spi[CONF_INTERFACE] = "software"
         if CONF_INTERFACE_INDEX in spi and not validate_hw_pins(
             spi, spi[CONF_INTERFACE_INDEX]
         ):
             raise cv.Invalid("Invalid pin selections for hardware SPI interface")
-        if CONF_DATA_PINS in spi and CONF_INTERFACE_INDEX not in spi:
-            raise cv.Invalid("Quad and octal modes requires a hardware interface")
+        bus_type = spi[CONF_TYPE]
+        if (
+            bus_type == TYPE_OCTAL
+            and spi[CONF_INTERFACE] != "software"
+            and get_target_variant()
+            not in [VARIANT_ESP32P4, VARIANT_ESP32S2, VARIANT_ESP32S3]
+        ):
+            raise cv.Invalid(
+                "Hardware octal SPI is only supported on ESP32-P4, ESP32-S2 and ESP32-S3; use interface: software"
+            )
 
     return config
 
@@ -357,15 +373,8 @@ def spi_mode_schema(mode):
     if mode == TYPE_SINGLE:
         return SPI_SINGLE_SCHEMA
     pin_count = 4 if mode == TYPE_QUAD else 8
-    onlys = [cv.only_on([PLATFORM_ESP32])]
-    if pin_count == 8:
-        onlys.append(
-            only_on_variant(
-                supported=[VARIANT_ESP32P4, VARIANT_ESP32S2, VARIANT_ESP32S3]
-            )
-        )
     return cv.All(
-        *onlys,
+        cv.only_on([PLATFORM_ESP32]),
         cv.Schema(
             {
                 cv.GenerateID(): cv.declare_id(TYPE_CLASS[mode]),
@@ -376,7 +385,7 @@ def spi_mode_schema(mode):
                 ),
                 cv.Optional(
                     CONF_INTERFACE, default="hardware"
-                ): one_of_interface_validator(["hardware"]),
+                ): one_of_interface_validator(["software", "hardware", "any"]),
                 cv.Optional(CONF_MISO_PIN): cv.invalid(
                     f"'miso_pin' should not be used with {mode} SPI"
                 ),

--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -2,6 +2,10 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
+#ifdef USE_ESP32
+#include "driver/gpio.h"
+#endif
+
 namespace esphome::spi {
 
 const char *const TAG = "spi";
@@ -54,11 +58,13 @@ void SPIComponent::setup() {
       this->mark_failed();
     }
   } else {
-    this->spi_bus_ = new SPIBus(this->clk_pin_, this->sdo_pin_, this->sdi_pin_);  // NOLINT
+    this->spi_bus_ = new SPIBus(this->clk_pin_, this->sdo_pin_, this->sdi_pin_, this->data_pins_);  // NOLINT
     this->clk_pin_->setup();
     this->clk_pin_->digital_write(true);
-    this->sdo_pin_->setup();
-    this->sdi_pin_->setup();
+    if (this->data_pins_.empty()) {
+      this->sdo_pin_->setup();
+      this->sdi_pin_->setup();
+    }
   }
 }
 
@@ -117,6 +123,168 @@ uint16_t SPIDelegateBitBash::transfer_(uint16_t data, size_t num_bits) {
   App.feed_wdt();
   return out_data;
 }
+
+#ifdef USE_ESP32
+void SPIDelegateMultiBitBash::setup_bus_() {
+  if (this->ready_)
+    return;
+
+  const int clk_pin = Utility::get_internal_pin_no(this->clk_pin_);
+  if (clk_pin < 0 || clk_pin > 31) {
+    ESP_LOGE(TAG, "Software quad/octal SPI clock pin must be an internal GPIO0-31 pin");
+    return;
+  }
+  this->clk_mask_ = 1UL << clk_pin;
+  if (Utility::is_inverted(this->clk_pin_)) {
+    this->clock_polarity_ = this->clock_polarity_ == CLOCK_POLARITY_HIGH ? CLOCK_POLARITY_LOW : CLOCK_POLARITY_HIGH;
+  }
+  this->clk_pin_->setup();
+  if (this->clock_polarity_) {
+    GPIO.out_w1ts = this->clk_mask_;
+  } else {
+    GPIO.out_w1tc = this->clk_mask_;
+  }
+
+  if (this->data_pins_.size() != 4 && this->data_pins_.size() != 8) {
+    ESP_LOGE(TAG, "Software multi-bit SPI requires exactly 4 or 8 data pins");
+    return;
+  }
+
+  this->data_clear_mask_ = 0;
+  for (uint8_t pin : this->data_pins_) {
+    if (pin > 31) {
+      ESP_LOGE(TAG, "Software quad/octal SPI data pins must be internal GPIO0-31 pins");
+      return;
+    }
+    gpio_reset_pin(static_cast<gpio_num_t>(pin));
+    gpio_set_direction(static_cast<gpio_num_t>(pin), GPIO_MODE_OUTPUT);
+    GPIO.out_w1tc = 1UL << pin;
+    this->data_clear_mask_ |= 1UL << pin;
+  }
+
+  for (uint16_t value = 0; value < this->data_set_masks_.size(); value++) {
+    uint32_t mask = 0;
+    for (uint8_t bit = 0; bit < this->data_pins_.size(); bit++) {
+      if (value & (1 << bit))
+        mask |= 1UL << this->data_pins_[bit];
+    }
+    this->data_set_masks_[value] = mask;
+  }
+  this->last_transition_ = arch_get_cpu_cycle_count();
+  this->ready_ = true;
+}
+
+uint8_t SPIDelegateMultiBitBash::transfer(uint8_t data) {
+  this->write_array(&data, 1);
+  return 0;
+}
+
+void SPIDelegateMultiBitBash::write_multi_width_(const uint8_t *data, size_t length, uint8_t bus_width) {
+  if (!this->ready_) {
+    ESP_LOGE(TAG, "Software multi-bit SPI bus is not ready");
+    return;
+  }
+  // This is deliberately expanded to avoid call and branch overhead.
+  if (bus_width == 8 && this->data_pins_.size() >= 8) {
+    if (this->clock_polarity_) {
+      while (length-- != 0) {
+        GPIO.out_w1tc = this->data_clear_mask_;
+        GPIO.out_w1ts = this->data_set_masks_[*data++];
+        this->cycle_clock_();
+        GPIO.out_w1tc = this->clk_mask_;
+        this->cycle_clock_();
+        GPIO.out_w1ts = this->clk_mask_;
+      }
+    } else {
+      while (length-- != 0) {
+        GPIO.out_w1tc = this->data_clear_mask_;
+        GPIO.out_w1ts = this->data_set_masks_[*data++];
+        this->cycle_clock_();
+        GPIO.out_w1ts = this->clk_mask_;
+        this->cycle_clock_();
+        GPIO.out_w1tc = this->clk_mask_;
+      }
+    }
+  } else if (bus_width == 4 && this->data_pins_.size() >= 4) {
+    if (this->clock_polarity_) {
+      while (length-- != 0) {
+        const uint8_t value = *data++;
+        GPIO.out_w1tc = this->data_clear_mask_;
+        GPIO.out_w1ts = this->data_set_masks_[value >> 4];
+        this->cycle_clock_();
+        GPIO.out_w1tc = this->clk_mask_;
+        this->cycle_clock_();
+        GPIO.out_w1ts = this->clk_mask_;
+        GPIO.out_w1tc = this->data_clear_mask_;
+        GPIO.out_w1ts = this->data_set_masks_[value & 0x0F];
+        this->cycle_clock_();
+        GPIO.out_w1tc = this->clk_mask_;
+        this->cycle_clock_();
+        GPIO.out_w1ts = this->clk_mask_;
+      }
+    } else {
+      while (length-- != 0) {
+        const uint8_t value = *data++;
+        GPIO.out_w1tc = this->data_clear_mask_;
+        GPIO.out_w1ts = this->data_set_masks_[value >> 4];
+        this->cycle_clock_();
+        GPIO.out_w1ts = this->clk_mask_;
+        this->cycle_clock_();
+        GPIO.out_w1tc = this->clk_mask_;
+        GPIO.out_w1tc = this->data_clear_mask_;
+        GPIO.out_w1ts = this->data_set_masks_[value & 0x0F];
+        this->cycle_clock_();
+        GPIO.out_w1ts = this->clk_mask_;
+        this->cycle_clock_();
+        GPIO.out_w1tc = this->clk_mask_;
+      }
+    }
+  } else {
+    this->write_bits_(0, 0);
+    ESP_LOGE(TAG, "Unsupported software SPI bus width %u for %u data pins", bus_width,
+             (unsigned) this->data_pins_.size());
+  }
+  App.feed_wdt();
+}
+
+void SPIDelegateMultiBitBash::write_bits_(uint32_t data, size_t num_bits) {
+  if (!this->ready_)
+    return;
+  for (size_t i = 0; i < num_bits; i++) {
+    const size_t shift = this->bit_order_ == BIT_ORDER_MSB_FIRST ? num_bits - 1 - i : i;
+    GPIO.out_w1tc = this->data_clear_mask_;
+    GPIO.out_w1ts = this->data_set_masks_[(data >> shift) & 0x01];
+    this->cycle_clock_();
+    if (this->clock_polarity_) {
+      GPIO.out_w1tc = this->clk_mask_;
+      this->cycle_clock_();
+      GPIO.out_w1ts = this->clk_mask_;
+    } else {
+      GPIO.out_w1ts = this->clk_mask_;
+      this->cycle_clock_();
+      GPIO.out_w1tc = this->clk_mask_;
+    }
+  }
+}
+
+void SPIDelegateMultiBitBash::write_cmd_addr_data(size_t cmd_bits, uint32_t cmd, size_t addr_bits, uint32_t address,
+                                                  const uint8_t *data, size_t length, uint8_t bus_width) {
+  this->setup_bus_();
+  if (!this->ready_)
+    return;
+  if (cmd_bits != 0)
+    this->write_bits_(cmd, cmd_bits);
+  if (addr_bits != 0)
+    this->write_bits_(address, addr_bits);
+  if (data != nullptr && length != 0)
+    this->write_multi_width_(data, length, bus_width);
+}
+
+void SPIDelegateMultiBitBash::write_array(const uint8_t *ptr, size_t length) {
+  this->setup_bus_();
+  this->write_multi_width_(ptr, length, this->data_pins_.size());
+}
+#endif
 
 #if !defined(USE_ESP32) && !defined(USE_ARDUINO)
 // Stub for unsupported platforms (host, Zephyr, etc.) - hardware SPI is unavailable

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -4,8 +4,13 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include <map>
+#include <array>
 #include <utility>
 #include <vector>
+
+#ifdef USE_ESP32
+#include "soc/gpio_struct.h"
+#endif
 
 #ifdef USE_ESP32
 
@@ -141,6 +146,16 @@ class Utility {
     if (((InternalGPIOPin *) pin)->is_inverted())
       return -1;
     return ((InternalGPIOPin *) pin)->get_pin();
+  }
+
+  static int get_internal_pin_no(GPIOPin *pin) {
+    if (pin == nullptr || !pin->is_internal())
+      return -1;
+    return ((InternalGPIOPin *) pin)->get_pin();
+  }
+
+  static bool is_inverted(GPIOPin *pin) {
+    return pin != nullptr && pin->is_internal() && ((InternalGPIOPin *) pin)->is_inverted();
   }
 
   static SPIMode get_mode(SPIClockPolarity polarity, SPIClockPhase phase) {
@@ -313,14 +328,61 @@ class SPIDelegateBitBash : public SPIDelegate {
   uint16_t transfer_(uint16_t data, size_t num_bits);
 };
 
+#ifdef USE_ESP32
+class SPIDelegateMultiBitBash : public SPIDelegate {
+ public:
+  SPIDelegateMultiBitBash(uint32_t clock, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin, GPIOPin *clk_pin,
+                          const std::vector<uint8_t> &data_pins)
+      : SPIDelegate(clock, bit_order, mode, cs_pin), clk_pin_(clk_pin), data_pins_(data_pins) {
+    this->wait_cycle_ = uint32_t(arch_get_cpu_freq_hz()) / this->data_rate_ / 2ULL;
+    this->clock_polarity_ = Utility::get_polarity(this->mode_);
+    this->clock_phase_ = Utility::get_phase(this->mode_);
+  }
+
+  bool is_ready() override { return this->ready_; }
+  uint8_t transfer(uint8_t data) override;
+  void write_cmd_addr_data(size_t cmd_bits, uint32_t cmd, size_t addr_bits, uint32_t address, const uint8_t *data,
+                           size_t length, uint8_t bus_width) override;
+  void write_array(const uint8_t *ptr, size_t length) override;
+
+ protected:
+  GPIOPin *clk_pin_;
+  std::vector<uint8_t> data_pins_;
+  std::array<uint32_t, 256> data_set_masks_{};
+  uint32_t data_clear_mask_{0};
+  uint32_t clk_mask_{0};
+  uint32_t last_transition_{0};
+  uint32_t wait_cycle_;
+  SPIClockPolarity clock_polarity_;
+  SPIClockPhase clock_phase_;
+  bool ready_{false};
+
+  void setup_bus_();
+  void HOT cycle_clock_() {
+    while (this->last_transition_ - arch_get_cpu_cycle_count() < this->wait_cycle_)
+      continue;
+    this->last_transition_ += this->wait_cycle_;
+  }
+
+  void write_multi_width_(const uint8_t *data, size_t length, uint8_t bus_width);
+  void write_bits_(uint32_t data, size_t num_bits);
+};
+#endif
+
 class SPIBus {
  public:
   SPIBus() = default;
 
-  SPIBus(GPIOPin *clk, GPIOPin *sdo, GPIOPin *sdi) : clk_pin_(clk), sdo_pin_(sdo), sdi_pin_(sdi) {}
+  SPIBus(GPIOPin *clk, GPIOPin *sdo, GPIOPin *sdi, std::vector<uint8_t> data_pins = {})
+      : clk_pin_(clk), sdo_pin_(sdo), sdi_pin_(sdi), data_pins_(std::move(data_pins)) {}
 
   virtual SPIDelegate *get_delegate(uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin,
                                     bool release_device, bool write_only) {
+#ifdef USE_ESP32
+    if (!this->data_pins_.empty()) {
+      return new SPIDelegateMultiBitBash(data_rate, bit_order, mode, cs_pin, this->clk_pin_, this->data_pins_);
+    }
+#endif
     return new SPIDelegateBitBash(data_rate, bit_order, mode, cs_pin, this->clk_pin_, this->sdo_pin_, this->sdi_pin_);
   }
 
@@ -330,6 +392,7 @@ class SPIBus {
   GPIOPin *clk_pin_{};
   GPIOPin *sdo_pin_{};
   GPIOPin *sdi_pin_{};
+  std::vector<uint8_t> data_pins_{};
 };
 
 class SPIClient;

--- a/tests/components/spi/test.esp32-idf.yaml
+++ b/tests/components/spi/test.esp32-idf.yaml
@@ -1,4 +1,19 @@
 packages:
   spi: !include ../../test_build_components/common/spi/esp32-idf.yaml
 
+spi:
+  - id: octal_sw_spi
+    type: octal
+    interface: software
+    clk_pin: GPIO4
+    data_pins:
+      - GPIO12
+      - GPIO13
+      - GPIO26
+      - GPIO25
+      - GPIO19
+      - GPIO18
+      - GPIO27
+      - GPIO14
+
 <<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

This allows setting `interface: software` for quad and octal SPI. On ESP32-S2/S3/P4 this is mostly unnecessary, but on classic ESP32 this is the only way to get octal SPI, which is necessary to use `mipi_spi` with 8080-style displays.

This only implements `interface: software` on ESP32, not on ESP8266 or RP2040.

The default for `interface` remains `hardware`, so if you specify `type: octal` on classic ESP32, you still get `No suitable hardware interface available` unless you explicitly request `interface: software`.

This only works for GPIOs 0 through 31, because implementing it for GPIO32 and GPIO33 would require a second register which would halve the throughput. Port expanders are not supported either.

Maximum throughput with 8 lanes on ESP32 is about 3 MB/s (330 ns per clock cycle). A considerable chunk of time goes into the `data_rate` limiting, so as a potential future improvement we could introduce `data_rate: unlimited`, which would push the throughput to 4.8 MB/s (210 ns per cycle).

As an overview, here are the possible values for `interface` (default in bold):

ESP32:
| type | Before | After |
|--------|--------|--------|
| Single | software, hardware, **any**, \<peripheral>| software, hardware, **any**, \<peripheral> |
| Quad | **hardware**, \<peripheral> | software, **hardware**, any, \<peripheral> |
| Octal | not supported | software, **hardware**, any, \<peripheral> |

ESP32-S2/S3/P4:
| type | Before | After |
|--------|--------|--------|
| Single | software, hardware, **any**, \<peripheral>| software, hardware, **any**, \<peripheral> |
| Quad | **hardware**, \<peripheral> | software, **hardware**, any, \<peripheral> |
| Octal | **hardware**, \<peripheral> | software, **hardware**, any, \<peripheral> |

Some throughput test results:

| Version                        | `data_rate`     | Cycle time | Byte rate (octal) |
| ------------------------------ | --------------- | ---------- | --------- |
| Without expanded loop          | `10MHz` default | 440 ns     | 2.3 MB/s  |
| This exact PR                  | `10MHz` default | 340 ns     | 2.9 MB/s  |
| This exact PR                  | `40MHz`         | 330 ns     | 3.0 MB/s  |
| Without `cycle_clock_()` calls | no effect       | 210 ns     | 4.8 MB/s  |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
spi:
  - id: lcd_spi
    type: octal
    interface: software
    clk_pin: GPIO4
    data_pins:
      - GPIO12
      - GPIO13
      - GPIO26
      - GPIO25
      - GPIO19
      - GPIO18
      - GPIO27
      - GPIO14
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
