### PR TITLE
[script] Fix duplicate import in build_codeowners.py

### DIFF
--- a/script/build_codeowners.py
+++ b/script/build_codeowners.py
@@ -61,6 +61,13 @@ for path in components_dir.iterdir():
     codeowners[f"esphome/components/{name}/*"].extend(comp.codeowners)
 
     for platform_path in path.iterdir():
+        if platform_path.name == "__init__.py":
+            # `import pkg.__init__` is valid but distinct from `import pkg`: it re-executes
+            # the component's __init__.py as a second, separate module. That's harmless for
+            # components whose top-level code is idempotent, but not guaranteed in general
+            # (e.g. code that registers into a global registry with a duplicate check), so
+            # never treat __init__.py itself as a platform candidate.
+            continue
         platform_name = platform_path.stem
         platform = get_platform(platform_name, name)
         if platform is None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

`script/build_codeowners.py` can double-import platform `__init__.py` files causing issues where the import is not idempotent.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
