### PR TITLE
[web_server] Use dict-style packages in tests so they can be batch-grouped

### DIFF
--- a/tests/components/web_server/test.esp32-ard.yaml
+++ b/tests/components/web_server/test.esp32-ard.yaml
@@ -1,1 +1,2 @@
-<<: !include common_v2.yaml
+packages:
+  web_server: !include common_v2.yaml

--- a/tests/components/web_server/test.esp32-idf.yaml
+++ b/tests/components/web_server/test.esp32-idf.yaml
@@ -1,4 +1,5 @@
-<<: !include common_v2.yaml
+packages:
+  web_server: !include common_v2.yaml
 
 web_server:
   auth:

--- a/tests/components/web_server/test.esp8266-ard.yaml
+++ b/tests/components/web_server/test.esp8266-ard.yaml
@@ -1,1 +1,2 @@
-<<: !include common_v2.yaml
+packages:
+  web_server: !include common_v2.yaml

--- a/tests/components/web_server/test.rp2040-ard.yaml
+++ b/tests/components/web_server/test.rp2040-ard.yaml
@@ -1,1 +1,2 @@
-<<: !include common_v2.yaml
+packages:
+  web_server: !include common_v2.yaml

--- a/tests/components/web_server/test_v1.esp32-ard.yaml
+++ b/tests/components/web_server/test_v1.esp32-ard.yaml
@@ -1,1 +1,2 @@
-<<: !include common_v1.yaml
+packages:
+  web_server: !include common_v1.yaml

--- a/tests/components/web_server/test_v1.esp32-idf.yaml
+++ b/tests/components/web_server/test_v1.esp32-idf.yaml
@@ -1,1 +1,2 @@
-<<: !include common_v1.yaml
+packages:
+  web_server: !include common_v1.yaml

--- a/tests/components/web_server/test_v3.esp32-ard.yaml
+++ b/tests/components/web_server/test_v3.esp32-ard.yaml
@@ -1,1 +1,2 @@
-<<: !include common_v3.yaml
+packages:
+  web_server: !include common_v3.yaml


### PR DESCRIPTION
# What does this implement/fix?

Migrates the `web_server` component test YAML files from the top-level merge key (`<<: !include`) to dict-style named packages. The CI batch-grouping scripts only understand dict-style `packages:`, so this lets these tests participate in bus grouping. Each `common_v*.yaml` is now included under the `web_server` package key. No behaviour change — all targets still pass `esphome config`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).