### PR TITLE
[lis3dh] Add LIS3DH 3-axis accelerometer component

### DIFF
--- a/esphome/components/lis3dh/LICENSE
+++ b/esphome/components/lis3dh/LICENSE
@@ -1,0 +1,33 @@
+The lis3dh_reg.h and .c files are licensed as follows
+
+==============================================================================
+
+BSD 3-Clause License
+
+Copyright (c) 2019, STMicroelectronics
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/esphome/components/lis3dh/__init__.py
+++ b/esphome/components/lis3dh/__init__.py
@@ -1,0 +1,216 @@
+from esphome import automation, pins
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_MODE, CONF_RANGE, CONF_TRIGGER_ID
+
+CODEOWNERS = ["@jthoward64"]
+
+CONF_LIS3DH_ID = "lis3dh_id"
+CONF_ODR = "odr"
+CONF_FIFO_ENABLED = "fifo_enabled"
+CONF_FIFO_MODE = "fifo_mode"
+CONF_FIFO_WATERMARK = "fifo_watermark"
+CONF_INT1_PIN = "int1_pin"
+CONF_INT2_PIN = "int2_pin"
+CONF_TAP_ENABLED = "tap_enabled"
+CONF_TAP_THRESHOLD = "tap_threshold"
+CONF_TAP_SHOCK_DURATION = "tap_shock_duration"
+CONF_TAP_QUIET_DURATION = "tap_quiet_duration"
+CONF_TAP_DOUBLE_TAP_TIMEOUT = "tap_double_tap_timeout"
+CONF_ACTIVITY_ENABLED = "activity_enabled"
+CONF_ACTIVITY_THRESHOLD = "activity_threshold"
+CONF_ACTIVITY_DURATION = "activity_duration"
+CONF_ACTIVITY_INTERRUPT_MODE = "activity_interrupt_mode"
+CONF_FREEFALL_ENABLED = "freefall_enabled"
+CONF_FREEFALL_THRESHOLD = "freefall_threshold"
+CONF_FREEFALL_DURATION = "freefall_duration"
+CONF_FREEFALL_INTERRUPT_MODE = "freefall_interrupt_mode"
+CONF_ENABLE_DEEP_SLEEP_WAKEUP = "enable_deep_sleep_wakeup"
+CONF_AUTO_LOW_POWER_ENABLED = "auto_low_power_enabled"
+CONF_AUTO_LOW_POWER_THRESHOLD = "auto_low_power_threshold"
+CONF_AUTO_LOW_POWER_DURATION = "auto_low_power_duration"
+CONF_HIGH_PASS_FILTER_ENABLED = "high_pass_filter_enabled"
+CONF_HIGH_PASS_FILTER_MODE = "high_pass_filter_mode"
+CONF_HIGH_PASS_FILTER_CUTOFF = "high_pass_filter_cutoff"
+CONF_TEMPERATURE_ENABLED = "temperature_enabled"
+CONF_ON_TAP = "on_tap"
+CONF_ON_DOUBLE_TAP = "on_double_tap"
+CONF_ON_ACTIVITY = "on_activity"
+CONF_ON_FREEFALL = "on_freefall"
+CONF_ON_ORIENTATION_CHANGE = "on_orientation_change"
+
+lis3dh_ns = cg.esphome_ns.namespace("lis3dh")
+LIS3DHComponent = lis3dh_ns.class_("LIS3DHComponent", cg.PollingComponent)
+
+LIS3DHRange = lis3dh_ns.enum("LIS3DHRange", is_class=True)
+LIS3DHMode = lis3dh_ns.enum("LIS3DHMode", is_class=True)
+LIS3DHDataRate = lis3dh_ns.enum("LIS3DHDataRate", is_class=True)
+LIS3DHFifoMode = lis3dh_ns.enum("LIS3DHFifoMode", is_class=True)
+LIS3DHInterruptMode = lis3dh_ns.enum("LIS3DHInterruptMode", is_class=True)
+
+TapTrigger = lis3dh_ns.class_("TapTrigger", automation.Trigger.template())
+DoubleTapTrigger = lis3dh_ns.class_("DoubleTapTrigger", automation.Trigger.template())
+ActivityTrigger = lis3dh_ns.class_("ActivityTrigger", automation.Trigger.template())
+FreefallTrigger = lis3dh_ns.class_("FreefallTrigger", automation.Trigger.template())
+OrientationChangeTrigger = lis3dh_ns.class_(
+    "OrientationChangeTrigger", automation.Trigger.template()
+)
+
+RANGE_OPTIONS = {
+    "2G": LIS3DHRange.RANGE_2G,
+    "4G": LIS3DHRange.RANGE_4G,
+    "8G": LIS3DHRange.RANGE_8G,
+    "16G": LIS3DHRange.RANGE_16G,
+}
+
+MODE_OPTIONS = {
+    "low_power": LIS3DHMode.MODE_LOW_POWER,
+    "normal": LIS3DHMode.MODE_NORMAL,
+    "high_resolution": LIS3DHMode.MODE_HIGH_RESOLUTION,
+}
+
+DATA_RATE_OPTIONS = {
+    "1Hz": LIS3DHDataRate.ODR_1HZ,
+    "10Hz": LIS3DHDataRate.ODR_10HZ,
+    "25Hz": LIS3DHDataRate.ODR_25HZ,
+    "50Hz": LIS3DHDataRate.ODR_50HZ,
+    "100Hz": LIS3DHDataRate.ODR_100HZ,
+    "200Hz": LIS3DHDataRate.ODR_200HZ,
+    "400Hz": LIS3DHDataRate.ODR_400HZ,
+    "1600Hz": LIS3DHDataRate.ODR_1600HZ,
+    "5376Hz": LIS3DHDataRate.ODR_5376HZ,
+}
+
+FIFO_MODE_OPTIONS = {
+    "bypass": LIS3DHFifoMode.FIFO_BYPASS,
+    "fifo": LIS3DHFifoMode.FIFO_MODE,
+    "stream": LIS3DHFifoMode.FIFO_STREAM,
+    "stream_to_fifo": LIS3DHFifoMode.FIFO_STREAM_TO_FIFO,
+}
+
+# See LIS3DH datasheet Table 64 "Interrupt mode".
+INTERRUPT_MODE_OPTIONS = {
+    "or": LIS3DHInterruptMode.OR,
+    "movement_6d": LIS3DHInterruptMode.MOVEMENT_6D,
+    "and": LIS3DHInterruptMode.AND,
+    "position_6d": LIS3DHInterruptMode.POSITION_6D,
+}
+
+
+CONFIG_SCHEMA_BASE = cv.Schema(
+    {
+        cv.Optional(CONF_RANGE, default="2G"): cv.enum(RANGE_OPTIONS, upper=True),
+        cv.Optional(CONF_MODE, default="normal"): cv.enum(MODE_OPTIONS, lower=True),
+        cv.Optional(CONF_ODR, default="100Hz"): cv.enum(DATA_RATE_OPTIONS),
+        cv.Optional(CONF_FIFO_ENABLED, default=True): cv.boolean,
+        # "stream_to_fifo" runs in stream mode until a trigger event, then switches into
+        # "fifo" mode and permanently stops collecting new samples once full -- a one-shot
+        # "freeze a snapshot around the trigger" mode. Since the LIS3DH's OUT_X/Y/Z registers
+        # are the FIFO's read window, that stop makes acceleration readings appear frozen
+        # forever the moment any trigger (e.g. activity detection) fires. "stream" is a plain
+        # circular buffer that never stops, which is what continuous live sensing needs.
+        cv.Optional(CONF_FIFO_MODE, default="stream"): cv.enum(
+            FIFO_MODE_OPTIONS, lower=True
+        ),
+        cv.Optional(CONF_FIFO_WATERMARK, default=25): cv.int_range(1, 32),
+        cv.Optional(CONF_INT1_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Optional(CONF_INT2_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Optional(CONF_TAP_ENABLED, default=False): cv.boolean,
+        cv.Optional(CONF_TAP_THRESHOLD, default=0x12): cv.int_range(0, 255),
+        cv.Optional(CONF_TAP_SHOCK_DURATION, default=0x20): cv.int_range(0, 255),
+        cv.Optional(CONF_TAP_QUIET_DURATION, default=0x20): cv.int_range(0, 255),
+        cv.Optional(CONF_TAP_DOUBLE_TAP_TIMEOUT, default=0x30): cv.int_range(0, 255),
+        cv.Optional(CONF_ACTIVITY_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_ACTIVITY_THRESHOLD, default=0x10): cv.int_range(0, 255),
+        cv.Optional(CONF_ACTIVITY_DURATION, default=0x05): cv.int_range(0, 255),
+        cv.Optional(CONF_ACTIVITY_INTERRUPT_MODE, default="or"): cv.enum(
+            INTERRUPT_MODE_OPTIONS, lower=True
+        ),
+        cv.Optional(CONF_FREEFALL_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_FREEFALL_THRESHOLD, default=0x08): cv.int_range(0, 255),
+        cv.Optional(CONF_FREEFALL_DURATION, default=0x01): cv.int_range(0, 255),
+        cv.Optional(CONF_FREEFALL_INTERRUPT_MODE, default="and"): cv.enum(
+            INTERRUPT_MODE_OPTIONS, lower=True
+        ),
+        cv.Optional(CONF_ENABLE_DEEP_SLEEP_WAKEUP, default=False): cv.boolean,
+        cv.Optional(CONF_AUTO_LOW_POWER_ENABLED, default=False): cv.boolean,
+        cv.Optional(CONF_AUTO_LOW_POWER_THRESHOLD, default=0x10): cv.int_range(0, 255),
+        cv.Optional(CONF_AUTO_LOW_POWER_DURATION, default=0x05): cv.int_range(0, 255),
+        cv.Optional(CONF_HIGH_PASS_FILTER_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_HIGH_PASS_FILTER_MODE, default=0): cv.int_range(0, 3),
+        cv.Optional(CONF_HIGH_PASS_FILTER_CUTOFF, default=0): cv.int_range(0, 3),
+        cv.Optional(CONF_TEMPERATURE_ENABLED, default=False): cv.boolean,
+        cv.Optional(CONF_ON_TAP): automation.validate_automation(
+            {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(TapTrigger)}
+        ),
+        cv.Optional(CONF_ON_DOUBLE_TAP): automation.validate_automation(
+            {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DoubleTapTrigger)}
+        ),
+        cv.Optional(CONF_ON_ACTIVITY): automation.validate_automation(
+            {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ActivityTrigger)}
+        ),
+        cv.Optional(CONF_ON_FREEFALL): automation.validate_automation(
+            {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(FreefallTrigger)}
+        ),
+        cv.Optional(CONF_ON_ORIENTATION_CHANGE): automation.validate_automation(
+            {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OrientationChangeTrigger)}
+        ),
+    }
+).extend(cv.polling_component_schema("60s"))
+
+
+async def setup_lis3dh_base(var, config):
+    """Apply all base LIS3DH configuration to a variable created by a platform component."""
+    cg.add(var.set_accel_range(config[CONF_RANGE]))
+    cg.add(var.set_operating_mode(config[CONF_MODE]))
+    cg.add(var.set_odr(config[CONF_ODR]))
+
+    cg.add(var.set_fifo_enabled(config[CONF_FIFO_ENABLED]))
+    cg.add(var.set_fifo_mode(config[CONF_FIFO_MODE]))
+    cg.add(var.set_fifo_watermark(config[CONF_FIFO_WATERMARK]))
+
+    if CONF_INT1_PIN in config:
+        int1_pin = await cg.gpio_pin_expression(config[CONF_INT1_PIN])
+        cg.add(var.set_int1_pin(int1_pin))
+    if CONF_INT2_PIN in config:
+        int2_pin = await cg.gpio_pin_expression(config[CONF_INT2_PIN])
+        cg.add(var.set_int2_pin(int2_pin))
+
+    cg.add(var.set_tap_enabled(config[CONF_TAP_ENABLED]))
+    cg.add(var.set_tap_threshold(config[CONF_TAP_THRESHOLD]))
+    cg.add(var.set_tap_shock_duration(config[CONF_TAP_SHOCK_DURATION]))
+    cg.add(var.set_tap_quiet_duration(config[CONF_TAP_QUIET_DURATION]))
+    cg.add(var.set_tap_double_tap_timeout(config[CONF_TAP_DOUBLE_TAP_TIMEOUT]))
+
+    cg.add(var.set_activity_enabled(config[CONF_ACTIVITY_ENABLED]))
+    cg.add(var.set_activity_threshold(config[CONF_ACTIVITY_THRESHOLD]))
+    cg.add(var.set_activity_duration(config[CONF_ACTIVITY_DURATION]))
+    cg.add(var.set_activity_interrupt_mode(config[CONF_ACTIVITY_INTERRUPT_MODE]))
+
+    cg.add(var.set_freefall_enabled(config[CONF_FREEFALL_ENABLED]))
+    cg.add(var.set_freefall_threshold(config[CONF_FREEFALL_THRESHOLD]))
+    cg.add(var.set_freefall_duration(config[CONF_FREEFALL_DURATION]))
+    cg.add(var.set_freefall_interrupt_mode(config[CONF_FREEFALL_INTERRUPT_MODE]))
+
+    cg.add(var.set_enable_deep_sleep_wakeup(config[CONF_ENABLE_DEEP_SLEEP_WAKEUP]))
+
+    cg.add(var.set_auto_low_power_enabled(config[CONF_AUTO_LOW_POWER_ENABLED]))
+    cg.add(var.set_auto_low_power_threshold(config[CONF_AUTO_LOW_POWER_THRESHOLD]))
+    cg.add(var.set_auto_low_power_duration(config[CONF_AUTO_LOW_POWER_DURATION]))
+
+    cg.add(var.set_high_pass_filter_enabled(config[CONF_HIGH_PASS_FILTER_ENABLED]))
+    cg.add(var.set_high_pass_filter_mode(config[CONF_HIGH_PASS_FILTER_MODE]))
+    cg.add(var.set_high_pass_filter_cutoff(config[CONF_HIGH_PASS_FILTER_CUTOFF]))
+
+    cg.add(var.set_temperature_enabled(config[CONF_TEMPERATURE_ENABLED]))
+
+    for conf_key in (
+        CONF_ON_TAP,
+        CONF_ON_DOUBLE_TAP,
+        CONF_ON_ACTIVITY,
+        CONF_ON_FREEFALL,
+        CONF_ON_ORIENTATION_CHANGE,
+    ):
+        for conf in config.get(conf_key, []):
+            trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+            await automation.build_automation(trigger, [], conf)

--- a/esphome/components/lis3dh/binary_sensor.py
+++ b/esphome/components/lis3dh/binary_sensor.py
@@ -1,0 +1,55 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+
+from . import CONF_LIS3DH_ID, LIS3DHComponent
+
+CONF_TAP = "tap"
+CONF_DOUBLE_TAP = "double_tap"
+CONF_ACTIVITY = "activity"
+CONF_FREEFALL = "freefall"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_LIS3DH_ID): cv.use_id(LIS3DHComponent),
+        cv.Optional(CONF_TAP): binary_sensor.binary_sensor_schema(
+            icon="mdi:gesture-tap"
+        ),
+        cv.Optional(CONF_DOUBLE_TAP): binary_sensor.binary_sensor_schema(
+            icon="mdi:gesture-double-tap"
+        ),
+        cv.Optional(CONF_ACTIVITY): binary_sensor.binary_sensor_schema(
+            icon="mdi:motion-sensor"
+        ),
+        cv.Optional(CONF_FREEFALL): binary_sensor.binary_sensor_schema(
+            icon="mdi:arrow-down"
+        ),
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_LIS3DH_ID])
+
+    if tap_conf := config.get(CONF_TAP):
+        cg.add(
+            hub.set_tap_binary_sensor(await binary_sensor.new_binary_sensor(tap_conf))
+        )
+    if dt_conf := config.get(CONF_DOUBLE_TAP):
+        cg.add(
+            hub.set_double_tap_binary_sensor(
+                await binary_sensor.new_binary_sensor(dt_conf)
+            )
+        )
+    if act_conf := config.get(CONF_ACTIVITY):
+        cg.add(
+            hub.set_activity_binary_sensor(
+                await binary_sensor.new_binary_sensor(act_conf)
+            )
+        )
+    if ff_conf := config.get(CONF_FREEFALL):
+        cg.add(
+            hub.set_freefall_binary_sensor(
+                await binary_sensor.new_binary_sensor(ff_conf)
+            )
+        )

