### PR TITLE
[as3935_i2c] Use repeated start when reading registers

### DIFF
--- a/esphome/components/as3935_i2c/as3935_i2c.cpp
+++ b/esphome/components/as3935_i2c/as3935_i2c.cpp
@@ -24,11 +24,7 @@ void I2CAS3935Component::write_register(uint8_t reg, uint8_t mask, uint8_t bits,
 
 uint8_t I2CAS3935Component::read_register(uint8_t reg) {
   uint8_t value;
-  if (write(&reg, 1) != i2c::ERROR_OK) {
-    ESP_LOGW(TAG, "Writing register failed!");
-    return 0;
-  }
-  if (read(&value, 1) != i2c::ERROR_OK) {
+  if (!this->read_byte(reg, &value)) {
     ESP_LOGW(TAG, "Reading register failed!");
     return 0;
   }


### PR DESCRIPTION
# What does this implement/fix?

`I2CAS3935Component::read_register()` performed the register read as two separate I2C transactions: a register-pointer write ending with a STOP, then a new read transaction. The AS3935 datasheet requires a repeated start between the pointer write and the read; after a STOP the chip does not honor the register pointer, so every read returned register 0x00 (the AFE gain register) instead of the requested one.

This explains all the symptoms in the linked issue:

- With `indoor: true` (default), REG0x00 holds `0x24`; the interrupt handler masks the low nibble and gets `0x04` = disturber, so the log fills with "Disturber was detected" no matter what `mask_disturber` or `spike_rejection` are set to.
- With `indoor: false`, REG0x00 holds `0x1C`; the low nibble `0x0C` matches no interrupt type, so all messages disappear — exactly as reported.
- The IRQ pin never clears, because reading REG0x03 is what clears it, and that read never actually happens.

The fix routes the read through `read_byte()`, which uses the combined `write_readv()` bus operation and therefore a repeated start on both the Arduino and ESP-IDF buses. Configuration writes were already correct (`write_register()` uses `read_byte()` for its read-modify-write).

The split read was introduced in #2303 (2021 I2C API migration), which also matches the timeline of the earlier report in #10248.

Compile-tested (`as3935_i2c` on esp32-idf); draft until the issue reporter can confirm on hardware.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17581

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:

as3935_i2c:
  irq_pin: GPIO14

binary_sensor:
  - platform: as3935
    name: Storm Alert

sensor:
  - platform: as3935
    lightning_energy:
      name: Lightning Energy
    distance:
      name: Distance Storm
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).