### PR TITLE
[cc1101] Export CC1101Listener to Python

### DIFF
--- a/esphome/components/cc1101/__init__.py
+++ b/esphome/components/cc1101/__init__.py
@@ -21,6 +21,7 @@ MULTI_CONF = True
 
 ns = cg.esphome_ns.namespace("cc1101")
 CC1101Component = ns.class_("CC1101Component", cg.Component, spi.SPIDevice)
+CC1101Listener = ns.class_("CC1101Listener")
 
 # Config keys
 CONF_RX_ATTENUATION = "rx_attenuation"


### PR DESCRIPTION
# What does this implement/fix?

The C++ `CC1101Listener` class and `CC1101Component::register_listener()` already exist and are used
internally, but the Python side never bound the class. External components that want to register
themselves as a packet listener from their own `__init__.py` (e.g. to type a `cv.use_id()` against it,
or declare a field of that type) currently have no way to reference `cc1101.CC1101Listener` from Python
without duplicating the class declaration. This adds the one missing binding line, matching the existing
`CC1101Component = ns.class_(...)` pattern right above it.

No C++ changes, no behavior changes, no new YAML options.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** -

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable, no user-facing configuration change.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No YAML change. This only makes cc1101.CC1101Listener importable from another
# component's Python code, e.g.:
#   from esphome.components import cc1101
#   MyListener = ns.class_("MyListener", cc1101.CC1101Listener)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). *(a one-line Python binding with no new runtime behavior; nothing new to assert)*

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). *(not applicable, no user-facing change)*