--- a/esphome/components/lis3dh/lis3dh.cpp
+++ b/esphome/components/lis3dh/lis3dh.cpp
@@ -1,0 +1,747 @@
+#include "lis3dh.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+#include <cmath>
+
+namespace esphome {
+namespace lis3dh {
+
+static const char *const TAG = "lis3dh";
+
+namespace {
+
+int32_t lis3dh_write_bridge(void *handle, uint8_t reg, const uint8_t *bufp, uint16_t len) {
+  auto *self = static_cast<LIS3DHComponent *>(handle);
+  return self->write_register(reg, bufp, len) ? 0 : -1;
+}
+
+int32_t lis3dh_read_bridge(void *handle, uint8_t reg, uint8_t *bufp, uint16_t len) {
+  auto *self = static_cast<LIS3DHComponent *>(handle);
+  return self->read_register(reg, bufp, len) ? 0 : -1;
+}
+
+const char *range_to_str(LIS3DHRange r) {
+  switch (r) {
+    case LIS3DHRange::RANGE_2G:
+      return "2G";
+    case LIS3DHRange::RANGE_4G:
+      return "4G";
+    case LIS3DHRange::RANGE_8G:
+      return "8G";
+    case LIS3DHRange::RANGE_16G:
+      return "16G";
+  }
+  return "unknown";
+}
+
+const char *mode_to_str(LIS3DHMode m) {
+  switch (m) {
+    case LIS3DHMode::MODE_LOW_POWER:
+      return "Low Power";
+    case LIS3DHMode::MODE_NORMAL:
+      return "Normal";
+    case LIS3DHMode::MODE_HIGH_RESOLUTION:
+      return "High Resolution";
+  }
+  return "unknown";
+}
+
+const char *odr_to_str(LIS3DHDataRate r) {
+  switch (r) {
+    case LIS3DHDataRate::ODR_1HZ:
+      return "1 Hz";
+    case LIS3DHDataRate::ODR_10HZ:
+      return "10 Hz";
+    case LIS3DHDataRate::ODR_25HZ:
+      return "25 Hz";
+    case LIS3DHDataRate::ODR_50HZ:
+      return "50 Hz";
+    case LIS3DHDataRate::ODR_100HZ:
+      return "100 Hz";
+    case LIS3DHDataRate::ODR_200HZ:
+      return "200 Hz";
+    case LIS3DHDataRate::ODR_400HZ:
+      return "400 Hz";
+    case LIS3DHDataRate::ODR_1600HZ:
+      return "1.6 kHz";
+    case LIS3DHDataRate::ODR_5376HZ:
+      return "5.376 kHz";
+  }
+  return "unknown";
+}
+
+const char *orientation_xy_to_str(LIS3DHOrientationXY o) {
+  switch (o) {
+    case LIS3DHOrientationXY::PORTRAIT_UPRIGHT:
+      return "Portrait Upright";
+    case LIS3DHOrientationXY::PORTRAIT_UPSIDE_DOWN:
+      return "Portrait Upside Down";
+    case LIS3DHOrientationXY::LANDSCAPE_LEFT:
+      return "Landscape Left";
+    case LIS3DHOrientationXY::LANDSCAPE_RIGHT:
+      return "Landscape Right";
+    case LIS3DHOrientationXY::FLAT:
+      return "Flat";
+  }
+  return "unknown";
+}
+
+const char *orientation_z_to_str(LIS3DHOrientationZ o) {
+  return o == LIS3DHOrientationZ::FACE_UP ? "Face Up" : "Face Down";
+}
+
+}  // namespace
+
+void IRAM_ATTR LIS3DHStore::int1_gpio_intr(LIS3DHStore *arg) {
+  arg->int1_triggered = true;
+  if (arg->parent != nullptr)
+    arg->parent->enable_loop_soon_any_context();
+}
+
+void IRAM_ATTR LIS3DHStore::int2_gpio_intr(LIS3DHStore *arg) {
+  arg->int2_triggered = true;
+  if (arg->parent != nullptr)
+    arg->parent->enable_loop_soon_any_context();
+}
+
+void LIS3DHComponent::setup() {
+  this->dev_ctx_.handle = this;
+  this->dev_ctx_.write_reg = lis3dh_write_bridge;
+  this->dev_ctx_.read_reg = lis3dh_read_bridge;
+  this->dev_ctx_.mdelay = [](uint32_t ms) { delay_microseconds_safe(ms * 1000); };
+
+  if (!this->verify_device_id_()) {
+    this->mark_failed();
+    return;
+  }
+  if (!this->configure_device_()) {
+    this->mark_failed();
+    return;
+  }
+
+  if (this->fifo_enabled_ && !this->configure_fifo_()) {
+    ESP_LOGW(TAG, "Failed to configure FIFO");
+  }
+  if (this->tap_enabled_ && !this->configure_tap_detection_()) {
+    ESP_LOGW(TAG, "Failed to configure tap detection");
+  }
+  if (this->activity_enabled_ && !this->configure_motion_detection_()) {
+    ESP_LOGW(TAG, "Failed to configure motion detection");
+  }
+  if (this->freefall_enabled_ && !this->configure_freefall_detection_()) {
+    ESP_LOGW(TAG, "Failed to configure free-fall detection");
+  }
+  if (this->auto_low_power_enabled_) {
+    if (!this->configure_auto_low_power_()) {
+      ESP_LOGW(TAG, "Failed to configure auto low-power mode");
+    }
+  } else if (lis3dh_act_threshold_set(&this->dev_ctx_, 0) != 0) {
+    // ACT_THS resets to 0 (disabled) on power-on, but the chip keeps its registers across
+    // ESP32 deep sleep/reboots, so an explicit disable is needed if the config changes.
+    ESP_LOGW(TAG, "Failed to disable auto low-power mode");
+  }
+  if (!this->configure_interrupt_routing_()) {
+    ESP_LOGW(TAG, "Failed to configure interrupt routing");
+  }
+
+  if (this->enable_deep_sleep_wakeup_) {
+    // A latched interrupt from before the last deep sleep can leave INT1 stuck high, which
+    // would make the ESP32 deep_sleep component see the wakeup pin as already asserted and
+    // refuse to sleep (or wake immediately). Read out the latch sources once at boot so the
+    // pin starts low.
+    uint8_t dummy;
+    this->read_register(LIS3DH_INT1_SRC, &dummy, 1);
+    this->read_register(LIS3DH_CLICK_SRC, &dummy, 1);
+  }
+
+  this->store_.parent = this;
+
+  if (this->int1_pin_ != nullptr) {
+    this->int1_pin_->setup();
+    this->store_.int1_pin = this->int1_pin_->to_isr();
+    this->int1_pin_->attach_interrupt(LIS3DHStore::int1_gpio_intr, &this->store_, gpio::INTERRUPT_RISING_EDGE);
+  }
+  if (this->int2_pin_ != nullptr) {
+    this->int2_pin_->setup();
+    this->store_.int2_pin = this->int2_pin_->to_isr();
+    this->int2_pin_->attach_interrupt(LIS3DHStore::int2_gpio_intr, &this->store_, gpio::INTERRUPT_RISING_EDGE);
+  }
+
+  // loop() only runs when an ISR re-enables it. If no INT pins are wired,
+  // event sources are polled in update() instead.
+  this->disable_loop();
+}
+
+void LIS3DHComponent::update() {
+  this->read_acceleration_data_();
+#ifdef USE_SENSOR
+  if (this->temperature_sensor_ != nullptr) {
+    this->read_temperature_data_();
+  }
+#endif
+
+  this->update_orientation_();
+
+  if (this->fifo_enabled_) {
+    this->read_fifo_data_();
+  }
+
+  // Polling fallback: if no INT pins are wired, drain event sources here.
+  if (!this->interrupt_driven_()) {
+    this->process_event_sources_();
+  }
+}
+
+void LIS3DHComponent::loop() {
+  if (this->store_.int1_triggered || this->store_.int2_triggered) {
+    this->store_.int1_triggered = false;
+    this->store_.int2_triggered = false;
+    this->process_event_sources_();
+  }
+  // Park the loop until the next ISR wakes us.
+  this->disable_loop();
+}
+
+void LIS3DHComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "LIS3DH:");
+  ESP_LOGCONFIG(TAG, "  Range: %s", range_to_str(this->range_));
+  ESP_LOGCONFIG(TAG, "  Mode: %s", mode_to_str(this->mode_));
+  ESP_LOGCONFIG(TAG, "  Data rate: %s", odr_to_str(this->data_rate_));
+  ESP_LOGCONFIG(TAG, "  FIFO: %s", YESNO(this->fifo_enabled_));
+  if (this->fifo_enabled_) {
+    ESP_LOGCONFIG(TAG, "  FIFO watermark: %u", this->fifo_watermark_);
+  }
+  ESP_LOGCONFIG(TAG, "  Tap detection: %s", YESNO(this->tap_enabled_));
+  ESP_LOGCONFIG(TAG, "  Activity detection: %s", YESNO(this->activity_enabled_));
+  ESP_LOGCONFIG(TAG, "  Free-fall detection: %s", YESNO(this->freefall_enabled_));
+  LOG_PIN("  INT1 pin: ", this->int1_pin_);
+  LOG_PIN("  INT2 pin: ", this->int2_pin_);
+  ESP_LOGCONFIG(TAG, "  Event source: %s", this->interrupt_driven_() ? "interrupt" : "polled (no INT pin wired)");
+  ESP_LOGCONFIG(TAG, "  Deep sleep wakeup: %s", YESNO(this->enable_deep_sleep_wakeup_));
+  ESP_LOGCONFIG(TAG, "  Auto low-power mode (10 Hz when still): %s", YESNO(this->auto_low_power_enabled_));
+  ESP_LOGCONFIG(TAG, "  Temperature: %s", YESNO(this->temperature_enabled_));
+  LOG_UPDATE_INTERVAL(this);
+
+#ifdef USE_SENSOR
+  LOG_SENSOR("  ", "Acceleration X", this->acceleration_x_sensor_);
+  LOG_SENSOR("  ", "Acceleration Y", this->acceleration_y_sensor_);
+  LOG_SENSOR("  ", "Acceleration Z", this->acceleration_z_sensor_);
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+#endif
+#ifdef USE_BINARY_SENSOR
+  LOG_BINARY_SENSOR("  ", "Tap", this->tap_binary_sensor_);
+  LOG_BINARY_SENSOR("  ", "Double Tap", this->double_tap_binary_sensor_);
+  LOG_BINARY_SENSOR("  ", "Activity", this->activity_binary_sensor_);
+  LOG_BINARY_SENSOR("  ", "Free-fall", this->freefall_binary_sensor_);
+#endif
+#ifdef USE_TEXT_SENSOR
+  LOG_TEXT_SENSOR("  ", "Orientation XY", this->orientation_xy_text_sensor_);
+  LOG_TEXT_SENSOR("  ", "Orientation Z", this->orientation_z_text_sensor_);
+#endif
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with LIS3DH failed");
+  }
+}
+
+bool LIS3DHComponent::write_register_verified_(uint8_t reg, uint8_t value) {
+  for (int attempt = 0; attempt < 2; attempt++) {
+    if (!this->write_register(reg, &value, 1))
+      return false;
+    uint8_t readback = 0;
+    if (!this->read_register(reg, &readback, 1))
+      return false;
+    if (readback == value)
+      return true;
+  }
+  return false;
+}
+
+bool LIS3DHComponent::verify_device_id_() {
+  uint8_t whoami = 0;
+  if (!this->read_register(LIS3DH_WHO_AM_I, &whoami, 1)) {
+    ESP_LOGE(TAG, "Failed to read WHO_AM_I register");
+    return false;
+  }
+  if (whoami != LIS3DH_ID) {
+    ESP_LOGE(TAG, "Invalid device ID: 0x%02X (expected 0x%02X)", whoami, LIS3DH_ID);
+    return false;
+  }
+  return true;
+}
+
+bool LIS3DHComponent::configure_device_() {
+  if (lis3dh_block_data_update_set(&this->dev_ctx_, PROPERTY_ENABLE) != 0) {
+    return false;
+  }
+
+  // Explicitly enable all three axes. No ST driver helper touches CTRL_REG1's Xen/Yen/Zen bits
+  // (the ODR/mode setters only modify their own fields), so if a previous session left them
+  // cleared -- the LIS3DH keeps its registers across ESP32 resets/deep sleep -- the output
+  // registers would otherwise stay frozen at their last converted value forever.
+  lis3dh_ctrl_reg1_t ctrl_reg1{};
+  if (!this->read_register(LIS3DH_CTRL_REG1, reinterpret_cast<uint8_t *>(&ctrl_reg1), 1)) {
+    return false;
+  }
+  ctrl_reg1.xen = 1;
+  ctrl_reg1.yen = 1;
+  ctrl_reg1.zen = 1;
+  if (!this->write_register(LIS3DH_CTRL_REG1, reinterpret_cast<uint8_t *>(&ctrl_reg1), 1)) {
+    return false;
+  }
+
+  if (this->temperature_enabled_ && lis3dh_aux_adc_set(&this->dev_ctx_, LIS3DH_AUX_ON_TEMPERATURE) != 0) {
+    return false;
+  }
+
+  lis3dh_fs_t fs;
+  switch (this->range_) {
+    case LIS3DHRange::RANGE_2G:
+      fs = LIS3DH_2g;
+      break;
+    case LIS3DHRange::RANGE_4G:
+      fs = LIS3DH_4g;
+      break;
+    case LIS3DHRange::RANGE_8G:
+      fs = LIS3DH_8g;
+      break;
+    case LIS3DHRange::RANGE_16G:
+      fs = LIS3DH_16g;
+      break;
+  }
+  if (lis3dh_full_scale_set(&this->dev_ctx_, fs) != 0) {
+    return false;
+  }
+
+  lis3dh_op_md_t op_md;
+  switch (this->mode_) {
+    case LIS3DHMode::MODE_LOW_POWER:
+      op_md = LIS3DH_LP_8bit;
+      break;
+    case LIS3DHMode::MODE_NORMAL:
+      op_md = LIS3DH_NM_10bit;
+      break;
+    case LIS3DHMode::MODE_HIGH_RESOLUTION:
+      op_md = LIS3DH_HR_12bit;
+      break;
+  }
+  if (lis3dh_operating_mode_set(&this->dev_ctx_, op_md) != 0) {
+    return false;
+  }
+
+  lis3dh_odr_t odr;
+  switch (this->data_rate_) {
+    case LIS3DHDataRate::ODR_1HZ:
+      odr = LIS3DH_ODR_1Hz;
+      break;
+    case LIS3DHDataRate::ODR_10HZ:
+      odr = LIS3DH_ODR_10Hz;
+      break;
+    case LIS3DHDataRate::ODR_25HZ:
+      odr = LIS3DH_ODR_25Hz;
+      break;
+    case LIS3DHDataRate::ODR_50HZ:
+      odr = LIS3DH_ODR_50Hz;
+      break;
+    case LIS3DHDataRate::ODR_100HZ:
+      odr = LIS3DH_ODR_100Hz;
+      break;
+    case LIS3DHDataRate::ODR_200HZ:
+      odr = LIS3DH_ODR_200Hz;
+      break;
+    case LIS3DHDataRate::ODR_400HZ:
+      odr = LIS3DH_ODR_400Hz;
+      break;
+    case LIS3DHDataRate::ODR_1600HZ:
+      odr = LIS3DH_ODR_1kHz620_LP;
+      break;
+    case LIS3DHDataRate::ODR_5376HZ:
+      odr = LIS3DH_ODR_5kHz376_LP_1kHz344_NM_HP;
+      break;
+  }
+  return lis3dh_data_rate_set(&this->dev_ctx_, odr) == 0;
+}
+
+bool LIS3DHComponent::configure_interrupt_routing_() {
+  // Always wire chip-side routing so that INT1/INT2 pads carry the right
+  // events. The MCU-side ISR is only attached if the user wired up the pin,
+  // but the chip-level routing is harmless when the pad is unused.
+  lis3dh_ctrl_reg3_t reg3{};
+  reg3.i1_click = this->tap_enabled_ ? PROPERTY_ENABLE : PROPERTY_DISABLE;
+  reg3.i1_ia1 = this->activity_enabled_ ? PROPERTY_ENABLE : PROPERTY_DISABLE;
+  // FIFO is always drained unconditionally in update() regardless of the watermark interrupt
+  // (see read_fifo_data_()), so nothing consumes this signal -- and routing it onto INT1 would
+  // pin that pad high (blocking deep-sleep wakeup) any time the bus can't drain the FIFO faster
+  // than ODR fills it. Never route it.
+  reg3.i1_wtm = PROPERTY_DISABLE;
+  if (lis3dh_pin_int1_config_set(&this->dev_ctx_, &reg3) != 0) {
+    return false;
+  }
+
+  lis3dh_ctrl_reg6_t reg6{};
+  reg6.i2_ia2 = this->freefall_enabled_ ? PROPERTY_ENABLE : PROPERTY_DISABLE;
+  if (lis3dh_pin_int2_config_set(&this->dev_ctx_, &reg6) != 0) {
+    return false;
+  }
+
+  // Latch INT1 whenever activity detection drives it, or whenever the caller wants INT1 to
+  // hold the ESP32's deep-sleep wakeup GPIO asserted until the event is read out. INT2
+  // (free-fall) is left non-latched so it tracks state.
+  const bool latch_int1 = this->activity_enabled_ || this->enable_deep_sleep_wakeup_;
+  if (latch_int1 && lis3dh_int1_pin_notification_mode_set(&this->dev_ctx_, LIS3DH_INT1_LATCHED) != 0) {
+    return false;
+  }
+  return true;
+}
+
+bool LIS3DHComponent::configure_fifo_() {
+  lis3dh_fm_t fifo_mode;
+  switch (this->fifo_mode_) {
+    case LIS3DHFifoMode::FIFO_BYPASS:
+      fifo_mode = LIS3DH_BYPASS_MODE;
+      break;
+    case LIS3DHFifoMode::FIFO_MODE:
+      fifo_mode = LIS3DH_FIFO_MODE;
+      break;
+    case LIS3DHFifoMode::FIFO_STREAM:
+      fifo_mode = LIS3DH_DYNAMIC_STREAM_MODE;
+      break;
+    case LIS3DHFifoMode::FIFO_STREAM_TO_FIFO:
+      fifo_mode = LIS3DH_STREAM_TO_FIFO_MODE;
+      break;
+  }
+  if (lis3dh_fifo_mode_set(&this->dev_ctx_, fifo_mode) != 0)
+    return false;
+  if (lis3dh_fifo_watermark_set(&this->dev_ctx_, this->fifo_watermark_) != 0)
+    return false;
+  return lis3dh_fifo_set(&this->dev_ctx_, PROPERTY_ENABLE) == 0;
+}
+
+bool LIS3DHComponent::configure_tap_detection_() {
+  lis3dh_click_cfg_t click_cfg{};
+  click_cfg.xs = PROPERTY_ENABLE;
+  click_cfg.ys = PROPERTY_ENABLE;
+  click_cfg.zs = PROPERTY_ENABLE;
+  click_cfg.xd = PROPERTY_ENABLE;
+  click_cfg.yd = PROPERTY_ENABLE;
+  click_cfg.zd = PROPERTY_ENABLE;
+
+  if (lis3dh_tap_conf_set(&this->dev_ctx_, &click_cfg) != 0)
+    return false;
+  if (lis3dh_tap_threshold_set(&this->dev_ctx_, this->tap_threshold_) != 0)
+    return false;
+  if (lis3dh_shock_dur_set(&this->dev_ctx_, this->tap_shock_duration_) != 0)
+    return false;
+  if (lis3dh_quiet_dur_set(&this->dev_ctx_, this->tap_quiet_duration_) != 0)
+    return false;
+  return lis3dh_double_tap_timeout_set(&this->dev_ctx_, this->tap_double_tap_timeout_) == 0;
+}
+
+bool LIS3DHComponent::configure_motion_detection_() {
+  lis3dh_int1_cfg_t int1_cfg{};
+  int1_cfg.xlie = PROPERTY_ENABLE;
+  int1_cfg.xhie = PROPERTY_ENABLE;
+  int1_cfg.ylie = PROPERTY_ENABLE;
+  int1_cfg.yhie = PROPERTY_ENABLE;
+  int1_cfg.zlie = PROPERTY_ENABLE;
+  int1_cfg.zhie = PROPERTY_ENABLE;
+  const auto activity_mode = static_cast<uint8_t>(this->activity_interrupt_mode_);
+  int1_cfg._6d = activity_mode & 0x01;
+  int1_cfg.aoi = (activity_mode >> 1) & 0x01;
+
+  if (!this->write_register_verified_(LIS3DH_INT1_CFG, *reinterpret_cast<uint8_t *>(&int1_cfg)))
+    return false;
+  if (lis3dh_int1_gen_threshold_set(&this->dev_ctx_, this->activity_threshold_) != 0)
+    return false;
+  if (lis3dh_int1_gen_duration_set(&this->dev_ctx_, this->activity_duration_) != 0)
+    return false;
+
+  // Always write the HP routing explicitly, even when disabling it -- the LIS3DH can stay
+  // powered continuously across ESP32 reboots, so a stale routing left over from an earlier
+  // configuration (e.g. when high_pass_filter_enabled was previously true) would otherwise
+  // persist in hardware indefinitely, silently no-op'ing this option.
+  const auto hp_routing = this->high_pass_filter_enabled_ ? LIS3DH_ON_INT1_GEN : LIS3DH_DISC_FROM_INT_GENERATOR;
+  if (lis3dh_high_pass_int_conf_set(&this->dev_ctx_, hp_routing) != 0)
+    return false;
+  // Keep the output data path (and FIFO) unfiltered regardless -- OUT_X/Y/Z must carry the DC
+  // component so orientation/6D zone recognition can use the gravity vector.
+  if (lis3dh_high_pass_on_outputs_set(&this->dev_ctx_, PROPERTY_DISABLE) != 0)
+    return false;
+
+  if (this->high_pass_filter_enabled_) {
+    uint8_t dummy;
+    if (lis3dh_filter_reference_get(&this->dev_ctx_, &dummy) != 0)
+      return false;
+  }
+  return true;
+}
+
+bool LIS3DHComponent::configure_freefall_detection_() {
+  lis3dh_int2_cfg_t int2_cfg{};
+  int2_cfg.xlie = PROPERTY_ENABLE;
+  int2_cfg.ylie = PROPERTY_ENABLE;
+  int2_cfg.zlie = PROPERTY_ENABLE;
+  const auto freefall_mode = static_cast<uint8_t>(this->freefall_interrupt_mode_);
+  int2_cfg._6d = freefall_mode & 0x01;
+  int2_cfg.aoi = (freefall_mode >> 1) & 0x01;
+
+  // Same INT1_CFG errata likely applies to INT2_CFG (same design family).
+  if (!this->write_register_verified_(LIS3DH_INT2_CFG, *reinterpret_cast<uint8_t *>(&int2_cfg)))
+    return false;
+  if (lis3dh_int2_gen_threshold_set(&this->dev_ctx_, this->freefall_threshold_) != 0)
+    return false;
+  return lis3dh_int2_gen_duration_set(&this->dev_ctx_, this->freefall_duration_) == 0;
+}
+
+bool LIS3DHComponent::configure_auto_low_power_() {
+  if (lis3dh_act_threshold_set(&this->dev_ctx_, this->auto_low_power_threshold_) != 0)
+    return false;
+  return lis3dh_act_timeout_set(&this->dev_ctx_, this->auto_low_power_duration_) == 0;
+}
+
+void LIS3DHComponent::read_acceleration_data_() {
+  uint8_t raw_data[6];
+  if (!this->read_register(LIS3DH_OUT_X_L, raw_data, 6)) {
+    ESP_LOGW(TAG, "Failed to read acceleration data");
+    return;
+  }
+
+  int16_t raw_x = static_cast<int16_t>((raw_data[1] << 8) | raw_data[0]);
+  int16_t raw_y = static_cast<int16_t>((raw_data[3] << 8) | raw_data[2]);
+  int16_t raw_z = static_cast<int16_t>((raw_data[5] << 8) | raw_data[4]);
+
+  this->accel_x_ms2_ = this->convert_acceleration_to_ms2_(raw_x);
+  this->accel_y_ms2_ = this->convert_acceleration_to_ms2_(raw_y);
+  this->accel_z_ms2_ = this->convert_acceleration_to_ms2_(raw_z);
+
+#ifdef USE_SENSOR
+  if (this->acceleration_x_sensor_ != nullptr) {
+    this->acceleration_x_sensor_->publish_state(this->accel_x_ms2_);
+  }
+  if (this->acceleration_y_sensor_ != nullptr) {
+    this->acceleration_y_sensor_->publish_state(this->accel_y_ms2_);
+  }
+  if (this->acceleration_z_sensor_ != nullptr) {
+    this->acceleration_z_sensor_->publish_state(this->accel_z_ms2_);
+  }
+#endif
+}
+
+void LIS3DHComponent::read_temperature_data_() {
+#ifdef USE_SENSOR
+  if (this->temperature_sensor_ == nullptr) {
+    return;
+  }
+  uint8_t raw_data[2];
+  if (!this->read_register(LIS3DH_OUT_ADC3_L, raw_data, 2)) {
+    ESP_LOGW(TAG, "Failed to read temperature data");
+    return;
+  }
+  int16_t temp_raw = static_cast<int16_t>((raw_data[1] << 8) | raw_data[0]);
+  this->temperature_sensor_->publish_state(this->convert_temperature_(static_cast<int8_t>(temp_raw >> 8)));
+#endif
+}
+
+void LIS3DHComponent::read_fifo_data_() {
+  uint8_t fifo_src;
+  if (!this->read_register(LIS3DH_FIFO_SRC_REG, &fifo_src, 1)) {
+    return;
+  }
+  // Drain any pending samples so the FIFO doesn't stall — we don't aggregate
+  // them, but holding state would prevent further watermark interrupts.
+  const uint8_t num_samples = fifo_src & 0x1F;
+  for (uint8_t i = 0; i < num_samples; i++) {
+    uint8_t raw_data[6];
+    if (!this->read_register(LIS3DH_OUT_X_L, raw_data, 6)) {
+      break;
+    }
+  }
+}
+
+void LIS3DHComponent::process_event_sources_() {
+  uint8_t int1_src = 0;
+  uint8_t int2_src = 0;
+  uint8_t click_src = 0;
+
+  if (this->activity_enabled_) {
+    this->read_register(LIS3DH_INT1_SRC, &int1_src, 1);
+  }
+  if (this->freefall_enabled_) {
+    this->read_register(LIS3DH_INT2_SRC, &int2_src, 1);
+  }
+  if (this->tap_enabled_) {
+    this->read_register(LIS3DH_CLICK_SRC, &click_src, 1);
+  }
+
+  const uint32_t now = millis();
+
+  if (this->tap_enabled_) {
+    if (click_src & 0x40) {  // double-tap
+      if (now - this->last_double_tap_event_ > 500) {
+        this->double_tap_callback_.call();
+#ifdef USE_BINARY_SENSOR
+        if (this->double_tap_binary_sensor_ != nullptr) {
+          this->double_tap_binary_sensor_->publish_state(true);
+          this->double_tap_binary_sensor_->publish_state(false);
+        }
+#endif
+        this->last_double_tap_event_ = now;
+      }
+    } else if (click_src & 0x20) {  // single-tap
+      if (now - this->last_tap_event_ > 500) {
+        this->tap_callback_.call();
+#ifdef USE_BINARY_SENSOR
+        if (this->tap_binary_sensor_ != nullptr) {
+          this->tap_binary_sensor_->publish_state(true);
+          this->tap_binary_sensor_->publish_state(false);
+        }
+#endif
+        this->last_tap_event_ = now;
+      }
+    }
+  }
+
+  if (this->activity_enabled_) {
+    const bool active = (int1_src & 0x40) != 0;  // IA bit
+    if (this->last_activity_state_ != active) {
+      if (active) {
+        this->activity_callback_.call();
+      }
+#ifdef USE_BINARY_SENSOR
+      if (this->activity_binary_sensor_ != nullptr) {
+        this->activity_binary_sensor_->publish_state(active);
+      }
+#endif
+      this->last_activity_state_ = active;
+    }
+  }
+
+  if (this->freefall_enabled_) {
+    const bool freefall = (int2_src & 0x40) != 0;
+    if (this->last_freefall_state_ != freefall) {
+      if (freefall) {
+        this->freefall_callback_.call();
+      }
+#ifdef USE_BINARY_SENSOR
+      if (this->freefall_binary_sensor_ != nullptr) {
+        this->freefall_binary_sensor_->publish_state(freefall);
+      }
+#endif
+      this->last_freefall_state_ = freefall;
+    }
+  }
+}
+
+void LIS3DHComponent::update_orientation_() {
+#ifdef USE_TEXT_SENSOR
+  if (this->orientation_xy_text_sensor_ == nullptr && this->orientation_z_text_sensor_ == nullptr) {
+    return;
+  }
+#else
+  if (this->orientation_change_callback_.size() == 0) {
+    return;
+  }
+#endif
+
+  // Compare absolute axis magnitudes; the dominant axis points along gravity.
+  const float ax = std::fabs(this->accel_x_ms2_);
+  const float ay = std::fabs(this->accel_y_ms2_);
+  const float az = std::fabs(this->accel_z_ms2_);
+  // Hysteresis: require >0.6g (~5.9 m/s²) along the dominant axis to commit.
+  static constexpr float MIN_DOMINANT_MS2 = 5.9f;
+
+  LIS3DHOrientationXY xy = this->last_orientation_xy_;
+  if (az > ax && az > ay) {
+    xy = LIS3DHOrientationXY::FLAT;
+  } else if (ay > ax && ay > MIN_DOMINANT_MS2) {
+    xy = this->accel_y_ms2_ > 0 ? LIS3DHOrientationXY::PORTRAIT_UPRIGHT : LIS3DHOrientationXY::PORTRAIT_UPSIDE_DOWN;
+  } else if (ax > MIN_DOMINANT_MS2) {
+    xy = this->accel_x_ms2_ > 0 ? LIS3DHOrientationXY::LANDSCAPE_RIGHT : LIS3DHOrientationXY::LANDSCAPE_LEFT;
+  }
+
+  LIS3DHOrientationZ z = this->accel_z_ms2_ >= 0 ? LIS3DHOrientationZ::FACE_UP : LIS3DHOrientationZ::FACE_DOWN;
+
+  const bool changed =
+      !this->orientation_published_ || xy != this->last_orientation_xy_ || z != this->last_orientation_z_;
+
+#ifdef USE_TEXT_SENSOR
+  if (this->orientation_xy_text_sensor_ != nullptr &&
+      (!this->orientation_published_ || xy != this->last_orientation_xy_)) {
+    this->orientation_xy_text_sensor_->publish_state(orientation_xy_to_str(xy));
+  }
+  if (this->orientation_z_text_sensor_ != nullptr &&
+      (!this->orientation_published_ || z != this->last_orientation_z_)) {
+    this->orientation_z_text_sensor_->publish_state(orientation_z_to_str(z));
+  }
+#endif
+
+  if (changed && this->orientation_published_) {
+    this->orientation_change_callback_.call();
+  }
+
+  this->last_orientation_xy_ = xy;
+  this->last_orientation_z_ = z;
+  this->orientation_published_ = true;
+}
+
+float LIS3DHComponent::convert_acceleration_to_ms2_(int16_t raw) {
+  float conversion_factor = 0.0f;
+
+  switch (this->mode_) {
+    case LIS3DHMode::MODE_LOW_POWER:
+      switch (this->range_) {
+        case LIS3DHRange::RANGE_2G:
+          conversion_factor = lis3dh_from_fs2_lp_to_mg(1.0f);
+          break;
+        case LIS3DHRange::RANGE_4G:
+          conversion_factor = lis3dh_from_fs4_lp_to_mg(1.0f);
+          break;
+        case LIS3DHRange::RANGE_8G:
+          conversion_factor = lis3dh_from_fs8_lp_to_mg(1.0f);
+          break;
+        case LIS3DHRange::RANGE_16G:
+          conversion_factor = lis3dh_from_fs16_lp_to_mg(1.0f);
+          break;
+      }
+      break;
+    case LIS3DHMode::MODE_NORMAL:
+      switch (this->range_) {
+        case LIS3DHRange::RANGE_2G:
+          conversion_factor = lis3dh_from_fs2_nm_to_mg(1.0f);
+          break;
+        case LIS3DHRange::RANGE_4G:
+          conversion_factor = lis3dh_from_fs4_nm_to_mg(1.0f);
+          break;
+        case LIS3DHRange::RANGE_8G:
+          conversion_factor = lis3dh_from_fs8_nm_to_mg(1.0f);
+          break;
+        case LIS3DHRange::RANGE_16G:
+          conversion_factor = lis3dh_from_fs16_nm_to_mg(1.0f);
+          break;
+      }
+      break;
+    case LIS3DHMode::MODE_HIGH_RESOLUTION:
+      switch (this->range_) {
+        case LIS3DHRange::RANGE_2G:
+          conversion_factor = lis3dh_from_fs2_hr_to_mg(1.0f);
+          break;
+        case LIS3DHRange::RANGE_4G:
+          conversion_factor = lis3dh_from_fs4_hr_to_mg(1.0f);
+          break;
+        case LIS3DHRange::RANGE_8G:
+          conversion_factor = lis3dh_from_fs8_hr_to_mg(1.0f);
+          break;
+        case LIS3DHRange::RANGE_16G:
+          conversion_factor = lis3dh_from_fs16_hr_to_mg(1.0f);
+          break;
+      }
+      break;
+  }
+
+  return (raw * conversion_factor / 1000.0f) * 9.80665f;
+}
+
+float LIS3DHComponent::convert_temperature_(int16_t raw) { return 25.0f + raw / 64.0f; }
+
+}  // namespace lis3dh
+}  // namespace esphome

