### PR TITLE
[opentherm] Rename OpenthermData accessors that collide with vendor SDK type macros

### DIFF
--- a/esphome/components/opentherm/hub.cpp
+++ b/esphome/components/opentherm/hub.cpp
@@ -27,11 +27,11 @@ uint8_t parse_u8_lb(OpenthermData &data) { return data.valueLB; }
 uint8_t parse_u8_hb(OpenthermData &data) { return data.valueHB; }
 int8_t parse_s8_lb(OpenthermData &data) { return (int8_t) data.valueLB; }
 int8_t parse_s8_hb(OpenthermData &data) { return (int8_t) data.valueHB; }
-uint16_t parse_u16(OpenthermData &data) { return data.u16(); }
+uint16_t parse_u16(OpenthermData &data) { return data.get_u16(); }
 uint16_t parse_u8_lb_60(OpenthermData &data) { return data.valueLB * 60; }
 uint16_t parse_u8_hb_60(OpenthermData &data) { return data.valueHB * 60; }
-int16_t parse_s16(OpenthermData &data) { return data.s16(); }
-float parse_f88(OpenthermData &data) { return data.f88(); }
+int16_t parse_s16(OpenthermData &data) { return data.get_s16(); }
+float parse_f88(OpenthermData &data) { return data.get_f88(); }
 
 void write_flag8_lb_0(const bool value, OpenthermData &data) { data.valueLB = write_bit(data.valueLB, 0, value); }
 void write_flag8_lb_1(const bool value, OpenthermData &data) { data.valueLB = write_bit(data.valueLB, 1, value); }
@@ -53,9 +53,9 @@ void write_u8_lb(const uint8_t value, OpenthermData &data) { data.valueLB = valu
 void write_u8_hb(const uint8_t value, OpenthermData &data) { data.valueHB = value; }
 void write_s8_lb(const int8_t value, OpenthermData &data) { data.valueLB = (uint8_t) value; }
 void write_s8_hb(const int8_t value, OpenthermData &data) { data.valueHB = (uint8_t) value; }
-void write_u16(const uint16_t value, OpenthermData &data) { data.u16(value); }
-void write_s16(const int16_t value, OpenthermData &data) { data.s16(value); }
-void write_f88(const float value, OpenthermData &data) { data.f88(value); }
+void write_u16(const uint16_t value, OpenthermData &data) { data.set_u16(value); }
+void write_s16(const int16_t value, OpenthermData &data) { data.set_s16(value); }
+void write_f88(const float value, OpenthermData &data) { data.set_f88(value); }
 
 }  // namespace message_data
 

--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -533,34 +533,34 @@ void OpenTherm::debug_data(OpenthermData &data) {
   ESP_LOGD(TAG, "%s %s %s %s", format_bin_to(type_buf, data.type), format_bin_to(id_buf, data.id),
            format_bin_to(hb_buf, data.valueHB), format_bin_to(lb_buf, data.valueLB));
   ESP_LOGD(TAG, "type: %s; id: %u; HB: %u; LB: %u; uint_16: %u; float: %f",
-           this->message_type_to_str((MessageType) data.type), data.id, data.valueHB, data.valueLB, data.u16(),
-           data.f88());
+           this->message_type_to_str((MessageType) data.type), data.id, data.valueHB, data.valueLB, data.get_u16(),
+           data.get_f88());
 }
 void OpenTherm::debug_error(OpenThermError &error) const {
   ESP_LOGD(TAG, "data: 0x%08" PRIx32 "; clock: %u; capture: 0x%08" PRIx32 "; bit_pos: %u", error.data, this->clock_,
            error.capture, error.bit_pos);
 }
 
-float OpenthermData::f88() { return ((float) this->s16()) / 256.0f; }
+float OpenthermData::get_f88() { return ((float) this->get_s16()) / 256.0f; }
 
-void OpenthermData::f88(float value) { this->s16((int16_t) (value * 256)); }
+void OpenthermData::set_f88(float value) { this->set_s16((int16_t) (value * 256)); }
 
