### PR TITLE
[cc1101] Add FOCCFG and BSCFG config options

### DIFF
--- a/esphome/components/cc1101/__init__.py
+++ b/esphome/components/cc1101/__init__.py
@@ -48,6 +48,15 @@ CONF_FILTER_LENGTH_FSK_MSK = "filter_length_fsk_msk"
 CONF_FILTER_LENGTH_ASK_OOK = "filter_length_ask_ook"
 CONF_FREEZE = "freeze"
 CONF_HYST_LEVEL = "hyst_level"
+CONF_FOC_BS_CS_GATE = "foc_bs_cs_gate"
+CONF_FOC_LIMIT = "foc_limit"
+CONF_FOC_PRE_K = "foc_pre_k"
+CONF_FOC_POST_K = "foc_post_k"
+CONF_BS_LIMIT = "bs_limit"
+CONF_BS_PRE_KI = "bs_pre_ki"
+CONF_BS_PRE_KP = "bs_pre_kp"
+CONF_BS_POST_KI = "bs_post_ki"
+CONF_BS_POST_KP = "bs_post_kp"
 
 # Packet mode config keys
 CONF_PACKET_MODE = "packet_mode"
@@ -161,6 +170,64 @@ HYST_LEVEL = {
     "High": HystLevel.HYST_LEVEL_HIGH,
 }
 
