### PR TITLE
[midea] Restrict to platforms where MideaUART actually builds

### DIFF
--- a/esphome/components/midea/ac_adapter.cpp
+++ b/esphome/components/midea/ac_adapter.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !defined(USE_RP2) && !defined(USE_LIBRETINY)
 
 #include "esphome/core/log.h"
 #include "ac_adapter.h"

--- a/esphome/components/midea/ac_adapter.h
+++ b/esphome/components/midea/ac_adapter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !defined(USE_RP2) && !defined(USE_LIBRETINY)
 
 // MideaUART
 #include <Appliance/AirConditioner/AirConditioner.h>

--- a/esphome/components/midea/ac_automations.h
+++ b/esphome/components/midea/ac_automations.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !defined(USE_RP2) && !defined(USE_LIBRETINY)
 
 #include "esphome/core/automation.h"
 #include "air_conditioner.h"

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !defined(USE_RP2) && !defined(USE_LIBRETINY)
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !defined(USE_RP2) && !defined(USE_LIBRETINY)
 
 // MideaUART
 #include <Appliance/AirConditioner/AirConditioner.h>

--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !defined(USE_RP2) && !defined(USE_LIBRETINY)
 
 // MideaUART
 #include <Appliance/ApplianceBase.h>

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -25,11 +25,8 @@ from esphome.const import (
     ICON_POWER,
     ICON_THERMOMETER,
     ICON_WATER_PERCENT,
-    PLATFORM_BK72XX,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
-    PLATFORM_LN882X,
-    PLATFORM_RTL87XX,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
     UNIT_PERCENT,
@@ -161,9 +158,6 @@ CONFIG_SCHEMA = cv.All(
         [
             PLATFORM_ESP32,
             PLATFORM_ESP8266,
-            PLATFORM_BK72XX,
-            PLATFORM_RTL87XX,
-            PLATFORM_LN882X,
         ]
     ),
 )

--- a/esphome/components/midea/ir_transmitter.h
+++ b/esphome/components/midea/ir_transmitter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ARDUINO) && !defined(USE_RP2)
+#if defined(USE_ARDUINO) && !defined(USE_RP2) && !defined(USE_LIBRETINY)
 #ifdef USE_REMOTE_TRANSMITTER
 #include "esphome/components/remote_base/midea_protocol.h"
 


### PR DESCRIPTION
# What does this implement/fix?

midea's config validation allows bk72xx/rtl87xx/ln882x, but the component has never been able to compile there: the bundled MideaUART library unconditionally falls back to `#include <ESP8266WiFi.h>` on every platform that is not `ARDUINO_ARCH_ESP32`, and no LibreTiny core ships that header. A LibreTiny user configuring midea today gets a validated config followed by a cryptic toolchain error:

```
MideaUART/src/Appliance/ApplianceBase.cpp:6:10: fatal error: ESP8266WiFi.h: No such file or directory
```

This trims `cv.only_on` to esp32/esp8266 (the platforms with test coverage, and the only ones the library supports) so the failure becomes a clear validation error, and extends the existing `!defined(USE_RP2)` source guards with `!defined(USE_LIBRETINY)` to match the platform list.

The guard change also lets the upcoming LibreTiny clang-tidy scans (#17491) drop `--exclude-header components/midea/`: MideaUART's `FrameData.h` forward-declares `class IPAddress;` at global scope, which is ambiguous against `arduino::IPAddress` (hoisted by a using-declaration) on ArduinoCore-API based cores. With midea's headers compiled out on LibreTiny, the all-headers TU passes under both `bk72xx-tidy` and `rtl87xxc-tidy` without the exclusion — verified locally.

Real LibreTiny support would need two small fixes in the MideaUART library (include `<IPAddress.h>` instead of the forward declaration, and fall back to `<WiFi.h>` rather than `<ESP8266WiFi.h>` on non-ESP8266 platforms); if that happens upstream, this restriction can be lifted again with test coverage.

Compile-tested: midea on esp32-ard passes, and an rtl87xx config now fails validation with "This feature is only available on [esp32, esp8266]".

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Validation change only; existing esp32/esp8266 configs are unaffected
climate:
  - platform: midea
    name: AC
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).