### PR TITLE
[libretiny] Code fixes for upcoming LibreTiny clang-tidy scans

### DIFF
--- a/esphome/components/beken_spi_led_strip/led_strip.cpp
+++ b/esphome/components/beken_spi_led_strip/led_strip.cpp
@@ -37,15 +37,15 @@ namespace esphome::beken_spi_led_strip {
 
 static const char *const TAG = "beken_spi_led_strip";
 
-struct spi_data_t {
+struct SpiData {
   SemaphoreHandle_t dma_tx_semaphore;
   volatile bool tx_in_progress;
   bool first_run;
 };
 
-static spi_data_t *spi_data = nullptr;
+static SpiData *spi_data = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-static void set_spi_ctrl_register(unsigned long bit, bool val) {
+static void set_spi_ctrl_register(uint32_t bit, bool val) {
   uint32_t value = REG_READ(SPI_CTRL);
   if (val == 0) {
     value &= ~bit;
@@ -55,7 +55,7 @@ static void set_spi_ctrl_register(unsigned long bit, bool val) {
   REG_WRITE(SPI_CTRL, value);
 }
 
-static void set_spi_config_register(unsigned long bit, bool val) {
+static void set_spi_config_register(uint32_t bit, bool val) {
   uint32_t value = REG_READ(SPI_CONFIG);
   if (val == 0) {
     value &= ~bit;
@@ -67,7 +67,7 @@ static void set_spi_config_register(unsigned long bit, bool val) {
 
 void spi_dma_tx_enable(bool enable) {
   GDMA_CFG_ST en_cfg;
-  set_spi_config_register(SPI_TX_EN, enable ? 1 : 0);
+  set_spi_config_register(SPI_TX_EN, enable);
   en_cfg.channel = SPI_TX_DMA_CHANNEL;
   en_cfg.param = enable ? 1 : 0;
   sddev_control(GDMA_DEV_NAME, CMD_GDMA_SET_DMA_ENABLE, &en_cfg);
@@ -110,13 +110,13 @@ static void spi_set_clock(uint32_t max_hz) {
   param &= ~(SPI_CKR_MASK << SPI_CKR_POSI);
   param |= (div << SPI_CKR_POSI);
   REG_WRITE(SPI_CTRL, param);
-  ESP_LOGD(TAG, "target frequency: %d, actual frequency: %d", max_hz, source_clk / 2 / div);
+  ESP_LOGD(TAG, "target frequency: %" PRIu32 ", actual frequency: %d", max_hz, source_clk / 2 / div);
 }
 
 void spi_dma_tx_finish_callback(unsigned int param) {
   spi_data->tx_in_progress = false;
   xSemaphoreGive(spi_data->dma_tx_semaphore);
-  spi_dma_tx_enable(0);
+  spi_dma_tx_enable(false);
 }
 
 void BekenSPILEDStripLightOutput::setup() {
@@ -161,7 +161,7 @@ void BekenSPILEDStripLightOutput::setup() {
     return;
   }
 
-  spi_data = (spi_data_t *) calloc(1, sizeof(spi_data_t));
+  spi_data = (SpiData *) calloc(1, sizeof(SpiData));  // NOLINT(cppcoreguidelines-no-malloc)
   if (spi_data == nullptr) {
     ESP_LOGE(TAG, "Cannot allocate spi_data!");
     this->mark_failed();
@@ -177,20 +177,20 @@ void BekenSPILEDStripLightOutput::setup() {
 
   spi_data->first_run = true;
 
-  set_spi_ctrl_register(MSTEN, 0);
-  set_spi_ctrl_register(BIT_WDTH, 0);
+  set_spi_ctrl_register(MSTEN, false);
+  set_spi_ctrl_register(BIT_WDTH, false);
   spi_set_clock(this->spi_frequency_);
-  set_spi_ctrl_register(CKPOL, 0);
-  set_spi_ctrl_register(CKPHA, 0);
-  set_spi_ctrl_register(MSTEN, 1);
-  set_spi_ctrl_register(SPIEN, 1);
+  set_spi_ctrl_register(CKPOL, false);
+  set_spi_ctrl_register(CKPHA, false);
+  set_spi_ctrl_register(MSTEN, true);
+  set_spi_ctrl_register(SPIEN, true);
 
-  set_spi_ctrl_register(TXINT_EN, 0);
-  set_spi_ctrl_register(RXINT_EN, 0);
-  set_spi_config_register(SPI_TX_FINISH_EN, 1);
-  set_spi_config_register(SPI_RX_FINISH_EN, 1);
-  set_spi_ctrl_register(RXOVR_EN, 0);
-  set_spi_ctrl_register(TXOVR_EN, 0);
+  set_spi_ctrl_register(TXINT_EN, false);
+  set_spi_ctrl_register(RXINT_EN, false);
+  set_spi_config_register(SPI_TX_FINISH_EN, true);
+  set_spi_config_register(SPI_RX_FINISH_EN, true);
+  set_spi_ctrl_register(RXOVR_EN, false);
+  set_spi_ctrl_register(TXOVR_EN, false);
 
   value = REG_READ(SPI_CTRL);
   value &= ~CTRL_NSSMD_3;
@@ -199,7 +199,7 @@ void BekenSPILEDStripLightOutput::setup() {
 
   value = GFUNC_MODE_SPI_DMA;
   sddev_control(GPIO_DEV_NAME, CMD_GPIO_ENABLE_SECOND, &value);
-  set_spi_ctrl_register(SPI_S_CS_UP_INT_EN, 0);
+  set_spi_ctrl_register(SPI_S_CS_UP_INT_EN, false);
 
   GDMA_CFG_ST en_cfg;
   GDMACFG_TPYES_ST init_cfg;
@@ -210,7 +210,7 @@ void BekenSPILEDStripLightOutput::setup() {
   init_cfg.dstptr_incr = 0;
   init_cfg.srcptr_incr = 1;
   init_cfg.src_start_addr = this->dma_buf_;
-  init_cfg.dst_start_addr = (void *) SPI_DAT;  // SPI_DMA_REG4_TXFIFO
+  init_cfg.dst_start_addr = (void *) SPI_DAT;  // NOLINT(performance-no-int-to-ptr) SPI_DMA_REG4_TXFIFO
   init_cfg.channel = SPI_TX_DMA_CHANNEL;
   init_cfg.prio = 0;  // 10
   init_cfg.u.type4.src_loop_start_addr = this->dma_buf_;
@@ -230,7 +230,7 @@ void BekenSPILEDStripLightOutput::setup() {
   en_cfg.param = 0;
   sddev_control(GDMA_DEV_NAME, CMD_GDMA_CFG_SRCADDR_LOOP, &en_cfg);
 
-  spi_dma_tx_enable(0);
+  spi_dma_tx_enable(false);
 
   value = REG_READ(SPI_CONFIG);
   value &= ~(0xFFF << 8);
@@ -247,7 +247,8 @@ void BekenSPILEDStripLightOutput::set_led_params(uint8_t bit0, uint8_t bit1, uin
 void BekenSPILEDStripLightOutput::write_state(light::LightState *state) {
   // protect from refreshing too often
   uint32_t now = micros();
-  if (*this->max_refresh_rate_ != 0 && (now - this->last_refresh_) < *this->max_refresh_rate_) {
+  if (this->max_refresh_rate_.has_value() && *this->max_refresh_rate_ != 0 &&
+      (now - this->last_refresh_) < *this->max_refresh_rate_) {
     // try again next loop iteration, so that this change won't get lost
     this->schedule_show();
     return;
@@ -293,7 +294,7 @@ void BekenSPILEDStripLightOutput::write_state(light::LightState *state) {
   }
 
   spi_data->first_run = false;
-  spi_dma_tx_enable(1);
+  spi_dma_tx_enable(true);
 
   this->status_clear_warning();
 }
@@ -376,7 +377,7 @@ void BekenSPILEDStripLightOutput::dump_config() {
                 "  RGB Order: %s\n"
                 "  Max refresh rate: %" PRIu32 "\n"
                 "  Number of LEDs: %u",
-                rgb_order, *this->max_refresh_rate_, this->num_leds_);
+                rgb_order, this->max_refresh_rate_.value_or(0), this->num_leds_);
 }
 
 float BekenSPILEDStripLightOutput::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/debug/debug_libretiny.cpp
+++ b/esphome/components/debug/debug_libretiny.cpp
@@ -28,7 +28,7 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
   ESP_LOGD(TAG,
            "LibreTiny debug info:\n"
            "  Version: %s\n"
-           "  Chip: %s (%04x) @ %u MHz\n"
+           "  Chip: %s (%04x) @ %" PRIu32 " MHz\n"
            "  Chip ID: 0x%06" PRIX32 "\n"
            "  Board: %s\n"
            "  Flash: %" PRIu32 " KiB\n"
@@ -38,7 +38,7 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
            lt_get_board_code(), flash_kib, ram_kib, reset_reason);
 
   pos = buf_append_str(buf, size, pos, "|Version: ");
-  pos = buf_append_str(buf, size, pos, LT_BANNER_STR + 10);
+  pos = buf_append_str(buf, size, pos, &LT_BANNER_STR[10]);
   pos = buf_append_str(buf, size, pos, "|Reset Reason: ");
   pos = buf_append_str(buf, size, pos, reset_reason);
   pos = buf_append_str(buf, size, pos, "|Chip Name: ");

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -354,7 +354,7 @@ async def to_code(config):
     if CONF_WAKEUP_PIN in config:
         pins_as_list = config.get(CONF_WAKEUP_PIN, [])
         if CORE.is_bk72xx:
-            cg.add(var.init_wakeup_pins_(len(pins_as_list)))
+            cg.add(var.init_wakeup_pins(len(pins_as_list)))
             for item in pins_as_list:
                 cg.add(
                     var.add_wakeup_pin(

--- a/esphome/components/deep_sleep/deep_sleep_bk72xx.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_bk72xx.cpp
@@ -30,13 +30,13 @@ void DeepSleepComponent::dump_config_platform_() {
   }
 }
 
-bool DeepSleepComponent::pin_prevents_sleep_(WakeUpPinItem &pinItem) const {
-  return (pinItem.wakeup_pin_mode == WAKEUP_PIN_MODE_KEEP_AWAKE && pinItem.wakeup_pin != nullptr &&
-          !this->sleep_duration_.has_value() && (pinItem.wakeup_level == get_real_pin_state_(*pinItem.wakeup_pin)));
+bool DeepSleepComponent::pin_prevents_sleep_(WakeUpPinItem &pin_item) const {
+  return (pin_item.wakeup_pin_mode == WAKEUP_PIN_MODE_KEEP_AWAKE && pin_item.wakeup_pin != nullptr &&
+          !this->sleep_duration_.has_value() && (pin_item.wakeup_level == get_real_pin_state_(*pin_item.wakeup_pin)));
 }
 
 bool DeepSleepComponent::prepare_to_sleep_() {
-  if (wakeup_pins_.size() > 0) {
+  if (!wakeup_pins_.empty()) {
     for (WakeUpPinItem &item : this->wakeup_pins_) {
       if (pin_prevents_sleep_(item)) {
         // Defer deep sleep until inactive
@@ -59,7 +59,7 @@ void DeepSleepComponent::deep_sleep_() {
         item.wakeup_level = !item.wakeup_level;
       }
     }
-    ESP_LOGI(TAG, "Wake-up on P%u %s (%d)", item.wakeup_pin->get_pin(), item.wakeup_level ? "HIGH" : "LOW",
+    ESP_LOGI(TAG, "Wake-up on P%u %s (%" PRId32 ")", item.wakeup_pin->get_pin(), item.wakeup_level ? "HIGH" : "LOW",
              static_cast<int32_t>(item.wakeup_pin_mode));
   }
 

--- a/esphome/components/deep_sleep/deep_sleep_bk72xx.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_bk72xx.cpp
@@ -36,9 +36,9 @@ bool DeepSleepComponent::pin_prevents_sleep_(WakeUpPinItem &pin_item) const {
 }
 
 bool DeepSleepComponent::prepare_to_sleep_() {
-  if (!wakeup_pins_.empty()) {
+  if (!this->wakeup_pins_.empty()) {
     for (WakeUpPinItem &item : this->wakeup_pins_) {
-      if (pin_prevents_sleep_(item)) {
+      if (this->pin_prevents_sleep_(item)) {
         // Defer deep sleep until inactive
         if (!this->next_enter_deep_sleep_) {
           this->status_set_warning();

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -143,7 +143,7 @@ class DeepSleepComponent final : public Component {
 #endif  // USE_ESP32
 
 #if defined(USE_BK72XX)
-  void init_wakeup_pins_(size_t capacity) { this->wakeup_pins_.init(capacity); }
+  void init_wakeup_pins(size_t capacity) { this->wakeup_pins_.init(capacity); }
   void add_wakeup_pin(InternalGPIOPin *wakeup_pin, WakeupPinMode wakeup_pin_mode) {
     this->wakeup_pins_.emplace_back(WakeUpPinItem{wakeup_pin, wakeup_pin_mode, !wakeup_pin->is_inverted()});
   }
@@ -191,7 +191,7 @@ class DeepSleepComponent final : public Component {
   bool should_teardown_();
 
 #ifdef USE_BK72XX
-  bool pin_prevents_sleep_(WakeUpPinItem &pinItem) const;
+  bool pin_prevents_sleep_(WakeUpPinItem &pin_item) const;
   bool get_real_pin_state_(InternalGPIOPin &pin) const { return (pin.digital_read() ^ pin.is_inverted()); }
 #endif  // USE_BK72XX
 

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !defined(USE_RP2) && !defined(USE_LIBRETINY)
 
 #include "fastled_light.h"
 #include "esphome/core/log.h"

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !defined(USE_RP2) && !defined(USE_LIBRETINY)
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -1,6 +1,6 @@
 #include "http_request_arduino.h"
 
-#if defined(USE_ARDUINO) && !defined(USE_ESP32)
+#if defined(USE_ARDUINO) && !defined(USE_ESP32) && !defined(USE_LIBRETINY)
 
 #include "esphome/components/network/util.h"
 #include "esphome/components/watchdog/watchdog.h"

--- a/esphome/components/http_request/http_request_arduino.h
+++ b/esphome/components/http_request/http_request_arduino.h
@@ -2,7 +2,7 @@
 
 #include "http_request.h"
 
-#if defined(USE_ARDUINO) && !defined(USE_ESP32)
+#if defined(USE_ARDUINO) && !defined(USE_ESP32) && !defined(USE_LIBRETINY)
 
 #if defined(USE_RP2)
 #include <HTTPClient.h>

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_ARDUINO) && !defined(USE_ESP32)
+#if defined(USE_ARDUINO) && !defined(USE_ESP32) && !defined(USE_LIBRETINY)
 
 #include "i2c_bus_arduino.h"
 #include <Arduino.h>

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_ESP32)
+#if defined(USE_ARDUINO) && !defined(USE_ESP32) && !defined(USE_LIBRETINY)
 
 #include <Wire.h>
 #include "esphome/core/component.h"

--- a/esphome/components/libretiny/hal.cpp
+++ b/esphome/components/libretiny/hal.cpp
@@ -44,7 +44,7 @@ void arch_init() {
 
 void arch_restart() {
   lt_reboot();
-  while (1) {
+  while (true) {
   }
 }
 

--- a/esphome/components/libretiny/hal.h
+++ b/esphome/components/libretiny/hal.h
@@ -44,6 +44,7 @@
 // it is callable from Thumb code via interworking. The MRS CPSR instruction
 // is ARM-only and user code here may be built in Thumb, so in_isr_context()
 // defers to this port helper on BK72xx instead of reading CPSR inline.
+// NOLINTNEXTLINE(readability-redundant-declaration)
 extern "C" uint32_t platform_is_in_interrupt_context(void);
 #endif
 
@@ -59,9 +60,11 @@ extern "C" void delayMicroseconds(unsigned int us);
 // Forward decls from libretiny's <lt_api.h> family for the inline arch_*
 // wrappers below. Pulling the full header would drag in the rest of the
 // LibreTiny C API.
+// NOLINTBEGIN(readability-redundant-declaration)
 extern "C" void lt_wdt_feed(void);
 extern "C" uint32_t lt_cpu_get_cycle_count(void);
 extern "C" uint32_t lt_cpu_get_freq(void);
+// NOLINTEND(readability-redundant-declaration)
 
 namespace esphome::libretiny {}
 

--- a/esphome/components/libretiny/lt_component.cpp
+++ b/esphome/components/libretiny/lt_component.cpp
@@ -13,14 +13,14 @@ void LTComponent::dump_config() {
                 "LibreTiny:\n"
                 "  Version: %s\n"
                 "  Loglevel: %u",
-                LT_BANNER_STR + 10, LT_LOGLEVEL);
+                &LT_BANNER_STR[10], LT_LOGLEVEL);
 #if defined(__OPTIMIZE_SIZE__) && __OPTIMIZE_LEVEL__ > 0 && __OPTIMIZE_LEVEL__ <= 3
   ESP_LOGCONFIG(TAG, "  Optimization: -Os, SDK: -O" STRINGIFY_MACRO(__OPTIMIZE_LEVEL__));
 #endif
 
 #ifdef USE_TEXT_SENSOR
   if (this->version_ != nullptr) {
-    this->version_->publish_state(LT_BANNER_STR + 10);
+    this->version_->publish_state(&LT_BANNER_STR[10]);
   }
 #endif  // USE_TEXT_SENSOR
 }

--- a/esphome/components/libretiny/preference_backend.h
+++ b/esphome/components/libretiny/preference_backend.h
@@ -5,8 +5,10 @@
 #include <cstdint>
 
 // Forward declare FlashDB types to avoid pulling in flashdb.h
+// NOLINTBEGIN(readability-identifier-naming)
 struct fdb_kvdb;
 struct fdb_blob;
+// NOLINTEND(readability-identifier-naming)
 
 namespace esphome::libretiny {
 

--- a/esphome/components/logger/task_log_buffer_libretiny.cpp
+++ b/esphome/components/logger/task_log_buffer_libretiny.cpp
@@ -20,7 +20,7 @@ TaskLogBuffer::~TaskLogBuffer() {
   }
 }
 
-size_t TaskLogBuffer::available_contiguous_space() const {
+size_t TaskLogBuffer::available_contiguous_space_() const {
   if (this->head_ >= this->tail_) {
     // head is ahead of or equal to tail
     // Available space is from head to end, plus from start to tail
@@ -81,7 +81,7 @@ void TaskLogBuffer::release_message_main_loop() {
     this->tail_ = 0;
   }
 
-  this->message_count_--;
+  this->message_count_ = this->message_count_ - 1;
   this->current_message_size_ = 0;
 
   xSemaphoreGive(this->mutex_);
@@ -117,7 +117,7 @@ bool TaskLogBuffer::send_message_thread_safe(uint8_t level, const char *tag, uin
   }
 
   // Check if we have enough contiguous space
-  size_t contiguous = this->available_contiguous_space();
+  size_t contiguous = this->available_contiguous_space_();
 
   if (contiguous < total_size) {
     // Not enough contiguous space at end
@@ -128,9 +128,9 @@ bool TaskLogBuffer::send_message_thread_safe(uint8_t level, const char *tag, uin
     }
 
     // Need at least enough space to safely write padding marker (level field is at end of struct)
-    constexpr size_t PADDING_MARKER_MIN_SPACE = offsetof(LogMessage, level) + 1;
+    constexpr size_t padding_marker_min_space = offsetof(LogMessage, level) + 1;
 
-    if (space_at_start >= total_size && this->head_ > 0 && contiguous >= PADDING_MARKER_MIN_SPACE) {
+    if (space_at_start >= total_size && this->head_ > 0 && contiguous >= padding_marker_min_space) {
       // Add padding marker (set level field to indicate this is padding, not a real message)
       LogMessage *padding = reinterpret_cast<LogMessage *>(this->storage_ + this->head_);
       padding->level = PADDING_MARKER_LEVEL;
@@ -180,7 +180,7 @@ bool TaskLogBuffer::send_message_thread_safe(uint8_t level, const char *tag, uin
     this->head_ = 0;
   }
 
-  this->message_count_++;
+  this->message_count_ = this->message_count_ + 1;
 
   xSemaphoreGive(this->mutex_);
   return true;

--- a/esphome/components/logger/task_log_buffer_libretiny.h
+++ b/esphome/components/logger/task_log_buffer_libretiny.h
@@ -84,7 +84,7 @@ class TaskLogBuffer {
   static inline size_t message_total_size(size_t text_length) { return sizeof(LogMessage) + text_length + 1; }
 
   // Calculate available contiguous space at write position
-  size_t available_contiguous_space() const;
+  size_t available_contiguous_space_() const;
 
   uint8_t storage_[ESPHOME_TASK_LOG_BUFFER_SIZE];  // Embedded in Logger (no separate heap allocation)
   size_t head_{0};                                 // Write position

--- a/esphome/components/mdns/mdns_libretiny.cpp
+++ b/esphome/components/mdns/mdns_libretiny.cpp
@@ -27,8 +27,8 @@ static void register_libretiny(MDNSComponent *, StaticVector<MDNSService, MDNS_S
     while (*service_type == '_') {
       service_type++;
     }
-    uint16_t port_ = service.port.value();
-    MDNS.addService(service_type, proto, port_);
+    uint16_t port = service.port.value();
+    MDNS.addService(service_type, proto, port);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service_type, proto, MDNS_STR_ARG(record.key), MDNS_STR_ARG(record.value));
     }

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -23,7 +23,9 @@
 #elif defined(USE_ESP8266)
 #include <ESP8266HTTPClient.h>
 #include <WiFiClientSecure.h>
-#endif  // USE_ESP32 vs USE_ESP8266
+#elif defined(USE_LIBRETINY)
+#include <HTTPClient.h>
+#endif  // USE_ESP32 vs USE_ESP8266 vs USE_LIBRETINY
 #endif  // USE_NEXTION_TFT_UPLOAD
 
 namespace esphome::nextion {

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -13,7 +13,7 @@
 
 using SPIInterface = spi_host_device_t;
 
-#elif defined(USE_ARDUINO)
+#elif defined(USE_ARDUINO) && !defined(USE_LIBRETINY)
 
 #include <SPI.h>
 

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -18,7 +18,7 @@ namespace esphome::uart {
 
 static const char *const TAG = "uart.lt";
 
-static const char *UART_TYPE[] = {
+static const char *const UART_TYPE[] = {
     "hardware",
     "software",
 };
@@ -45,17 +45,17 @@ uint16_t LibreTinyUARTComponent::get_config() {
 }
 
 void LibreTinyUARTComponent::setup() {
-  int8_t tx_pin = tx_pin_ == nullptr ? -1 : tx_pin_->get_pin();
-  int8_t rx_pin = rx_pin_ == nullptr ? -1 : rx_pin_->get_pin();
-  bool tx_inverted = tx_pin_ != nullptr && tx_pin_->is_inverted();
-  bool rx_inverted = rx_pin_ != nullptr && rx_pin_->is_inverted();
+  int16_t tx_pin = tx_pin_ == nullptr ? -1 : tx_pin_->get_pin();
+  int16_t rx_pin = rx_pin_ == nullptr ? -1 : rx_pin_->get_pin();
 
-  auto shouldFallbackToSoftwareSerial = [&]() -> bool {
-    auto hasFlags = [](InternalGPIOPin *pin, const gpio::Flags mask) -> bool {
+  auto should_fallback_to_software_serial = [&]() -> bool {
+    auto has_flags = [](InternalGPIOPin *pin, const gpio::Flags mask) -> bool {
       return pin && (pin->get_flags() & mask) != gpio::Flags::FLAG_NONE;
     };
-    if (hasFlags(this->tx_pin_, gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN) ||
-        hasFlags(this->rx_pin_, gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN)) {
+    if (has_flags(this->tx_pin_,
+                  gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN) ||
+        has_flags(this->rx_pin_,
+                  gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN)) {
 #if LT_ARD_HAS_SOFTSERIAL
       ESP_LOGI(TAG, "Pins has flags set. Using Software Serial");
       return true;
@@ -66,25 +66,26 @@ void LibreTinyUARTComponent::setup() {
     return false;
   };
 
-  if (false)
+  if (false) {  // NOLINT(readability-simplify-boolean-expr)
     return;
+  }
 #if LT_HW_UART0
   else if ((tx_pin == -1 || tx_pin == PIN_SERIAL0_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL0_RX) &&
-           !shouldFallbackToSoftwareSerial()) {
+           !should_fallback_to_software_serial()) {
     this->serial_ = &Serial0;
     this->hardware_idx_ = 0;
   }
 #endif
 #if LT_HW_UART1
   else if ((tx_pin == -1 || tx_pin == PIN_SERIAL1_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL1_RX) &&
-           !shouldFallbackToSoftwareSerial()) {
+           !should_fallback_to_software_serial()) {
     this->serial_ = &Serial1;
     this->hardware_idx_ = 1;
   }
 #endif
 #if LT_HW_UART2
   else if ((tx_pin == -1 || tx_pin == PIN_SERIAL2_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL2_RX) &&
-           !shouldFallbackToSoftwareSerial()) {
+           !should_fallback_to_software_serial()) {
     this->serial_ = &Serial2;
     this->hardware_idx_ = 2;
   }
@@ -97,6 +98,8 @@ void LibreTinyUARTComponent::setup() {
     if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
       this->tx_pin_->setup();
     }
+    bool tx_inverted = tx_pin_ != nullptr && tx_pin_->is_inverted();
+    bool rx_inverted = rx_pin_ != nullptr && rx_pin_->is_inverted();
     this->serial_ = new SoftwareSerial(rx_pin, tx_pin, rx_inverted || tx_inverted);
 #else
     this->serial_ = &Serial;
@@ -133,7 +136,7 @@ void LibreTinyUARTComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  RX Buffer Size: %u", this->rx_buffer_size_);
   }
   ESP_LOGCONFIG(TAG,
-                "  Baud Rate: %u baud\n"
+                "  Baud Rate: %" PRIu32 " baud\n"
                 "  Data Bits: %u\n"
                 "  Parity: %s\n"
                 "  Stop bits: %u",

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -57,7 +57,7 @@ void LibreTinyUARTComponent::setup() {
         has_flags(this->rx_pin_,
                   gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN)) {
 #if LT_ARD_HAS_SOFTSERIAL
-      ESP_LOGI(TAG, "Pins has flags set. Using Software Serial");
+      ESP_LOGI(TAG, "Pins have flags set. Using Software Serial");
       return true;
 #else
       ESP_LOGW(TAG, "Pin flags are set but not supported for hardware serial. Ignoring");

--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -13,7 +13,7 @@
 #include <WiFiUdp.h>
 #endif
 
-#ifdef USE_BK72XX
+#ifdef USE_LIBRETINY
 #include <WiFiUdp.h>
 #endif
 

--- a/esphome/components/wled/wled_light_effect.h
+++ b/esphome/components/wled/wled_light_effect.h
@@ -8,7 +8,7 @@
 #include <vector>
 #include <memory>
 
-#ifdef USE_RP2
+#if defined(USE_RP2) || defined(USE_LIBRETINY)
 namespace arduino {
 class UDP;
 }  // namespace arduino


### PR DESCRIPTION
# What does this implement/fix?

Component-level fixes found while bringing up clang-tidy environments for the LibreTiny variants (#17491), split out so they can be reviewed independently of the CI/tooling changes. Everything here stands on its own; the scan infrastructure follows in #17491.

## Real support gaps

- **wled** only included `WiFiUdp.h` on bk72xx — ln882x/rtl87xx builds of wled do not compile today. Now included for all LibreTiny families.
- **nextion** TFT upload declares `HTTPClient` methods on all Arduino platforms but only included the header for esp8266; LibreTiny bundles the library, so include it there too.
- **uart** (libretiny) used `int8_t` pin locals, so hardware-serial pin matching against LN882H's pin-255 serial pins could never succeed. Widened to `int16_t`.
- **beken_spi_led_strip** dereferenced an empty `optional<uint32_t>` whenever `max_refresh_rate` was unset (undefined behavior); now guarded with `has_value()`.

## Platform guards

**spi**/**i2c**/**http_request**/**fastled_base** Arduino implementations are compiled out on LibreTiny. None of the four is configurable there today (spi, http_request and fastled are rejected by explicit platform validation; i2c pins require an input+output+open-drain mode that LibreTiny's gpio validation never accepts), so real builds are unaffected — this only stops the LibreTiny scans from analyzing implementations those platforms can never use.

## Findings and cleanups

beken_spi_led_strip (bool literals, MMIO NOLINTs, `PRIu32` format, naming), task_log_buffer_libretiny volatile increment/decrement (deprecated in C++20) and naming, uart_component_libretiny cleanup (const array, lambda naming, unused inverted flags moved into the softserial branch, `PRIu32` format), lt_component/debug `LT_BANNER_STR` pointer arithmetic, mdns/deep_sleep/hal naming (including the misnamed public `init_wakeup_pins_` codegen method), NOLINTs for FlashDB and `lt_*` SDK declarations.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Internal fixes only, no configuration impact
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).