### PR TITLE
[improv_base] Bump Improv library to 1.2.6

### DIFF
--- a/esphome/components/improv_base/__init__.py
+++ b/esphome/components/improv_base/__init__.py
@@ -42,4 +42,4 @@ async def setup_improv_core(var: MockObj, config: ConfigType, component: str):
         cg.add(var.set_next_url(_process_next_url(next_url)))
         cg.add_define(f"USE_{component.upper()}_NEXT_URL")
 
-    cg.add_library("improv/Improv", "1.2.4")
+    cg.add_library("improv/Improv", "1.2.6")

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     esphome/noise-c@0.1.11                 ; api
-    improv/Improv@1.2.4                    ; improv_serial / esp32_improv
+    improv/Improv@1.2.6                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
     https://github.com/bitbank2/JPEGDEC.git#1.8.4    ; online_image


### PR DESCRIPTION
# What does this implement/fix?

Bumps the bundled Improv library from 1.2.4 to 1.2.6 ([release notes](https://github.com/improv-wifi/sdk-cpp/releases/tag/v1.2.6)).

The new version adds enum values for the `Get Network State` (`0x07`) RPC command and its `NetworkState` flags (improv-wifi/sdk-cpp#34), and the spec's Hostname/Device Name commands and `BAD_HOSTNAME` error (improv-wifi/sdk-cpp#35, improv-wifi/sdk-cpp#36). All changes are additive; there is no behavior change for existing `improv_serial` / `esp32_improv` code.

Split out of #17598 so the library bump can merge independently; #17598 builds on the new enum values.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- improv-wifi/sdk-cpp#34
- #17598 (uses the new enum values)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; library version bump only.
logger:

improv_serial:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
