### PR TITLE
[toshiba] Add RAS-B10N3KV2 model support

### DIFF
--- a/esphome/components/toshiba/climate.py
+++ b/esphome/components/toshiba/climate.py
@@ -15,6 +15,7 @@ MODELS = {
     "RAC-PT1411HWRU-C": Model.MODEL_RAC_PT1411HWRU_C,
     "RAC-PT1411HWRU-F": Model.MODEL_RAC_PT1411HWRU_F,
     "RAS-2819T": Model.MODEL_RAS_2819T,
+    "RAS-B10N3KV2": Model.MODEL_RAS_B10N3KV2,
 }
 
 CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(ToshibaClimate).extend(

--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -23,7 +23,7 @@ const uint16_t TOSHIBA_ONE_SPACE = 1620;
 const uint16_t TOSHIBA_CARRIER_FREQUENCY = 38000;
 const uint8_t TOSHIBA_HEADER_LENGTH = 4;
 const ToshibaTimings TOSHIBA_GENERIC_TIMINGS{TOSHIBA_HEADER_MARK, TOSHIBA_HEADER_SPACE, TOSHIBA_BIT_MARK,
-                                             TOSHIBA_ONE_SPACE, TOSHIBA_ZERO_SPACE, TOSHIBA_GAP_SPACE};
+                                             TOSHIBA_ONE_SPACE,   TOSHIBA_ZERO_SPACE,   TOSHIBA_GAP_SPACE};
 // The RAS-B10N3KV2 family uses the same message content as GENERIC but requires the timings
 // used by the RAS-B13 remote family (values from IRremoteESP8266's TOSHIBA_AC protocol)
 const ToshibaTimings RAS_B10N3KV2_TIMINGS{4400, 4300, 580, 1600, 490, 7400};

--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -22,7 +22,13 @@ const uint16_t TOSHIBA_ZERO_SPACE = 540;
 const uint16_t TOSHIBA_ONE_SPACE = 1620;
 const uint16_t TOSHIBA_CARRIER_FREQUENCY = 38000;
 const uint8_t TOSHIBA_HEADER_LENGTH = 4;
+const ToshibaTimings TOSHIBA_GENERIC_TIMINGS{TOSHIBA_HEADER_MARK, TOSHIBA_HEADER_SPACE, TOSHIBA_BIT_MARK,
+                                             TOSHIBA_ONE_SPACE, TOSHIBA_ZERO_SPACE, TOSHIBA_GAP_SPACE};
+// The RAS-B10N3KV2 family uses the same message content as GENERIC but requires the timings
+// used by the RAS-B13 remote family (values from IRremoteESP8266's TOSHIBA_AC protocol)
+const ToshibaTimings RAS_B10N3KV2_TIMINGS{4400, 4300, 580, 1600, 490, 7400};
 // Generic Toshiba commands/flags
+const uint8_t TOSHIBA_GENERIC_MESSAGE_LENGTH = 9;
 const uint8_t TOSHIBA_COMMAND_DEFAULT = 0x01;
 const uint8_t TOSHIBA_COMMAND_TIMER = 0x02;
 const uint8_t TOSHIBA_COMMAND_POWER = 0x08;
@@ -445,14 +451,15 @@ void ToshibaClimate::transmit_state() {
     this->transmit_rac_pt1411hwru_();
   } else if (this->model_ == MODEL_RAS_2819T) {
     this->transmit_ras_2819t_();
+  } else if (this->model_ == MODEL_RAS_B10N3KV2) {
+    this->transmit_ras_b10n3kv2_();
   } else {
     this->transmit_generic_();
   }
 }
 
