### PR TITLE
[core] Warn instead of failing when a component alias shadows an existing package

### DIFF
--- a/esphome/loader.py
+++ b/esphome/loader.py
@@ -389,10 +389,14 @@ def _build_alias_map() -> tuple[dict[str, str], dict[str, AliasMeta]]:
 
     Raises if the same alias is claimed by two canonical components, since
     silently picking one would cause non-deterministic routing depending on
-    directory-iteration order. Also raises if an alias shadows an existing
-    component package: that would hijack a live component domain and, in the
-    self-alias case (alias == canonical), send ``_lookup_module`` into
-    infinite recursion redirecting a domain to itself.
+    directory-iteration order. An alias that shadows an existing component
+    package is skipped with a warning instead: the on-disk package keeps
+    working and the alias is ignored. Shadowing would otherwise hijack a
+    live component domain and, in the self-alias case (alias == canonical),
+    send ``_lookup_module`` into infinite recursion redirecting a domain to
+    itself. A hard error here would break every config on installs that
+    have a stale leftover directory from a previous version (e.g. an
+    interrupted upgrade), so this is deliberately not fatal.
     """
     import ast
 
@@ -414,13 +418,19 @@ def _build_alias_map() -> tuple[dict[str, str], dict[str, AliasMeta]]:
         canonical = child.name
         for alias in aliases:
             if (CORE_COMPONENTS_PATH / alias / "__init__.py").is_file():
-                from esphome.core import EsphomeError
-
-                raise EsphomeError(
-                    f"Component alias '{alias}' (declared by '{canonical}') "
-                    "shadows an existing component package of the same name. "
-                    "An alias may only name a component that no longer exists."
+                _LOGGER.warning(
+                    "Component alias '%s' (declared by '%s') shadows an existing "
+                    "component package of the same name; ignoring the alias. "
+                    "This usually means an external component was copied or "
+                    "mounted into %s, or the directory is a leftover from a "
+                    "previous ESPHome version. Load external components via "
+                    "the 'external_components' config option instead, or "
+                    "reinstall ESPHome to clean up stale files.",
+                    alias,
+                    canonical,
+                    CORE_COMPONENTS_PATH / alias,
                 )
+                continue
             if alias in alias_to_canonical:
                 from esphome.core import EsphomeError
 

--- a/esphome/loader.py
+++ b/esphome/loader.py
@@ -419,13 +419,9 @@ def _build_alias_map() -> tuple[dict[str, str], dict[str, AliasMeta]]:
         for alias in aliases:
             if (CORE_COMPONENTS_PATH / alias / "__init__.py").is_file():
                 _LOGGER.warning(
-                    "Component alias '%s' (declared by '%s') shadows an existing "
-                    "component package of the same name; ignoring the alias. "
-                    "This usually means an external component was copied or "
-                    "mounted into %s, or the directory is a leftover from a "
-                    "previous ESPHome version. Load external components via "
-                    "the 'external_components' config option instead, or "
-                    "reinstall ESPHome to clean up stale files.",
+                    "Ignoring component alias '%s' (declared by '%s'): a component "
+                    "with that name still exists at %s. This is usually a copied-in "
+                    "external component or a leftover from a previous ESPHome version.",
                     alias,
                     canonical,
                     CORE_COMPONENTS_PATH / alias,

--- a/esphome/loader.py
+++ b/esphome/loader.py
@@ -420,8 +420,9 @@ def _build_alias_map() -> tuple[dict[str, str], dict[str, AliasMeta]]:
             if (CORE_COMPONENTS_PATH / alias / "__init__.py").is_file():
                 _LOGGER.warning(
                     "Ignoring component alias '%s' (declared by '%s'): a component "
-                    "with that name still exists at %s. This is usually a copied-in "
-                    "external component or a leftover from a previous ESPHome version.",
+                    "with that name still exists at %s. This usually means an external "
+                    "component was copied into the ESPHome installation; use the "
+                    "'external_components' config option instead.",
                     alias,
                     canonical,
                     CORE_COMPONENTS_PATH / alias,

--- a/tests/unit_tests/test_loader.py
+++ b/tests/unit_tests/test_loader.py
@@ -470,7 +470,7 @@ def test_build_alias_map_skips_alias_shadowing_existing_component(
 
     with (
         patch("esphome.loader.CORE_COMPONENTS_PATH", tmp_path),
-        caplog.at_level(logging.WARNING),
+        caplog.at_level(logging.WARNING, logger="esphome.loader"),
     ):
         alias_map, meta_map = _build_alias_map()
 

--- a/tests/unit_tests/test_loader.py
+++ b/tests/unit_tests/test_loader.py
@@ -477,7 +477,7 @@ def test_build_alias_map_skips_alias_shadowing_existing_component(
     assert "oldcomp" not in alias_map
     assert alias_map == {"gone": "newcomp"}
     assert "gone" in meta_map
-    assert "shadows an existing component package" in caplog.text
+    assert "Ignoring component alias 'oldcomp'" in caplog.text
 
 
 def test_build_alias_map_handles_missing_dir(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_loader.py
+++ b/tests/unit_tests/test_loader.py
@@ -1,6 +1,7 @@
 """Unit tests for esphome.loader module."""
 
 import ast
+import logging
 from pathlib import Path
 import sys
 import textwrap
@@ -454,6 +455,29 @@ def test_build_alias_map_rejects_duplicate_alias(tmp_path: Path) -> None:
         pytest.raises(EsphomeError, match="shared"),
     ):
         _build_alias_map()
+
+
+def test_build_alias_map_skips_alias_shadowing_existing_component(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An alias that names a component package still present on disk is
+    ignored with a warning rather than raising. A stale leftover directory
+    from a previous version (e.g. an interrupted upgrade) must not make
+    every config on the install fail to load; the on-disk package wins and
+    other aliases keep working."""
+    _write_component(tmp_path, "newcomp", "ALIASES = ['oldcomp', 'gone']\n")
+    _write_component(tmp_path, "oldcomp", "")
+
+    with (
+        patch("esphome.loader.CORE_COMPONENTS_PATH", tmp_path),
+        caplog.at_level(logging.WARNING),
+    ):
+        alias_map, meta_map = _build_alias_map()
+
+    assert "oldcomp" not in alias_map
+    assert alias_map == {"gone": "newcomp"}
+    assert "gone" in meta_map
+    assert "shadows an existing component package" in caplog.text
 
 
 def test_build_alias_map_handles_missing_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