--- a/esphome/components/lis3dh/lis3dh.h
+++ b/esphome/components/lis3dh/lis3dh.h
@@ -1,0 +1,306 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/gpio.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+
+#include "lis3dh_reg.h"
+
+namespace esphome {
+namespace lis3dh {
+
+enum class LIS3DHRange : uint8_t {
+  RANGE_2G = 0,
+  RANGE_4G = 1,
+  RANGE_8G = 2,
+  RANGE_16G = 3,
+};
+
+enum class LIS3DHMode : uint8_t {
+  MODE_LOW_POWER = 0,
+  MODE_NORMAL = 1,
+  MODE_HIGH_RESOLUTION = 2,
+};
+
+enum class LIS3DHDataRate : uint8_t {
+  ODR_1HZ = 0x01,
+  ODR_10HZ = 0x02,
+  ODR_25HZ = 0x03,
+  ODR_50HZ = 0x04,
+  ODR_100HZ = 0x05,
+  ODR_200HZ = 0x06,
+  ODR_400HZ = 0x07,
+  ODR_1600HZ = 0x08,
+  ODR_5376HZ = 0x09,
+};
+
+enum class LIS3DHFifoMode : uint8_t {
+  FIFO_BYPASS = 0,
+  FIFO_MODE = 1,
+  FIFO_STREAM = 2,
+  FIFO_STREAM_TO_FIFO = 3,
+};
+
+// Matches the AOI/6D encoding in INT1_CFG/INT2_CFG (AOI is the high bit, 6D the low bit) so it
+// can be written directly: see ST LIS3DH datasheet Table 64 "Interrupt mode".
+enum class LIS3DHInterruptMode : uint8_t {
+  OR = 0,           // AOI=0, 6D=0: OR combination of interrupt events
+  MOVEMENT_6D = 1,  // AOI=0, 6D=1: 6-direction movement recognition
+  AND = 2,          // AOI=1, 6D=0: AND combination of interrupt events
+  POSITION_6D = 3,  // AOI=1, 6D=1: 6-direction position recognition
+};
+
+enum class LIS3DHOrientationXY : uint8_t {
+  PORTRAIT_UPRIGHT,
+  PORTRAIT_UPSIDE_DOWN,
+  LANDSCAPE_LEFT,
+  LANDSCAPE_RIGHT,
+  FLAT,
+};
+
+enum class LIS3DHOrientationZ : uint8_t {
+  FACE_UP,
+  FACE_DOWN,
+};
+
+// ISR-side store, kept POD so it lives outside the vtable-bearing class.
+struct LIS3DHStore {
+  ISRInternalGPIOPin int1_pin;
+  ISRInternalGPIOPin int2_pin;
+  volatile bool int1_triggered{false};
+  volatile bool int2_triggered{false};
+  Component *parent{nullptr};
+
+  static void IRAM_ATTR int1_gpio_intr(LIS3DHStore *arg);
+  static void IRAM_ATTR int2_gpio_intr(LIS3DHStore *arg);
+};
+
+class LIS3DHComponent : public PollingComponent {
+ public:
+  LIS3DHComponent() = default;
+
+  void setup() override;
+  void update() override;
+  void loop() override;
+  void dump_config() override;
+
+  float get_setup_priority() const override { return setup_priority::BUS; }
+
+  void set_accel_range(LIS3DHRange range) { this->range_ = range; }
+  void set_operating_mode(LIS3DHMode mode) { this->mode_ = mode; }
+  void set_odr(LIS3DHDataRate rate) { this->data_rate_ = rate; }
+
+  void set_fifo_enabled(bool enabled) { this->fifo_enabled_ = enabled; }
+  void set_fifo_mode(LIS3DHFifoMode mode) { this->fifo_mode_ = mode; }
+  void set_fifo_watermark(uint8_t watermark) { this->fifo_watermark_ = watermark; }
+
+  void set_int1_pin(InternalGPIOPin *pin) { this->int1_pin_ = pin; }
+  void set_int2_pin(InternalGPIOPin *pin) { this->int2_pin_ = pin; }
+
+  void set_tap_enabled(bool enabled) { this->tap_enabled_ = enabled; }
+  void set_tap_threshold(uint8_t threshold) { this->tap_threshold_ = threshold; }
+  void set_tap_shock_duration(uint8_t duration) { this->tap_shock_duration_ = duration; }
+  void set_tap_quiet_duration(uint8_t duration) { this->tap_quiet_duration_ = duration; }
+  void set_tap_double_tap_timeout(uint8_t timeout) { this->tap_double_tap_timeout_ = timeout; }
+
+  void set_activity_enabled(bool enabled) { this->activity_enabled_ = enabled; }
+  void set_activity_threshold(uint8_t threshold) { this->activity_threshold_ = threshold; }
+  void set_activity_duration(uint8_t duration) { this->activity_duration_ = duration; }
+  void set_activity_interrupt_mode(LIS3DHInterruptMode mode) { this->activity_interrupt_mode_ = mode; }
+
+  void set_freefall_enabled(bool enabled) { this->freefall_enabled_ = enabled; }
+  void set_freefall_threshold(uint8_t threshold) { this->freefall_threshold_ = threshold; }
+  void set_freefall_duration(uint8_t duration) { this->freefall_duration_ = duration; }
+  void set_freefall_interrupt_mode(LIS3DHInterruptMode mode) { this->freefall_interrupt_mode_ = mode; }
+
+  void set_enable_deep_sleep_wakeup(bool enabled) { this->enable_deep_sleep_wakeup_ = enabled; }
+
+  // "Sleep-to-wake" / "return-to-sleep": hardware-only ODR throttling, distinct from the
+  // INT1 activity generator (which raises an interrupt) above. When enabled, the chip drops
+  // itself to 10 Hz ODR after acceleration stays below auto_low_power_threshold_ for
+  // auto_low_power_duration_, then restores the configured ODR/mode as soon as acceleration
+  // exceeds the threshold again -- with no CPU involvement.
+  void set_auto_low_power_enabled(bool enabled) { this->auto_low_power_enabled_ = enabled; }
+  void set_auto_low_power_threshold(uint8_t threshold) { this->auto_low_power_threshold_ = threshold; }
+  void set_auto_low_power_duration(uint8_t duration) { this->auto_low_power_duration_ = duration; }
+
+  void set_high_pass_filter_enabled(bool enabled) { this->high_pass_filter_enabled_ = enabled; }
+  void set_high_pass_filter_mode(uint8_t mode) { this->high_pass_filter_mode_ = mode; }
+  void set_high_pass_filter_cutoff(uint8_t cutoff) { this->high_pass_filter_cutoff_ = cutoff; }
+
+  void set_temperature_enabled(bool enabled) { this->temperature_enabled_ = enabled; }
+
+#ifdef USE_SENSOR
+  SUB_SENSOR(acceleration_x)
+  SUB_SENSOR(acceleration_y)
+  SUB_SENSOR(acceleration_z)
+  SUB_SENSOR(temperature)
+#endif
+
+#ifdef USE_BINARY_SENSOR
+  SUB_BINARY_SENSOR(tap)
+  SUB_BINARY_SENSOR(double_tap)
+  SUB_BINARY_SENSOR(activity)
+  SUB_BINARY_SENSOR(freefall)
+#endif
+
+#ifdef USE_TEXT_SENSOR
+  SUB_TEXT_SENSOR(orientation_xy)
+  SUB_TEXT_SENSOR(orientation_z)
+#endif
+
+  template<typename F> void add_on_tap_callback(F &&callback) { this->tap_callback_.add(std::forward<F>(callback)); }
+  template<typename F> void add_on_double_tap_callback(F &&callback) {
+    this->double_tap_callback_.add(std::forward<F>(callback));
+  }
+  template<typename F> void add_on_activity_callback(F &&callback) {
+    this->activity_callback_.add(std::forward<F>(callback));
+  }
+  template<typename F> void add_on_freefall_callback(F &&callback) {
+    this->freefall_callback_.add(std::forward<F>(callback));
+  }
+  template<typename F> void add_on_orientation_change_callback(F &&callback) {
+    this->orientation_change_callback_.add(std::forward<F>(callback));
+  }
+
+  // Public for STMems driver C-callback bridge.
+  virtual bool read_register(uint8_t reg, uint8_t *data, uint16_t len) = 0;
+  virtual bool write_register(uint8_t reg, const uint8_t *data, uint16_t len) = 0;
+
+ protected:
+  // Errata: the LIS3DH's first write to INT1_CFG/INT2_CFG after power-up can be silently
+  // dropped. Writes, reads back to confirm, and retries once more if the readback mismatches.
+  bool write_register_verified_(uint8_t reg, uint8_t value);
+
+  bool verify_device_id_();
+  bool configure_device_();
+  bool configure_interrupt_routing_();
+  bool configure_fifo_();
+  bool configure_tap_detection_();
+  bool configure_motion_detection_();
+  bool configure_freefall_detection_();
+  bool configure_auto_low_power_();
+
+  void read_acceleration_data_();
+  void read_temperature_data_();
+  void read_fifo_data_();
+  void process_event_sources_();
+  void update_orientation_();
+
+  float convert_acceleration_to_ms2_(int16_t raw);
+  float convert_temperature_(int16_t raw);
+
+  // Whether ISR pins drive the loop. False means we always poll from update().
+  bool interrupt_driven_() const { return this->int1_pin_ != nullptr || this->int2_pin_ != nullptr; }
+
+  stmdev_ctx_t dev_ctx_{};
+
+  LIS3DHRange range_;
+  LIS3DHMode mode_;
+  LIS3DHDataRate data_rate_;
+
+  bool fifo_enabled_;
+  LIS3DHFifoMode fifo_mode_;
+  uint8_t fifo_watermark_;
+
+  InternalGPIOPin *int1_pin_{nullptr};
+  InternalGPIOPin *int2_pin_{nullptr};
+
+  bool tap_enabled_;
+  uint8_t tap_threshold_;
+  uint8_t tap_shock_duration_;
+  uint8_t tap_quiet_duration_;
+  uint8_t tap_double_tap_timeout_;
+
+  bool activity_enabled_;
+  uint8_t activity_threshold_;
+  uint8_t activity_duration_;
+  LIS3DHInterruptMode activity_interrupt_mode_{LIS3DHInterruptMode::OR};
+
+  bool freefall_enabled_;
+  uint8_t freefall_threshold_;
+  uint8_t freefall_duration_;
+  LIS3DHInterruptMode freefall_interrupt_mode_{LIS3DHInterruptMode::AND};
+
+  bool enable_deep_sleep_wakeup_;
+
+  bool auto_low_power_enabled_;
+  uint8_t auto_low_power_threshold_;
+  uint8_t auto_low_power_duration_;
+
+  bool high_pass_filter_enabled_;
+  uint8_t high_pass_filter_mode_;
+  uint8_t high_pass_filter_cutoff_;
+
+  bool temperature_enabled_;
+
+  uint32_t last_tap_event_{0};
+  uint32_t last_double_tap_event_{0};
+  bool last_activity_state_{false};
+  bool last_freefall_state_{false};
+
+  LIS3DHOrientationXY last_orientation_xy_{LIS3DHOrientationXY::FLAT};
+  LIS3DHOrientationZ last_orientation_z_{LIS3DHOrientationZ::FACE_UP};
+  bool orientation_published_{false};
+
+  CallbackManager<void()> tap_callback_;
+  CallbackManager<void()> double_tap_callback_;
+  CallbackManager<void()> activity_callback_;
+  CallbackManager<void()> freefall_callback_;
+  CallbackManager<void()> orientation_change_callback_;
+
+  float accel_x_ms2_{0};
+  float accel_y_ms2_{0};
+  float accel_z_ms2_{0};
+
+  LIS3DHStore store_;
+};
+
+class TapTrigger : public Trigger<> {
+ public:
+  explicit TapTrigger(LIS3DHComponent *parent) {
+    parent->add_on_tap_callback([this]() { this->trigger(); });
+  }
+};
+
+class DoubleTapTrigger : public Trigger<> {
+ public:
+  explicit DoubleTapTrigger(LIS3DHComponent *parent) {
+    parent->add_on_double_tap_callback([this]() { this->trigger(); });
+  }
+};
+
+class ActivityTrigger : public Trigger<> {
+ public:
+  explicit ActivityTrigger(LIS3DHComponent *parent) {
+    parent->add_on_activity_callback([this]() { this->trigger(); });
+  }
+};
+
+class FreefallTrigger : public Trigger<> {
+ public:
+  explicit FreefallTrigger(LIS3DHComponent *parent) {
+    parent->add_on_freefall_callback([this]() { this->trigger(); });
+  }
+};
+
+class OrientationChangeTrigger : public Trigger<> {
+ public:
+  explicit OrientationChangeTrigger(LIS3DHComponent *parent) {
+    parent->add_on_orientation_change_callback([this]() { this->trigger(); });
+  }
+};
+
+}  // namespace lis3dh
+}  // namespace esphome