-void ToshibaClimate::transmit_generic_() {
-  uint8_t message[16] = {0};
-  uint8_t message_length = 9;
+void ToshibaClimate::build_generic_message_(uint8_t *message) {
+  const uint8_t message_length = TOSHIBA_GENERIC_MESSAGE_LENGTH;
 
   // Header
   message[0] = 0xf2;
@@ -536,12 +543,30 @@ void ToshibaClimate::transmit_generic_() {
   for (uint8_t i = 4; i < 8; i++) {
     message[8] ^= message[i];
   }
+}
+
+void ToshibaClimate::transmit_generic_() {
+  uint8_t message[16] = {0};
+  this->build_generic_message_(message);
 
   // Transmit
   auto transmit = this->transmitter_->transmit();
   auto *data = transmit.get_data();
 
-  this->encode_(data, message, message_length, 1);
+  this->encode_(data, message, TOSHIBA_GENERIC_MESSAGE_LENGTH, 1, TOSHIBA_GENERIC_TIMINGS);
+
+  transmit.perform();
+}
+
+void ToshibaClimate::transmit_ras_b10n3kv2_() {
+  uint8_t message[16] = {0};
+  this->build_generic_message_(message);
+
+  // Transmit
+  auto transmit = this->transmitter_->transmit();
+  auto *data = transmit.get_data();
+
+  this->encode_(data, message, TOSHIBA_GENERIC_MESSAGE_LENGTH, 1, RAS_B10N3KV2_TIMINGS);
 
   transmit.perform();
 }
@@ -661,10 +686,10 @@ void ToshibaClimate::transmit_rac_pt1411hwru_() {
   }
 
   // load first block of IR code and repeat it once
-  this->encode_(data, &message[0], RAC_PT1411HWRU_MESSAGE_LENGTH, 1);
+  this->encode_(data, &message[0], RAC_PT1411HWRU_MESSAGE_LENGTH, 1, TOSHIBA_GENERIC_TIMINGS);
   // load second block of IR code, if present
   if (message[6] != 0) {
-    this->encode_(data, &message[6], RAC_PT1411HWRU_MESSAGE_LENGTH, 0);
+    this->encode_(data, &message[6], RAC_PT1411HWRU_MESSAGE_LENGTH, 0, TOSHIBA_GENERIC_TIMINGS);
   }
 
   transmit.perform();
@@ -674,12 +699,12 @@ void ToshibaClimate::transmit_rac_pt1411hwru_() {
   data->space(TOSHIBA_PACKET_SPACE);
   switch (this->swing_mode) {
     case climate::CLIMATE_SWING_VERTICAL:
-      this->encode_(data, &RAC_PT1411HWRU_SWING_VERTICAL[0], RAC_PT1411HWRU_MESSAGE_LENGTH, 1);
+      this->encode_(data, &RAC_PT1411HWRU_SWING_VERTICAL[0], RAC_PT1411HWRU_MESSAGE_LENGTH, 1, TOSHIBA_GENERIC_TIMINGS);
       break;
 
     case climate::CLIMATE_SWING_OFF:
     default:
-      this->encode_(data, &RAC_PT1411HWRU_SWING_OFF[0], RAC_PT1411HWRU_MESSAGE_LENGTH, 1);
+      this->encode_(data, &RAC_PT1411HWRU_SWING_OFF[0], RAC_PT1411HWRU_MESSAGE_LENGTH, 1, TOSHIBA_GENERIC_TIMINGS);
   }
 
   data->space(TOSHIBA_PACKET_SPACE);
@@ -739,7 +764,7 @@ void ToshibaClimate::transmit_rac_pt1411hwru_temp_(const bool cs_state, const bo
     message[5] = ~message[4];
 
     // load IR code and repeat it once
-    this->encode_(data, message, RAC_PT1411HWRU_MESSAGE_LENGTH, 1);
+    this->encode_(data, message, RAC_PT1411HWRU_MESSAGE_LENGTH, 1, TOSHIBA_GENERIC_TIMINGS);
 
     transmit.perform();
   }
@@ -772,7 +797,7 @@ void ToshibaClimate::transmit_ras_2819t_() {
     swing_message[5] = RAS_2819T_SWING_TOGGLE & 0xFF;
 
     // Use single packet transmission WITH repeat (like regular commands)
-    this->encode_(swing_data, swing_message, RAS_2819T_MESSAGE_LENGTH, 1);
+    this->encode_(swing_data, swing_message, RAS_2819T_MESSAGE_LENGTH, 1, TOSHIBA_GENERIC_TIMINGS);
     swing_transmit.perform();
 
     // Update all state tracking
@@ -933,11 +958,11 @@ void ToshibaClimate::transmit_ras_2819t_() {
   auto *data = transmit.get_data();
 
   // Use existing Toshiba encode function for proper timing
-  this->encode_(data, message1, RAS_2819T_MESSAGE_LENGTH, 1);
+  this->encode_(data, message1, RAS_2819T_MESSAGE_LENGTH, 1, TOSHIBA_GENERIC_TIMINGS);
 
   if (this->mode != climate::CLIMATE_MODE_OFF) {
     // Send second packet with gap
-    this->encode_(data, message2, RAS_2819T_MESSAGE_LENGTH, 0);
+    this->encode_(data, message2, RAS_2819T_MESSAGE_LENGTH, 0, TOSHIBA_GENERIC_TIMINGS);
   }
 
   transmit.perform();
@@ -1336,23 +1361,23 @@ bool ToshibaClimate::on_receive(remote_base::RemoteReceiveData data) {
 }
 
 void ToshibaClimate::encode_(remote_base::RemoteTransmitData *data, const uint8_t *message, const uint8_t nbytes,
-                             const uint8_t repeat) {
+                             const uint8_t repeat, const ToshibaTimings &timings) {
   data->set_carrier_frequency(TOSHIBA_CARRIER_FREQUENCY);
 
   for (uint8_t copy = 0; copy <= repeat; copy++) {
-    data->item(TOSHIBA_HEADER_MARK, TOSHIBA_HEADER_SPACE);
+    data->item(timings.header_mark, timings.header_space);
 
     for (uint8_t byte = 0; byte < nbytes; byte++) {
       for (uint8_t bit = 0; bit < 8; bit++) {
-        data->mark(TOSHIBA_BIT_MARK);
+        data->mark(timings.bit_mark);
         if (message[byte] & (1 << (7 - bit))) {
-          data->space(TOSHIBA_ONE_SPACE);
+          data->space(timings.one_space);
         } else {
-          data->space(TOSHIBA_ZERO_SPACE);
+          data->space(timings.zero_space);
         }
       }
     }
-    data->item(TOSHIBA_BIT_MARK, TOSHIBA_GAP_SPACE);
+    data->item(timings.bit_mark, timings.gap_space);
   }
 }
 

--- a/esphome/components/toshiba/toshiba.h
+++ b/esphome/components/toshiba/toshiba.h
@@ -11,6 +11,7 @@ enum Model {
   MODEL_RAC_PT1411HWRU_C = 1,  // Temperature range is from 16 to 30
   MODEL_RAC_PT1411HWRU_F = 2,  // Temperature range is from 16 to 30
   MODEL_RAS_2819T = 3,         // RAS-2819T protocol variant, temperature range 18 to 30
+  MODEL_RAS_B10N3KV2 = 4,      // Same message content as GENERIC but with RAS-B13-style timings, 17 to 30
 };
 
 // Supported temperature ranges
@@ -22,6 +23,16 @@ const float TOSHIBA_RAC_PT1411HWRU_TEMP_F_MIN = 60.0;
 const float TOSHIBA_RAC_PT1411HWRU_TEMP_F_MAX = 86.0;
 const float TOSHIBA_RAS_2819T_TEMP_C_MIN = 18.0;
 const float TOSHIBA_RAS_2819T_TEMP_C_MAX = 30.0;
+
+// IR pulse timings; some models require different timings even though the message content is identical
+struct ToshibaTimings {
+  uint16_t header_mark;
+  uint16_t header_space;
+  uint16_t bit_mark;
+  uint16_t one_space;
+  uint16_t zero_space;
+  uint16_t gap_space;
+};
 
 class ToshibaClimate final : public climate_ir::ClimateIR {
  public:
@@ -36,6 +47,7 @@ class ToshibaClimate final : public climate_ir::ClimateIR {
  protected:
   void transmit_state() override;
   void transmit_generic_();
+  void transmit_ras_b10n3kv2_();
   void transmit_rac_pt1411hwru_();
   void transmit_rac_pt1411hwru_temp_(bool cs_state = true, bool cs_send_update = true);
   void transmit_ras_2819t_();
@@ -71,11 +83,13 @@ class ToshibaClimate final : public climate_ir::ClimateIR {
     return TOSHIBA_GENERIC_TEMP_C_MAX;  // Default to GENERIC for unknown models
   }
   climate::ClimateSwingModeMask toshiba_swing_modes_() {
-    return (this->model_ == MODEL_GENERIC)
+    return (this->model_ == MODEL_GENERIC || this->model_ == MODEL_RAS_B10N3KV2)
                ? climate::ClimateSwingModeMask()
                : climate::ClimateSwingModeMask{climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL};
   }
-  void encode_(remote_base::RemoteTransmitData *data, const uint8_t *message, uint8_t nbytes, uint8_t repeat);
+  void build_generic_message_(uint8_t *message);
+  void encode_(remote_base::RemoteTransmitData *data, const uint8_t *message, uint8_t nbytes, uint8_t repeat,
+               const ToshibaTimings &timings);
   bool decode_(remote_base::RemoteReceiveData *data, uint8_t *message, uint8_t nbytes);
 
   Model model_;

--- a/tests/components/toshiba/common_ras_b10n3kv2.yaml
+++ b/tests/components/toshiba/common_ras_b10n3kv2.yaml
@@ -1,0 +1,5 @@
+climate:
+  - platform: toshiba
+    name: RAS-B10N3KV2 Climate
+    model: RAS-B10N3KV2
+    receiver_id: rcvr

--- a/tests/components/toshiba/test-ras-b10n3kv2.esp32-idf.yaml
+++ b/tests/components/toshiba/test-ras-b10n3kv2.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+  remote_receiver: !include ../../test_build_components/common/remote_receiver/esp32-idf.yaml
+  toshiba: !include common_ras_b10n3kv2.yaml

--- a/tests/components/toshiba/test-ras-b10n3kv2.esp8266-ard.yaml
+++ b/tests/components/toshiba/test-ras-b10n3kv2.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+  remote_receiver: !include ../../test_build_components/common/remote_receiver/esp8266-ard.yaml
+  toshiba: !include common_ras_b10n3kv2.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a new `RAS-B10N3KV2` model to the `toshiba` climate component, supporting the Toshiba RAS-B10N3KV2 family of air conditioners (e.g. RAS-B10N3KV2-E1, part of the RAS-B13* remote family).

These units use the exact same 9-byte message content as the existing `GENERIC` model (header `F2 0D 03 FC`, temperature `(T - 17) << 4`, fan|mode byte, XOR checksum) but do not respond to the `GENERIC` IR pulse timings. The new model sends the identical message with the timings used by the RAS-B13 remote family, matching IRremoteESP8266's `TOSHIBA_AC` protocol (header 4400/4300 µs, bit mark 580 µs, one space 1600 µs, zero space 490 µs, gap 7400 µs).

Implementation notes:
- The `encode_()` helper now takes a timings struct, so the message-building code is shared between `GENERIC` and the new model; all existing models keep their exact previous timings and behavior.
- The message construction was extracted from `transmit_generic_()` into `build_generic_message_()` and is reused unchanged by the new model.
- Receiving works through the existing generic decode path (the remote's timings are within the receiver tolerance), so state stays in sync with the original remote.
- Temperature range is 17-30 °C, same as `GENERIC`. Like `GENERIC`, the model does not report swing modes.

Verified on a real RAS-B10N3KV2-E1 unit: power on/off, cool/heat/dry/fan-only/auto modes, target temperature changes, all fan speeds (including quiet), and state synchronization when using the original remote.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6979

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
climate:
  - platform: toshiba
    name: "Toshiba AC"
    model: RAS-B10N3KV2
    receiver_id: default_ir_receiver
    transmitter_id: default_ir_transmitter
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