When a component declares an alias (e.g. `rp2` declares `ALIASES = ["rp2040"]`) and a directory with the alias's name still exists in the installed components tree, the alias scanner raised a hard `EsphomeError`. Because the scan runs while reading any config, one stray directory made every config on the install fail with:

```
ERROR Error while reading config: Component alias 'rp2040' (declared by 'rp2') shadows an existing component package of the same name.
```

This is an environment problem (an old component copied into the ESPHome installation instead of being loaded via `external_components`, or files overlaid onto an existing install), not something in the user's YAML — the 2026.7.0 wheel and Docker image don't ship a `rp2040` directory. A hard failure of every config is too harsh for it.

This change downgrades the shadow case to a warning: the alias is skipped, the on-disk package wins, and everything else keeps loading. The warning points the user at the `external_components` config option:

```
Ignoring component alias 'rp2040' (declared by 'rp2'): a component with that name still exists at <path>. This usually means an external component was copied into the ESPHome installation; use the 'external_components' config option instead.
```

Skipping the alias also still avoids the infinite-recursion hazard the original check protected against, and the duplicate-alias case (two components claiming the same alias) still raises since that is a genuine developer error in a clean tree. A unit test covers the new behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not config-related; Python loader change only. Reproduce by creating a stale
# components/rp2040/__init__.py in the installed tree - any config then fails
# to load before this change.
esp8266:
  board: esp12e
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).