### PR TITLE
[web_server] Use alarm_control_panel as the domain in JSON

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1907,7 +1907,7 @@ json::SerializationBuffer<> WebServer::alarm_control_panel_json_(alarm_control_p
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  set_json_icon_state_value(root, obj, "alarm-control-panel",
+  set_json_icon_state_value(root, obj, "alarm_control_panel",
                             json_state_str(alarm_control_panel_state_to_string(value)), value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);


### PR DESCRIPTION
# What does this implement/fix?

The web server JSON advertised the alarm control panel domain as `alarm-control-panel`, but the router only ever accepted `alarm_control_panel`, so the `domain` and `id` fields pointed at a route that does not exist. A consumer that built a URL from the advertised `domain` got no reply at all, on a domain that otherwise works fine; the handler behind the underscore route is fully functional and accepts arm, disarm and a code. Every other multi word domain already uses underscores, `binary_sensor`, `text_sensor` and `water_heater` among them, so this was the only outlier.

The dashes are original rather than a regression. The call used to pass the whole id, `"alarm-control-panel-" + obj->get_object_id()`; a later change turned that argument into a prefix the callee appends `-object_id` to, which kept the legacy id byte for byte but also carried the spelling into the `domain` and `id` fields, where it matches no route.

This is currently invisible in the web UI, so nothing regresses for normal users: v1 renders no alarm rows at all, and v2 and v3 pick action buttons by looking up `render_{domain}`, which has no alarm entry, so no frontend ever builds the URL. It does affect third party integrations that follow the Web API and use `domain`. It is worth doing now rather than later because #17586 is already changing the `id` format in this release, so the two breaks land together; it also makes `id` honest, since after that PR `id` looks like the new routable format but would 404 for this one domain.

No docs change; the dashed spelling is not documented anywhere.

Verified on an esp32-poe-iso running a template alarm control panel. The device now advertises `"domain":"alarm_control_panel"`, and a POST to the advertised domain arms the panel:

```
POST /alarm_control_panel/Mock%20Alarm%20Panel/arm_away   -> 200, state DISARMED -> ARMED_AWAY
POST /alarm-control-panel/Mock%20Alarm%20Panel/disarm     -> no reply, state unchanged
```

The dashed form the payload used to advertise gets no reply at all, so this was reachable for anything that built a URL from the `domain` field.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Pairs with #17586, which changes the `id` format in the same release

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
web_server:
  port: 80

alarm_control_panel:
  - platform: template
    name: Alarm Panel
    binary_sensors:
      - input: my_binary_sensor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
