### PR TITLE
[web_server] Switch entity id to the new format and drop name_id

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -558,26 +558,19 @@ static void set_json_id(JsonObject &root, EntityBase *obj, const char *prefix, J
   size_t device_len = device_name ? strlen(device_name) : 0;
 #endif
 
-  // Single stack buffer for both id formats - ArduinoJson copies the string before we overwrite
+  // Stack buffer for the id - ArduinoJson copies the string before it goes out of scope
   // Buffer sizes use constants from entity_base.h validated in core/config.py
   // Note: Device name uses ESPHOME_FRIENDLY_NAME_MAX_LEN (sub-device max 120), not ESPHOME_DEVICE_NAME_MAX_LEN
   // (hostname)
-  // Without USE_DEVICES: legacy id ({prefix}-{object_id}) is the largest format
-  // With USE_DEVICES: name_id ({prefix}/{device}/{name}) is the largest format
-  static constexpr size_t LEGACY_ID_SIZE = ESPHOME_DOMAIN_MAX_LEN + 1 + OBJECT_ID_MAX_LEN;
 #ifdef USE_DEVICES
   static constexpr size_t ID_BUF_SIZE =
-      std::max(ESPHOME_DOMAIN_MAX_LEN + 1 + ESPHOME_FRIENDLY_NAME_MAX_LEN + 1 + ESPHOME_FRIENDLY_NAME_MAX_LEN + 1,
-               LEGACY_ID_SIZE);
+      ESPHOME_DOMAIN_MAX_LEN + 1 + ESPHOME_FRIENDLY_NAME_MAX_LEN + 1 + ESPHOME_FRIENDLY_NAME_MAX_LEN + 1;
 #else
-  static constexpr size_t ID_BUF_SIZE =
-      std::max(ESPHOME_DOMAIN_MAX_LEN + 1 + ESPHOME_FRIENDLY_NAME_MAX_LEN + 1, LEGACY_ID_SIZE);
+  static constexpr size_t ID_BUF_SIZE = ESPHOME_DOMAIN_MAX_LEN + 1 + ESPHOME_FRIENDLY_NAME_MAX_LEN + 1;
 #endif
   char id_buf[ID_BUF_SIZE];
   memcpy(id_buf, prefix, prefix_len);  // NOLINT(bugprone-not-null-terminated-result)
 
-  // name_id: new format {prefix}/{device?}/{name} - frontend should prefer this
-  // Remove in 2026.8.0 when id switches to new format permanently
   char *p = id_buf + prefix_len;
   *p++ = '/';
 #ifdef USE_DEVICES
@@ -589,12 +582,6 @@ static void set_json_id(JsonObject &root, EntityBase *obj, const char *prefix, J
 #endif
   memcpy(p, name.c_str(), name_len);
   p[name_len] = '\0';
-  root[ESPHOME_F("name_id")] = id_buf;
-
-  // id: old format {prefix}-{object_id} for backward compatibility
-  // Will switch to new format in 2026.8.0 - reuses prefix already in id_buf
-  id_buf[prefix_len] = '-';
-  obj->write_object_id_to(id_buf + prefix_len + 1, ID_BUF_SIZE - prefix_len - 1);
   root[ESPHOME_F("id")] = id_buf;
 
   if (start_config == DETAIL_ALL) {


### PR DESCRIPTION
# What does this implement/fix?

Completes the entity id migration announced for 2026.8.0; the `id` field in the web server JSON now carries the new `{domain}/{device?}/{name}` format and `name_id` is removed. `name_id` was added in 2026.1.3 precisely so frontends could move over ahead of this switch.

The legacy `{domain}-{object_id}` value has not been usable for a while; routing matches on the entity name, so the old id could not round-trip into a working URL. That mismatch is why the new format was introduced. All current frontends read `name_id || id` and detect the format by looking for a slash, so once `name_id` goes away they fall back to `id`, see the slash, and keep working. That covers the rolling CDN bundles and the vendored `local` assets; I decompressed both `server_index_v2.h` and `server_index_v3.h` and confirmed they contain the fallback. The break is limited to a browser loading a pinned or self hosted bundle from before 2026.1.3, or a custom frontend keyed off the old id.

Dropping the legacy format also lets the buffer sizing lose its legacy floor, so the stack buffer shrinks from 149 to 142 bytes when sub-devices are not used.

Out of scope, left for their own PRs: the `alarm-control-panel` prefix uses dashes while the router expects underscores, which is broken today either way; `version: 1` and the `auth` scheme default are both slated for 2027.1.0.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Completes the migration started in #13535; the timeline is already published in the 2026.1.0 changelog and on the Web API page

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6999

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

