### PR TITLE
[mlx90393] Compile out on BK72xx where the bundled library cannot build

### DIFF
--- a/esphome/components/mlx90393/sensor_mlx90393.cpp
+++ b/esphome/components/mlx90393/sensor_mlx90393.cpp
@@ -1,3 +1,5 @@
+#ifndef USE_LIBRETINY
+
 #include "sensor_mlx90393.h"
 #include "esphome/core/log.h"
 
@@ -270,3 +272,5 @@ void MLX90393Cls::verify_settings_timeout_(MLX90393Setting stage) {
 }
 
 }  // namespace esphome::mlx90393
+
+#endif  // USE_LIBRETINY

--- a/esphome/components/mlx90393/sensor_mlx90393.cpp
+++ b/esphome/components/mlx90393/sensor_mlx90393.cpp
@@ -1,4 +1,4 @@
-#ifndef USE_LIBRETINY
+#ifndef USE_BK72XX
 
 #include "sensor_mlx90393.h"
 #include "esphome/core/log.h"
@@ -273,4 +273,4 @@ void MLX90393Cls::verify_settings_timeout_(MLX90393Setting stage) {
 
 }  // namespace esphome::mlx90393
 
-#endif  // USE_LIBRETINY
+#endif  // USE_BK72XX

--- a/esphome/components/mlx90393/sensor_mlx90393.h
+++ b/esphome/components/mlx90393/sensor_mlx90393.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifndef USE_LIBRETINY
+
 #include <MLX90393.h>
 #include <MLX90393Hal.h>
 #include "esphome/components/i2c/i2c.h"
@@ -76,3 +78,5 @@ class MLX90393Cls final : public PollingComponent, public i2c::I2CDevice, public
 };
 
 }  // namespace esphome::mlx90393
+
+#endif  // USE_LIBRETINY

--- a/esphome/components/mlx90393/sensor_mlx90393.h
+++ b/esphome/components/mlx90393/sensor_mlx90393.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifndef USE_LIBRETINY
+#ifndef USE_BK72XX
 
 #include <MLX90393.h>
 #include <MLX90393Hal.h>
@@ -79,4 +79,4 @@ class MLX90393Cls final : public PollingComponent, public i2c::I2CDevice, public
 
 }  // namespace esphome::mlx90393
 
-#endif  // USE_LIBRETINY
+#endif  // USE_BK72XX


### PR DESCRIPTION
# What does this implement/fix?

Wraps the mlx90393 sources in `#ifndef USE_BK72XX`.

The component includes the bundled arduino-MLX90393 library headers directly, and that library's Arduino HAL unconditionally does `#include <Wire.h>` whenever it detects an Arduino build. The beken-72xx LibreTiny core ships no Wire library (only Serial and WiFi), so the include is a hard "file not found" there. The realtek and ln882h cores do ship Wire, so the guard is scoped to bk72xx only — if i2c support ever lands for the other LibreTiny families, this component needs no further changes.

No user-visible behavior changes: i2c is not configurable on any LibreTiny platform today (i2c pins require an input+output mode that LibreTiny's gpio validation does not accept), so no existing configuration can reach this code path.

This lets the upcoming LibreTiny clang-tidy scans (#17491) drop their last `--exclude-header` flag: with the guard in place, the all-headers TU passes under all four LibreTiny environments with no exclusions at all (verified locally on bk72xx, ln882h, rtl87xxb and rtl87xxc, the latter three with mlx90393 included in the TU).

Compile-tested: mlx90393 on esp32-idf passes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Internal guard only, no configuration impact
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).