### PR TITLE
[haier][teleinfo][hlk_fm22x][rp2040_ble] Rename enum members that collide with vendor SDK macros

### DIFF
--- a/esphome/components/haier/haier_base.cpp
+++ b/esphome/components/haier/haier_base.cpp
@@ -132,7 +132,7 @@ void HaierClimateBase::save_settings() {
 }
 
 bool HaierClimateBase::get_display_state() const {
-  return (this->display_status_ == SwitchState::ON) || (this->display_status_ == SwitchState::PENDING_ON);
+  return (this->display_status_ == SwitchState::SWITCH_ON) || (this->display_status_ == SwitchState::PENDING_ON);
 }
 
 void HaierClimateBase::set_display_state(bool state) {
@@ -144,7 +144,7 @@ void HaierClimateBase::set_display_state(bool state) {
 }
 
 bool HaierClimateBase::get_health_mode() const {
-  return (this->health_mode_ == SwitchState::ON) || (this->health_mode_ == SwitchState::PENDING_ON);
+  return (this->health_mode_ == SwitchState::SWITCH_ON) || (this->health_mode_ == SwitchState::PENDING_ON);
 }
 
 void HaierClimateBase::set_health_mode(bool state) {

--- a/esphome/components/haier/haier_base.h
+++ b/esphome/components/haier/haier_base.h
@@ -147,8 +147,8 @@ class HaierClimateBase : public esphome::Component,
     esphome::optional<haier_protocol::HaierMessage> message;
   };
   enum class SwitchState {
-    OFF = 0b00,
-    ON = 0b01,
+    SWITCH_OFF = 0b00,
+    SWITCH_ON = 0b01,
     PENDING_OFF = 0b10,
     PENDING_ON = 0b11,
   };
@@ -157,8 +157,8 @@ class HaierClimateBase : public esphome::Component,
   esphome::optional<PendingAction> action_request_;
   uint8_t fan_mode_speed_;
   uint8_t other_modes_fan_speed_;
-  SwitchState display_status_{SwitchState::ON};
-  SwitchState health_mode_{SwitchState::OFF};
+  SwitchState display_status_{SwitchState::SWITCH_ON};
+  SwitchState health_mode_{SwitchState::SWITCH_OFF};
   bool force_send_control_;
   bool forced_request_status_;
   bool reset_protocol_request_;

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -50,7 +50,7 @@ void HonClimate::set_quiet_mode_state(bool state) {
       this->quiet_mode_state_ = state ? SwitchState::PENDING_ON : SwitchState::PENDING_OFF;
       this->force_send_control_ = true;
     } else {
-      this->quiet_mode_state_ = state ? SwitchState::ON : SwitchState::OFF;
+      this->quiet_mode_state_ = state ? SwitchState::SWITCH_ON : SwitchState::SWITCH_OFF;
     }
     this->settings_.quiet_mode_state = state;
 #ifdef USE_SWITCH
@@ -63,7 +63,7 @@ void HonClimate::set_quiet_mode_state(bool state) {
 }
 
 bool HonClimate::get_quiet_mode_state() const {
-  return (this->quiet_mode_state_ == SwitchState::ON) || (this->quiet_mode_state_ == SwitchState::PENDING_ON);
+  return (this->quiet_mode_state_ == SwitchState::SWITCH_ON) || (this->quiet_mode_state_ == SwitchState::PENDING_ON);
 }
 
 esphome::optional<hon_protocol::VerticalSwingMode> HonClimate::get_vertical_airflow() const {
@@ -513,7 +513,7 @@ void HonClimate::initialization() {
   }
   this->current_vertical_swing_ = this->settings_.last_vertiacal_swing;
   this->current_horizontal_swing_ = this->settings_.last_horizontal_swing;
-  this->quiet_mode_state_ = this->settings_.quiet_mode_state ? SwitchState::ON : SwitchState::OFF;
+  this->quiet_mode_state_ = this->settings_.quiet_mode_state ? SwitchState::SWITCH_ON : SwitchState::SWITCH_OFF;
 }
 
 haier_protocol::HaierMessage HonClimate::get_control_message() {
@@ -939,14 +939,14 @@ haier_protocol::HandlerError HonClimate::process_status_message_(const uint8_t *
         // AC just turned on from remote need to turn off display
         this->force_send_control_ = true;
       } else if ((((uint8_t) this->display_status_) & 0b10) == 0) {
-        this->display_status_ = disp_status ? SwitchState::ON : SwitchState::OFF;
+        this->display_status_ = disp_status ? SwitchState::SWITCH_ON : SwitchState::SWITCH_OFF;
       }
     }
   }
   // Health mode
   if ((((uint8_t) this->health_mode_) & 0b10) == 0) {
     bool old_health_mode = this->get_health_mode();
-    this->health_mode_ = packet.control.health_mode == 1 ? SwitchState::ON : SwitchState::OFF;
+    this->health_mode_ = packet.control.health_mode == 1 ? SwitchState::SWITCH_ON : SwitchState::SWITCH_OFF;
     should_publish = should_publish || (old_health_mode != this->get_health_mode());
   }
   {
@@ -1008,7 +1008,7 @@ haier_protocol::HandlerError HonClimate::process_status_message_(const uint8_t *
       // In proper mode and not in pending state
       bool new_quiet_mode = packet.control.quiet_mode != 0;
       if (new_quiet_mode != this->get_quiet_mode_state()) {
-        this->quiet_mode_state_ = new_quiet_mode ? SwitchState::ON : SwitchState::OFF;
+        this->quiet_mode_state_ = new_quiet_mode ? SwitchState::SWITCH_ON : SwitchState::SWITCH_OFF;
         this->settings_.quiet_mode_state = new_quiet_mode;
 #ifdef USE_SWITCH
         if (this->quiet_mode_switch_ != nullptr) {

--- a/esphome/components/haier/hon_climate.h
+++ b/esphome/components/haier/hon_climate.h
@@ -197,7 +197,7 @@ class HonClimate final : public HaierClimateBase {
   esphome::optional<hon_protocol::HorizontalSwingMode> current_horizontal_swing_{};
   HonSettings settings_{};
   ESPPreferenceObject hon_rtc_;
-  SwitchState quiet_mode_state_{SwitchState::OFF};
+  SwitchState quiet_mode_state_{SwitchState::SWITCH_OFF};
 };
 
 }  // namespace esphome::haier

--- a/esphome/components/haier/smartair2_climate.cpp
+++ b/esphome/components/haier/smartair2_climate.cpp
@@ -464,14 +464,14 @@ haier_protocol::HandlerError Smartair2Climate::process_status_message_(const uin
         // AC just turned on from remote need to turn off display
         this->force_send_control_ = true;
       } else if ((((uint8_t) this->health_mode_) & 0b10) == 0) {
-        this->display_status_ = disp_status ? SwitchState::ON : SwitchState::OFF;
+        this->display_status_ = disp_status ? SwitchState::SWITCH_ON : SwitchState::SWITCH_OFF;
       }
     }
   }
   // Health mode
   if ((((uint8_t) this->health_mode_) & 0b10) == 0) {
     bool old_health_mode = this->get_health_mode();
-    this->health_mode_ = packet.control.health_mode == 1 ? SwitchState::ON : SwitchState::OFF;
+    this->health_mode_ = packet.control.health_mode == 1 ? SwitchState::SWITCH_ON : SwitchState::SWITCH_OFF;
     should_publish = should_publish || (old_health_mode != this->get_health_mode());
   }
   {

--- a/esphome/components/hlk_fm22x/hlk_fm22x.cpp
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.cpp
@@ -242,7 +242,7 @@ void HlkFm22xComponent::handle_reply_(const uint8_t *data, size_t length) {
     return;
   }
 
-  if (data[1] != HlkFm22xResult::SUCCESS) {
+  if (data[1] != HlkFm22xResult::SUCCEEDED) {
     ESP_LOGE(TAG, "Command <0x%.2X> failed. Error: 0x%.2X", data[0], data[1]);
     switch (expected) {
       case HlkFm22xCommand::ENROLL:

--- a/esphome/components/hlk_fm22x/hlk_fm22x.h
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.h
@@ -41,7 +41,7 @@ enum HlkFm22xNoteType {
 };
 
 enum HlkFm22xResult {
-  SUCCESS = 0x00,
+  SUCCEEDED = 0x00,
   REJECTED = 0x01,
   ABORTED = 0x02,
   FAILED4_CAMERA = 0x04,

--- a/esphome/components/rp2040_ble/rp2040_ble.cpp
+++ b/esphome/components/rp2040_ble/rp2040_ble.cpp
@@ -48,7 +48,7 @@ void RP2040BLE::enable() {
 }
 
 void RP2040BLE::disable() {
-  if (this->state_ == BLEComponentState::DISABLED || this->state_ == BLEComponentState::OFF) {
+  if (this->state_ == BLEComponentState::DISABLED || this->state_ == BLEComponentState::STATE_OFF) {
     return;
   }
 
@@ -70,7 +70,7 @@ void RP2040BLE::loop() {
 
 static const char *state_to_str(BLEComponentState state) {
   switch (state) {
-    case BLEComponentState::OFF:
+    case BLEComponentState::STATE_OFF:
       return "OFF";
     case BLEComponentState::ENABLING:
       return "ENABLING";

--- a/esphome/components/rp2040_ble/rp2040_ble.h
+++ b/esphome/components/rp2040_ble/rp2040_ble.h
@@ -11,7 +11,7 @@
 namespace esphome::rp2040_ble {
 
 enum class BLEComponentState : uint8_t {
-  OFF = 0,
+  STATE_OFF = 0,
   ENABLING,
   ACTIVE,
   DISABLING,
@@ -37,7 +37,7 @@ class RP2040BLE final : public Component {
   btstack_packet_callback_registration_t hci_event_callback_registration_{};
   btstack_packet_callback_registration_t sm_event_callback_registration_{};
 
-  BLEComponentState state_{BLEComponentState::OFF};
+  BLEComponentState state_{BLEComponentState::STATE_OFF};
   bool enable_on_boot_{true};
   bool btstack_initialized_{false};
   bool active_logged_{false};

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -57,7 +57,7 @@ bool TeleInfo::read_chars_until_(bool drop, uint8_t c) {
      */
     if (buf_index_ >= (MAX_BUF_SIZE - 1)) {
       ESP_LOGW(TAG, "Internal buffer full");
-      state_ = OFF;
+      state_ = STATE_OFF;
       return false;
     }
     buf_[buf_index_++] = received;
@@ -65,18 +65,18 @@ bool TeleInfo::read_chars_until_(bool drop, uint8_t c) {
 
   return false;
 }
-void TeleInfo::setup() { state_ = OFF; }
+void TeleInfo::setup() { state_ = STATE_OFF; }
 void TeleInfo::update() {
-  if (state_ == OFF) {
+  if (state_ == STATE_OFF) {
     buf_index_ = 0;
-    state_ = ON;
+    state_ = STATE_ON;
   }
 }
 void TeleInfo::loop() {
   switch (state_) {
-    case OFF:
+    case STATE_OFF:
       break;
-    case ON:
+    case STATE_ON:
       /* Dequeue chars until start frame (0x2) */
       if (read_chars_until_(true, 0x2))
         state_ = START_FRAME_RECEIVED;
@@ -173,7 +173,7 @@ void TeleInfo::loop() {
 
         publish_value_(std::string(tag_), std::string(val_));
       }
-      state_ = OFF;
+      state_ = STATE_OFF;
       break;
   }
 }

--- a/esphome/components/teleinfo/teleinfo.h
+++ b/esphome/components/teleinfo/teleinfo.h
@@ -40,11 +40,11 @@ class TeleInfo final : public PollingComponent, public uart::UARTDevice {
   char val_[MAX_VAL_SIZE];
   char timestamp_[MAX_TIMESTAMP_SIZE];
   enum State {
-    OFF,
-    ON,
+    STATE_OFF,
+    STATE_ON,
     START_FRAME_RECEIVED,
     END_FRAME_RECEIVED,
-  } state_{OFF};
+  } state_{STATE_OFF};
   bool read_chars_until_(bool drop, uint8_t c);
   bool check_crc_(const char *grp, const char *grp_end);
   void publish_value_(const std::string &tag, const std::string &val);


### PR DESCRIPTION
# What does this implement/fix?

Renames enum members whose names collide with object macros defined by the Realtek SDK's `basic_types.h` (`#define ON 1`, `#define OFF 0`, `#define SUCCESS 0`):

- haier `SwitchState`: `OFF`/`ON` → `SWITCH_OFF`/`SWITCH_ON`
- teleinfo `State`: `OFF`/`ON` → `STATE_OFF`/`STATE_ON`
- hlk_fm22x `HlkFm22xResult`: `SUCCESS` → `SUCCEEDED`
- rp2040_ble `BLEComponentState`: `OFF` → `STATE_OFF`

These macros reach any translation unit that includes `Arduino.h` on the rtl87xx platforms, where the preprocessor rewrites e.g. `OFF = 0b00` into `0 = 0b00`. Real builds happen to survive because each component's own header is included before anything that pulls in the SDK, but the synthetic all-headers file used by clang-tidy includes headers alphabetically, so the upcoming LibreTiny clang-tidy scans (#17491) hit the collision. Renaming the members fixes it at the source instead of patching macros in the lint harness, and protects against any future include-order change doing the same to real builds.

All enums are internal component state with no user-facing configuration impact. Split out of #17491 so it can be reviewed independently; the LibreTiny scan PR shrinks accordingly once this lands.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Internal rename only, no configuration impact
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).