+FocLimit = ns.enum("FocLimit", True)
+FOC_LIMIT = {
+    "Disabled": FocLimit.FOC_LIMIT_DISABLED,
+    "BW/8": FocLimit.FOC_LIMIT_BW_8,
+    "BW/4": FocLimit.FOC_LIMIT_BW_4,
+    "BW/2": FocLimit.FOC_LIMIT_BW_2,
+}
+
+FocPreK = ns.enum("FocPreK", True)
+FOC_PRE_K = {
+    "K": FocPreK.FOC_PRE_K_K,
+    "2K": FocPreK.FOC_PRE_K_2K,
+    "3K": FocPreK.FOC_PRE_K_3K,
+    "4K": FocPreK.FOC_PRE_K_4K,
+}
+
+FocPostK = ns.enum("FocPostK", True)
+FOC_POST_K = {
+    "Same": FocPostK.FOC_POST_K_SAME,
+    "K/2": FocPostK.FOC_POST_K_K_2,
+}
+
+BsLimit = ns.enum("BsLimit", True)
+BS_LIMIT = {
+    "Disabled": BsLimit.BS_LIMIT_DISABLED,
+    "3.125%": BsLimit.BS_LIMIT_3P125_PERCENT,
+    "6.25%": BsLimit.BS_LIMIT_6P25_PERCENT,
+    "12.5%": BsLimit.BS_LIMIT_12P5_PERCENT,
+}
+
+BsPreKi = ns.enum("BsPreKi", True)
+BS_PRE_KI = {
+    "KI": BsPreKi.BS_PRE_KI_KI,
+    "2KI": BsPreKi.BS_PRE_KI_2KI,
+    "3KI": BsPreKi.BS_PRE_KI_3KI,
+    "4KI": BsPreKi.BS_PRE_KI_4KI,
+}
+
+BsPreKp = ns.enum("BsPreKp", True)
+BS_PRE_KP = {
+    "KP": BsPreKp.BS_PRE_KP_KP,
+    "2KP": BsPreKp.BS_PRE_KP_2KP,
+    "3KP": BsPreKp.BS_PRE_KP_3KP,
+    "4KP": BsPreKp.BS_PRE_KP_4KP,
+}
+
+BsPostKi = ns.enum("BsPostKi", True)
+BS_POST_KI = {
+    "Same": BsPostKi.BS_POST_KI_SAME,
+    "KI/2": BsPostKi.BS_POST_KI_KI_2,
+}
+
+BsPostKp = ns.enum("BsPostKp", True)
+BS_POST_KP = {
+    "Same": BsPostKp.BS_POST_KP_SAME,
+    "KP": BsPostKp.BS_POST_KP_KP,
+}
+
 # Optional settings to generate setter calls for
 CONFIG_MAP = {
     cv.Optional(CONF_OUTPUT_POWER, default=10): cv.float_range(min=-30.0, max=11.0),
@@ -214,6 +281,15 @@ CONFIG_MAP = {
     cv.Optional(CONF_FREEZE): cv.enum(FREEZE, upper=False),
     cv.Optional(CONF_WAIT_TIME, default="32"): cv.enum(WAIT_TIME, upper=False),
     cv.Optional(CONF_HYST_LEVEL): cv.enum(HYST_LEVEL, upper=False),
+    cv.Optional(CONF_FOC_BS_CS_GATE): cv.boolean,
+    cv.Optional(CONF_FOC_LIMIT): cv.enum(FOC_LIMIT, upper=False),
+    cv.Optional(CONF_FOC_PRE_K): cv.enum(FOC_PRE_K, upper=False),
+    cv.Optional(CONF_FOC_POST_K): cv.enum(FOC_POST_K, upper=False),
+    cv.Optional(CONF_BS_LIMIT): cv.enum(BS_LIMIT, upper=False),
+    cv.Optional(CONF_BS_PRE_KI): cv.enum(BS_PRE_KI, upper=False),
+    cv.Optional(CONF_BS_PRE_KP): cv.enum(BS_PRE_KP, upper=False),
+    cv.Optional(CONF_BS_POST_KI): cv.enum(BS_POST_KI, upper=False),
+    cv.Optional(CONF_BS_POST_KP): cv.enum(BS_POST_KP, upper=False),
     cv.Optional(CONF_PACKET_MODE, default=False): cv.boolean,
     cv.Optional(CONF_PACKET_LENGTH): cv.uint8_t,
     cv.Optional(CONF_CRC_ENABLE, default=False): cv.boolean,

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -672,6 +672,69 @@ void CC1101Component::set_hyst_level(HystLevel value) {
   }
 }
 
+void CC1101Component::set_foc_bs_cs_gate(bool value) {
+  this->state_.FOC_BS_CS_GATE = value ? 1 : 0;
+  if (this->initialized_) {
+    this->write_(Register::FOCCFG);
+  }
+}
+
+void CC1101Component::set_foc_limit(FocLimit value) {
+  this->state_.FOC_LIMIT = static_cast<uint8_t>(value);
+  if (this->initialized_) {
+    this->write_(Register::FOCCFG);
+  }
+}
+
+void CC1101Component::set_foc_pre_k(FocPreK value) {
+  this->state_.FOC_PRE_K = static_cast<uint8_t>(value);
+  if (this->initialized_) {
+    this->write_(Register::FOCCFG);
+  }
+}
+
+void CC1101Component::set_foc_post_k(FocPostK value) {
+  this->state_.FOC_POST_K = static_cast<uint8_t>(value);
+  if (this->initialized_) {
+    this->write_(Register::FOCCFG);
+  }
+}
+
+void CC1101Component::set_bs_limit(BsLimit value) {
+  this->state_.BS_LIMIT = static_cast<uint8_t>(value);
+  if (this->initialized_) {
+    this->write_(Register::BSCFG);
+  }
+}
+
+void CC1101Component::set_bs_pre_ki(BsPreKi value) {
+  this->state_.BS_PRE_KI = static_cast<uint8_t>(value);
+  if (this->initialized_) {
+    this->write_(Register::BSCFG);
+  }
+}
+
+void CC1101Component::set_bs_pre_kp(BsPreKp value) {
+  this->state_.BS_PRE_KP = static_cast<uint8_t>(value);
+  if (this->initialized_) {
+    this->write_(Register::BSCFG);
+  }
+}
+
+void CC1101Component::set_bs_post_ki(BsPostKi value) {
+  this->state_.BS_POST_KI = static_cast<uint8_t>(value);
+  if (this->initialized_) {
+    this->write_(Register::BSCFG);
+  }
+}
+
+void CC1101Component::set_bs_post_kp(BsPostKp value) {
+  this->state_.BS_POST_KP = static_cast<uint8_t>(value);
+  if (this->initialized_) {
+    this->write_(Register::BSCFG);
+  }
+}
+
 void CC1101Component::set_packet_mode(bool value) {
   this->state_.PKT_FORMAT =
       static_cast<uint8_t>(value ? PacketFormat::PACKET_FORMAT_FIFO : PacketFormat::PACKET_FORMAT_ASYNC_SERIAL);

--- a/esphome/components/cc1101/cc1101.h
+++ b/esphome/components/cc1101/cc1101.h
@@ -71,6 +71,17 @@ class CC1101Component final : public Component,
   void set_wait_time(WaitTime value);
   void set_hyst_level(HystLevel value);
 
+  // Frequency offset compensation and bit synchronization settings
+  void set_foc_bs_cs_gate(bool value);
+  void set_foc_limit(FocLimit value);
+  void set_foc_pre_k(FocPreK value);
+  void set_foc_post_k(FocPostK value);
+  void set_bs_limit(BsLimit value);
+  void set_bs_pre_ki(BsPreKi value);
+  void set_bs_pre_kp(BsPreKp value);
+  void set_bs_post_ki(BsPostKi value);
+  void set_bs_post_kp(BsPostKp value);
+
   // Packet mode settings
   void set_packet_mode(bool value);
   void set_packet_length(uint8_t value);

--- a/esphome/components/cc1101/cc1101defs.h
+++ b/esphome/components/cc1101/cc1101defs.h
@@ -231,6 +231,56 @@ enum class HystLevel : uint8_t {
   HYST_LEVEL_HIGH,
 };
 
+enum class FocLimit : uint8_t {
+  FOC_LIMIT_DISABLED,
+  FOC_LIMIT_BW_8,
+  FOC_LIMIT_BW_4,
+  FOC_LIMIT_BW_2,
+};
+
+enum class FocPreK : uint8_t {
+  FOC_PRE_K_K,
+  FOC_PRE_K_2K,
+  FOC_PRE_K_3K,
+  FOC_PRE_K_4K,
+};
+
+enum class FocPostK : uint8_t {
+  FOC_POST_K_SAME,
+  FOC_POST_K_K_2,
+};
+
+enum class BsLimit : uint8_t {
+  BS_LIMIT_DISABLED,
+  BS_LIMIT_3P125_PERCENT,
+  BS_LIMIT_6P25_PERCENT,
+  BS_LIMIT_12P5_PERCENT,
+};
+
+enum class BsPreKi : uint8_t {
+  BS_PRE_KI_KI,
+  BS_PRE_KI_2KI,
+  BS_PRE_KI_3KI,
+  BS_PRE_KI_4KI,
+};
+
+enum class BsPreKp : uint8_t {
+  BS_PRE_KP_KP,
+  BS_PRE_KP_2KP,
+  BS_PRE_KP_3KP,
+  BS_PRE_KP_4KP,
+};
+
+enum class BsPostKi : uint8_t {
+  BS_POST_KI_SAME,
+  BS_POST_KI_KI_2,
+};
+
+enum class BsPostKp : uint8_t {
+  BS_POST_KP_SAME,
+  BS_POST_KP_KP,
+};
+
 enum class PacketFormat : uint8_t {
   PACKET_FORMAT_FIFO,
   PACKET_FORMAT_SYNC_SERIAL,

--- a/tests/components/cc1101/common.yaml
+++ b/tests/components/cc1101/common.yaml
@@ -17,6 +17,15 @@ cc1101:
   sync0: 0x91
   sync1: 0xD3
   num_preamble: 2
+  foc_bs_cs_gate: true
+  foc_pre_k: "2K"
+  foc_post_k: "K/2"
+  foc_limit: "BW/4"
+  bs_pre_ki: "3KI"
+  bs_pre_kp: "4KP"
+  bs_post_ki: "KI/2"
+  bs_post_kp: "KP"
+  bs_limit: "12.5%"
   on_packet:
     then:
       - lambda: |-


### PR DESCRIPTION
# What does this implement/fix?

Exposes the CC1101's frequency offset compensation (`FOCCFG`) and bit synchronization (`BSCFG`) register
fields as YAML options: `foc_bs_cs_gate`, `foc_limit`, `foc_pre_k`, `foc_post_k`, `bs_limit`, `bs_pre_ki`,
`bs_pre_kp`, `bs_post_ki`, `bs_post_kp`. All are optional; when omitted, the datasheet power-on-reset
defaults are kept, so existing configurations are unaffected.

These registers control how aggressively the receiver tracks frequency offset and bit timing. The
built-in defaults are tuned for the common case, but for narrowband/low-deviation protocols (e.g.
wM-Bus) the default FOC/BS tuning can be too loose or too aggressive to reliably lock onto the signal;
being able to set these from YAML makes that tunable without a custom component fork.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** -

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#6992

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
cc1101:
  id: transceiver
  cs_pin: GPIO7
  gdo0_pin: GPIO10
  frequency: 868.95MHz
  # ... other required options ...
  foc_bs_cs_gate: true
  foc_pre_k: "2K"
  foc_post_k: "K/2"
  foc_limit: "BW/4"
  bs_pre_ki: "3KI"
  bs_pre_kp: "4KP"
  bs_post_ki: "KI/2"
  bs_post_kp: "KP"
  bs_limit: "12.5%"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). *(extended `tests/components/cc1101/common.yaml` with all nine new options, covering both the ESP32 IDF and ESP8266 test targets)*

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). *(esphome-docs#6992)*