### PR TITLE
[ci] Extend variant clang-tidy scans to USB logger, tsens and LP peripheral code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -745,7 +745,7 @@ jobs:
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 S3
             # yamllint disable-line rule:line-length
-            options: --environment esp32s3-idf-tidy --grep USE_ESP32_VARIANT_ESP32S3 --grep SOC_TEMP_SENSOR_SUPPORTED --grep USE_LOGGER_USB_CDC
+            options: --environment esp32s3-idf-tidy --grep SOC_TEMP_SENSOR_SUPPORTED --grep USE_ESP32_VARIANT_ESP32S3 --grep USE_LOGGER_USB_CDC
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 P4
             # P4 has no native Wi-Fi/BLE; those run over the hosted co-processor,
@@ -755,7 +755,7 @@ jobs:
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 C6
             # yamllint disable-line rule:line-length
-            options: --environment esp32c6-idf-tidy --grep USE_ESP32_VARIANT_ESP32C6 --grep USE_OPENTHREAD --grep USE_ZIGBEE --grep SOC_LP_I2C_SUPPORTED
+            options: --environment esp32c6-idf-tidy --grep SOC_LP_I2C_SUPPORTED --grep USE_ESP32_VARIANT_ESP32C6 --grep USE_OPENTHREAD --grep USE_ZIGBEE
 
     steps:
       - name: Check out code from GitHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -744,7 +744,10 @@ jobs:
         include:
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 S3
-            options: --environment esp32s3-idf-tidy --grep USE_ESP32_VARIANT_ESP32S3
+            # Also lint the USB-CDC logger paths and the tsens temperature driver,
+            # which the original ESP32 build compiles out.
+            # yamllint disable-line rule:line-length
+            options: --environment esp32s3-idf-tidy --grep USE_ESP32_VARIANT_ESP32S3 --grep SOC_TEMP_SENSOR_SUPPORTED --grep USE_LOGGER_USB_CDC
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 P4
             # P4 has no native Wi-Fi/BLE; those run over the hosted co-processor,
@@ -753,8 +756,10 @@ jobs:
             options: --environment esp32p4-idf-tidy --grep USE_ESP32_VARIANT_ESP32P4 --grep USE_ESP32_HOSTED --grep USE_WIFI --grep USE_BLE
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 C6
+            # Also lint the low-power I2C/UART peripheral code, which only newer
+            # chips (C5/C6/P4) have.
             # yamllint disable-line rule:line-length
-            options: --environment esp32c6-idf-tidy --grep USE_ESP32_VARIANT_ESP32C6 --grep USE_OPENTHREAD --grep USE_ZIGBEE
+            options: --environment esp32c6-idf-tidy --grep USE_ESP32_VARIANT_ESP32C6 --grep USE_OPENTHREAD --grep USE_ZIGBEE --grep SOC_LP_I2C_SUPPORTED --grep SOC_UART_LP_NUM
 
     steps:
       - name: Check out code from GitHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -756,10 +756,10 @@ jobs:
             options: --environment esp32p4-idf-tidy --grep USE_ESP32_VARIANT_ESP32P4 --grep USE_ESP32_HOSTED --grep USE_WIFI --grep USE_BLE
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 C6
-            # Also lint the low-power I2C/UART peripheral code, which only newer
+            # Also lint the low-power I2C peripheral code, which only newer
             # chips (C5/C6/P4) have.
             # yamllint disable-line rule:line-length
-            options: --environment esp32c6-idf-tidy --grep USE_ESP32_VARIANT_ESP32C6 --grep USE_OPENTHREAD --grep USE_ZIGBEE --grep SOC_LP_I2C_SUPPORTED --grep SOC_UART_LP_NUM
+            options: --environment esp32c6-idf-tidy --grep USE_ESP32_VARIANT_ESP32C6 --grep USE_OPENTHREAD --grep USE_ZIGBEE --grep SOC_LP_I2C_SUPPORTED
 
     steps:
       - name: Check out code from GitHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -744,8 +744,6 @@ jobs:
         include:
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 S3
-            # Also lint the USB-CDC logger paths and the tsens temperature driver,
-            # which the original ESP32 build compiles out.
             # yamllint disable-line rule:line-length
             options: --environment esp32s3-idf-tidy --grep USE_ESP32_VARIANT_ESP32S3 --grep SOC_TEMP_SENSOR_SUPPORTED --grep USE_LOGGER_USB_CDC
           - id: clang-tidy
@@ -756,8 +754,6 @@ jobs:
             options: --environment esp32p4-idf-tidy --grep USE_ESP32_VARIANT_ESP32P4 --grep USE_ESP32_HOSTED --grep USE_WIFI --grep USE_BLE
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 C6
-            # Also lint the low-power I2C peripheral code, which only newer
-            # chips (C5/C6/P4) have.
             # yamllint disable-line rule:line-length
             options: --environment esp32c6-idf-tidy --grep USE_ESP32_VARIANT_ESP32C6 --grep USE_OPENTHREAD --grep USE_ZIGBEE --grep SOC_LP_I2C_SUPPORTED
 


### PR DESCRIPTION
# What does this implement/fix?

The variant clang-tidy jobs (S3/P4/C6) select files by grepping for variant-specific strings, since the comprehensive esp32-idf pass only analyzes code that is active on the original ESP32. An audit of every `USE_ESP32_VARIANT_*` guard, variant-conditional define in `defines.h`, and `SOC_*`-gated source file found code paths that no job currently analyzes, because their files contain none of the existing grep strings:

- `logger/logger_esp32.cpp` — the `USE_LOGGER_USB_CDC` / `USE_LOGGER_USB_SERIAL_JTAG` logger paths (active on every variant except the original ESP32)
- `internal_temperature/internal_temperature_esp32.cpp` — the `SOC_TEMP_SENSOR_SUPPORTED` tsens driver branch (every variant except the original ESP32)
- `i2c/i2c_bus_esp_idf.cpp` — the `SOC_LP_I2C_SUPPORTED` low-power I2C support (C5/C6/P4)

This adds `--grep SOC_TEMP_SENSOR_SUPPORTED --grep USE_LOGGER_USB_CDC` to the S3 job (the S3 build enables both USB logger defines) and `--grep SOC_LP_I2C_SUPPORTED` to the C6 job. Cost is small: 6 extra files in the S3 job and 1 in the C6 job. The `USE_LOGGER_USB_CDC` grep also pulls in the rp2/zephyr logger files, which preprocess to nothing under the S3 environment.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# CI-only change, no configuration impact
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).