### PR TITLE
[runtime_image] Prevent integer overflow in image buffer size calculation

### DIFF
--- a/esphome/components/runtime_image/image_decoder.cpp
+++ b/esphome/components/runtime_image/image_decoder.cpp
@@ -10,12 +10,16 @@ static const char *const TAG = "image_decoder";
 
 bool ImageDecoder::set_size(int width, int height) {
   bool success = this->image_->resize(width, height) > 0;
+  this->size_valid_ = success;
   this->x_scale_ = static_cast<double>(this->image_->get_buffer_width()) / width;
   this->y_scale_ = static_cast<double>(this->image_->get_buffer_height()) / height;
   return success;
 }
 
 void ImageDecoder::draw(int x, int y, int w, int h, const Color &color) {
+  if (!this->size_valid_) {
+    return;
+  }
   auto width = std::min(this->image_->get_buffer_width(), static_cast<int>(std::ceil((x + w) * this->x_scale_)));
   auto height = std::min(this->image_->get_buffer_height(), static_cast<int>(std::ceil((y + h) * this->y_scale_)));
   for (int i = x * this->x_scale_; i < width; i++) {

--- a/esphome/components/runtime_image/image_decoder.h
+++ b/esphome/components/runtime_image/image_decoder.h
@@ -108,6 +108,7 @@ class ImageDecoder {
   size_t decoded_bytes_ = 0;  // Bytes processed so far
   double x_scale_ = 1.0;
   double y_scale_ = 1.0;
+  bool size_valid_ = true;  // Last set_size() result; draw() no-ops while false
 };
 
 }  // namespace esphome::runtime_image

--- a/esphome/components/runtime_image/png_decoder.cpp
+++ b/esphome/components/runtime_image/png_decoder.cpp
@@ -20,7 +20,7 @@ namespace esphome::runtime_image {
  */
 static void init_callback(pngle_t *pngle, uint32_t w, uint32_t h) {
   PngDecoder *decoder = (PngDecoder *) pngle_get_user_data(pngle);
-  decoder->set_size_valid(decoder->set_size(w, h));
+  decoder->set_size(w, h);
 }
 
 /**
@@ -36,9 +36,6 @@ static void init_callback(pngle_t *pngle, uint32_t w, uint32_t h) {
  */
 static void draw_callback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, const uint8_t rgba[4]) {
   PngDecoder *decoder = (PngDecoder *) pngle_get_user_data(pngle);
-  if (!decoder->size_valid()) {
-    return;
-  }
   Color color(rgba[0], rgba[1], rgba[2], rgba[3]);
   decoder->draw(x, y, w, h, color);
 

--- a/esphome/components/runtime_image/png_decoder.cpp
+++ b/esphome/components/runtime_image/png_decoder.cpp
@@ -20,7 +20,7 @@ namespace esphome::runtime_image {
  */
 static void init_callback(pngle_t *pngle, uint32_t w, uint32_t h) {
   PngDecoder *decoder = (PngDecoder *) pngle_get_user_data(pngle);
-  decoder->set_size(w, h);
+  decoder->set_size_valid(decoder->set_size(w, h));
 }
 
 /**
@@ -36,6 +36,9 @@ static void init_callback(pngle_t *pngle, uint32_t w, uint32_t h) {
  */
 static void draw_callback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, const uint8_t rgba[4]) {
   PngDecoder *decoder = (PngDecoder *) pngle_get_user_data(pngle);
+  if (!decoder->size_valid()) {
+    return;
+  }
   Color color(rgba[0], rgba[1], rgba[2], rgba[3]);
   decoder->draw(x, y, w, h, color);
 
@@ -96,6 +99,8 @@ int HOT PngDecoder::decode(uint8_t *buffer, size_t size) {
   if (fed < 0) {
     ESP_LOGE(TAG, "Error decoding image: %s", pngle_error(this->pngle_));
     return DECODE_ERROR_INTERNAL_DECODER_ERROR;
+  } else if (!this->size_valid_) {
+    return DECODE_ERROR_OUT_OF_MEMORY;
   } else {
     this->decoded_bytes_ += fed;
   }

--- a/esphome/components/runtime_image/png_decoder.h
+++ b/esphome/components/runtime_image/png_decoder.h
@@ -28,9 +28,13 @@ class PngDecoder : public ImageDecoder {
   void increment_pixels_decoded(uint32_t count) { this->pixels_decoded_ += count; }
   uint32_t get_pixels_decoded() const { return this->pixels_decoded_; }
 
+  void set_size_valid(bool valid) { this->size_valid_ = valid; }
+  bool size_valid() const { return this->size_valid_; }
+
  protected:
   pngle_t *pngle_{nullptr};
   uint32_t pixels_decoded_{0};
+  bool size_valid_{true};
 };
 
 }  // namespace esphome::runtime_image

--- a/esphome/components/runtime_image/png_decoder.h
+++ b/esphome/components/runtime_image/png_decoder.h
@@ -28,13 +28,9 @@ class PngDecoder : public ImageDecoder {
   void increment_pixels_decoded(uint32_t count) { this->pixels_decoded_ += count; }
   uint32_t get_pixels_decoded() const { return this->pixels_decoded_; }
 
-  void set_size_valid(bool valid) { this->size_valid_ = valid; }
-  bool size_valid() const { return this->size_valid_; }
-
  protected:
   pngle_t *pngle_{nullptr};
   uint32_t pixels_decoded_{0};
-  bool size_valid_{true};
 };
 
 }  // namespace esphome::runtime_image

--- a/esphome/components/runtime_image/runtime_image.cpp
+++ b/esphome/components/runtime_image/runtime_image.cpp
@@ -19,6 +19,9 @@ namespace esphome::runtime_image {
 
 static const char *const TAG = "runtime_image";
 
+// Widest supported format is 4 bytes/pixel, so 32767 * 32767 * 4 still fits a 32-bit size_t
+static constexpr int MAX_IMAGE_DIMENSION = 32767;
+
 inline bool is_color_on(const Color &color) {
   // This produces the most accurate monochrome conversion, but is slightly slower.
   //  return (0.2125 * color.r + 0.7154 * color.g + 0.0721 * color.b) > 127;
@@ -292,30 +295,15 @@ size_t RuntimeImage::resize_buffer_(int width, int height) {
 }
 
 size_t RuntimeImage::get_buffer_size_(int width, int height) const {
-  // Image dimensions come from a remote header; reject anything that overflows size_t
-  if (width <= 0 || height <= 0) {
+  // Dimensions come from a remote image header; reject absurd values so the size math cannot overflow
+  if (width <= 0 || height <= 0 || width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION) {
     return 0;
   }
-  size_t w = width;
-  size_t h = height;
-  size_t size;
   if (this->get_type() == image::IMAGE_TYPE_RGB565 && this->transparency_ == image::TRANSPARENCY_ALPHA_CHANNEL) {
     // Add extra alpha channel for RGB565 with alpha
-    if (__builtin_mul_overflow(w, h, &size) || __builtin_mul_overflow(size, static_cast<size_t>(3), &size)) {
-      return 0;
-    }
-    return size;
+    return static_cast<size_t>(width) * height * 3;
   }
-  // (get_bpp() * width + 7) / 8 * height
-  size_t bits;
-  if (__builtin_mul_overflow(static_cast<size_t>(this->get_bpp()), w, &bits)) {
-    return 0;
-  }
-  size_t row_bytes = bits / 8u + (bits % 8u != 0u ? 1u : 0u);
-  if (__builtin_mul_overflow(row_bytes, h, &size)) {
-    return 0;
-  }
-  return size;
+  return (static_cast<size_t>(this->get_bpp()) * width + 7u) / 8u * height;
 }
 
 int RuntimeImage::get_position_(int x, int y) const { return (x + y * this->buffer_width_) * this->get_bpp() / 8; }

--- a/esphome/components/runtime_image/runtime_image.cpp
+++ b/esphome/components/runtime_image/runtime_image.cpp
@@ -3,7 +3,9 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
+#include <limits>
 
 #ifdef USE_RUNTIME_IMAGE_BMP
 #include "bmp_decoder.h"
@@ -21,6 +23,10 @@ static const char *const TAG = "runtime_image";
 
 // Widest supported format is 4 bytes/pixel, so 32767 * 32767 * 4 still fits a 32-bit size_t
 static constexpr int MAX_IMAGE_DIMENSION = 32767;
+static constexpr int MAX_IMAGE_BPP = 32;
+static_assert((static_cast<uint64_t>(MAX_IMAGE_BPP) * MAX_IMAGE_DIMENSION + 7) / 8 * MAX_IMAGE_DIMENSION <=
+                  std::numeric_limits<size_t>::max(),
+              "MAX_IMAGE_DIMENSION must keep the worst-case buffer size within size_t");
 
 inline bool is_color_on(const Color &color) {
   // This produces the most accurate monochrome conversion, but is slightly slower.

--- a/esphome/components/runtime_image/runtime_image.cpp
+++ b/esphome/components/runtime_image/runtime_image.cpp
@@ -3,7 +3,6 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include <algorithm>
-#include <cstdint>
 #include <cstring>
 
 #ifdef USE_RUNTIME_IMAGE_BMP
@@ -293,23 +292,30 @@ size_t RuntimeImage::resize_buffer_(int width, int height) {
 }
 
 size_t RuntimeImage::get_buffer_size_(int width, int height) const {
+  // Image dimensions come from a remote header; reject anything that overflows size_t
   if (width <= 0 || height <= 0) {
     return 0;
   }
-  // 64-bit math: image dimensions come from a remote header and must not wrap size_t
-  uint64_t size;
+  size_t w = width;
+  size_t h = height;
+  size_t size;
   if (this->get_type() == image::IMAGE_TYPE_RGB565 && this->transparency_ == image::TRANSPARENCY_ALPHA_CHANNEL) {
     // Add extra alpha channel for RGB565 with alpha
-    size = static_cast<uint64_t>(width) * height * 3;
-  } else {
-    size = (static_cast<uint64_t>(this->get_bpp()) * width + 7u) / 8u * height;
+    if (__builtin_mul_overflow(w, h, &size) || __builtin_mul_overflow(size, static_cast<size_t>(3), &size)) {
+      return 0;
+    }
+    return size;
   }
-#if SIZE_MAX < UINT64_MAX
-  if (size > SIZE_MAX) {
+  // (get_bpp() * width + 7) / 8 * height
+  size_t bits;
+  if (__builtin_mul_overflow(static_cast<size_t>(this->get_bpp()), w, &bits)) {
     return 0;
   }
-#endif
-  return static_cast<size_t>(size);
+  size_t row_bytes = bits / 8u + (bits % 8u != 0u ? 1u : 0u);
+  if (__builtin_mul_overflow(row_bytes, h, &size)) {
+    return 0;
+  }
+  return size;
 }
 
 int RuntimeImage::get_position_(int x, int y) const { return (x + y * this->buffer_width_) * this->get_bpp() / 8; }

--- a/esphome/components/runtime_image/runtime_image.cpp
+++ b/esphome/components/runtime_image/runtime_image.cpp
@@ -3,6 +3,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 
 #ifdef USE_RUNTIME_IMAGE_BMP
@@ -257,6 +258,11 @@ void RuntimeImage::release_buffer_() {
 size_t RuntimeImage::resize_buffer_(int width, int height) {
   size_t new_size = this->get_buffer_size_(width, height);
 
+  if (new_size == 0) {
+    ESP_LOGE(TAG, "Refusing to allocate buffer for invalid image dimensions %dx%d", width, height);
+    return 0;
+  }
+
   if (this->buffer_ && this->buffer_width_ == width && this->buffer_height_ == height) {
     // Buffer already allocated with correct size
     return new_size;
@@ -287,11 +293,23 @@ size_t RuntimeImage::resize_buffer_(int width, int height) {
 }
 
 size_t RuntimeImage::get_buffer_size_(int width, int height) const {
+  if (width <= 0 || height <= 0) {
+    return 0;
+  }
+  // 64-bit math: image dimensions come from a remote header and must not wrap size_t
+  uint64_t size;
   if (this->get_type() == image::IMAGE_TYPE_RGB565 && this->transparency_ == image::TRANSPARENCY_ALPHA_CHANNEL) {
     // Add extra alpha channel for RGB565 with alpha
-    return width * height * 3;
+    size = static_cast<uint64_t>(width) * height * 3;
+  } else {
+    size = (static_cast<uint64_t>(this->get_bpp()) * width + 7u) / 8u * height;
   }
-  return (this->get_bpp() * width + 7u) / 8u * height;
+#if SIZE_MAX < UINT64_MAX
+  if (size > SIZE_MAX) {
+    return 0;
+  }
+#endif
+  return static_cast<size_t>(size);
 }
 
 int RuntimeImage::get_position_(int x, int y) const { return (x + y * this->buffer_width_) * this->get_bpp() / 8; }


### PR DESCRIPTION
# What does this implement/fix?

`RuntimeImage::get_buffer_size_()` computed the image buffer size with `int`/`size_t` arithmetic:

```cpp
return (this->get_bpp() * width + 7u) / 8u * height;
```

The width and height come from the decoded image header (`online_image` fetches the image from a remote URL, so these are attacker-influenced values). On 32-bit targets a large declared size overflows: for example a 4096 × 524289 RGB565 image should need ~4 GB, but the calculation wraps to a small value (8192 bytes in that case). The undersized buffer is then allocated while the image object keeps the original large width/height, and the per-pixel bounds check in `draw_pixel()` only compares against those stored dimensions — not the real allocation — so decoding writes past the end of the buffer.

This rejects absurd dimensions up front. The widest supported format is 4 bytes/pixel, so bounding each dimension to 32767 keeps `width * height * 4` within a 32-bit `size_t` (32767 × 32767 × 4 = 4,294,705,156 < 2^32), which makes the existing size math safe with no wider types or compiler builtins. `resize_buffer_()` now treats a returned size of 0 as "refuse to allocate". A 32767 × 32767 image is ~4 billion pixels — far beyond anything an ESP32 could hold — so the cap has no effect on real images; oversized headers now fail cleanly instead of corrupting the heap.

Verified with a 32-bit `size_t` simulation: the wrapping cases (4096×524289, 32768×1) return 0/rejected, the boundary case (32767² × 4) stays within `size_t`, and normal images (320×240 RGB565 → 153600 bytes, 8×8 binary → 8 bytes) compute unchanged. Compile-tested with `online_image` on esp32-idf.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
online_image:
  - url: "http://example.com/image.png"
    format: PNG
    id: my_image
    type: RGB565
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).