### PR TITLE
[bluetooth_proxy] Bound GATT characteristic/descriptor enumeration to allocated size

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -245,7 +245,9 @@ void BluetoothConnection::send_service_for_discovery_() {
       service_resp.characteristics.init(total_char_count);
       uint16_t char_offset = 0;
       esp_gattc_char_elem_t char_result;
-      while (true) {  // characteristics
+      // Bound by total_char_count: the vector is sized for it, and a malicious peripheral
+      // can make enumeration return more entries than the count query reported
+      while (char_offset < total_char_count) {  // characteristics
         uint16_t char_count = 1;
         esp_gatt_status_t char_status =
             esp_ble_gattc_get_all_char(this->gattc_if_, this->conn_id_, service_result.start_handle,
@@ -287,7 +289,7 @@ void BluetoothConnection::send_service_for_discovery_() {
         characteristic_resp.descriptors.init(total_desc_count);
         uint16_t desc_offset = 0;
         esp_gattc_descr_elem_t desc_result;
-        while (true) {  // descriptors
+        while (desc_offset < total_desc_count) {  // descriptors
           uint16_t desc_count = 1;
           esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
               this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);


### PR DESCRIPTION
# What does this implement/fix?

During GATT discovery the proxy sizes two `FixedVector`s from a count query and then fills them from a separate enumeration loop:

```cpp
service_resp.characteristics.init(total_char_count);   // esp_ble_gattc_get_attr_count
while (true) {
  ... esp_ble_gattc_get_all_char(...);                 // separate enumeration
  service_resp.characteristics.emplace_back();          // unchecked append
}
```

`FixedVector::init(n)` allocates exactly `n` slots and `emplace_back()` is documented as unchecked (the caller must ensure `size < capacity`). The loops only stop on an error/`NOT_FOUND`/zero-count return, never when the vector reaches the count it was sized for. If the enumeration returns more records than the count query reported, `emplace_back()` constructs objects past the end of the allocation.

The two ESP-IDF Bluedroid queries can disagree: `esp_ble_gattc_get_attr_count()` counts descriptors on the first cached characteristic matching a value handle, while the per-offset `esp_ble_gattc_get_all_descr()` enumeration walks every matching characteristic. A malicious peripheral that exposes two characteristics sharing one value handle makes the enumeration return more descriptors than the count, overflowing the vector with peripheral-controlled handle/UUID bytes into adjacent heap.

This bounds both loops (`characteristics` and `descriptors`) by the count the vector was allocated for, so the enumeration can never append past the `FixedVector` capacity. Legitimate peripherals are unaffected — the counts match, and the loop now also skips one redundant SDK call after the last record. The proxy connects only to an address supplied by an authenticated API controller, so the realistic impact is a nearby/malicious peripheral crashing the device during discovery; this closes the out-of-bounds write regardless.

Compile-tested on esp32-s3-idf, esp32-c6-idf, esp32-p4-idf.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).