### PR TITLE
[zephyr] implement ISRInternalGPIOPin::digital_write

### DIFF
--- a/esphome/components/zephyr/gpio.cpp
+++ b/esphome/components/zephyr/gpio.cpp
@@ -173,6 +173,14 @@ bool IRAM_ATTR ISRInternalGPIOPin::digital_read() {
   return bool(gpio_pin_get(arg->gpio, arg->pin % arg->gpio_size) != arg->inverted);
 }
 
+void IRAM_ATTR ISRInternalGPIOPin::digital_write(bool value) {
+  auto *arg = (zephyr::ISRPinArg *) this->arg_;
+  if (arg == nullptr || arg->gpio == nullptr) {
+    return;
+  }
+  gpio_pin_set(arg->gpio, arg->pin % arg->gpio_size, value != arg->inverted ? 1 : 0);
+}
+
 }  // namespace esphome
 
 #endif


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This PR implements the missing `esphome::ISRInternalGPIOPin::digital_write(bool)` function, allowing things like ultrasonic sensors and other any gpio bus components to work.

Specifically, it fixes the following issue:

```
/home/quantum/.cache/esphome/sdk-nrf/toolchains/0.17.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: app/libapp.a(ultrasonic_sensor.cpp.obj): in function `esphome::ultrasonic::UltrasonicSensorComponent::send_trigger_pulse_()':
/home/quantum/dev/esphome/config/.esphome/build/nrf52-ultrasonic/src/esphome/components/ultrasonic/ultrasonic_sensor.cpp:33: undefined reference to `esphome::ISRInternalGPIOPin::digital_write(bool)'
/home/quantum/.cache/esphome/sdk-nrf/toolchains/0.17.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: /home/quantum/dev/esphome/config/.esphome/build/nrf52-ultrasonic/src/esphome/components/ultrasonic/ultrasonic_sensor.cpp:35: undefined reference to `esphome::ISRInternalGPIOPin::digital_write(bool)'
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #16163

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: nrf52-ultrasonic

nrf52:
  board: adafruit_itsybitsy_nrf52840

sensor:
  - platform: ultrasonic
    echo_pin: P0.17
    trigger_pin: P0.20
    id: sensor_ultrasonic_1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