--- a/esphome/components/lis3dh/lis3dh_reg.cpp
+++ b/esphome/components/lis3dh/lis3dh_reg.cpp
@@ -1,0 +1,2675 @@
+/**
+ ******************************************************************************
+ * @file    lis3dh_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LIS3DH driver file
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2021 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file
+ * in the same directory as this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
+ */
+
+#include "lis3dh_reg.h"
+
+namespace esphome {
+namespace lis3dh {
+
+/**
+ * @defgroup  LIS3DH
+ * @brief     This file provides a set of functions needed to drive the
+ *            lis3dh enanced inertial module.
+ * @{
+ *
+ */
+
+/**
+ * @defgroup  LIS3DH_Interfaces_Functions
+ * @brief     This section provide a set of functions used to read and
+ *            write a generic register of the device.
+ *            MANDATORY: return 0 -> no Error.
+ * @{
+ *
+ */
+
+/**
+ * @brief  Read generic device register
+ *
+ * @param  ctx   read / write interface definitions(ptr)
+ * @param  reg   register to read
+ * @param  data  pointer to buffer that store the data read(ptr)
+ * @param  len   number of consecutive register to read
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t __weak lis3dh_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data, uint16_t len) {
+  int32_t ret;
+
+  if (ctx == NULL) {
+    return -1;
+  }
+
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+
+  return ret;
+}
+
+/**
+ * @brief  Write generic device register
+ *
+ * @param  ctx   read / write interface definitions(ptr)
+ * @param  reg   register to write
+ * @param  data  pointer to data to write in register reg(ptr)
+ * @param  len   number of consecutive register to write
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t __weak lis3dh_write_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data, uint16_t len) {
+  int32_t ret;
+
+  if (ctx == NULL) {
+    return -1;
+  }
+
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+
+  return ret;
+}
+
+/**
+ * @}
+ *
+ */
+
+/**
+ * @defgroup    LIS3DH_Sensitivity
+ * @brief       These functions convert raw-data into engineering units.
+ * @{
+ *
+ */
+
+float_t lis3dh_from_fs2_hr_to_mg(int16_t lsb) { return ((float_t) lsb / 16.0f) * 1.0f; }
+
+float_t lis3dh_from_fs4_hr_to_mg(int16_t lsb) { return ((float_t) lsb / 16.0f) * 2.0f; }
+
+float_t lis3dh_from_fs8_hr_to_mg(int16_t lsb) { return ((float_t) lsb / 16.0f) * 4.0f; }
+
+float_t lis3dh_from_fs16_hr_to_mg(int16_t lsb) { return ((float_t) lsb / 16.0f) * 12.0f; }
+
+float_t lis3dh_from_lsb_hr_to_celsius(int16_t lsb) { return (((float_t) lsb / 64.0f) / 4.0f) + 25.0f; }
+
+float_t lis3dh_from_fs2_nm_to_mg(int16_t lsb) { return ((float_t) lsb / 64.0f) * 4.0f; }
+
+float_t lis3dh_from_fs4_nm_to_mg(int16_t lsb) { return ((float_t) lsb / 64.0f) * 8.0f; }
+
+float_t lis3dh_from_fs8_nm_to_mg(int16_t lsb) { return ((float_t) lsb / 64.0f) * 16.0f; }
+
+float_t lis3dh_from_fs16_nm_to_mg(int16_t lsb) { return ((float_t) lsb / 64.0f) * 48.0f; }
+
+float_t lis3dh_from_lsb_nm_to_celsius(int16_t lsb) { return (((float_t) lsb / 64.0f) / 4.0f) + 25.0f; }
+
+float_t lis3dh_from_fs2_lp_to_mg(int16_t lsb) { return ((float_t) lsb / 256.0f) * 16.0f; }
+
+float_t lis3dh_from_fs4_lp_to_mg(int16_t lsb) { return ((float_t) lsb / 256.0f) * 32.0f; }
+
+float_t lis3dh_from_fs8_lp_to_mg(int16_t lsb) { return ((float_t) lsb / 256.0f) * 64.0f; }
+
+float_t lis3dh_from_fs16_lp_to_mg(int16_t lsb) { return ((float_t) lsb / 256.0f) * 192.0f; }
+
+float_t lis3dh_from_lsb_lp_to_celsius(int16_t lsb) { return (((float_t) lsb / 256.0f) * 1.0f) + 25.0f; }
+
+/**
+ * @}
+ *
+ */
+
+/**
+ * @defgroup  LIS3DH_Data_generation
+ * @brief     This section group all the functions concerning data generation.
+ * @{
+ *
+ */
+
+/**
+ * @brief  Temperature status register.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  buff     buffer that stores data read
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_temp_status_reg_get(const stmdev_ctx_t *ctx, uint8_t *buff) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG_AUX, buff, 1);
+
+  return ret;
+}
+/**
+ * @brief  Temperature data available.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of tda in reg STATUS_REG_AUX
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_temp_data_ready_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG_AUX, (uint8_t *) &status_reg_aux, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = status_reg_aux._3da;
+
+  return ret;
+}
+/**
+ * @brief  Temperature data overrun.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of tor in reg STATUS_REG_AUX
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_temp_data_ovr_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG_AUX, (uint8_t *) &status_reg_aux, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = status_reg_aux._3or;
+
+  return ret;
+}
+/**
+ * @brief  Temperature output value.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  buff     buffer that stores data read
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val) {
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_OUT_ADC3_L, buff, 2);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (int16_t) buff[1];
+  *val = (*val * 256) + (int16_t) buff[0];
+
+  return ret;
+}
+
+/**
+ * @brief  ADC output value.[get]
+ *         Sample frequency: the same as the ODR CTRL_REG1
+ *         The resolution:
+ *                    10bit if LPen bit in CTRL_REG1 (20h) is clear
+ *                     8bit if LPen bit in CTRL_REG1 (20h) is set
+ *         Data Format:
+ *                     Outputs are Left Justified in 2’ complements
+ *                     range 800mV
+ *                     code zero means an analogue value of about 1.2V
+ *                     Voltage values smaller than centre values are positive
+ *                           (Example:  800mV = 7Fh / 127 dec)
+ *                     Voltage values bigger than centre values are negative
+ *                           (Example: 1600mV = 80h / -128 dec)
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  buff     buffer that stores data read
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_adc_raw_get(const stmdev_ctx_t *ctx, int16_t *val) {
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_OUT_ADC1_L, buff, 6);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  val[0] = (int16_t) buff[1];
+  val[0] = (val[0] * 256) + (int16_t) buff[0];
+  val[1] = (int16_t) buff[3];
+  val[1] = (val[1] * 256) + (int16_t) buff[2];
+  val[2] = (int16_t) buff[5];
+  val[2] = (val[2] * 256) + (int16_t) buff[4];
+
+  return ret;
+}
+
+/**
+ * @brief  Auxiliary ADC.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      configure the auxiliary ADC
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_aux_adc_set(const stmdev_ctx_t *ctx, lis3dh_temp_en_t val) {
+  lis3dh_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TEMP_CFG_REG, (uint8_t *) &temp_cfg_reg, 1);
+
+  if (ret == 0) {
+    if (val != LIS3DH_AUX_DISABLE) {
+      /* Required in order to use auxiliary adc */
+      ret = lis3dh_block_data_update_set(ctx, PROPERTY_ENABLE);
+    }
+  }
+
+  if (ret == 0) {
+    temp_cfg_reg.temp_en = ((uint8_t) val & 0x02U) >> 1;
+    temp_cfg_reg.adc_pd = (uint8_t) val & 0x01U;
+    ret = lis3dh_write_reg(ctx, LIS3DH_TEMP_CFG_REG, (uint8_t *) &temp_cfg_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Auxiliary ADC.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      configure the auxiliary ADC
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_aux_adc_get(const stmdev_ctx_t *ctx, lis3dh_temp_en_t *val) {
+  lis3dh_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TEMP_CFG_REG, (uint8_t *) &temp_cfg_reg, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  if ((temp_cfg_reg.temp_en & temp_cfg_reg.adc_pd) == PROPERTY_ENABLE) {
+    *val = LIS3DH_AUX_ON_TEMPERATURE;
+  }
+
+  if ((temp_cfg_reg.temp_en == PROPERTY_DISABLE) && (temp_cfg_reg.adc_pd == PROPERTY_ENABLE)) {
+    *val = LIS3DH_AUX_ON_PADS;
+  }
+
+  else {
+    *val = LIS3DH_AUX_DISABLE;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Operating mode selection.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of lpen in reg CTRL_REG1
+ *                  and HR in reg CTRL_REG4
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_operating_mode_set(const stmdev_ctx_t *ctx, lis3dh_op_md_t val) {
+  lis3dh_ctrl_reg1_t ctrl_reg1;
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG1, (uint8_t *) &ctrl_reg1, 1);
+  ret += lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret == 0) {
+    if (val == LIS3DH_HR_12bit) {
+      ctrl_reg1.lpen = 0;
+      ctrl_reg4.hr = 1;
+    }
+
+    if (val == LIS3DH_NM_10bit) {
+      ctrl_reg1.lpen = 0;
+      ctrl_reg4.hr = 0;
+    }
+
+    if (val == LIS3DH_LP_8bit) {
+      ctrl_reg1.lpen = 1;
+      ctrl_reg4.hr = 0;
+    }
+
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG1, (uint8_t *) &ctrl_reg1, 1);
+  }
+
+  if (ret == 0) {
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Operating mode selection.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of lpen in reg CTRL_REG1
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_operating_mode_get(const stmdev_ctx_t *ctx, lis3dh_op_md_t *val) {
+  lis3dh_ctrl_reg1_t ctrl_reg1;
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG1, (uint8_t *) &ctrl_reg1, 1);
+  ret += lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  if (ctrl_reg1.lpen == PROPERTY_ENABLE) {
+    *val = LIS3DH_LP_8bit;
+  }
+
+  else if (ctrl_reg4.hr == PROPERTY_ENABLE) {
+    *val = LIS3DH_HR_12bit;
+  }
+
+  else {
+    *val = LIS3DH_NM_10bit;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Output data rate selection.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of odr in reg CTRL_REG1
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_data_rate_set(const stmdev_ctx_t *ctx, lis3dh_odr_t val) {
+  lis3dh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG1, (uint8_t *) &ctrl_reg1, 1);
+
+  if (ret == 0) {
+    ctrl_reg1.odr = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG1, (uint8_t *) &ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Output data rate selection.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      get the values of odr in reg CTRL_REG1
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_data_rate_get(const stmdev_ctx_t *ctx, lis3dh_odr_t *val) {
+  lis3dh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG1, (uint8_t *) &ctrl_reg1, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (ctrl_reg1.odr) {
+    case 0x00:
+      *val = LIS3DH_POWER_DOWN;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_ODR_1Hz;
+      break;
+
+    case 0x02:
+      *val = LIS3DH_ODR_10Hz;
+      break;
+
+    case 0x03:
+      *val = LIS3DH_ODR_25Hz;
+      break;
+
+    case 0x04:
+      *val = LIS3DH_ODR_50Hz;
+      break;
+
+    case 0x05:
+      *val = LIS3DH_ODR_100Hz;
+      break;
+
+    case 0x06:
+      *val = LIS3DH_ODR_200Hz;
+      break;
+
+    case 0x07:
+      *val = LIS3DH_ODR_400Hz;
+      break;
+
+    case 0x08:
+      *val = LIS3DH_ODR_1kHz620_LP;
+      break;
+
+    case 0x09:
+      *val = LIS3DH_ODR_5kHz376_LP_1kHz344_NM_HP;
+      break;
+
+    default:
+      *val = LIS3DH_POWER_DOWN;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief   High pass data from internal filter sent to output register
+ *          and FIFO.
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of fds in reg CTRL_REG2
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_high_pass_on_outputs_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+
+  if (ret == 0) {
+    ctrl_reg2.fds = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief   High pass data from internal filter sent to output register
+ *          and FIFO.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of fds in reg CTRL_REG2
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_high_pass_on_outputs_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) ctrl_reg2.fds;
+
+  return ret;
+}
+
+/**
+ * @brief   High-pass filter cutoff frequency selection.[set]
+ *
+ * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+ * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+ * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+ * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+ * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of hpcf in reg CTRL_REG2
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_high_pass_bandwidth_set(const stmdev_ctx_t *ctx, lis3dh_hpcf_t val) {
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+
+  if (ret == 0) {
+    ctrl_reg2.hpcf = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief   High-pass filter cutoff frequency selection.[get]
+ *
+ * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+ * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+ * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+ * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+ * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      get the values of hpcf in reg CTRL_REG2
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_high_pass_bandwidth_get(const stmdev_ctx_t *ctx, lis3dh_hpcf_t *val) {
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (ctrl_reg2.hpcf) {
+    case 0x00:
+      *val = LIS3DH_AGGRESSIVE;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_STRONG;
+      break;
+
+    case 0x02:
+      *val = LIS3DH_MEDIUM;
+      break;
+
+    case 0x03:
+      *val = LIS3DH_LIGHT;
+      break;
+
+    default:
+      *val = LIS3DH_LIGHT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  High-pass filter mode selection.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of hpm in reg CTRL_REG2
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_high_pass_mode_set(const stmdev_ctx_t *ctx, lis3dh_hpm_t val) {
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+
+  if (ret == 0) {
+    ctrl_reg2.hpm = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  High-pass filter mode selection.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      get the values of hpm in reg CTRL_REG2
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_high_pass_mode_get(const stmdev_ctx_t *ctx, lis3dh_hpm_t *val) {
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (ctrl_reg2.hpm) {
+    case 0x00:
+      *val = LIS3DH_NORMAL_WITH_RST;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_REFERENCE_MODE;
+      break;
+
+    case 0x02:
+      *val = LIS3DH_NORMAL;
+      break;
+
+    case 0x03:
+      *val = LIS3DH_AUTORST_ON_INT;
+      break;
+
+    default:
+      *val = LIS3DH_NORMAL_WITH_RST;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Full-scale configuration.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of fs in reg CTRL_REG4
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_full_scale_set(const stmdev_ctx_t *ctx, lis3dh_fs_t val) {
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret == 0) {
+    ctrl_reg4.fs = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Full-scale configuration.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      get the values of fs in reg CTRL_REG4
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_full_scale_get(const stmdev_ctx_t *ctx, lis3dh_fs_t *val) {
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (ctrl_reg4.fs) {
+    case 0x00:
+      *val = LIS3DH_2g;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_4g;
+      break;
+
+    case 0x02:
+      *val = LIS3DH_8g;
+      break;
+
+    case 0x03:
+      *val = LIS3DH_16g;
+      break;
+
+    default:
+      *val = LIS3DH_2g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Block Data Update.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of bdu in reg CTRL_REG4
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret == 0) {
+    ctrl_reg4.bdu = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Block Data Update.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of bdu in reg CTRL_REG4
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_block_data_update_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) ctrl_reg4.bdu;
+
+  return ret;
+}
+
+/**
+ * @brief  Reference value for interrupt generation.[set]
+ *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  buff     buffer that contains data to write
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_filter_reference_set(const stmdev_ctx_t *ctx, uint8_t *buff) {
+  int32_t ret;
+
+  ret = lis3dh_write_reg(ctx, LIS3DH_REFERENCE, buff, 1);
+
+  return ret;
+}
+
+/**
+ * @brief  Reference value for interrupt generation.[get]
+ *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  buff     buffer that stores data read
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_filter_reference_get(const stmdev_ctx_t *ctx, uint8_t *buff) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_REFERENCE, buff, 1);
+
+  return ret;
+}
+/**
+ * @brief  Acceleration set of data available.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of zyxda in reg STATUS_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_xl_data_ready_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG, (uint8_t *) &status_reg, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+/**
+ * @brief  Acceleration set of data overrun.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of zyxor in reg STATUS_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_xl_data_ovr_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG, (uint8_t *) &status_reg, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = status_reg.zyxor;
+
+  return ret;
+}
+/**
+ * @brief  Acceleration output value.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  buff     buffer that stores data read
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val) {
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_OUT_X_L, buff, 6);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  val[0] = (int16_t) buff[1];
+  val[0] = (val[0] * 256) + (int16_t) buff[0];
+  val[1] = (int16_t) buff[3];
+  val[1] = (val[1] * 256) + (int16_t) buff[2];
+  val[2] = (int16_t) buff[5];
+  val[2] = (val[2] * 256) + (int16_t) buff[4];
+
+  return ret;
+}
+/**
+ * @}
+ *
+ */
+
+/**
+ * @defgroup  LIS3DH_Common
+ * @brief     This section group common useful functions
+ * @{
+ *
+ */
+
+/**
+ * @brief  DeviceWhoamI .[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  buff     buffer that stores data read
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_device_id_get(const stmdev_ctx_t *ctx, uint8_t *buff) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_WHO_AM_I, buff, 1);
+
+  return ret;
+}
+/**
+ * @brief  Self Test.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of st in reg CTRL_REG4
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_self_test_set(const stmdev_ctx_t *ctx, lis3dh_st_t val) {
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret == 0) {
+    ctrl_reg4.st = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Self Test.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      Get the values of st in reg CTRL_REG4
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_self_test_get(const stmdev_ctx_t *ctx, lis3dh_st_t *val) {
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (ctrl_reg4.st) {
+    case 0x00:
+      *val = LIS3DH_ST_DISABLE;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_ST_POSITIVE;
+      break;
+
+    case 0x02:
+      *val = LIS3DH_ST_NEGATIVE;
+      break;
+
+    default:
+      *val = LIS3DH_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Big/Little Endian data selection.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of ble in reg CTRL_REG4
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_data_format_set(const stmdev_ctx_t *ctx, lis3dh_ble_t val) {
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret == 0) {
+    ctrl_reg4.ble = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Big/Little Endian data selection.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      get the values of ble in reg CTRL_REG4
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_data_format_get(const stmdev_ctx_t *ctx, lis3dh_ble_t *val) {
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (ctrl_reg4.ble) {
+    case 0x00:
+      *val = LIS3DH_LSB_AT_LOW_ADD;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_MSB_AT_LOW_ADD;
+      break;
+
+    default:
+      *val = LIS3DH_LSB_AT_LOW_ADD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Reboot memory content. Reload the calibration parameters.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of boot in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_boot_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret == 0) {
+    ctrl_reg5.boot = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Reboot memory content. Reload the calibration parameters.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of boot in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_boot_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) ctrl_reg5.boot;
+
+  return ret;
+}
+
+/**
+ * @brief  Info about device status.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      register STATUS_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_status_get(const stmdev_ctx_t *ctx, lis3dh_status_reg_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG, (uint8_t *) val, 1);
+
+  return ret;
+}
+/**
+ * @}
+ *
+ */
+
+/**
+ * @defgroup   LIS3DH_Interrupts_generator_1
+ * @brief      This section group all the functions that manage the first
+ *             interrupts generator
+ * @{
+ *
+ */
+
+/**
+ * @brief  Interrupt generator 1 configuration register.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      register INT1_CFG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int1_gen_conf_set(const stmdev_ctx_t *ctx, lis3dh_int1_cfg_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_write_reg(ctx, LIS3DH_INT1_CFG, (uint8_t *) val, 1);
+
+  return ret;
+}
+
+/**
+ * @brief  Interrupt generator 1 configuration register.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      register INT1_CFG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int1_gen_conf_get(const stmdev_ctx_t *ctx, lis3dh_int1_cfg_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_CFG, (uint8_t *) val, 1);
+
+  return ret;
+}
+
+/**
+ * @brief  Interrupt generator 1 source register.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      Registers INT1_SRC
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int1_gen_source_get(const stmdev_ctx_t *ctx, lis3dh_int1_src_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_SRC, (uint8_t *) val, 1);
+
+  return ret;
+}
+/**
+ * @brief  User-defined threshold value for xl interrupt event on
+ *         generator 1.[set]
+ *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of ths in reg INT1_THS
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int1_gen_threshold_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_THS, (uint8_t *) &int1_ths, 1);
+
+  if (ret == 0) {
+    int1_ths.ths = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_INT1_THS, (uint8_t *) &int1_ths, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  User-defined threshold value for xl interrupt event on
+ *         generator 1.[get]
+ *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of ths in reg INT1_THS
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int1_gen_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_THS, (uint8_t *) &int1_ths, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) int1_ths.ths;
+
+  return ret;
+}
+
+/**
+ * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+ *         recognized.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of d in reg INT1_DURATION
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int1_gen_duration_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_DURATION, (uint8_t *) &int1_duration, 1);
+
+  if (ret == 0) {
+    int1_duration.d = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_INT1_DURATION, (uint8_t *) &int1_duration, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+ *         recognized.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of d in reg INT1_DURATION
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int1_gen_duration_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_DURATION, (uint8_t *) &int1_duration, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) int1_duration.d;
+
+  return ret;
+}
+
+/**
+ * @}
+ *
+ */
+
+/**
+ * @defgroup   LIS3DH_Interrupts_generator_2
+ * @brief      This section group all the functions that manage the second
+ *             interrupts generator
+ * @{
+ *
+ */
+
+/**
+ * @brief  Interrupt generator 2 configuration register.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      registers INT2_CFG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int2_gen_conf_set(const stmdev_ctx_t *ctx, lis3dh_int2_cfg_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_write_reg(ctx, LIS3DH_INT2_CFG, (uint8_t *) val, 1);
+
+  return ret;
+}
+
+/**
+ * @brief  Interrupt generator 2 configuration register.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      registers INT2_CFG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int2_gen_conf_get(const stmdev_ctx_t *ctx, lis3dh_int2_cfg_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_CFG, (uint8_t *) val, 1);
+
+  return ret;
+}
+/**
+ * @brief  Interrupt generator 2 source register.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      registers INT2_SRC
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int2_gen_source_get(const stmdev_ctx_t *ctx, lis3dh_int2_src_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_SRC, (uint8_t *) val, 1);
+
+  return ret;
+}
+/**
+ * @brief   User-defined threshold value for xl interrupt event on
+ *          generator 2.[set]
+ *          LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of ths in reg INT2_THS
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int2_gen_threshold_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_THS, (uint8_t *) &int2_ths, 1);
+
+  if (ret == 0) {
+    int2_ths.ths = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_INT2_THS, (uint8_t *) &int2_ths, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  User-defined threshold value for xl interrupt event on
+ *         generator 2.[get]
+ *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of ths in reg INT2_THS
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int2_gen_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_THS, (uint8_t *) &int2_ths, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) int2_ths.ths;
+
+  return ret;
+}
+
+/**
+ * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+ *         recognized .[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of d in reg INT2_DURATION
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int2_gen_duration_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_DURATION, (uint8_t *) &int2_duration, 1);
+
+  if (ret == 0) {
+    int2_duration.d = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_INT2_DURATION, (uint8_t *) &int2_duration, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+ *         recognized.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of d in reg INT2_DURATION
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int2_gen_duration_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_DURATION, (uint8_t *) &int2_duration, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) int2_duration.d;
+
+  return ret;
+}
+
+/**
+ * @}
+ *
+ */
+
+/**
+ * @defgroup  LIS3DH_Interrupt_pins
+ * @brief     This section group all the functions that manage interrupt pins
+ * @{
+ *
+ */
+
+/**
+ * @brief  High-pass filter on interrupts/tap generator.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of hp in reg CTRL_REG2
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_high_pass_int_conf_set(const stmdev_ctx_t *ctx, lis3dh_hp_t val) {
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+
+  if (ret == 0) {
+    ctrl_reg2.hp = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  High-pass filter on interrupts/tap generator.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      Get the values of hp in reg CTRL_REG2
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_high_pass_int_conf_get(const stmdev_ctx_t *ctx, lis3dh_hp_t *val) {
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t *) &ctrl_reg2, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (ctrl_reg2.hp) {
+    case 0x00:
+      *val = LIS3DH_DISC_FROM_INT_GENERATOR;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_ON_INT1_GEN;
+      break;
+
+    case 0x02:
+      *val = LIS3DH_ON_INT2_GEN;
+      break;
+
+    case 0x04:
+      *val = LIS3DH_ON_TAP_GEN;
+      break;
+
+    case 0x03:
+      *val = LIS3DH_ON_INT1_INT2_GEN;
+      break;
+
+    case 0x05:
+      *val = LIS3DH_ON_INT1_TAP_GEN;
+      break;
+
+    case 0x06:
+      *val = LIS3DH_ON_INT2_TAP_GEN;
+      break;
+
+    case 0x07:
+      *val = LIS3DH_ON_INT1_INT2_TAP_GEN;
+      break;
+
+    default:
+      *val = LIS3DH_DISC_FROM_INT_GENERATOR;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Int1 pin routing configuration register.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      registers CTRL_REG3
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_pin_int1_config_set(const stmdev_ctx_t *ctx, lis3dh_ctrl_reg3_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG3, (uint8_t *) val, 1);
+
+  return ret;
+}
+
+/**
+ * @brief  Int1 pin routing configuration register.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      registers CTRL_REG3
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_pin_int1_config_get(const stmdev_ctx_t *ctx, lis3dh_ctrl_reg3_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG3, (uint8_t *) val, 1);
+
+  return ret;
+}
+/**
+ * @brief  int2_pin_detect_4d: [set]  4D enable: 4D detection is enabled
+ *                                    on INT2 pin when 6D bit on
+ *                                    INT2_CFG (34h) is set to 1.
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of d4d_int2 in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int2_pin_detect_4d_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret == 0) {
+    ctrl_reg5.d4d_int2 = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  4D enable: 4D detection is enabled on INT2 pin when 6D bit on
+ *         INT2_CFG (34h) is set to 1.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of d4d_int2 in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int2_pin_detect_4d_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) ctrl_reg5.d4d_int2;
+
+  return ret;
+}
+
+/**
+ * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+ *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+ *          itself.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of lir_int2 in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int2_pin_notification_mode_set(const stmdev_ctx_t *ctx, lis3dh_lir_int2_t val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret == 0) {
+    ctrl_reg5.lir_int2 = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+ *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+ *          itself.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      Get the values of lir_int2 in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int2_pin_notification_mode_get(const stmdev_ctx_t *ctx, lis3dh_lir_int2_t *val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (ctrl_reg5.lir_int2) {
+    case 0x00:
+      *val = LIS3DH_INT2_PULSED;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_INT2_LATCHED;
+      break;
+
+    default:
+      *val = LIS3DH_INT2_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit
+ *                    on INT1_CFG(30h) is set to 1.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of d4d_int1 in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int1_pin_detect_4d_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret == 0) {
+    ctrl_reg5.d4d_int1 = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit on
+ *         INT1_CFG(30h) is set to 1.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of d4d_int1 in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int1_pin_detect_4d_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) ctrl_reg5.d4d_int1;
+
+  return ret;
+}
+
+/**
+ * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+ *          register cleared by reading INT1_SRC (31h) itself.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of lir_int1 in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int1_pin_notification_mode_set(const stmdev_ctx_t *ctx, lis3dh_lir_int1_t val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret == 0) {
+    ctrl_reg5.lir_int1 = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+ *          register cleared by reading INT1_SRC (31h) itself.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      Get the values of lir_int1 in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_int1_pin_notification_mode_get(const stmdev_ctx_t *ctx, lis3dh_lir_int1_t *val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (ctrl_reg5.lir_int1) {
+    case 0x00:
+      *val = LIS3DH_INT1_PULSED;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_INT1_LATCHED;
+      break;
+
+    default:
+      *val = LIS3DH_INT1_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Int2 pin routing configuration register.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      registers CTRL_REG6
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_pin_int2_config_set(const stmdev_ctx_t *ctx, lis3dh_ctrl_reg6_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG6, (uint8_t *) val, 1);
+
+  return ret;
+}
+
+/**
+ * @brief  Int2 pin routing configuration register.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      registers CTRL_REG6
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_pin_int2_config_get(const stmdev_ctx_t *ctx, lis3dh_ctrl_reg6_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG6, (uint8_t *) val, 1);
+
+  return ret;
+}
+/**
+ * @}
+ *
+ */
+
+/**
+ * @defgroup  LIS3DH_Fifo
+ * @brief     This section group all the functions concerning the fifo usage
+ * @{
+ *
+ */
+
+/**
+ * @brief  FIFO enable.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of fifo_en in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret == 0) {
+    ctrl_reg5.fifo_en = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  FIFO enable.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of fifo_en in reg CTRL_REG5
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t *) &ctrl_reg5, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) ctrl_reg5.fifo_en;
+
+  return ret;
+}
+
+/**
+ * @brief  FIFO watermark level selection.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of fth in reg FIFO_CTRL_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_watermark_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t *) &fifo_ctrl_reg, 1);
+
+  if (ret == 0) {
+    fifo_ctrl_reg.fth = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t *) &fifo_ctrl_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  FIFO watermark level selection.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of fth in reg FIFO_CTRL_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_watermark_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t *) &fifo_ctrl_reg, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) fifo_ctrl_reg.fth;
+
+  return ret;
+}
+
+/**
+ * @brief  Trigger FIFO selection.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of tr in reg FIFO_CTRL_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_trigger_event_set(const stmdev_ctx_t *ctx, lis3dh_tr_t val) {
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t *) &fifo_ctrl_reg, 1);
+
+  if (ret == 0) {
+    fifo_ctrl_reg.tr = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t *) &fifo_ctrl_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Trigger FIFO selection.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      Get the values of tr in reg FIFO_CTRL_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_trigger_event_get(const stmdev_ctx_t *ctx, lis3dh_tr_t *val) {
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t *) &fifo_ctrl_reg, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (fifo_ctrl_reg.tr) {
+    case 0x00:
+      *val = LIS3DH_INT1_GEN;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_INT2_GEN;
+      break;
+
+    default:
+      *val = LIS3DH_INT1_GEN;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  FIFO mode selection.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of fm in reg FIFO_CTRL_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_mode_set(const stmdev_ctx_t *ctx, lis3dh_fm_t val) {
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t *) &fifo_ctrl_reg, 1);
+
+  if (ret == 0) {
+    fifo_ctrl_reg.fm = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t *) &fifo_ctrl_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  FIFO mode selection.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      Get the values of fm in reg FIFO_CTRL_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_mode_get(const stmdev_ctx_t *ctx, lis3dh_fm_t *val) {
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t *) &fifo_ctrl_reg, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (fifo_ctrl_reg.fm) {
+    case 0x00:
+      *val = LIS3DH_BYPASS_MODE;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_FIFO_MODE;
+      break;
+
+    case 0x02:
+      *val = LIS3DH_DYNAMIC_STREAM_MODE;
+      break;
+
+    case 0x03:
+      *val = LIS3DH_STREAM_TO_FIFO_MODE;
+      break;
+
+    default:
+      *val = LIS3DH_BYPASS_MODE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  FIFO status register.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      registers FIFO_SRC_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_status_get(const stmdev_ctx_t *ctx, lis3dh_fifo_src_reg_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_SRC_REG, (uint8_t *) val, 1);
+
+  return ret;
+}
+/**
+ * @brief  FIFO stored data level.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of fss in reg FIFO_SRC_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_data_level_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_SRC_REG, (uint8_t *) &fifo_src_reg, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) fifo_src_reg.fss;
+
+  return ret;
+}
+/**
+ * @brief  Empty FIFO status flag.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of empty in reg FIFO_SRC_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_empty_flag_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_SRC_REG, (uint8_t *) &fifo_src_reg, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) fifo_src_reg.empty;
+
+  return ret;
+}
+/**
+ * @brief  FIFO overrun status flag.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of ovrn_fifo in reg FIFO_SRC_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_SRC_REG, (uint8_t *) &fifo_src_reg, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) fifo_src_reg.ovrn_fifo;
+
+  return ret;
+}
+/**
+ * @brief  FIFO watermark status.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of wtm in reg FIFO_SRC_REG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_fifo_fth_flag_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_SRC_REG, (uint8_t *) &fifo_src_reg, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) fifo_src_reg.wtm;
+
+  return ret;
+}
+/**
+ * @}
+ *
+ */
+
+/**
+ * @defgroup  LIS3DH_Tap_generator
+ * @brief     This section group all the functions that manage the tap and
+ *            double tap event generation
+ * @{
+ *
+ */
+
+/**
+ * @brief  Tap/Double Tap generator configuration register.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      registers CLICK_CFG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_tap_conf_set(const stmdev_ctx_t *ctx, lis3dh_click_cfg_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_write_reg(ctx, LIS3DH_CLICK_CFG, (uint8_t *) val, 1);
+
+  return ret;
+}
+
+/**
+ * @brief  Tap/Double Tap generator configuration register.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      registers CLICK_CFG
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_tap_conf_get(const stmdev_ctx_t *ctx, lis3dh_click_cfg_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_CFG, (uint8_t *) val, 1);
+
+  return ret;
+}
+/**
+ * @brief  Tap/Double Tap generator source register.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      registers CLICK_SRC
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_tap_source_get(const stmdev_ctx_t *ctx, lis3dh_click_src_t *val) {
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_SRC, (uint8_t *) val, 1);
+
+  return ret;
+}
+/**
+ * @brief  User-defined threshold value for Tap/Double Tap event.[set]
+ *         1 LSB = full scale/128
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of ths in reg CLICK_THS
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_tap_threshold_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_THS, (uint8_t *) &click_ths, 1);
+
+  if (ret == 0) {
+    click_ths.ths = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CLICK_THS, (uint8_t *) &click_ths, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  User-defined threshold value for Tap/Double Tap event.[get]
+ *         1 LSB = full scale/128
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of ths in reg CLICK_THS
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_tap_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_THS, (uint8_t *) &click_ths, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) click_ths.ths;
+
+  return ret;
+}
+
+/**
+ * @brief   If the LIR_Click bit is not set, the interrupt is kept high
+ *          for the duration of the latency window.
+ *          If the LIR_Click bit is set, the interrupt is kept high until the
+ *          CLICK_SRC(39h) register is read.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of lir_click in reg CLICK_THS
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_tap_notification_mode_set(const stmdev_ctx_t *ctx, lis3dh_lir_click_t val) {
+  lis3dh_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_THS, (uint8_t *) &click_ths, 1);
+
+  if (ret == 0) {
+    click_ths.lir_click = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CLICK_THS, (uint8_t *) &click_ths, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief   If the LIR_Click bit is not set, the interrupt is kept high
+ *          for the duration of the latency window.
+ *          If the LIR_Click bit is set, the interrupt is kept high until the
+ *          CLICK_SRC(39h) register is read.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      Get the values of lir_click in reg CLICK_THS
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_tap_notification_mode_get(const stmdev_ctx_t *ctx, lis3dh_lir_click_t *val) {
+  lis3dh_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_THS, (uint8_t *) &click_ths, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (click_ths.lir_click) {
+    case 0x00:
+      *val = LIS3DH_TAP_PULSED;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_TAP_LATCHED;
+      break;
+
+    default:
+      *val = LIS3DH_TAP_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse
+ *         between the start of the click-detection procedure and when the
+ *         acceleration falls back below the threshold.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of tli in reg TIME_LIMIT
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_shock_dur_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_LIMIT, (uint8_t *) &time_limit, 1);
+
+  if (ret == 0) {
+    time_limit.tli = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_TIME_LIMIT, (uint8_t *) &time_limit, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse between
+ *         the start of the click-detection procedure and when the
+ *         acceleration falls back below the threshold.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of tli in reg TIME_LIMIT
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_shock_dur_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_LIMIT, (uint8_t *) &time_limit, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) time_limit.tli;
+
+  return ret;
+}
+
+/**
+ * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+ *         click detection where the click-detection procedure is
+ *         disabled, in cases where the device is configured for
+ *         double-click detection.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of tla in reg TIME_LATENCY
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_quiet_dur_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_LATENCY, (uint8_t *) &time_latency, 1);
+
+  if (ret == 0) {
+    time_latency.tla = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_TIME_LATENCY, (uint8_t *) &time_latency, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+ *         click detection where the click-detection procedure is
+ *         disabled, in cases where the device is configured for
+ *         double-click detection.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of tla in reg TIME_LATENCY
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_quiet_dur_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_LATENCY, (uint8_t *) &time_latency, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) time_latency.tla;
+
+  return ret;
+}
+
+/**
+ * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+ *         after the end of the latency interval in which the click-detection
+ *         procedure can start, in cases where the device is configured
+ *         for double-click detection.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of tw in reg TIME_WINDOW
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_double_tap_timeout_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_time_window_t time_window;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_WINDOW, (uint8_t *) &time_window, 1);
+
+  if (ret == 0) {
+    time_window.tw = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_TIME_WINDOW, (uint8_t *) &time_window, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+ *         after the end of the latency interval in which the
+ *         click-detection procedure can start, in cases where the device
+ *         is configured for double-click detection.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of tw in reg TIME_WINDOW
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_double_tap_timeout_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_time_window_t time_window;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_WINDOW, (uint8_t *) &time_window, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) time_window.tw;
+
+  return ret;
+}
+
+/**
+ * @}
+ *
+ */
+
+/**
+ * @defgroup  LIS3DH_Activity_inactivity
+ * @brief     This section group all the functions concerning activity
+ *            inactivity functionality
+ * @{
+ *
+ */
+
+/**
+ * @brief    Sleep-to-wake, return-to-sleep activation threshold in
+ *           low-power mode.[set]
+ *           1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of acth in reg ACT_THS
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_act_threshold_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_ACT_THS, (uint8_t *) &act_ths, 1);
+
+  if (ret == 0) {
+    act_ths.acth = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_ACT_THS, (uint8_t *) &act_ths, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Sleep-to-wake, return-to-sleep activation threshold in low-power
+ *         mode.[get]
+ *         1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of acth in reg ACT_THS
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_act_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_ACT_THS, (uint8_t *) &act_ths, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) act_ths.acth;
+
+  return ret;
+}
+
+/**
+ * @brief  Sleep-to-wake, return-to-sleep.[set]
+ *         duration = (8*1[LSb]+1)/ODR
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of actd in reg ACT_DUR
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_act_timeout_set(const stmdev_ctx_t *ctx, uint8_t val) {
+  lis3dh_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_ACT_DUR, (uint8_t *) &act_dur, 1);
+
+  if (ret == 0) {
+    act_dur.actd = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_ACT_DUR, (uint8_t *) &act_dur, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Sleep-to-wake, return-to-sleep.[get]
+ *         duration = (8*1[LSb]+1)/ODR
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of actd in reg ACT_DUR
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_act_timeout_get(const stmdev_ctx_t *ctx, uint8_t *val) {
+  lis3dh_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_ACT_DUR, (uint8_t *) &act_dur, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  *val = (uint8_t) act_dur.actd;
+
+  return ret;
+}
+
+/**
+ * @}
+ *
+ */
+
+/**
+ * @defgroup  LIS3DH_Serial_interface
+ * @brief     This section group all the functions concerning serial
+ *            interface management
+ * @{
+ *
+ */
+
+/**
+ * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of sdo_pu_disc in reg CTRL_REG0
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_pin_sdo_sa0_mode_set(const stmdev_ctx_t *ctx, lis3dh_sdo_pu_disc_t val) {
+  lis3dh_ctrl_reg0_t ctrl_reg0;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG0, (uint8_t *) &ctrl_reg0, 1);
+
+  if (ret == 0) {
+    ctrl_reg0.sdo_pu_disc = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG0, (uint8_t *) &ctrl_reg0, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      Get the values of sdo_pu_disc in reg CTRL_REG0
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_pin_sdo_sa0_mode_get(const stmdev_ctx_t *ctx, lis3dh_sdo_pu_disc_t *val) {
+  lis3dh_ctrl_reg0_t ctrl_reg0;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG0, (uint8_t *) &ctrl_reg0, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (ctrl_reg0.sdo_pu_disc) {
+    case 0x01:
+      *val = LIS3DH_PULL_UP_DISCONNECT;
+      break;
+
+    case 0x00:
+      *val = LIS3DH_PULL_UP_CONNECT;
+      break;
+
+    default:
+      *val = LIS3DH_PULL_UP_DISCONNECT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  SPI Serial Interface Mode selection.[set]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      change the values of sim in reg CTRL_REG4
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_spi_mode_set(const stmdev_ctx_t *ctx, lis3dh_sim_t val) {
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret == 0) {
+    ctrl_reg4.sim = (uint8_t) val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief  SPI Serial Interface Mode selection.[get]
+ *
+ * @param  ctx      read / write interface definitions
+ * @param  val      Get the values of sim in reg CTRL_REG4
+ * @retval          interface status (MANDATORY: return 0 -> no Error)
+ *
+ */
+int32_t lis3dh_spi_mode_get(const stmdev_ctx_t *ctx, lis3dh_sim_t *val) {
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t *) &ctrl_reg4, 1);
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  switch (ctrl_reg4.sim) {
+    case 0x00:
+      *val = LIS3DH_SPI_4_WIRE;
+      break;
+
+    case 0x01:
+      *val = LIS3DH_SPI_3_WIRE;
+      break;
+
+    default:
+      *val = LIS3DH_SPI_4_WIRE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @}
+ *
+ */
+
+/**
+ * @}
+ *
+ */
+
+}  // namespace lis3dh
+}  // namespace esphome

--- a/esphome/components/lis3dh/lis3dh_reg.h
+++ b/esphome/components/lis3dh/lis3dh_reg.h
@@ -1,0 +1,939 @@
+/**
+ ******************************************************************************
+ * @file    lis3dh_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis3dh_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2021 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file
+ * in the same directory as this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <math.h>
+
+namespace esphome {
+namespace lis3dh {
+
+// Endianness — ESPHome targets only GCC/Clang which always provide __BYTE_ORDER__.
+
+/**
+ * @}
+ *
+ */
+
+/** @defgroup STMicroelectronics sensors common types
+ * @{
+ *
+ */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t bit0 : 1;
+  uint8_t bit1 : 1;
+  uint8_t bit2 : 1;
+  uint8_t bit3 : 1;
+  uint8_t bit4 : 1;
+  uint8_t bit5 : 1;
+  uint8_t bit6 : 1;
+  uint8_t bit7 : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t bit7 : 1;
+  uint8_t bit6 : 1;
+  uint8_t bit5 : 1;
+  uint8_t bit4 : 1;
+  uint8_t bit3 : 1;
+  uint8_t bit2 : 1;
+  uint8_t bit1 : 1;
+  uint8_t bit0 : 1;
+#endif /* DRV_BYTE_ORDER */
+} bitwise_t;
+
+#define PROPERTY_DISABLE (0U)
+#define PROPERTY_ENABLE (1U)
+
+/** @addtogroup  Interfaces_Functions
+ * @brief       This section provide a set of functions used to read and
+ *              write a generic register of the device.
+ *              MANDATORY: return 0 -> no Error.
+ * @{
+ *
+ */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, const uint8_t *, uint16_t);
+typedef int32_t (*stmdev_read_ptr)(void *, uint8_t, uint8_t *, uint16_t);
+typedef void (*stmdev_mdelay_ptr)(uint32_t millisec);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr write_reg;
+  stmdev_read_ptr read_reg;
+  /** Component optional fields **/
+  stmdev_mdelay_ptr mdelay;
+  /** Customizable optional pointer **/
+  void *handle;
+
+  /** private data **/
+  void *priv_data;
+} stmdev_ctx_t;
+
+/**
+ * @}
+ *
+ */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+ * @brief       This structure is useful to load a predefined configuration
+ *              of a sensor.
+ *              You can create a sensor configuration by your own or using
+ *              Unico / Unicleo tools available on STMicroelectronics
+ *              web site.
+ *
+ * @{
+ *
+ */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+ * @}
+ *
+ */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+ * @}
+ *
+ */
+
+/** @defgroup LIS3DH_Infos
+ * @{
+ *
+ */
+
+/** I2C Device Address 8 bit format if SA0=0 -> 31 if SA0=1 -> 33 **/
+#define LIS3DH_I2C_ADD_L 0x31U
+#define LIS3DH_I2C_ADD_H 0x33U
+
+/** Device Identification (Who am I) **/
+#define LIS3DH_ID 0x33U
+
+/**
+ * @}
+ *
+ */
+
+#define LIS3DH_STATUS_REG_AUX 0x07U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t _1da : 1;
+  uint8_t _2da : 1;
+  uint8_t _3da : 1;
+  uint8_t _321da : 1;
+  uint8_t _1or : 1;
+  uint8_t _2or : 1;
+  uint8_t _3or : 1;
+  uint8_t _321or : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t _321or : 1;
+  uint8_t _3or : 1;
+  uint8_t _2or : 1;
+  uint8_t _1or : 1;
+  uint8_t _321da : 1;
+  uint8_t _3da : 1;
+  uint8_t _2da : 1;
+  uint8_t _1da : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_status_reg_aux_t;
+
+#define LIS3DH_OUT_ADC1_L 0x08U
+#define LIS3DH_OUT_ADC1_H 0x09U
+#define LIS3DH_OUT_ADC2_L 0x0AU
+#define LIS3DH_OUT_ADC2_H 0x0BU
+#define LIS3DH_OUT_ADC3_L 0x0CU
+#define LIS3DH_OUT_ADC3_H 0x0DU
+#define LIS3DH_WHO_AM_I 0x0FU
+
+#define LIS3DH_CTRL_REG0 0x1EU
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t not_used_01 : 7;
+  uint8_t sdo_pu_disc : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t sdo_pu_disc : 1;
+  uint8_t not_used_01 : 7;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_ctrl_reg0_t;
+
+#define LIS3DH_TEMP_CFG_REG 0x1FU
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t not_used_01 : 6;
+  uint8_t temp_en : 1;
+  uint8_t adc_pd : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t adc_pd : 1;
+  uint8_t temp_en : 1;
+  uint8_t not_used_01 : 6;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_temp_cfg_reg_t;
+
+#define LIS3DH_CTRL_REG1 0x20U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t xen : 1;
+  uint8_t yen : 1;
+  uint8_t zen : 1;
+  uint8_t lpen : 1;
+  uint8_t odr : 4;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t odr : 4;
+  uint8_t lpen : 1;
+  uint8_t zen : 1;
+  uint8_t yen : 1;
+  uint8_t xen : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_ctrl_reg1_t;
+
+#define LIS3DH_CTRL_REG2 0x21U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t hp : 3; /* HPCLICK + HP_IA2 + HP_IA1 -> HP */
+  uint8_t fds : 1;
+  uint8_t hpcf : 2;
+  uint8_t hpm : 2;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t hpm : 2;
+  uint8_t hpcf : 2;
+  uint8_t fds : 1;
+  uint8_t hp : 3; /* HPCLICK + HP_IA2 + HP_IA1 -> HP */
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_ctrl_reg2_t;
+
+#define LIS3DH_CTRL_REG3 0x22U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t not_used_01 : 1;
+  uint8_t i1_overrun : 1;
+  uint8_t i1_wtm : 1;
+  uint8_t i1_321da : 1;
+  uint8_t i1_zyxda : 1;
+  uint8_t i1_ia2 : 1;
+  uint8_t i1_ia1 : 1;
+  uint8_t i1_click : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t i1_click : 1;
+  uint8_t i1_ia1 : 1;
+  uint8_t i1_ia2 : 1;
+  uint8_t i1_zyxda : 1;
+  uint8_t i1_321da : 1;
+  uint8_t i1_wtm : 1;
+  uint8_t i1_overrun : 1;
+  uint8_t not_used_01 : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_ctrl_reg3_t;
+
+#define LIS3DH_CTRL_REG4 0x23U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t sim : 1;
+  uint8_t st : 2;
+  uint8_t hr : 1;
+  uint8_t fs : 2;
+  uint8_t ble : 1;
+  uint8_t bdu : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t bdu : 1;
+  uint8_t ble : 1;
+  uint8_t fs : 2;
+  uint8_t hr : 1;
+  uint8_t st : 2;
+  uint8_t sim : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_ctrl_reg4_t;
+
+#define LIS3DH_CTRL_REG5 0x24U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t d4d_int2 : 1;
+  uint8_t lir_int2 : 1;
+  uint8_t d4d_int1 : 1;
+  uint8_t lir_int1 : 1;
+  uint8_t not_used_01 : 2;
+  uint8_t fifo_en : 1;
+  uint8_t boot : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t boot : 1;
+  uint8_t fifo_en : 1;
+  uint8_t not_used_01 : 2;
+  uint8_t lir_int1 : 1;
+  uint8_t d4d_int1 : 1;
+  uint8_t lir_int2 : 1;
+  uint8_t d4d_int2 : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_ctrl_reg5_t;
+
+#define LIS3DH_CTRL_REG6 0x25U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t not_used_01 : 1;
+  uint8_t int_polarity : 1;
+  uint8_t not_used_02 : 1;
+  uint8_t i2_act : 1;
+  uint8_t i2_boot : 1;
+  uint8_t i2_ia2 : 1;
+  uint8_t i2_ia1 : 1;
+  uint8_t i2_click : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t i2_click : 1;
+  uint8_t i2_ia1 : 1;
+  uint8_t i2_ia2 : 1;
+  uint8_t i2_boot : 1;
+  uint8_t i2_act : 1;
+  uint8_t not_used_02 : 1;
+  uint8_t int_polarity : 1;
+  uint8_t not_used_01 : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_ctrl_reg6_t;
+
+#define LIS3DH_REFERENCE 0x26U
+#define LIS3DH_STATUS_REG 0x27U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t xda : 1;
+  uint8_t yda : 1;
+  uint8_t zda : 1;
+  uint8_t zyxda : 1;
+  uint8_t _xor : 1;
+  uint8_t yor : 1;
+  uint8_t zor : 1;
+  uint8_t zyxor : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t zyxor : 1;
+  uint8_t zor : 1;
+  uint8_t yor : 1;
+  uint8_t _xor : 1;
+  uint8_t zyxda : 1;
+  uint8_t zda : 1;
+  uint8_t yda : 1;
+  uint8_t xda : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_status_reg_t;
+
+#define LIS3DH_OUT_X_L 0x28U
+#define LIS3DH_OUT_X_H 0x29U
+#define LIS3DH_OUT_Y_L 0x2AU
+#define LIS3DH_OUT_Y_H 0x2BU
+#define LIS3DH_OUT_Z_L 0x2CU
+#define LIS3DH_OUT_Z_H 0x2DU
+#define LIS3DH_FIFO_CTRL_REG 0x2EU
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t fth : 5;
+  uint8_t tr : 1;
+  uint8_t fm : 2;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t fm : 2;
+  uint8_t tr : 1;
+  uint8_t fth : 5;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_fifo_ctrl_reg_t;
+
+#define LIS3DH_FIFO_SRC_REG 0x2FU
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t fss : 5;
+  uint8_t empty : 1;
+  uint8_t ovrn_fifo : 1;
+  uint8_t wtm : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t wtm : 1;
+  uint8_t ovrn_fifo : 1;
+  uint8_t empty : 1;
+  uint8_t fss : 5;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_fifo_src_reg_t;
+
+#define LIS3DH_INT1_CFG 0x30U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t xlie : 1;
+  uint8_t xhie : 1;
+  uint8_t ylie : 1;
+  uint8_t yhie : 1;
+  uint8_t zlie : 1;
+  uint8_t zhie : 1;
+  uint8_t _6d : 1;
+  uint8_t aoi : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t aoi : 1;
+  uint8_t _6d : 1;
+  uint8_t zhie : 1;
+  uint8_t zlie : 1;
+  uint8_t yhie : 1;
+  uint8_t ylie : 1;
+  uint8_t xhie : 1;
+  uint8_t xlie : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_int1_cfg_t;
+
+#define LIS3DH_INT1_SRC 0x31U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t xl : 1;
+  uint8_t xh : 1;
+  uint8_t yl : 1;
+  uint8_t yh : 1;
+  uint8_t zl : 1;
+  uint8_t zh : 1;
+  uint8_t ia : 1;
+  uint8_t not_used_01 : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t not_used_01 : 1;
+  uint8_t ia : 1;
+  uint8_t zh : 1;
+  uint8_t zl : 1;
+  uint8_t yh : 1;
+  uint8_t yl : 1;
+  uint8_t xh : 1;
+  uint8_t xl : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_int1_src_t;
+
+#define LIS3DH_INT1_THS 0x32U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t ths : 7;
+  uint8_t not_used_01 : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t not_used_01 : 1;
+  uint8_t ths : 7;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_int1_ths_t;
+
+#define LIS3DH_INT1_DURATION 0x33U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t d : 7;
+  uint8_t not_used_01 : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t not_used_01 : 1;
+  uint8_t d : 7;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_int1_duration_t;
+
+#define LIS3DH_INT2_CFG 0x34U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t xlie : 1;
+  uint8_t xhie : 1;
+  uint8_t ylie : 1;
+  uint8_t yhie : 1;
+  uint8_t zlie : 1;
+  uint8_t zhie : 1;
+  uint8_t _6d : 1;
+  uint8_t aoi : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t aoi : 1;
+  uint8_t _6d : 1;
+  uint8_t zhie : 1;
+  uint8_t zlie : 1;
+  uint8_t yhie : 1;
+  uint8_t ylie : 1;
+  uint8_t xhie : 1;
+  uint8_t xlie : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_int2_cfg_t;
+
+#define LIS3DH_INT2_SRC 0x35U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t xl : 1;
+  uint8_t xh : 1;
+  uint8_t yl : 1;
+  uint8_t yh : 1;
+  uint8_t zl : 1;
+  uint8_t zh : 1;
+  uint8_t ia : 1;
+  uint8_t not_used_01 : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t not_used_01 : 1;
+  uint8_t ia : 1;
+  uint8_t zh : 1;
+  uint8_t zl : 1;
+  uint8_t yh : 1;
+  uint8_t yl : 1;
+  uint8_t xh : 1;
+  uint8_t xl : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_int2_src_t;
+
+#define LIS3DH_INT2_THS 0x36U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t ths : 7;
+  uint8_t not_used_01 : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t not_used_01 : 1;
+  uint8_t ths : 7;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_int2_ths_t;
+
+#define LIS3DH_INT2_DURATION 0x37U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t d : 7;
+  uint8_t not_used_01 : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t not_used_01 : 1;
+  uint8_t d : 7;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_int2_duration_t;
+
+#define LIS3DH_CLICK_CFG 0x38U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t xs : 1;
+  uint8_t xd : 1;
+  uint8_t ys : 1;
+  uint8_t yd : 1;
+  uint8_t zs : 1;
+  uint8_t zd : 1;
+  uint8_t not_used_01 : 2;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t not_used_01 : 2;
+  uint8_t zd : 1;
+  uint8_t zs : 1;
+  uint8_t yd : 1;
+  uint8_t ys : 1;
+  uint8_t xd : 1;
+  uint8_t xs : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_click_cfg_t;
+
+#define LIS3DH_CLICK_SRC 0x39U
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t x : 1;
+  uint8_t y : 1;
+  uint8_t z : 1;
+  uint8_t sign : 1;
+  uint8_t sclick : 1;
+  uint8_t dclick : 1;
+  uint8_t ia : 1;
+  uint8_t not_used_01 : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t not_used_01 : 1;
+  uint8_t ia : 1;
+  uint8_t dclick : 1;
+  uint8_t sclick : 1;
+  uint8_t sign : 1;
+  uint8_t z : 1;
+  uint8_t y : 1;
+  uint8_t x : 1;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_click_src_t;
+
+#define LIS3DH_CLICK_THS 0x3AU
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t ths : 7;
+  uint8_t lir_click : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t lir_click : 1;
+  uint8_t ths : 7;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_click_ths_t;
+
+#define LIS3DH_TIME_LIMIT 0x3BU
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t tli : 7;
+  uint8_t not_used_01 : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t not_used_01 : 1;
+  uint8_t tli : 7;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_time_limit_t;
+
+#define LIS3DH_TIME_LATENCY 0x3CU
+typedef struct {
+  uint8_t tla : 8;
+} lis3dh_time_latency_t;
+
+#define LIS3DH_TIME_WINDOW 0x3DU
+typedef struct {
+  uint8_t tw : 8;
+} lis3dh_time_window_t;
+
+#define LIS3DH_ACT_THS 0x3EU
+typedef struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t acth : 7;
+  uint8_t not_used_01 : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t not_used_01 : 1;
+  uint8_t acth : 7;
+#endif /* DRV_BYTE_ORDER */
+} lis3dh_act_ths_t;
+
+#define LIS3DH_ACT_DUR 0x3FU
+typedef struct {
+  uint8_t actd : 8;
+} lis3dh_act_dur_t;
+
+/**
+ * @defgroup LIS3DH_Register_Union
+ * @brief    This union group all the registers having a bit-field
+ *           description.
+ *           This union is useful but it's not needed by the driver.
+ *
+ *           REMOVING this union you are compliant with:
+ *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+ *
+ * @{
+ *
+ */
+typedef union {
+  lis3dh_status_reg_aux_t status_reg_aux;
+  lis3dh_ctrl_reg0_t ctrl_reg0;
+  lis3dh_temp_cfg_reg_t temp_cfg_reg;
+  lis3dh_ctrl_reg1_t ctrl_reg1;
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  lis3dh_ctrl_reg3_t ctrl_reg3;
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  lis3dh_ctrl_reg6_t ctrl_reg6;
+  lis3dh_status_reg_t status_reg;
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  lis3dh_fifo_src_reg_t fifo_src_reg;
+  lis3dh_int1_cfg_t int1_cfg;
+  lis3dh_int1_src_t int1_src;
+  lis3dh_int1_ths_t int1_ths;
+  lis3dh_int1_duration_t int1_duration;
+  lis3dh_int2_cfg_t int2_cfg;
+  lis3dh_int2_src_t int2_src;
+  lis3dh_int2_ths_t int2_ths;
+  lis3dh_int2_duration_t int2_duration;
+  lis3dh_click_cfg_t click_cfg;
+  lis3dh_click_src_t click_src;
+  lis3dh_click_ths_t click_ths;
+  lis3dh_time_limit_t time_limit;
+  lis3dh_time_latency_t time_latency;
+  lis3dh_time_window_t time_window;
+  lis3dh_act_ths_t act_ths;
+  lis3dh_act_dur_t act_dur;
+  bitwise_t bitwise;
+  uint8_t byte;
+} lis3dh_reg_t;
+
+/**
+ * @}
+ *
+ */
+
+#ifndef __weak
+#define __weak __attribute__((weak))
+#endif /* __weak */
+
+/*
+ * These are the basic platform dependent I/O routines to read
+ * and write device registers connected on a standard bus.
+ * The driver keeps offering a default implementation based on function
+ * pointers to read/write routines for backward compatibility.
+ * The __weak directive allows the final application to overwrite
+ * them with a custom implementation.
+ */
+
+int32_t lis3dh_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data, uint16_t len);
+int32_t lis3dh_write_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data, uint16_t len);
+
+float_t lis3dh_from_fs2_hr_to_mg(int16_t lsb);
+float_t lis3dh_from_fs4_hr_to_mg(int16_t lsb);
+float_t lis3dh_from_fs8_hr_to_mg(int16_t lsb);
+float_t lis3dh_from_fs16_hr_to_mg(int16_t lsb);
+float_t lis3dh_from_lsb_hr_to_celsius(int16_t lsb);
+
+float_t lis3dh_from_fs2_nm_to_mg(int16_t lsb);
+float_t lis3dh_from_fs4_nm_to_mg(int16_t lsb);
+float_t lis3dh_from_fs8_nm_to_mg(int16_t lsb);
+float_t lis3dh_from_fs16_nm_to_mg(int16_t lsb);
+float_t lis3dh_from_lsb_nm_to_celsius(int16_t lsb);
+
+float_t lis3dh_from_fs2_lp_to_mg(int16_t lsb);
+float_t lis3dh_from_fs4_lp_to_mg(int16_t lsb);
+float_t lis3dh_from_fs8_lp_to_mg(int16_t lsb);
+float_t lis3dh_from_fs16_lp_to_mg(int16_t lsb);
+float_t lis3dh_from_lsb_lp_to_celsius(int16_t lsb);
+
+int32_t lis3dh_temp_status_reg_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dh_temp_data_ready_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_temp_data_ovr_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lis3dh_adc_raw_get(const stmdev_ctx_t *ctx, int16_t *buff);
+
+typedef enum {
+  LIS3DH_AUX_DISABLE = 0,
+  LIS3DH_AUX_ON_TEMPERATURE = 3,
+  LIS3DH_AUX_ON_PADS = 1,
+} lis3dh_temp_en_t;
+int32_t lis3dh_aux_adc_set(const stmdev_ctx_t *ctx, lis3dh_temp_en_t val);
+int32_t lis3dh_aux_adc_get(const stmdev_ctx_t *ctx, lis3dh_temp_en_t *val);
+
+typedef enum {
+  LIS3DH_HR_12bit = 0,
+  LIS3DH_NM_10bit = 1,
+  LIS3DH_LP_8bit = 2,
+} lis3dh_op_md_t;
+int32_t lis3dh_operating_mode_set(const stmdev_ctx_t *ctx, lis3dh_op_md_t val);
+int32_t lis3dh_operating_mode_get(const stmdev_ctx_t *ctx, lis3dh_op_md_t *val);
+
+typedef enum {
+  LIS3DH_POWER_DOWN = 0x00,
+  LIS3DH_ODR_1Hz = 0x01,
+  LIS3DH_ODR_10Hz = 0x02,
+  LIS3DH_ODR_25Hz = 0x03,
+  LIS3DH_ODR_50Hz = 0x04,
+  LIS3DH_ODR_100Hz = 0x05,
+  LIS3DH_ODR_200Hz = 0x06,
+  LIS3DH_ODR_400Hz = 0x07,
+  LIS3DH_ODR_1kHz620_LP = 0x08,
+  LIS3DH_ODR_5kHz376_LP_1kHz344_NM_HP = 0x09,
+} lis3dh_odr_t;
+int32_t lis3dh_data_rate_set(const stmdev_ctx_t *ctx, lis3dh_odr_t val);
+int32_t lis3dh_data_rate_get(const stmdev_ctx_t *ctx, lis3dh_odr_t *val);
+
+int32_t lis3dh_high_pass_on_outputs_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_high_pass_on_outputs_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_AGGRESSIVE = 0,
+  LIS3DH_STRONG = 1,
+  LIS3DH_MEDIUM = 2,
+  LIS3DH_LIGHT = 3,
+} lis3dh_hpcf_t;
+int32_t lis3dh_high_pass_bandwidth_set(const stmdev_ctx_t *ctx, lis3dh_hpcf_t val);
+int32_t lis3dh_high_pass_bandwidth_get(const stmdev_ctx_t *ctx, lis3dh_hpcf_t *val);
+
+typedef enum {
+  LIS3DH_NORMAL_WITH_RST = 0,
+  LIS3DH_REFERENCE_MODE = 1,
+  LIS3DH_NORMAL = 2,
+  LIS3DH_AUTORST_ON_INT = 3,
+} lis3dh_hpm_t;
+int32_t lis3dh_high_pass_mode_set(const stmdev_ctx_t *ctx, lis3dh_hpm_t val);
+int32_t lis3dh_high_pass_mode_get(const stmdev_ctx_t *ctx, lis3dh_hpm_t *val);
+
+typedef enum {
+  LIS3DH_2g = 0,
+  LIS3DH_4g = 1,
+  LIS3DH_8g = 2,
+  LIS3DH_16g = 3,
+} lis3dh_fs_t;
+int32_t lis3dh_full_scale_set(const stmdev_ctx_t *ctx, lis3dh_fs_t val);
+int32_t lis3dh_full_scale_get(const stmdev_ctx_t *ctx, lis3dh_fs_t *val);
+
+int32_t lis3dh_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_block_data_update_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_filter_reference_set(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dh_filter_reference_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis3dh_xl_data_ready_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_xl_data_ovr_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lis3dh_device_id_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS3DH_ST_DISABLE = 0,
+  LIS3DH_ST_POSITIVE = 1,
+  LIS3DH_ST_NEGATIVE = 2,
+} lis3dh_st_t;
+int32_t lis3dh_self_test_set(const stmdev_ctx_t *ctx, lis3dh_st_t val);
+int32_t lis3dh_self_test_get(const stmdev_ctx_t *ctx, lis3dh_st_t *val);
+
+typedef enum {
+  LIS3DH_LSB_AT_LOW_ADD = 0,
+  LIS3DH_MSB_AT_LOW_ADD = 1,
+} lis3dh_ble_t;
+int32_t lis3dh_data_format_set(const stmdev_ctx_t *ctx, lis3dh_ble_t val);
+int32_t lis3dh_data_format_get(const stmdev_ctx_t *ctx, lis3dh_ble_t *val);
+
+int32_t lis3dh_boot_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_boot_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_status_get(const stmdev_ctx_t *ctx, lis3dh_status_reg_t *val);
+
+int32_t lis3dh_int1_gen_conf_set(const stmdev_ctx_t *ctx, lis3dh_int1_cfg_t *val);
+int32_t lis3dh_int1_gen_conf_get(const stmdev_ctx_t *ctx, lis3dh_int1_cfg_t *val);
+
+int32_t lis3dh_int1_gen_source_get(const stmdev_ctx_t *ctx, lis3dh_int1_src_t *val);
+
+int32_t lis3dh_int1_gen_threshold_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int1_gen_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_int1_gen_duration_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int1_gen_duration_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_int2_gen_conf_set(const stmdev_ctx_t *ctx, lis3dh_int2_cfg_t *val);
+int32_t lis3dh_int2_gen_conf_get(const stmdev_ctx_t *ctx, lis3dh_int2_cfg_t *val);
+
+int32_t lis3dh_int2_gen_source_get(const stmdev_ctx_t *ctx, lis3dh_int2_src_t *val);
+
+int32_t lis3dh_int2_gen_threshold_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int2_gen_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_int2_gen_duration_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int2_gen_duration_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_DISC_FROM_INT_GENERATOR = 0,
+  LIS3DH_ON_INT1_GEN = 1,
+  LIS3DH_ON_INT2_GEN = 2,
+  LIS3DH_ON_TAP_GEN = 4,
+  LIS3DH_ON_INT1_INT2_GEN = 3,
+  LIS3DH_ON_INT1_TAP_GEN = 5,
+  LIS3DH_ON_INT2_TAP_GEN = 6,
+  LIS3DH_ON_INT1_INT2_TAP_GEN = 7,
+} lis3dh_hp_t;
+int32_t lis3dh_high_pass_int_conf_set(const stmdev_ctx_t *ctx, lis3dh_hp_t val);
+int32_t lis3dh_high_pass_int_conf_get(const stmdev_ctx_t *ctx, lis3dh_hp_t *val);
+
+int32_t lis3dh_pin_int1_config_set(const stmdev_ctx_t *ctx, lis3dh_ctrl_reg3_t *val);
+int32_t lis3dh_pin_int1_config_get(const stmdev_ctx_t *ctx, lis3dh_ctrl_reg3_t *val);
+
+int32_t lis3dh_int2_pin_detect_4d_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int2_pin_detect_4d_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_INT2_PULSED = 0,
+  LIS3DH_INT2_LATCHED = 1,
+} lis3dh_lir_int2_t;
+int32_t lis3dh_int2_pin_notification_mode_set(const stmdev_ctx_t *ctx, lis3dh_lir_int2_t val);
+int32_t lis3dh_int2_pin_notification_mode_get(const stmdev_ctx_t *ctx, lis3dh_lir_int2_t *val);
+
+int32_t lis3dh_int1_pin_detect_4d_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int1_pin_detect_4d_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_INT1_PULSED = 0,
+  LIS3DH_INT1_LATCHED = 1,
+} lis3dh_lir_int1_t;
+int32_t lis3dh_int1_pin_notification_mode_set(const stmdev_ctx_t *ctx, lis3dh_lir_int1_t val);
+int32_t lis3dh_int1_pin_notification_mode_get(const stmdev_ctx_t *ctx, lis3dh_lir_int1_t *val);
+
+int32_t lis3dh_pin_int2_config_set(const stmdev_ctx_t *ctx, lis3dh_ctrl_reg6_t *val);
+int32_t lis3dh_pin_int2_config_get(const stmdev_ctx_t *ctx, lis3dh_ctrl_reg6_t *val);
+
+int32_t lis3dh_fifo_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_fifo_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_fifo_watermark_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_fifo_watermark_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_INT1_GEN = 0,
+  LIS3DH_INT2_GEN = 1,
+} lis3dh_tr_t;
+int32_t lis3dh_fifo_trigger_event_set(const stmdev_ctx_t *ctx, lis3dh_tr_t val);
+int32_t lis3dh_fifo_trigger_event_get(const stmdev_ctx_t *ctx, lis3dh_tr_t *val);
+
+typedef enum {
+  LIS3DH_BYPASS_MODE = 0,
+  LIS3DH_FIFO_MODE = 1,
+  LIS3DH_DYNAMIC_STREAM_MODE = 2,
+  LIS3DH_STREAM_TO_FIFO_MODE = 3,
+} lis3dh_fm_t;
+int32_t lis3dh_fifo_mode_set(const stmdev_ctx_t *ctx, lis3dh_fm_t val);
+int32_t lis3dh_fifo_mode_get(const stmdev_ctx_t *ctx, lis3dh_fm_t *val);
+
+int32_t lis3dh_fifo_status_get(const stmdev_ctx_t *ctx, lis3dh_fifo_src_reg_t *val);
+
+int32_t lis3dh_fifo_data_level_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_fifo_empty_flag_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_fifo_fth_flag_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_tap_conf_set(const stmdev_ctx_t *ctx, lis3dh_click_cfg_t *val);
+int32_t lis3dh_tap_conf_get(const stmdev_ctx_t *ctx, lis3dh_click_cfg_t *val);
+
+int32_t lis3dh_tap_source_get(const stmdev_ctx_t *ctx, lis3dh_click_src_t *val);
+
+int32_t lis3dh_tap_threshold_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_tap_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_TAP_PULSED = 0,
+  LIS3DH_TAP_LATCHED = 1,
+} lis3dh_lir_click_t;
+int32_t lis3dh_tap_notification_mode_set(const stmdev_ctx_t *ctx, lis3dh_lir_click_t val);
+int32_t lis3dh_tap_notification_mode_get(const stmdev_ctx_t *ctx, lis3dh_lir_click_t *val);
+
+int32_t lis3dh_shock_dur_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_shock_dur_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_quiet_dur_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_quiet_dur_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_double_tap_timeout_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_double_tap_timeout_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_act_threshold_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_act_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_act_timeout_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_act_timeout_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_PULL_UP_CONNECT = 0,
+  LIS3DH_PULL_UP_DISCONNECT = 1,
+} lis3dh_sdo_pu_disc_t;
+int32_t lis3dh_pin_sdo_sa0_mode_set(const stmdev_ctx_t *ctx, lis3dh_sdo_pu_disc_t val);
+int32_t lis3dh_pin_sdo_sa0_mode_get(const stmdev_ctx_t *ctx, lis3dh_sdo_pu_disc_t *val);
+
+typedef enum {
+  LIS3DH_SPI_4_WIRE = 0,
+  LIS3DH_SPI_3_WIRE = 1,
+} lis3dh_sim_t;
+int32_t lis3dh_spi_mode_set(const stmdev_ctx_t *ctx, lis3dh_sim_t val);
+int32_t lis3dh_spi_mode_get(const stmdev_ctx_t *ctx, lis3dh_sim_t *val);
+
+/**
+ * @}
+ *
+ */
+
+}  // namespace lis3dh
+}  // namespace esphome

