### PR TITLE
esp32_ble: Add init_key and rsp_key configuration parameters to confi…

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -249,11 +249,28 @@ CONF_IO_CAPABILITY = "io_capability"
 CONF_AUTH_REQ_MODE = "auth_req_mode"
 CONF_MAX_KEY_SIZE = "max_key_size"
 CONF_MIN_KEY_SIZE = "min_key_size"
+CONF_INIT_KEY = "init_key"
+CONF_RSP_KEY = "rsp_key"
 CONF_ADVERTISING = "advertising"
 CONF_ADVERTISING_CYCLE_TIME = "advertising_cycle_time"
 CONF_DISABLE_BT_LOGS = "disable_bt_logs"
 CONF_CONNECTION_TIMEOUT = "connection_timeout"
 CONF_MAX_NOTIFICATIONS = "max_notifications"
+
+KEY_MASKS = {
+    "enc": 1 << 0,  # ESP_BLE_ENC_KEY_MASK
+    "id": 1 << 1,  # ESP_BLE_ID_KEY_MASK
+    "sign": 1 << 2,  # ESP_BLE_CSRK_KEY_MASK
+    "link": 1 << 3,  # ESP_BLE_LINK_KEY_MASK
+}
+
+
+def validate_key_mask(value):
+    mask = 0
+    for key in value:
+        mask |= KEY_MASKS[key]
+    return mask
+
 
 # BLE connection limits
 # ESP-IDF CONFIG_BT_ACL_CONNECTIONS has range 1-9, default 4
@@ -331,6 +348,12 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_AUTH_REQ_MODE): cv.enum(AUTH_REQ_MODE, lower=True),
         cv.Optional(CONF_MAX_KEY_SIZE): cv.int_range(min=7, max=16),
         cv.Optional(CONF_MIN_KEY_SIZE): cv.int_range(min=7, max=16),
+        cv.Optional(CONF_INIT_KEY): cv.All(
+            cv.ensure_list(cv.enum(KEY_MASKS, lower=True)), validate_key_mask
+        ),
+        cv.Optional(CONF_RSP_KEY): cv.All(
+            cv.ensure_list(cv.enum(KEY_MASKS, lower=True)), validate_key_mask
+        ),
         cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
         cv.Optional(CONF_ADVERTISING, default=False): cv.boolean,
         cv.Optional(
@@ -585,6 +608,8 @@ async def to_code(config):
         CONF_AUTH_REQ_MODE in config
         or CONF_MAX_KEY_SIZE in config
         or CONF_MIN_KEY_SIZE in config
+        or CONF_INIT_KEY in config
+        or CONF_RSP_KEY in config
     ):
         cg.add_define("ESPHOME_ESP32_BLE_EXTENDED_AUTH_PARAMS", None)
 
@@ -594,6 +619,10 @@ async def to_code(config):
         cg.add(var.set_max_key_size(config[CONF_MAX_KEY_SIZE]))
     if CONF_MIN_KEY_SIZE in config:
         cg.add(var.set_min_key_size(config[CONF_MIN_KEY_SIZE]))
+    if CONF_INIT_KEY in config:
+        cg.add(var.set_init_key(config[CONF_INIT_KEY]))
+    if CONF_RSP_KEY in config:
+        cg.add(var.set_rsp_key(config[CONF_RSP_KEY]))
 
     cg.add(var.set_advertising_cycle_time(config[CONF_ADVERTISING_CYCLE_TIME]))
     if (name := config.get(CONF_NAME)) is not None:

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -361,6 +361,22 @@ bool ESP32BLE::ble_setup_() {
       return false;
     }
   }
+
+  if (this->init_key_) {
+    err = esp_ble_gap_set_security_param(ESP_BLE_SM_SET_INIT_KEY, &(this->init_key_.value()), sizeof(uint8_t));
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_ble_gap_set_security_param init_key failed: %d", err);
+      return false;
+    }
+  }
+
+  if (this->rsp_key_) {
+    err = esp_ble_gap_set_security_param(ESP_BLE_SM_SET_RSP_KEY, &(this->rsp_key_.value()), sizeof(uint8_t));
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_ble_gap_set_security_param rsp_key failed: %d", err);
+      return false;
+    }
+  }
 #endif  // ESPHOME_ESP32_BLE_EXTENDED_AUTH_PARAMS
 
   // BLE takes some time to be fully set up, 200ms should be more than enough

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -95,6 +95,8 @@ class ESP32BLE final : public Component {
   void set_max_key_size(uint8_t key_size) { this->max_key_size_ = key_size; }
   void set_min_key_size(uint8_t key_size) { this->min_key_size_ = key_size; }
   void set_auth_req(AuthReqMode req) { this->auth_req_mode_ = (esp_ble_auth_req_t) req; }
+  void set_init_key(uint8_t key) { this->init_key_ = key; }
+  void set_rsp_key(uint8_t key) { this->rsp_key_ = key; }
 #endif
 
   void set_advertising_cycle_time(uint32_t advertising_cycle_time) {
@@ -227,6 +229,8 @@ class ESP32BLE final : public Component {
 
 #ifdef ESPHOME_ESP32_BLE_EXTENDED_AUTH_PARAMS
   optional<esp_ble_auth_req_t> auth_req_mode_;
+  optional<uint8_t> init_key_;
+  optional<uint8_t> rsp_key_;
 
   uint8_t max_key_size_{0};  // range is 7..16, 0 is unset
   uint8_t min_key_size_{0};  // range is 7..16, 0 is unset

--- a/tests/components/esp32_ble/common.yaml
+++ b/tests/components/esp32_ble/common.yaml
@@ -1,2 +1,4 @@
 esp32_ble:
   io_capability: keyboard_only
+  init_key: [enc, sign, link]
+  rsp_key: [enc]


### PR DESCRIPTION
…gure key distribution masks

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
