### PR TITLE
[api] Warn when Home Assistant actions are sent with no subscribed client

### DIFF
--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -166,10 +166,13 @@ class APIConnection final : public APIServerConnectionBase {
 #endif
   bool try_send_log_message(int level, const char *tag, const char *line, size_t message_len);
 #ifdef USE_API_HOMEASSISTANT_SERVICES
-  void send_homeassistant_action(const HomeassistantActionRequest &call) {
+  // Returns false if this client has not (yet) subscribed to Home Assistant actions,
+  // so the caller can warn when an action was not delivered to any client.
+  bool send_homeassistant_action(const HomeassistantActionRequest &call) {
     if (!this->flags_.service_call_subscription)
-      return;
+      return false;
     this->send_message(call);
+    return true;
   }
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
   void on_homeassistant_action_response(const HomeassistantActionResponse &msg);

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -166,8 +166,9 @@ class APIConnection final : public APIServerConnectionBase {
 #endif
   bool try_send_log_message(int level, const char *tag, const char *line, size_t message_len);
 #ifdef USE_API_HOMEASSISTANT_SERVICES
-  // Returns false if this client has not (yet) subscribed to Home Assistant actions,
-  // so the caller can warn when an action was not delivered to any client.
+  // Returns whether this client has subscribed to Home Assistant actions; the message
+  // is only handed to the send path when subscribed. A true return does not guarantee
+  // delivery - it lets the caller warn when no connected client has the subscription.
   bool send_homeassistant_action(const HomeassistantActionRequest &call) {
     if (!this->flags_.service_call_subscription)
       return false;

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -426,11 +426,11 @@ void APIServer::set_batch_delay(uint16_t batch_delay) { this->batch_delay_ = bat
 
 #ifdef USE_API_HOMEASSISTANT_SERVICES
 void APIServer::send_homeassistant_action(const HomeassistantActionRequest &call) {
-  bool sent = false;
+  bool has_subscriber = false;
   for (auto &client : this->active_clients()) {
-    sent |= client->send_homeassistant_action(call);
+    has_subscriber |= client->send_homeassistant_action(call);
   }
-  if (!sent) {
+  if (!has_subscriber) {
     // Home Assistant subscribes to actions shortly *after* authenticating, so actions
     // fired right at connection time (on_client_connected, on_time_sync, ...) can
     // arrive before the subscription and are lost - warn instead of failing silently.

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -426,8 +426,16 @@ void APIServer::set_batch_delay(uint16_t batch_delay) { this->batch_delay_ = bat
 
 #ifdef USE_API_HOMEASSISTANT_SERVICES
 void APIServer::send_homeassistant_action(const HomeassistantActionRequest &call) {
+  bool sent = false;
   for (auto &client : this->active_clients()) {
-    client->send_homeassistant_action(call);
+    sent |= client->send_homeassistant_action(call);
+  }
+  if (!sent) {
+    // Home Assistant subscribes to actions shortly *after* authenticating, so actions
+    // fired right at connection time (on_client_connected, on_time_sync, ...) can
+    // arrive before the subscription and are lost - warn instead of failing silently.
+    ESP_LOGW(TAG, "Home Assistant %s '%s' dropped; %s", call.is_event ? "event" : "action", call.service.c_str(),
+             this->is_connected() ? "client has not subscribed to actions (yet)" : "no client connected");
   }
 }
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES

--- a/tests/integration/fixtures/api_homeassistant_action_no_subscriber.yaml
+++ b/tests/integration/fixtures/api_homeassistant_action_no_subscriber.yaml
@@ -1,0 +1,30 @@
+esphome:
+  name: test-ha-action-no-subscriber
+  friendly_name: Home Assistant Action No Subscriber Test
+  on_boot:
+    # Fires before any client is connected - dropped with a warning.
+    - homeassistant.action:
+        action: test.boot_action
+
+host:
+
+api:
+  on_client_connected:
+    # Fires at authentication time, before the client has subscribed to
+    # Home Assistant actions - dropped with a warning.
+    - homeassistant.action:
+        action: test.connected_action
+
+logger:
+  level: DEBUG
+
+button:
+  - platform: template
+    name: Send Action Button
+    id: send_action_button
+    on_press:
+      # Pressed only after the client has subscribed - must be delivered.
+      - homeassistant.action:
+          action: test.button_action
+          data:
+            value: subscribed

--- a/tests/integration/test_api_homeassistant_action_no_subscriber.py
+++ b/tests/integration/test_api_homeassistant_action_no_subscriber.py
@@ -1,0 +1,79 @@
+"""Integration test for Home Assistant actions fired without a subscriber.
+
+Home Assistant subscribes to device actions shortly after authenticating, while
+on_client_connected (and similar triggers) fire right at authentication. Actions
+fired before any client has subscribed cannot be delivered - they must produce a
+warning in the log instead of vanishing silently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from aioesphomeapi import ButtonInfo, HomeassistantServiceCall
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_api_homeassistant_action_no_subscriber(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Undeliverable actions warn in the log; actions after subscribing arrive."""
+    loop = asyncio.get_running_loop()
+
+    boot_warning_future = loop.create_future()
+    connected_warning_future = loop.create_future()
+    button_action_future = loop.create_future()
+
+    def check_output(line: str) -> None:
+        if (
+            not boot_warning_future.done()
+            and "Home Assistant action 'test.boot_action' dropped; no client connected"
+            in line
+        ):
+            boot_warning_future.set_result(True)
+        if (
+            not connected_warning_future.done()
+            and "Home Assistant action 'test.connected_action' dropped; "
+            "client has not subscribed to actions (yet)"
+            in line
+        ):
+            connected_warning_future.set_result(True)
+
+    service_calls: list[HomeassistantServiceCall] = []
+
+    def on_service_call(service_call: HomeassistantServiceCall) -> None:
+        service_calls.append(service_call)
+        if (
+            service_call.service == "test.button_action"
+            and not button_action_future.done()
+        ):
+            button_action_future.set_result(service_call)
+
+    async with run_compiled(yaml_config, line_callback=check_output):
+        # The on_boot action fires with no client connected at all.
+        await asyncio.wait_for(boot_warning_future, timeout=10.0)
+
+        async with api_client_connected() as client:
+            device_info = await client.device_info()
+            assert device_info.name == "test-ha-action-no-subscriber"
+
+            # on_client_connected fired at authentication, before this client
+            # subscribed to Home Assistant actions.
+            await asyncio.wait_for(connected_warning_future, timeout=5.0)
+
+            # After subscribing, actions must be delivered normally (and the
+            # dropped ones must not suddenly show up).
+            client.subscribe_service_calls(on_service_call)
+
+            entities, _ = await client.list_entities_services()
+            button = next(e for e in entities if isinstance(e, ButtonInfo))
+            client.button_command(button.key)
+
+            button_call = await asyncio.wait_for(button_action_future, timeout=5.0)
+            assert button_call.data == {"value": "subscribed"}
+            assert [call.service for call in service_calls] == ["test.button_action"]


### PR DESCRIPTION
# What does this implement/fix?

Home Assistant subscribes to device actions shortly *after* the API connection authenticates, while `api.connected`, `on_client_connected` and `on_time_sync` all become true right at authentication. Any `homeassistant.action` or `homeassistant.event` fired in that window - the very common "perform an action when the API connects" pattern, and every fresh connection on a deep-sleep battery device - was dropped without any trace: `APIConnection::send_homeassistant_action()` returned early when the client had not subscribed yet, no log line was produced on either side, and with `capture_response` configured neither `on_success` nor `on_error` fired.

This PR makes `APIServer::send_homeassistant_action()` log a warning when no connected client has subscribed to actions, distinguishing the two causes so the race is diagnosable from the device log:

```text
[W][api:xxx] Home Assistant action 'calendar.get_events' dropped; client has not subscribed to actions (yet)
[W][api:xxx] Home Assistant action 'calendar.get_events' dropped; no client connected
```

No behavior change otherwise; the code is only compiled when `homeassistant.action`/`homeassistant.event` is used.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6984

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
  on_client_connected:
    - homeassistant.action:
        action: calendar.get_events
        data:
          entity_id: calendar.home
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
