### PR TITLE
[esp32_ble] Remove deprecated ESPBTUUID::to_string()

### DIFF
--- a/esphome/components/esp32_ble/ble_uuid.cpp
+++ b/esphome/components/esp32_ble/ble_uuid.cpp
@@ -181,12 +181,6 @@ const char *ESPBTUUID::to_str(std::span<char, UUID_STR_LEN> output) const {
       return output.data();
   }
 }
-std::string ESPBTUUID::to_string() const {
-  char buf[UUID_STR_LEN];
-  this->to_str(buf);
-  return std::string(buf);
-}
-
 }  // namespace esphome::esp32_ble
 
 #endif  // USE_ESP32_BLE_UUID

--- a/esphome/components/esp32_ble/ble_uuid.h
+++ b/esphome/components/esp32_ble/ble_uuid.h
@@ -46,9 +46,6 @@ class ESPBTUUID {
 
   esp_bt_uuid_t get_uuid() const;
 
-  // Remove before 2026.8.0
-  ESPDEPRECATED("Use to_str() instead. Removed in 2026.8.0", "2026.2.0")
-  std::string to_string() const;  // NOLINT
   const char *to_str(std::span<char, UUID_STR_LEN> output) const;
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

Removes `ESPBTUUID::to_string()`, which was deprecated in 2026.2.0 for removal in 2026.8.0; the deprecation window has now elapsed and no callers remain in the tree. Callers should use `to_str()` with a `char buf[UUID_STR_LEN]`, which is what the deprecation message pointed at and avoids the `std::string` return.

`to_str()` is untouched.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; this is an internal C++ API cleanup
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
