### PR TITLE
DNM: verify memory impact reporting on esp32-idf

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -15,6 +15,7 @@
 #include "esphome/core/version.h"
 #include "esphome/core/hal.h"
 #include <algorithm>
+#include <array>
 #include <ranges>
 
 #ifdef USE_STATUS_LED
@@ -50,6 +51,63 @@ static void insertion_sort_by_priority(Iterator first, Iterator last) {
   }
 }
 
+// ===========================================================================
+// DO NOT MERGE
+//
+// Test-only code that deliberately adds flash, so the memory impact analysis
+// has something to report. Exists to prove the analysis reports the component
+// breakdown and the symbol level tables again; delete before merging.
+//
+// Living in core (not in a component) makes the analysis take its fallback
+// path, which pins it to the api component on esp32-idf.
+// ===========================================================================
+namespace dnm_flash_test {
+
+// Read through a volatile so the table and the mixers survive the optimizer.
+volatile uint32_t sink = 0;
+
+constexpr size_t LOOKUP_SIZE = 512;
+
+constexpr std::array<uint32_t, LOOKUP_SIZE> make_lookup() {
+  std::array<uint32_t, LOOKUP_SIZE> table{};
+  for (uint32_t i = 0; i < LOOKUP_SIZE; i++) {
+    table[i] = (i * 2654435761u) ^ (i << 7);
+  }
+  return table;
+}
+
+// ~2 KB of rodata
+const std::array<uint32_t, LOOKUP_SIZE> LOOKUP = make_lookup();
+
+// noinline keeps each of these as its own symbol in the memory impact tables
+__attribute__((noinline)) uint32_t mix_a(uint32_t v) {
+  v ^= v >> 15;
+  v *= 2246822519u;
+  return v ^ (v >> 13);
+}
+
+__attribute__((noinline)) uint32_t mix_b(uint32_t v) {
+  v += 0x9e3779b9u;
+  v = (v << 7) | (v >> 25);
+  return v * 2654435761u;
+}
+
+__attribute__((noinline)) uint32_t mix_c(uint32_t v) {
+  v ^= LOOKUP[v % LOOKUP_SIZE];
+  v = (v >> 3) | (v << 29);
+  return v ^ 0x85ebca6bu;
+}
+
+__attribute__((noinline)) uint32_t run(uint32_t seed) {
+  uint32_t v = seed;
+  for (uint32_t i = 0; i < 8; i++) {
+    v = mix_c(mix_b(mix_a(v + i)));
+  }
+  return v;
+}
+
+}  // namespace dnm_flash_test
+
 void Application::register_component_impl_(Component *comp, bool has_loop) {
   if (has_loop) {
     comp->component_state_ |= COMPONENT_HAS_LOOP;
@@ -57,6 +115,9 @@ void Application::register_component_impl_(Component *comp, bool has_loop) {
   this->components_.push_back(comp);
 }
 void Application::setup() {
+  // DO NOT MERGE: keeps the test-only flash above from being stripped
+  dnm_flash_test::sink = dnm_flash_test::run(dnm_flash_test::sink);
+
   ESP_LOGI(TAG, "Running through setup()");
   ESP_LOGV(TAG, "Sorting components by setup priority");
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

**Do not merge.** This exists only to prove #17587 works, and should be closed once it has.

Chained on #17587; the diff here is the one test commit on top of it. Please review and merge #17587 first.

#17587 restores the component breakdown and the symbol level tables that the memory impact comment has been dropping on ESP-IDF builds. It cannot demonstrate itself: it only touches scripts and Python, so `determine-jobs` does not run memory impact on it at all, and the jobs are skipped.

So this adds about 2 KB of flash in `esphome/core/application.cpp`; a 2 KB lookup table plus four small mixer functions, read through a volatile so the linker keeps them. Putting it in core rather than in a component is deliberate: a core C++ change with no component change takes the fallback path, which pins the analysis to `api` on `esp32-idf`, the same pairing as #17585 and #14988. That makes the comment on this PR directly comparable to those two.

What the comment should show, if #17587 works:

* a flash increase of roughly 2 KB, where the totals alone would have been the only thing reported before;
* a **Component Memory Breakdown** with an `[esphome]core` row;
* **Symbol-Level Changes** listing `mix_a`, `mix_b`, `mix_c` and `run` as new symbols.

If it still shows only the RAM and Flash table, #17587 has not fixed it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Verifies #17587

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A, this is never merging

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; this only exists to move the flash number

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
