### PR TITLE
[esp32_ble_server] Validate descriptor write length before copying

### DIFF
--- a/esphome/components/esp32_ble_server/ble_descriptor.cpp
+++ b/esphome/components/esp32_ble_server/ble_descriptor.cpp
@@ -77,6 +77,10 @@ void BLEDescriptor::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_
     case ESP_GATTS_WRITE_EVT: {
       if (this->handle_ != param->write.handle)
         break;
+      if (param->write.len > this->value_.attr_max_len) {
+        ESP_LOGE(TAG, "Size %d too large, must be no bigger than %d", param->write.len, this->value_.attr_max_len);
+        break;
+      }
       this->value_.attr_len = param->write.len;
       memcpy(this->value_.attr_value, param->write.value, param->write.len);
       if (this->on_write_callback_) {


### PR DESCRIPTION
# What does this implement/fix?

The descriptor write handler copied `param->write.len` bytes from a BLE write event into the fixed `attr_value` buffer with no bounds check:

```cpp
case ESP_GATTS_WRITE_EVT: {
  if (this->handle_ != param->write.handle)
    break;
  this->value_.attr_len = param->write.len;
  memcpy(this->value_.attr_value, param->write.value, param->write.len);   // unchecked
```

`attr_value` is allocated once at construction to exactly `attr_max_len` bytes. The firmware-facing setter `set_value_impl_()` in the same file already treats `attr_max_len` as the authority and rejects oversized input, but the write-event path did not apply the same bound. If a connected central writes more than `attr_max_len` bytes to a writable descriptor, the `memcpy` writes past the heap allocation with attacker-controlled contents.

A writable custom descriptor is reachable through ordinary configuration (a descriptor with a manual small `max_length`, or one auto-sized from a short initial value, defaults to read+write). The BLE stack's own length check only protects Bluedroid's separate attribute copy — it still delivers the write event to the application with the original length — so ESPHome must enforce the bound on its own buffer.

This adds the same check `set_value_impl_()` uses: reject the write and log if `param->write.len > attr_max_len`, before the copy. No behavior change for valid writes.

Compile-tested on esp32-idf, esp32-c3-idf, esp32-p4-idf.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32_ble_server:
  services:
    - uuid: 0fd1a000-1234-2345-3456-456789abcdef
      characteristics:
        - uuid: 0fd1a001-1234-2345-3456-456789abcdef
          descriptors:
            - uuid: 0fd1a002-1234-2345-3456-456789abcdef
              value: [0x00, 0x00]
              write: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).