### PR TITLE
[web_server_idf] Use core format_hex_to helper for digest auth (fixes Arduino build)

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -381,16 +381,6 @@ void AsyncWebServerRequest::init_response_(AsyncWebServerResponse *rsp, int code
 #ifdef USE_WEBSERVER_AUTH_DIGEST
 namespace {
 
-// Hex-encode `len` bytes into `out`, which must hold at least 2 * len + 1 bytes. Null-terminated.
-void bytes_to_hex(const uint8_t *data, size_t len, char *out) {
-  static const char HEX_CHARS[] = "0123456789abcdef";
-  for (size_t i = 0; i < len; i++) {
-    out[i * 2] = HEX_CHARS[data[i] >> 4];
-    out[i * 2 + 1] = HEX_CHARS[data[i] & 0x0f];
-  }
-  out[len * 2] = '\0';
-}
-
 // Extract the value of a Digest auth parameter (e.g. "nonce") from the comma-separated
 // parameter list. Values may be quoted or bare. Returns an empty ref when the key is absent.
 // Only whole parameter names match, so "nc" does not match inside "cnonce".
@@ -468,7 +458,7 @@ bool check_digest_auth(const char *username, const char *password, const std::st
   esp_rom_md5_update(&ctx, ":", 1);
   esp_rom_md5_update(&ctx, password, strlen(password));
   esp_rom_md5_final(digest, &ctx);
-  bytes_to_hex(digest, sizeof(digest), ha1);
+  format_hex_to(ha1, digest, sizeof(digest));
 
   // HA2 = MD5(method:uri) -- uses the uri the client echoed back.
   char ha2[33];
@@ -477,7 +467,7 @@ bool check_digest_auth(const char *username, const char *password, const std::st
   esp_rom_md5_update(&ctx, ":", 1);
   esp_rom_md5_update(&ctx, uri.c_str(), uri.size());
   esp_rom_md5_final(digest, &ctx);
-  bytes_to_hex(digest, sizeof(digest), ha2);
+  format_hex_to(ha2, digest, sizeof(digest));
 
   // expected = MD5(HA1:nonce:nc:cnonce:qop:HA2)
   char expected[33];
@@ -494,7 +484,7 @@ bool check_digest_auth(const char *username, const char *password, const std::st
   esp_rom_md5_update(&ctx, ":", 1);
   esp_rom_md5_update(&ctx, ha2, 32);
   esp_rom_md5_final(digest, &ctx);
-  bytes_to_hex(digest, sizeof(digest), expected);
+  format_hex_to(expected, digest, sizeof(digest));
 
   // Constant-time comparison of the two 32-char hex digests.
   uint8_t result = 0;
@@ -592,9 +582,9 @@ void AsyncWebServerRequest::requestAuthentication() const {
   char opaque[33];
   char header[160];
   esp_fill_random(random_bytes, sizeof(random_bytes));
-  bytes_to_hex(random_bytes, sizeof(random_bytes), nonce);
+  format_hex_to(nonce, random_bytes, sizeof(random_bytes));
   esp_fill_random(random_bytes, sizeof(random_bytes));
-  bytes_to_hex(random_bytes, sizeof(random_bytes), opaque);
+  format_hex_to(opaque, random_bytes, sizeof(random_bytes));
   snprintf(header, sizeof(header), R"(Digest realm="Login Required", qop="auth", nonce="%s", opaque="%s")", nonce,
            opaque);
   httpd_resp_set_hdr(*this, "WWW-Authenticate", header);

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -383,10 +383,10 @@ namespace {
 
 // Hex-encode `len` bytes into `out`, which must hold at least 2 * len + 1 bytes. Null-terminated.
 void bytes_to_hex(const uint8_t *data, size_t len, char *out) {
-  static const char hex_chars[] = "0123456789abcdef";
+  static const char HEX_CHARS[] = "0123456789abcdef";
   for (size_t i = 0; i < len; i++) {
-    out[i * 2] = hex_chars[data[i] >> 4];
-    out[i * 2 + 1] = hex_chars[data[i] & 0x0f];
+    out[i * 2] = HEX_CHARS[data[i] >> 4];
+    out[i * 2 + 1] = HEX_CHARS[data[i] & 0x0f];
   }
   out[len * 2] = '\0';
 }

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -383,10 +383,10 @@ namespace {
 
 // Hex-encode `len` bytes into `out`, which must hold at least 2 * len + 1 bytes. Null-terminated.
 void bytes_to_hex(const uint8_t *data, size_t len, char *out) {
-  static const char HEX[] = "0123456789abcdef";
+  static const char hex_chars[] = "0123456789abcdef";
   for (size_t i = 0; i < len; i++) {
-    out[i * 2] = HEX[data[i] >> 4];
-    out[i * 2 + 1] = HEX[data[i] & 0x0f];
+    out[i * 2] = hex_chars[data[i] >> 4];
+    out[i * 2 + 1] = hex_chars[data[i] & 0x0f];
   }
   out[len * 2] = '\0';
 }

--- a/tests/components/web_server/test.esp32-ard.yaml
+++ b/tests/components/web_server/test.esp32-ard.yaml
@@ -1,2 +1,8 @@
 packages:
   web_server: !include common_v2.yaml
+
+web_server:
+  auth:
+    username: admin
+    password: password
+    type: digest


### PR DESCRIPTION
# What does this implement/fix?

ESPHome 2026.7.0 fails to compile `web_server_idf.cpp` on the ESP32 Arduino framework when web server digest authentication is enabled. The digest auth code added in #17541 used a local `bytes_to_hex()` helper containing an array named `HEX`, but the Arduino core's `Print.h` defines `HEX` as the macro `16`, so the declaration fails to preprocess:

```
../managed_components/espressif__arduino-esp32/cores/esp32/Print.h:31:13: error: expected unqualified-id before numeric constant
   31 | #define HEX 16
```

Rather than just renaming the array, this removes the local `bytes_to_hex()` helper entirely and uses ESPHome's existing `format_hex_to()` from `esphome/core/helpers.h` at all five call sites. That helper produces the same output the digest code needs — lowercase, null-terminated hex — and is bounds-checked against the destination buffer size, so it both fixes the macro collision (no more `HEX` identifier) and removes duplicated hex-encoding code.

It also adds `auth: type: digest` to the web_server `test.esp32-ard.yaml` so the Arduino + digest combination is covered by CI going forward (only the IDF test enabled digest auth, which is why this wasn't caught).

Verified locally with `script/test_build_components -e compile -c web_server -t esp32-ard`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17600

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
web_server:
  auth:
    username: admin
    password: password
    type: digest
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).