### PR TITLE
[network] Remove deprecated IPAddress::str()

### DIFF
--- a/esphome/components/network/ip_address.h
+++ b/esphome/components/network/ip_address.h
@@ -71,15 +71,6 @@ struct IPAddress {
   bool is_ip4() const { return false; }
   bool is_ip6() const { return this->is_set(); }
   bool is_multicast() const { return net_ipv6_is_addr_mcast(&ip_addr_); }
-  // Remove before 2026.8.0
-  ESPDEPRECATED(
-      "str() is deprecated: use 'char buf[IP_ADDRESS_BUFFER_SIZE]; ip.str_to(buf);' instead. Removed in 2026.8.0",
-      "2026.2.0")
-  std::string str() const {
-    char buf[IP_ADDRESS_BUFFER_SIZE];
-    this->str_to(buf);
-    return buf;
-  }
   char *str_to(char *buf) const {
     if (inet_ntop(AF_INET6, &ip_addr_, buf, IP_ADDRESS_BUFFER_SIZE) == nullptr)
       buf[0] = '\0';
@@ -95,15 +86,6 @@ struct IPAddress {
   }
   IPAddress(const std::string &in_address) { inet_aton(in_address.c_str(), &ip_addr_); }
   IPAddress(const ip_addr_t *other_ip) { ip_addr_ = *other_ip; }
-  // Remove before 2026.8.0
-  ESPDEPRECATED(
-      "str() is deprecated: use 'char buf[IP_ADDRESS_BUFFER_SIZE]; ip.str_to(buf);' instead. Removed in 2026.8.0",
-      "2026.2.0")
-  std::string str() const {
-    char buf[IP_ADDRESS_BUFFER_SIZE];
-    this->str_to(buf);
-    return buf;
-  }
   /// Write IP address to buffer. Buffer must be at least IP_ADDRESS_BUFFER_SIZE bytes.
   char *str_to(char *buf) const {
     inet_ntop(AF_INET, &ip_addr_, buf, IP_ADDRESS_BUFFER_SIZE);
@@ -186,15 +168,6 @@ struct IPAddress {
   bool is_ip4() const { return IP_IS_V4(&ip_addr_); }
   bool is_ip6() const { return IP_IS_V6(&ip_addr_); }
   bool is_multicast() const { return ip_addr_ismulticast(&ip_addr_); }
-  // Remove before 2026.8.0
-  ESPDEPRECATED(
-      "str() is deprecated: use 'char buf[IP_ADDRESS_BUFFER_SIZE]; ip.str_to(buf);' instead. Removed in 2026.8.0",
-      "2026.2.0")
-  std::string str() const {
-    char buf[IP_ADDRESS_BUFFER_SIZE];
-    this->str_to(buf);
-    return buf;
-  }
   /// Write IP address to buffer. Buffer must be at least IP_ADDRESS_BUFFER_SIZE bytes.
   /// Output is lowercased per RFC 5952 (IPv6 hex digits a-f).
   char *str_to(char *buf) const {


### PR DESCRIPTION
# What does this implement/fix?

Removes `IPAddress::str()`, which was deprecated in 2026.2.0 for removal in 2026.8.0; the deprecation window has now elapsed and no callers remain in the tree. Callers should use `str_to()` with a `char buf[IP_ADDRESS_BUFFER_SIZE]`, which is what the deprecation message pointed at and avoids the `std::string` return.

The method existed three times, once per platform branch (Zephyr, host and lwIP); all three go. `str_to()` is untouched.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; this is an internal C++ API cleanup
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
