### PR TITLE
[http_request] Fix use-after-return of header collection state in IDF backend

### DIFF
--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -19,11 +19,6 @@ namespace esphome::http_request {
 static const char *const TAG = "http_request.idf";
 static constexpr uint32_t ERROR_DURATION_MS = 1000;
 
-struct UserData {
-  const std::vector<std::string> &lower_case_collect_headers;
-  std::vector<Header> &response_headers;
-};
-
 void HttpRequestIDF::dump_config() {
   HttpRequestComponent::dump_config();
   ESP_LOGCONFIG(TAG,
@@ -34,15 +29,15 @@ void HttpRequestIDF::dump_config() {
 }
 
 esp_err_t HttpRequestIDF::http_event_handler(esp_http_client_event_t *evt) {
-  UserData *user_data = (UserData *) evt->user_data;
+  auto *container = (HttpContainerIDF *) evt->user_data;
 
   switch (evt->event_id) {
     case HTTP_EVENT_ON_HEADER: {
       const std::string header_name = str_lower_case(evt->header_key);  // NOLINT
-      if (should_collect_header(user_data->lower_case_collect_headers, header_name)) {
+      if (should_collect_header(container->collect_headers_, header_name)) {
         const std::string header_value = evt->header_value;
         ESP_LOGD(TAG, "Received response header, name: %s, value: %s", header_name.c_str(), header_value.c_str());
-        user_data->response_headers.push_back({header_name, header_value});
+        container->response_headers_.push_back({header_name, header_value});
       }
       break;
     }
@@ -124,8 +119,8 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
 
   container->set_secure(secure);
 
-  auto user_data = UserData{lower_case_collect_headers, container->response_headers_};
-  esp_http_client_set_user_data(client, static_cast<void *>(&user_data));
+  container->collect_headers_ = lower_case_collect_headers;
+  esp_http_client_set_user_data(client, static_cast<void *>(container.get()));
 
   for (const auto &header : request_headers) {
     esp_http_client_set_header(client, header.name.c_str(), header.value.c_str());

--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -24,8 +24,7 @@ class HttpContainerIDF : public HttpContainer {
  protected:
   friend class HttpRequestIDF;
   esp_http_client_handle_t client_;
-  // Owned copy: the response header event handler runs during read(), after perform() has
-  // returned, so it cannot reference perform()'s (often temporary) collect-headers argument
+  // Owned copy (not a reference): must outlive perform() for the response-header event handler
   std::vector<std::string> collect_headers_;
 };
 

--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -24,6 +24,9 @@ class HttpContainerIDF : public HttpContainer {
  protected:
   friend class HttpRequestIDF;
   esp_http_client_handle_t client_;
+  // Owned copy: the response header event handler runs during read(), after perform() has
+  // returned, so it cannot reference perform()'s (often temporary) collect-headers argument
+  std::vector<std::string> collect_headers_;
 };
 
 class HttpRequestIDF final : public HttpRequestComponent {


### PR DESCRIPTION
# What does this implement/fix?

The ESP-IDF backend registered a stack-local object as the HTTP client's `user_data`:

```cpp
auto user_data = UserData{lower_case_collect_headers, container->response_headers_};
esp_http_client_set_user_data(client, static_cast<void *>(&user_data));
```

`user_data` lives on `perform()`'s stack, but the returned `HttpContainerIDF` keeps the ESP-IDF client alive after `perform()` returns. Later `HttpContainerIDF::read()` calls `esp_http_client_read()`, which can dispatch `HTTP_EVENT_ON_HEADER` events — for example a chunked response with trailing headers, which arrive after the body during `read()`. The event handler then dereferences `evt->user_data`, which points at the stack frame `perform()` already unwound. It also captured a reference to `lower_case_collect_headers`, which is frequently a temporary (`start()` builds a local lowercased vector, or passes `{}`), so that reference dangles too.

This moves the header-collection state into `HttpContainerIDF` so it shares the container's lifetime:

- the container now owns a copy of the collect-headers list (`collect_headers_`);
- the response header vector is already a container member (`response_headers_`);
- the container itself is passed as `user_data`, and it stays valid for as long as the client (which it owns) can dispatch events.

The `UserData` struct is removed. Behavior is unchanged for valid responses; the header handler now reads/writes container-owned state instead of dangling stack references. A server-controlled response can no longer trigger a read or write through a freed stack frame.

Compile-tested with `http_request` on esp32-idf.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
http_request:
  id: my_http

# Later, a request that collects response headers exercises the handler:
# my_http->get(url, {}, {"content-type"});
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).