### PR TITLE
[nextion] Fix unbounded queue growth and OOM crash when display sends no data

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -905,7 +905,6 @@ void Nextion::process_nextion_commands_() {
   }
 
   ESP_LOGN(TAG, "Loop end");
-  // App.feed_wdt(); Remove before master merge
   this->process_serial_();
 }  // Nextion::process_nextion_commands_()
 

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -1,6 +1,7 @@
 #include "nextion.h"
 
 #include <cinttypes>
+#include <new>
 
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
@@ -352,8 +353,9 @@ void Nextion::loop() {
     this->connection_state_.ignore_is_setup_ = false;
   }
 
-  this->process_serial_();            // Receive serial data
-  this->process_nextion_commands_();  // Process nextion return commands
+  this->process_serial_();             // Receive serial data
+  this->process_nextion_commands_();   // Process nextion return commands
+  this->purge_stale_queue_entries_();  // Drop expired entries even when the display sends no data
 
   if (!this->connection_state_.nextion_reports_is_setup_) {
     if (this->started_ms_ == 0)
@@ -902,6 +904,12 @@ void Nextion::process_nextion_commands_() {
     this->command_data_.erase(0, to_process_length + DELIMITER_SIZE + 1);
   }
 
+  ESP_LOGN(TAG, "Loop end");
+  // App.feed_wdt(); Remove before master merge
+  this->process_serial_();
+}  // Nextion::process_nextion_commands_()
+
+void Nextion::purge_stale_queue_entries_() {
   const uint32_t ms = App.get_loop_component_start_time();
 
   if (this->max_q_age_ms_ > 0 && !this->nextion_queue_.empty() &&
@@ -927,10 +935,7 @@ void Nextion::process_nextion_commands_() {
       }
     }
   }
-  ESP_LOGN(TAG, "Loop end");
-  // App.feed_wdt(); Remove before master merge
-  this->process_serial_();
-}  // Nextion::process_nextion_commands_()
+}
 
 void Nextion::set_nextion_sensor_state(int queue_type, const std::string &name, float state) {
   this->set_nextion_sensor_state(static_cast<NextionQueueType>(queue_type), name, state);
@@ -1101,7 +1106,13 @@ void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
   new (nextion_queue) nextion::NextionQueue();
 
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-  nextion_queue->component = new nextion::NextionComponentBase;
+  nextion_queue->component = new (std::nothrow) nextion::NextionComponentBase;
+  if (nextion_queue->component == nullptr) {
+    ESP_LOGW(TAG, "Component alloc failed");
+    nextion_queue->~NextionQueue();
+    allocator.deallocate(nextion_queue, 1);
+    return;
+  }
   nextion_queue->component->set_variable_name(variable_name);
 
   nextion_queue->queue_time = App.get_loop_component_start_time();
@@ -1157,7 +1168,13 @@ void Nextion::add_no_result_to_queue_with_pending_command_(const std::string &va
   }
   new (nextion_queue) nextion::NextionQueue();
 
-  nextion_queue->component = new nextion::NextionComponentBase;
+  nextion_queue->component = new (std::nothrow) nextion::NextionComponentBase;
+  if (nextion_queue->component == nullptr) {
+    ESP_LOGW(TAG, "Component alloc failed");
+    nextion_queue->~NextionQueue();
+    allocator.deallocate(nextion_queue, 1);
+    return;
+  }
   nextion_queue->component->set_variable_name(variable_name);
   nextion_queue->queue_time = App.get_loop_component_start_time();
   nextion_queue->pending_command = command;  // Store command for retry

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -1486,6 +1486,10 @@ class Nextion final : public NextionBase, public PollingComponent, public uart::
 
   void process_nextion_commands_();
   void process_serial_();
+  /// Drop queue entries older than max_q_age_ms_. Called from loop() so it also runs when the
+  /// display sends no data at all (disconnected or asleep), which would otherwise grow the queue
+  /// without bound.
+  void purge_stale_queue_entries_();
   uint16_t touch_sleep_timeout_ = 0;
   uint8_t wake_up_page_ = 255;
 #ifdef USE_NEXTION_CONF_START_UP_PAGE


### PR DESCRIPTION
# What does this implement/fix?

Fixes a heap-exhaustion crash (`abort()` from the C++ exception stub after a failed `operator new`) that occurs when a Nextion display stops sending data — for example when it is disconnected or unresponsive — while the device keeps publishing values to it.

**Root cause.** The `max_queue_age` purge (always compiled in, default 8 s) is the mechanism that is supposed to bound the command queue. It ran only at the end of `process_nextion_commands_()`, which returns early when `command_data_` is empty. With a display that sends no data at all, that early return is taken on every loop, so the purge never ran. Meanwhile every published value keeps appending to `nextion_queue_` (a `NextionQueue` entry, a heap-allocated `NextionComponentBase`, its name string, and a list node), nothing ever drains it, and the heap is eventually exhausted. The crash then surfaces as an `abort()` because the per-entry `NextionComponentBase` is allocated with a bare `new`, which calls the ESP-IDF exception stub on failure.

**Changes:**

- The purge is extracted into `purge_stale_queue_entries_()` and called from `loop()` unconditionally, so `max_queue_age` is enforced even when the display sends nothing. The purge logic itself is unchanged. With this fix, queue growth with a dead display is bounded to roughly `max_queue_age` worth of traffic, and a queue that filled during a disconnect self-clears instead of staying wedged until display traffic resumes.
- Both `NextionComponentBase` allocations (the plain path and the `command_spacing` retry path) now use `new (std::nothrow)` and, on failure, log a warning, release the queue entry, and drop the command — matching the graceful handling of the `RAMAllocator` allocation directly above them. Under heap pressure from any source, the display now misses an update instead of crashing the device.

**Why `max_queue_size` is not the answer here:** it is opt-in and compile-gated, so default configurations are unprotected; and a size cap drops the *newest* commands while the queue is full of stale ones, whereas the age purge drops the *oldest* — for state-sync traffic, keeping dead entries and discarding fresh values is the wrong priority. The two options remain complementary: age keeps the queue fresh, size provides a hard ceiling for burst overload.

**Relationship to #15412:** that PR changes the queue container (`std::list` → compile-time `StaticRingBuffer` when `max_queue_size` is set) but keeps the purge inside `process_nextion_commands_()` behind the early return, and keeps the bare `new` for the per-entry component, so it does not address either issue fixed here. The two PRs touch the same regions, so whichever merges second needs a small rebase (the `#ifdef` split from #15412 moves inside the extracted method).

**Verification on hardware (ESP32-S3, ESP-IDF):** a device publishing sensor values to a disconnected display previously crashed with the abort backtrace within about 8 minutes, reproducibly. With this fix it has run for over two hours and counting under the same conditions, with stale entries visibly purged (`Remove old queue` at verbose logging).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
uart:
  tx_pin: 17
  rx_pin: 16
  baud_rate: 115200

display:
  - platform: nextion
    id: main_lcd
    max_queue_age: 8s

sensor:
  - platform: nextion
    nextion_id: main_lcd
    name: Temperature
    variable_name: temperature
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). (The existing configuration tests cover this component; no configuration options were added or changed.)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io). (No user-facing options change; `max_queue_age` now behaves as already documented.)