-uint16_t OpenthermData::u16() {
+uint16_t OpenthermData::get_u16() {
   uint16_t const value = this->valueHB;
   return (value << 8) | this->valueLB;
 }
 
-void OpenthermData::u16(uint16_t value) {
+void OpenthermData::set_u16(uint16_t value) {
   this->valueLB = value & 0xFF;
   this->valueHB = (value >> 8) & 0xFF;
 }
 
-int16_t OpenthermData::s16() {
+int16_t OpenthermData::get_s16() {
   int16_t const value = this->valueHB;
   return (value << 8) | this->valueLB;
 }
 
-void OpenthermData::s16(int16_t value) {
+void OpenthermData::set_s16(int16_t value) {
   this->valueLB = value & 0xFF;
   this->valueHB = (value >> 8) & 0xFF;
 }

--- a/esphome/components/opentherm/opentherm.h
+++ b/esphome/components/opentherm/opentherm.h
@@ -178,7 +178,7 @@ enum BitPositions { STOP_BIT = 33 };
 
 /**
  * Structure to hold Opentherm data packet content.
- * Use f88(), u16() or s16() functions to get appropriate value of data packet accoridng to id of message.
+ * Use get_f88(), get_u16() or get_s16() functions to get appropriate value of data packet accoridng to id of message.
  */
 struct OpenthermData {
   uint8_t type;
@@ -191,32 +191,32 @@ struct OpenthermData {
   /**
    * @return float representation of data packet value
    */
-  float f88();
+  float get_f88();
 
   /**
    * @param float number to set as value of this data packet
    */
-  void f88(float value);
+  void set_f88(float value);
 
   /**
    * @return unsigned 16b integer representation of data packet value
    */
-  uint16_t u16();
+  uint16_t get_u16();
 
   /**
    * @param unsigned 16b integer number to set as value of this data packet
    */
-  void u16(uint16_t value);
+  void set_u16(uint16_t value);
 
   /**
    * @return signed 16b integer representation of data packet value
    */
-  int16_t s16();
+  int16_t get_s16();
 
   /**
    * @param signed 16b integer number to set as value of this data packet
    */
-  void s16(int16_t value);
+  void set_s16(int16_t value);
 };
 
 struct OpenThermError {

--- a/esphome/components/opentherm/opentherm.h
+++ b/esphome/components/opentherm/opentherm.h
@@ -178,7 +178,7 @@ enum BitPositions { STOP_BIT = 33 };
 
 /**
  * Structure to hold Opentherm data packet content.
- * Use get_f88(), get_u16() or get_s16() functions to get appropriate value of data packet accoridng to id of message.
+ * Use get_f88(), get_u16() or get_s16() functions to get appropriate value of data packet according to id of message.
  */
 struct OpenthermData {
   uint8_t type;


### PR DESCRIPTION
# What does this implement/fix?

Renames the `OpenthermData` value accessors `f88()`/`u16()`/`s16()` (and their setter overloads) to `get_f88()`/`set_f88()` etc.

The Realtek SDKs used by the rtl87xx LibreTiny platforms define `u16`, `s16` and friends as bare object macros in `basic_types.h` (`#define u16 uint16_t`), so any translation unit that sees those SDK headers rewrites `void s16(int16_t value)` into `void int16_t(int16_t value)`. This breaks opentherm's headers in the synthetic all-headers file used by the upcoming LibreTiny clang-tidy scans (#17491), which currently has to exclude the component with `--exclude-header components/opentherm/`. With the rename that exclusion can be dropped and opentherm's headers get scanned under the LibreTiny environments like everything else — verified locally: the all-headers TU passes under both `rtl87xxb-tidy` and `rtl87xxc-tidy` with opentherm included.

The rename is fully internal: the schema vocabulary (`message_data="u16"` etc.) and the generated `parse_*`/`write_*` hooks are unchanged; only the three struct methods and their call sites in `opentherm.cpp`/`hub.cpp` are touched. Compile-tested (`opentherm` on esp32-idf).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Internal rename only, no configuration impact
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).