--- a/esphome/components/lis3dh/sensor.py
+++ b/esphome/components/lis3dh/sensor.py
@@ -1,0 +1,56 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ACCELERATION_X,
+    CONF_ACCELERATION_Y,
+    CONF_ACCELERATION_Z,
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_TEMPERATURE,
+    ICON_ACCELERATION_X,
+    ICON_ACCELERATION_Y,
+    ICON_ACCELERATION_Z,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_METER_PER_SECOND_SQUARED,
+)
+
+from . import CONF_LIS3DH_ID, LIS3DHComponent
+
+
+def _accel_schema(icon):
+    return sensor.sensor_schema(
+        unit_of_measurement=UNIT_METER_PER_SECOND_SQUARED,
+        icon=icon,
+        accuracy_decimals=2,
+        state_class=STATE_CLASS_MEASUREMENT,
+    )
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_LIS3DH_ID): cv.use_id(LIS3DHComponent),
+        cv.Optional(CONF_ACCELERATION_X): _accel_schema(ICON_ACCELERATION_X),
+        cv.Optional(CONF_ACCELERATION_Y): _accel_schema(ICON_ACCELERATION_Y),
+        cv.Optional(CONF_ACCELERATION_Z): _accel_schema(ICON_ACCELERATION_Z),
+        cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_LIS3DH_ID])
+
+    if axis_conf := config.get(CONF_ACCELERATION_X):
+        cg.add(hub.set_acceleration_x_sensor(await sensor.new_sensor(axis_conf)))
+    if axis_conf := config.get(CONF_ACCELERATION_Y):
+        cg.add(hub.set_acceleration_y_sensor(await sensor.new_sensor(axis_conf)))
+    if axis_conf := config.get(CONF_ACCELERATION_Z):
+        cg.add(hub.set_acceleration_z_sensor(await sensor.new_sensor(axis_conf)))
+    if temp_conf := config.get(CONF_TEMPERATURE):
+        cg.add(hub.set_temperature_sensor(await sensor.new_sensor(temp_conf)))

