### PR TITLE
[rc522_i2c] Change default address to match whats in the docs

### DIFF
--- a/esphome/components/rc522_i2c/__init__.py
+++ b/esphome/components/rc522_i2c/__init__.py
@@ -16,7 +16,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(RC522I2C),
         }
-    ).extend(i2c.i2c_device_schema(0x2C))
+    ).extend(i2c.i2c_device_schema(0x28))
 )
 
 


### PR DESCRIPTION


# What does this implement/fix?

Esphome docs state the default address is 0x28
https://esphome.io/components/binary_sensor/rc522/#over-ic
This makes more sense than 0x2C because with EA low and ADR_0-2 all low the resulting address is 0x28
On most boards this is very easy to accomplish by bridging pins, but getting the address 0x2C is a lot more involved due to some of the address pins being not connected to the board.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**



**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:
  - id: bus_a
    scl: D1
    sda: D2
    scan: False
    frequency: 400kHz

rc522_i2c:
  i2c_id: bus_a

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
