### PR TITLE
[nextion] Fix RP2040 clang-tidy failure from TFT upload guard mismatch

### DIFF
--- a/esphome/components/nextion/__init__.py
+++ b/esphome/components/nextion/__init__.py
@@ -19,7 +19,6 @@ FILTER_SOURCE_FILES = filter_source_files_from_platform(
         },
         "nextion_upload_arduino.cpp": {
             PlatformFramework.ESP8266_ARDUINO,
-            PlatformFramework.RP2_ARDUINO,
             PlatformFramework.BK72XX_ARDUINO,
             PlatformFramework.RTL87XX_ARDUINO,
             PlatformFramework.LN882X_ARDUINO,

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -4,7 +4,17 @@ from esphome import automation
 import esphome.codegen as cg
 from esphome.components import display, esp32, uart
 import esphome.config_validation as cv
-from esphome.const import CONF_BRIGHTNESS, CONF_ID, CONF_LAMBDA, CONF_ON_TOUCH
+from esphome.const import (
+    CONF_BRIGHTNESS,
+    CONF_ID,
+    CONF_LAMBDA,
+    CONF_ON_TOUCH,
+    PLATFORM_BK72XX,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_LN882X,
+    PLATFORM_RTL87XX,
+)
 from esphome.core import CORE, TimePeriod
 
 from . import (  # noqa: F401  pylint: disable=unused-import
@@ -135,7 +145,20 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_TFT_UPLOAD_WATCHDOG_TIMEOUT
             ): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_TFT_URL): cv.url,
+            # TFT upload needs an HTTP client and runtime UART reconfiguration,
+            # neither of which is implemented for the RP2 or host platforms.
+            cv.Optional(CONF_TFT_URL): cv.All(
+                cv.url,
+                cv.only_on(
+                    [
+                        PLATFORM_ESP32,
+                        PLATFORM_ESP8266,
+                        PLATFORM_BK72XX,
+                        PLATFORM_RTL87XX,
+                        PLATFORM_LN882X,
+                    ]
+                ),
+            ),
             cv.Optional(CONF_TOUCH_SLEEP_TIMEOUT): cv.Any(
                 0, cv.int_range(min=3, max=65535)
             ),

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -1566,7 +1566,7 @@ class Nextion final : public NextionBase, public PollingComponent, public uart::
    * @return position of last byte transferred, -1 for failure.
    */
   int upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &range_start);
-#elif defined(USE_ARDUINO)
+#elif defined(USE_ESP8266) || defined(USE_LIBRETINY)
   /**
    * will request chunk_size chunks from the web server
    * and send each to the nextion
@@ -1575,7 +1575,7 @@ class Nextion final : public NextionBase, public PollingComponent, public uart::
    * @return position of last byte transferred, -1 for failure.
    */
   int upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start);
-#endif  // USE_ESP32 vs USE_ARDUINO
+#endif  // USE_ESP32 vs USE_ESP8266/USE_LIBRETINY
 
   /**
    * Ends the upload process, restart Nextion and, if successful,

--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -1,7 +1,7 @@
 #include "nextion.h"
 
 #ifdef USE_NEXTION_TFT_UPLOAD
-#ifndef USE_ESP32
+#if defined(USE_ESP8266) || defined(USE_LIBRETINY)
 
 #include <cinttypes>
 #include "esphome/components/network/util.h"
@@ -378,5 +378,5 @@ WiFiClient *Nextion::get_wifi_client_() {
 
 }  // namespace esphome::nextion
 
-#endif  // NOT USE_ESP32
+#endif  // USE_ESP8266 || USE_LIBRETINY
 #endif  // USE_NEXTION_TFT_UPLOAD


### PR DESCRIPTION
# What does this implement/fix?

Fixes a latent guard mismatch in nextion's TFT upload code that makes clang-tidy for RP2 fail on any PR whose scan set includes nextion (for example, anything touching `uart`, which nextion depends on):

```
esphome/components/nextion/nextion.h:1577:25: error: unknown type name 'HTTPClient' [clang-diagnostic-error]
```

The HTTP client includes at the top of `nextion.h` are guarded per platform — `USE_ESP32` gets `esp_http_client.h`, `USE_ESP8266` gets `ESP8266HTTPClient.h`, `USE_LIBRETINY` gets `HTTPClient.h` — but the `upload_by_chunks_()` declaration further down was still guarded by the generic `#elif defined(USE_ARDUINO)`. RP2040 defines `USE_ARDUINO` while matching none of the include branches, so the declaration references `HTTPClient` without any declaration of it in sight. The mismatch dates to the December ESP32 `esp_http_client` migration (0707f383a); it went unnoticed because the RP2 clang-tidy job only pulls `nextion.h` into its all-include check when nextion is in a PR's scan set. Reproduced on clean `dev` with `script/clang-tidy --environment rp2-tidy --grep USE_RP2 --all-headers --changed` after touching a nextion file.

Changes:

- Align the declaration guard with the include block: `#elif defined(USE_ESP8266) || defined(USE_LIBRETINY)`.
- Tighten `nextion_upload_arduino.cpp`'s `#ifndef USE_ESP32` to the same platform list, so the definition cannot compile on platforms that lack the declaration.
- Reject `tft_url` at config time on platforms where TFT upload cannot compile. Verified with a real `rpipicow` build that a config with `tft_url` fails on two independent counts -- the missing HTTP client above, and `nextion_upload.cpp` calling `UARTComponent::load_settings()`, which the RP2 UART component does not implement -- so this turns a C++ compile error into a clear validation error for a feature that has never been buildable there.

No behavior change on ESP8266 or LibreTiny — both define `USE_ARDUINO`, so the compiled code is identical before and after. TFT upload on RP2040 never compiled (no HTTP client header has ever been included for it), so nothing that worked is removed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Unblocks CI for esphome/esphome#11689

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (no user-facing change)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: nextion
    tft_url: http://esphome.io/default35.tft
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). (No new tests; the existing ESP8266 TFT-upload compile test covers the changed code, and the RP2 case is exercised by the clang-tidy job itself.)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

Verified locally: the RP2 clang-tidy repro passes with this change, and the existing `nextion` ESP8266 TFT-upload component test (`test.esp8266-ard.yaml`, which includes `common_tft_upload.yaml`) still compiles.