--- a/esphome/components/lis3dh/text_sensor.py
+++ b/esphome/components/lis3dh/text_sensor.py
@@ -1,0 +1,35 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+
+from . import CONF_LIS3DH_ID, LIS3DHComponent
+
+CONF_ORIENTATION_XY = "orientation_xy"
+CONF_ORIENTATION_Z = "orientation_z"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_LIS3DH_ID): cv.use_id(LIS3DHComponent),
+        cv.Optional(CONF_ORIENTATION_XY): text_sensor.text_sensor_schema(
+            icon="mdi:axis-x-y-arrow-right"
+        ),
+        cv.Optional(CONF_ORIENTATION_Z): text_sensor.text_sensor_schema(
+            icon="mdi:axis-z-arrow"
+        ),
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_LIS3DH_ID])
+
+    if xy_conf := config.get(CONF_ORIENTATION_XY):
+        cg.add(
+            hub.set_orientation_xy_text_sensor(
+                await text_sensor.new_text_sensor(xy_conf)
+            )
+        )
+    if z_conf := config.get(CONF_ORIENTATION_Z):
+        cg.add(
+            hub.set_orientation_z_text_sensor(await text_sensor.new_text_sensor(z_conf))
+        )

--- a/esphome/components/lis3dh_i2c/__init__.py
+++ b/esphome/components/lis3dh_i2c/__init__.py
@@ -1,0 +1,25 @@
+import esphome.codegen as cg
+from esphome.components import i2c
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+from ..lis3dh import CONFIG_SCHEMA_BASE, LIS3DHComponent, setup_lis3dh_base
+
+AUTO_LOAD = ["lis3dh"]
+CODEOWNERS = ["@jthoward64"]
+DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
+
+lis3dh_i2c_ns = cg.esphome_ns.namespace("lis3dh_i2c")
+LIS3DHI2C = lis3dh_i2c_ns.class_("LIS3DHI2C", LIS3DHComponent, i2c.I2CDevice)
+
+CONFIG_SCHEMA = (
+    CONFIG_SCHEMA_BASE.extend({cv.GenerateID(): cv.declare_id(LIS3DHI2C)})
+).extend(i2c.i2c_device_schema(0x18))
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+    await setup_lis3dh_base(var, config)

--- a/esphome/components/lis3dh_i2c/lis3dh_i2c.cpp
+++ b/esphome/components/lis3dh_i2c/lis3dh_i2c.cpp
@@ -1,0 +1,30 @@
+#include "lis3dh_i2c.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace lis3dh_i2c {
+
+static const char *const TAG = "lis3dh_i2c";
+
+void LIS3DHI2C::dump_config() {
+  LIS3DHComponent::dump_config();
+  LOG_I2C_DEVICE(this);
+}
+
+bool LIS3DHI2C::read_register(uint8_t reg, uint8_t *data, uint16_t len) {
+  // Bit 7 set enables address auto-increment for multi-byte transfers.
+  if (len > 1) {
+    reg |= 0x80;
+  }
+  return this->read_bytes(reg, data, len);
+}
+
+bool LIS3DHI2C::write_register(uint8_t reg, const uint8_t *data, uint16_t len) {
+  if (len > 1) {
+    reg |= 0x80;
+  }
+  return this->write_bytes(reg, data, len);
+}
+
+}  // namespace lis3dh_i2c
+}  // namespace esphome

--- a/esphome/components/lis3dh_i2c/lis3dh_i2c.h
+++ b/esphome/components/lis3dh_i2c/lis3dh_i2c.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/lis3dh/lis3dh.h"
+
+namespace esphome {
+namespace lis3dh_i2c {
+
+class LIS3DHI2C : public lis3dh::LIS3DHComponent, public i2c::I2CDevice {
+ public:
+  void dump_config() override;
+
+  bool read_register(uint8_t reg, uint8_t *data, uint16_t len) override;
+  bool write_register(uint8_t reg, const uint8_t *data, uint16_t len) override;
+};
+
+}  // namespace lis3dh_i2c
+}  // namespace esphome

--- a/esphome/components/lis3dh_spi/__init__.py
+++ b/esphome/components/lis3dh_spi/__init__.py
@@ -1,0 +1,25 @@
+import esphome.codegen as cg
+from esphome.components import spi
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+from ..lis3dh import CONFIG_SCHEMA_BASE, LIS3DHComponent, setup_lis3dh_base
+
+AUTO_LOAD = ["lis3dh"]
+CODEOWNERS = ["@jthoward64"]
+DEPENDENCIES = ["spi"]
+MULTI_CONF = True
+
+lis3dh_spi_ns = cg.esphome_ns.namespace("lis3dh_spi")
+LIS3DHSPI = lis3dh_spi_ns.class_("LIS3DHSPI", LIS3DHComponent, spi.SPIDevice)
+
+CONFIG_SCHEMA = (
+    CONFIG_SCHEMA_BASE.extend({cv.GenerateID(): cv.declare_id(LIS3DHSPI)})
+).extend(spi.spi_device_schema(cs_pin_required=True))
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await spi.register_spi_device(var, config)
+    await setup_lis3dh_base(var, config)

--- a/esphome/components/lis3dh_spi/lis3dh_spi.cpp
+++ b/esphome/components/lis3dh_spi/lis3dh_spi.cpp
@@ -1,0 +1,40 @@
+#include "lis3dh_spi.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace lis3dh_spi {
+
+static const char *const TAG = "lis3dh_spi";
+
+void LIS3DHSPI::dump_config() {
+  LIS3DHComponent::dump_config();
+  LOG_PIN("  CS pin: ", this->cs_);
+}
+
+bool LIS3DHSPI::read_register(uint8_t reg, uint8_t *data, uint16_t len) {
+  // Bit 7 = read, bit 6 = address auto-increment for multi-byte transfers.
+  uint8_t cmd = reg | 0x80;
+  if (len > 1) {
+    cmd |= 0x40;
+  }
+  this->enable();
+  this->write_byte(cmd);
+  this->read_array(data, len);
+  this->disable();
+  return true;
+}
+
+bool LIS3DHSPI::write_register(uint8_t reg, const uint8_t *data, uint16_t len) {
+  uint8_t cmd = reg & 0x7F;
+  if (len > 1) {
+    cmd |= 0x40;
+  }
+  this->enable();
+  this->write_byte(cmd);
+  this->write_array(data, len);
+  this->disable();
+  return true;
+}
+
+}  // namespace lis3dh_spi
+}  // namespace esphome

--- a/esphome/components/lis3dh_spi/lis3dh_spi.h
+++ b/esphome/components/lis3dh_spi/lis3dh_spi.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/components/lis3dh/lis3dh.h"
+#include "esphome/components/spi/spi.h"
+
+namespace esphome {
+namespace lis3dh_spi {
+
+class LIS3DHSPI : public lis3dh::LIS3DHComponent,
+                  public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
+                                        spi::DATA_RATE_2MHZ> {
+ public:
+  void setup() override {
+    this->spi_setup();
+    LIS3DHComponent::setup();
+  }
+  void dump_config() override;
+
+  bool read_register(uint8_t reg, uint8_t *data, uint16_t len) override;
+  bool write_register(uint8_t reg, const uint8_t *data, uint16_t len) override;
+};
+
+}  // namespace lis3dh_spi
+}  // namespace esphome

--- a/tests/components/lis3dh/common.yaml
+++ b/tests/components/lis3dh/common.yaml
@@ -1,0 +1,64 @@
+lis3dh_i2c:
+  id: lis3dh_id
+  i2c_id: i2c_bus
+  address: 0x18
+  update_interval: 100ms
+  range: 2G
+  odr: 100Hz
+  mode: normal
+  fifo_enabled: true
+  fifo_mode: stream_to_fifo
+  fifo_watermark: 25
+  tap_enabled: true
+  tap_threshold: 0x12
+  tap_shock_duration: 0x20
+  tap_quiet_duration: 0x20
+  tap_double_tap_timeout: 0x30
+  activity_enabled: true
+  activity_threshold: 0x10
+  activity_duration: 0x05
+  freefall_enabled: true
+  freefall_threshold: 0x08
+  freefall_duration: 0x01
+  enable_deep_sleep_wakeup: false
+  high_pass_filter_enabled: true
+  high_pass_filter_mode: 0
+  high_pass_filter_cutoff: 0
+  on_tap:
+    - then:
+        - logger.log: "LIS3DH tap detected"
+  on_double_tap:
+    - then:
+        - logger.log: "LIS3DH double-tap detected"
+
+sensor:
+  - platform: lis3dh
+    lis3dh_id: lis3dh_id
+    acceleration_x:
+      name: LIS3DH X-axis acceleration
+    acceleration_y:
+      name: LIS3DH Y-axis acceleration
+    acceleration_z:
+      name: LIS3DH Z-axis acceleration
+    temperature:
+      name: LIS3DH temperature
+
+binary_sensor:
+  - platform: lis3dh
+    lis3dh_id: lis3dh_id
+    tap:
+      name: LIS3DH tap
+    double_tap:
+      name: LIS3DH double tap
+    activity:
+      name: LIS3DH activity
+    freefall:
+      name: LIS3DH freefall
+
+text_sensor:
+  - platform: lis3dh
+    lis3dh_id: lis3dh_id
+    orientation_xy:
+      name: LIS3DH orientation XY
+    orientation_z:
+      name: LIS3DH orientation Z

--- a/tests/components/lis3dh/test.esp32-idf.yaml
+++ b/tests/components/lis3dh/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/lis3dh/test.esp8266-ard.yaml
+++ b/tests/components/lis3dh/test.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/lis3dh/test.rp2040-ard.yaml
+++ b/tests/components/lis3dh/test.rp2040-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/lis3dh_spi/common.yaml
+++ b/tests/components/lis3dh_spi/common.yaml
@@ -1,0 +1,38 @@
+lis3dh_spi:
+  id: lis3dh_spi_id
+  spi_id: spi_bus
+  cs_pin: ${cs_pin}
+  update_interval: 100ms
+  range: 4G
+  odr: 100Hz
+  mode: high_resolution
+  fifo_enabled: true
+  fifo_mode: stream_to_fifo
+  fifo_watermark: 20
+  tap_enabled: true
+  activity_enabled: true
+  freefall_enabled: true
+
+sensor:
+  - platform: lis3dh
+    lis3dh_id: lis3dh_spi_id
+    acceleration_x:
+      name: LIS3DH SPI X-axis acceleration
+    acceleration_y:
+      name: LIS3DH SPI Y-axis acceleration
+    acceleration_z:
+      name: LIS3DH SPI Z-axis acceleration
+    temperature:
+      name: LIS3DH SPI temperature
+
+binary_sensor:
+  - platform: lis3dh
+    lis3dh_id: lis3dh_spi_id
+    tap:
+      name: LIS3DH SPI tap
+    double_tap:
+      name: LIS3DH SPI double tap
+    activity:
+      name: LIS3DH SPI activity
+    freefall:
+      name: LIS3DH SPI freefall

--- a/tests/components/lis3dh_spi/test.esp32-idf.yaml
+++ b/tests/components/lis3dh_spi/test.esp32-idf.yaml
@@ -1,0 +1,7 @@
+substitutions:
+  cs_pin: GPIO5
+
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
Adds a hub/platform-split component for the STMicroelectronics LIS3DH accelerometer with `lis3dh_i2c` and `lis3dh_spi` platform components and sensor / binary_sensor / text_sensor sub-platforms.

Bundles ST's official lis3dh_reg.c register driver (BSD-3-Clause).

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
