### PR TITLE
[mt6701] Add MT6701 (MagnTek magnetic encoder) component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -364,6 +364,9 @@ esphome/components/mpl3115a2/* @kbickar
 esphome/components/mpu6886/* @fabaff
 esphome/components/ms8607/* @e28eta
 esphome/components/msa3xx/* @latonita
+esphome/components/mt6701/* @slimcdk
+esphome/components/mt6701_i2c/* @slimcdk
+esphome/components/mt6701_spi/* @slimcdk
 esphome/components/nau7802/* @cujomalainey
 esphome/components/network/* @esphome/core
 esphome/components/nextion/* @edwardtfn @senexcrenshaw

--- a/esphome/components/mt6701/__init__.py
+++ b/esphome/components/mt6701/__init__.py
@@ -1,0 +1,42 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+
+CODEOWNERS = ["@slimcdk"]
+
+mt6701_ns = cg.esphome_ns.namespace("mt6701")
+MT6701Component = mt6701_ns.class_("MT6701Component", cg.PollingComponent)
+
+CONF_MT6701_ID = "mt6701_id"
+
+# The configurable position registers (zero offset, analog start/stop) are
+# 12-bit values covering one full revolution.
+RESOLUTION_12BIT = 4096
+MAX_POSITION_12BIT = RESOLUTION_12BIT - 1
+ANGLE_TO_POSITION_12 = RESOLUTION_12BIT / 360
+
+
+def _angle_to_position_12(value):
+    value = cv.float_range(min=0, max=360)(
+        cv.float_with_unit("angle", "(°|deg)")(value)
+    )
+    # The register cannot represent a full 360°, so clamp the top of the range
+    # to the maximum count instead of letting it wrap back to 0.
+    return min(round(value * ANGLE_TO_POSITION_12), MAX_POSITION_12BIT)
+
+
+def _percent_to_position_12(value):
+    value = cv.percentage(value)
+    return min(round(value * RESOLUTION_12BIT), MAX_POSITION_12BIT)
+
+
+def position12(value):
+    """Validate a 12-bit position register value.
+
+    Accepts a raw integer count (0-4095), an angle such as ``45deg`` or ``90°``,
+    or a percentage of a full revolution such as ``25%``.
+    """
+    if isinstance(value, str) and value.endswith("%"):
+        return _percent_to_position_12(value)
+    if isinstance(value, str) and value.endswith(("°", "deg")):
+        return _angle_to_position_12(value)
+    return cv.int_range(min=0, max=MAX_POSITION_12BIT)(value)

--- a/esphome/components/mt6701/mt6701.cpp
+++ b/esphome/components/mt6701/mt6701.cpp
@@ -1,0 +1,47 @@
+#include "mt6701.h"
+#include "esphome/core/log.h"
+
+namespace esphome::mt6701 {
+
+uint8_t crc6_mt6701(uint32_t data18) {
+  uint8_t crc = 0;
+  for (int8_t i = 17; i >= 0; i--) {
+    uint8_t bit = ((data18 >> i) & 0x01) ^ ((crc >> 5) & 0x01);
+    crc = (crc << 1) & 0x3F;
+    if (bit != 0)
+      crc ^= 0x03;  // x^6 + x + 1 -> feedback taps at bit 1 and bit 0
+  }
+  return crc;
+}
+
+void MT6701Component::handle_read_error_() {
+  if (this->consecutive_errors_ >= MAX_CONSECUTIVE_ERRORS)
+    return;
+  this->consecutive_errors_++;
+  if (this->consecutive_errors_ == MAX_CONSECUTIVE_ERRORS) {
+    // The message overload logs once on the transition and is a no-op while
+    // the warning is already set.
+    this->status_set_warning("repeated read/CRC errors");
+  }
+}
+
+bool MT6701Component::read_encoder() {
+  // Leave the bus alone while a transport has suspended it (EEPROM burn).
+  if (this->suspend_sampling_)
+    return false;
+
+  uint16_t count;
+  if (!this->read_count(count)) {
+    this->handle_read_error_();
+    return false;
+  }
+  if (this->consecutive_errors_ != 0) {
+    this->consecutive_errors_ = 0;
+    this->status_clear_warning();
+  }
+
+  this->count_ = count;
+  return true;
+}
+
+}  // namespace esphome::mt6701

--- a/esphome/components/mt6701/mt6701.h
+++ b/esphome/components/mt6701/mt6701.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "esphome/core/component.h"
+
+namespace esphome::mt6701 {
+
+// The MT6701 is a 14-bit absolute magnetic angle encoder: one mechanical
+// revolution maps to 16384 counts.
+static const uint16_t COUNTS_PER_REV = 16384;
+static const float COUNTS_TO_DEGREES = 360.0f / COUNTS_PER_REV;
+
+// Number of consecutive read/CRC failures tolerated before the component
+// reports a warning status.
+static const uint8_t MAX_CONSECUTIVE_ERRORS = 5;
+
+/// Magnetic field strength reported by the encoder (SSI interface only).
+enum class MT6701FieldStatus : uint8_t {
+  NORMAL = 0,
+  TOO_STRONG = 1,
+  TOO_WEAK = 2,
+};
+
+/// Compute the 6-bit CRC used by the MT6701 SSI frame.
+///
+/// The CRC covers the 18 most significant bits of the frame (the 14-bit angle
+/// D[13:0] followed by the 4-bit magnetic-field status Mg[3:0]). The polynomial
+/// is x^6 + x + 1, shifted in most-significant-bit first, starting from zero.
+/// ESPHome's core only ships crc8/crc16 helpers, so this 6-bit variant is local.
+uint8_t crc6_mt6701(uint32_t data18);
+
+/// Bus-independent core of the MT6701 driver.
+///
+/// The concrete I2C and SSI/SPI components provide the actual transport by
+/// implementing read_count(). The hub polls the encoder itself on its
+/// update_interval (which also refreshes the SSI status entities), and the
+/// sensor platform triggers an extra read whenever it polls so published angles
+/// are always fresh. Derived quantities such as multi-turn position or
+/// rotational speed are intentionally left to the user to compute in YAML (see
+/// the component's README), keeping the component itself a minimal driver.
+class MT6701Component : public PollingComponent {
+ public:
+  float get_setup_priority() const override { return setup_priority::DATA; }
+  void update() override { this->read_encoder(); }
+
+  /// Read a fresh angle from the bus. Returns false on a bus or CRC error (the
+  /// cached value is left unchanged) or while the bus is suspended (EEPROM
+  /// programming in flight).
+  bool read_encoder();
+
+  /// Most recent absolute angle as a raw count in the range [0, 16383].
+  uint16_t get_count() const { return this->count_; }
+  /// Most recent absolute shaft angle in degrees, in the range [0, 360).
+  float get_angle_degrees() const { return this->count_ * COUNTS_TO_DEGREES; }
+
+ protected:
+  /// Read the current 14-bit count from the bus into count.
+  /// Returns false on a bus or CRC error, in which case the sample is dropped.
+  virtual bool read_count(uint16_t &count) = 0;
+
+  /// Account for a dropped sample and raise a warning after repeated failures.
+  void handle_read_error_();
+
+  uint16_t count_{0};
+  uint8_t consecutive_errors_{0};
+  // Gates all bus access; set by transports while the bus must stay untouched
+  // (the I2C hub uses it during the 600 ms EEPROM programming window).
+  bool suspend_sampling_{false};
+};
+
+}  // namespace esphome::mt6701

--- a/esphome/components/mt6701/sensor/__init__.py
+++ b/esphome/components/mt6701/sensor/__init__.py
@@ -1,0 +1,51 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    ICON_ROTATE_RIGHT,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_DEGREES,
+    UNIT_EMPTY,
+)
+
+from .. import CONF_MT6701_ID, MT6701Component, mt6701_ns
+
+AUTO_LOAD = ["mt6701"]
+
+MT6701Sensor = mt6701_ns.class_("MT6701Sensor", sensor.Sensor, cg.PollingComponent)
+
+CONF_RAW_COUNT = "raw_count"
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(
+        MT6701Sensor,
+        unit_of_measurement=UNIT_DEGREES,
+        accuracy_decimals=2,
+        icon=ICON_ROTATE_RIGHT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    )
+    .extend(
+        {
+            cv.GenerateID(CONF_MT6701_ID): cv.use_id(MT6701Component),
+            cv.Optional(CONF_RAW_COUNT): sensor.sensor_schema(
+                unit_of_measurement=UNIT_EMPTY,
+                accuracy_decimals=0,
+                icon=ICON_ROTATE_RIGHT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_parented(var, config[CONF_MT6701_ID])
+    await cg.register_component(var, config)
+    await sensor.register_sensor(var, config)
+
+    if raw_count_config := config.get(CONF_RAW_COUNT):
+        sens = await sensor.new_sensor(raw_count_config)
+        cg.add(var.set_raw_count_sensor(sens))

--- a/esphome/components/mt6701/sensor/mt6701_sensor.cpp
+++ b/esphome/components/mt6701/sensor/mt6701_sensor.cpp
@@ -1,0 +1,29 @@
+#include "mt6701_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome::mt6701 {
+
+static const char *const TAG = "mt6701.sensor";
+
+void MT6701Sensor::update() {
+  // A hub that failed setup must not be polled: on SSI, bus noise can pass the
+  // 6-bit CRC and would publish garbage from a dead device.
+  if (this->parent_->is_failed())
+    return;
+  // Trigger a fresh read; skip publishing when it failed so we never emit a
+  // stale or garbage value.
+  if (!this->parent_->read_encoder())
+    return;
+
+  this->publish_state(this->parent_->get_angle_degrees());
+  if (this->raw_count_sensor_ != nullptr)
+    this->raw_count_sensor_->publish_state(this->parent_->get_count());
+}
+
+void MT6701Sensor::dump_config() {
+  LOG_SENSOR("", "MT6701 Sensor", this);
+  LOG_UPDATE_INTERVAL(this);
+  LOG_SENSOR("  ", "Raw Count", this->raw_count_sensor_);
+}
+
+}  // namespace esphome::mt6701

--- a/esphome/components/mt6701/sensor/mt6701_sensor.h
+++ b/esphome/components/mt6701/sensor/mt6701_sensor.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/mt6701/mt6701.h"
+
+namespace esphome::mt6701 {
+
+/// Publishes readings from an MT6701 hub (I2C or SSI/SPI) as ESPHome sensors.
+///
+/// The main entity is the absolute shaft angle in degrees; the raw count is an
+/// optional sub-sensor. Derived values such as multi-turn position or speed are
+/// left to the user to compute in YAML (see the README examples).
+class MT6701Sensor final : public PollingComponent, public Parented<MT6701Component>, public sensor::Sensor {
+  SUB_SENSOR(raw_count)
+
+ public:
+  void update() override;
+  void dump_config() override;
+};
+
+}  // namespace esphome::mt6701

--- a/esphome/components/mt6701_i2c/__init__.py
+++ b/esphome/components/mt6701_i2c/__init__.py
@@ -1,0 +1,181 @@
+from esphome import automation
+import esphome.codegen as cg
+from esphome.components import i2c
+import esphome.config_validation as cv
+from esphome.const import CONF_DIRECTION, CONF_HYSTERESIS, CONF_ID, CONF_MODE
+
+from ..mt6701 import MT6701Component, position12
+
+CODEOWNERS = ["@slimcdk"]
+AUTO_LOAD = ["mt6701"]
+DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
+
+mt6701_i2c_ns = cg.esphome_ns.namespace("mt6701_i2c")
+MT6701I2CComponent = mt6701_i2c_ns.class_(
+    "MT6701I2CComponent", MT6701Component, i2c.I2CDevice
+)
+SaveEEPROMAction = mt6701_i2c_ns.class_("SaveEEPROMAction", automation.Action)
+
+CONF_ZERO_OFFSET = "zero_offset"
+CONF_OUTPUT_MODE = "output_mode"
+CONF_ABZ = "abz"
+CONF_PULSES_PER_REVOLUTION = "pulses_per_revolution"
+CONF_Z_PULSE_WIDTH = "z_pulse_width"
+CONF_UVW = "uvw"
+CONF_POLE_PAIRS = "pole_pairs"
+CONF_OUT_PIN = "out_pin"
+CONF_PWM_FREQUENCY = "pwm_frequency"
+CONF_PWM_POLARITY = "pwm_polarity"
+CONF_ANALOG_START = "analog_start"
+CONF_ANALOG_STOP = "analog_stop"
+
+# Register bit value written for each rotation direction (DIR bit, datasheet
+# section 8.1: DIR=1 means the angle increases clockwise).
+DIRECTION = {
+    "CLOCKWISE": 1,
+    "COUNTERCLOCKWISE": 0,
+}
+
+# Hysteresis expressed in output LSBs -> HYST register code.
+HYSTERESIS = {
+    0: 4,
+    0.25: 5,
+    0.5: 6,
+    1: 0,
+    2: 1,
+    4: 2,
+    8: 3,
+}
+
+Z_PULSE_WIDTH = {
+    "1LSB": 0,
+    "2LSB": 1,
+    "4LSB": 2,
+    "8LSB": 3,
+    "12LSB": 4,
+    "16LSB": 5,
+    "180DEG": 6,
+}
+
+OUTPUT_MODE = {
+    "ABZ": 0,
+    "UVW": 1,
+}
+
+OUT_PIN_MODE = {
+    "ANALOG": 0,
+    "PWM": 1,
+}
+
+PWM_FREQUENCY = {
+    "994.4HZ": 0,
+    "497.2HZ": 1,
+}
+
+PWM_POLARITY = {
+    "HIGH": 0,
+    "LOW": 1,
+}
+
+
+def validate_hysteresis(value):
+    value = cv.float_(value)
+    if value not in HYSTERESIS:
+        raise cv.Invalid(
+            f"Hysteresis must be one of {sorted(HYSTERESIS)} (LSBs), got {value}"
+        )
+    return HYSTERESIS[value]
+
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(MT6701I2CComponent),
+            cv.Optional(CONF_DIRECTION): cv.enum(DIRECTION, upper=True),
+            cv.Optional(CONF_ZERO_OFFSET): position12,
+            cv.Optional(CONF_HYSTERESIS): validate_hysteresis,
+            cv.Optional(CONF_OUTPUT_MODE): cv.enum(OUTPUT_MODE, upper=True),
+            cv.Optional(CONF_ABZ): cv.Schema(
+                {
+                    cv.Optional(CONF_PULSES_PER_REVOLUTION): cv.int_range(
+                        min=1, max=1024
+                    ),
+                    cv.Optional(CONF_Z_PULSE_WIDTH): cv.enum(Z_PULSE_WIDTH, upper=True),
+                }
+            ),
+            cv.Optional(CONF_UVW): cv.Schema(
+                {
+                    cv.Required(CONF_POLE_PAIRS): cv.int_range(min=1, max=16),
+                }
+            ),
+            cv.Optional(CONF_OUT_PIN): cv.Schema(
+                {
+                    cv.Required(CONF_MODE): cv.enum(OUT_PIN_MODE, upper=True),
+                    cv.Optional(CONF_PWM_FREQUENCY): cv.enum(PWM_FREQUENCY, upper=True),
+                    cv.Optional(CONF_PWM_POLARITY): cv.enum(PWM_POLARITY, upper=True),
+                    cv.Optional(CONF_ANALOG_START): position12,
+                    cv.Optional(CONF_ANALOG_STOP): position12,
+                }
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x06))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    if (direction := config.get(CONF_DIRECTION)) is not None:
+        cg.add(var.set_direction(direction))
+    if (zero_offset := config.get(CONF_ZERO_OFFSET)) is not None:
+        cg.add(var.set_zero_offset(zero_offset))
+    if (hysteresis := config.get(CONF_HYSTERESIS)) is not None:
+        cg.add(var.set_hysteresis(hysteresis))
+    if (output_mode := config.get(CONF_OUTPUT_MODE)) is not None:
+        # cv.enum returns the (always truthy) key string; the register code
+        # sits in enum_value (ABZ=0, UVW=1).
+        cg.add(var.set_output_mode_uvw(bool(output_mode.enum_value)))
+
+    if abz := config.get(CONF_ABZ):
+        if (ppr := abz.get(CONF_PULSES_PER_REVOLUTION)) is not None:
+            cg.add(var.set_abz_pulses_per_revolution(ppr))
+        if (width := abz.get(CONF_Z_PULSE_WIDTH)) is not None:
+            cg.add(var.set_z_pulse_width(width))
+
+    if uvw := config.get(CONF_UVW):
+        cg.add(var.set_uvw_pole_pairs(uvw[CONF_POLE_PAIRS]))
+
+    if out_pin := config.get(CONF_OUT_PIN):
+        # Same enum-key caveat as output_mode above (ANALOG=0, PWM=1).
+        cg.add(var.set_out_pin_pwm(bool(out_pin[CONF_MODE].enum_value)))
+        if (freq := out_pin.get(CONF_PWM_FREQUENCY)) is not None:
+            cg.add(var.set_pwm_frequency(freq))
+        if (pol := out_pin.get(CONF_PWM_POLARITY)) is not None:
+            cg.add(var.set_pwm_polarity(pol))
+        if (start := out_pin.get(CONF_ANALOG_START)) is not None:
+            cg.add(var.set_analog_start(start))
+        if (stop := out_pin.get(CONF_ANALOG_STOP)) is not None:
+            cg.add(var.set_analog_stop(stop))
+
+
+MT6701_SAVE_EEPROM_ACTION_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.Required(CONF_ID): cv.use_id(MT6701I2CComponent),
+    }
+)
+
+
+@automation.register_action(
+    "mt6701_i2c.save_eeprom",
+    SaveEEPROMAction,
+    MT6701_SAVE_EEPROM_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def save_eeprom_action_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, parent)

--- a/esphome/components/mt6701_i2c/mt6701_i2c.cpp
+++ b/esphome/components/mt6701_i2c/mt6701_i2c.cpp
@@ -1,0 +1,175 @@
+#include "mt6701_i2c.h"
+#include "esphome/core/log.h"
+
+namespace esphome::mt6701_i2c {
+
+static const char *const TAG = "mt6701_i2c";
+
+// Registers touched by apply_config_(), each read-modify-written at most once.
+static const uint8_t CONFIG_REGS[] = {
+    REG_ABZ_MUX_DIR, REG_RES_H, REG_ABZ_RES_L, REG_CONFIG_H,  REG_ZERO_L,
+    REG_HYST_L,      REG_OUT,   REG_A_HIGH,    REG_A_START_L, REG_A_STOP_L,
+};
+static const uint8_t CONFIG_REG_COUNT = sizeof(CONFIG_REGS);
+
+void MT6701I2CComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Running setup");
+  // Probe the device by reading the angle registers.
+  uint16_t count;
+  if (!this->read_count(count)) {
+    ESP_LOGE(TAG, "MT6701 not responding on I2C");
+    this->mark_failed();
+    return;
+  }
+  this->apply_config_();
+}
+
+void MT6701I2CComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "MT6701 (I2C):");
+  LOG_I2C_DEVICE(this);
+  LOG_UPDATE_INTERVAL(this);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
+    return;
+  }
+  if (this->direction_.has_value())
+    ESP_LOGCONFIG(TAG, "  Direction bit: %u", *this->direction_);
+  if (this->zero_offset_.has_value())
+    ESP_LOGCONFIG(TAG, "  Zero offset: %u", *this->zero_offset_);
+  if (this->hysteresis_.has_value())
+    ESP_LOGCONFIG(TAG, "  Hysteresis code: %u", *this->hysteresis_);
+  if (this->output_mode_uvw_.has_value())
+    ESP_LOGCONFIG(TAG, "  Output mode: %s", *this->output_mode_uvw_ ? "UVW" : "ABZ");
+  if (this->abz_ppr_.has_value())
+    ESP_LOGCONFIG(TAG, "  ABZ pulses/rev: %u", *this->abz_ppr_);
+  if (this->z_pulse_width_.has_value())
+    ESP_LOGCONFIG(TAG, "  Z pulse width code: %u", *this->z_pulse_width_);
+  if (this->uvw_pole_pairs_.has_value())
+    ESP_LOGCONFIG(TAG, "  UVW pole pairs: %u", *this->uvw_pole_pairs_);
+  if (this->out_pin_pwm_.has_value())
+    ESP_LOGCONFIG(TAG, "  Output pin mode: %s", *this->out_pin_pwm_ ? "PWM" : "analog");
+  if (this->pwm_freq_.has_value())
+    ESP_LOGCONFIG(TAG, "  PWM frequency code: %u", *this->pwm_freq_);
+  if (this->pwm_pol_.has_value())
+    ESP_LOGCONFIG(TAG, "  PWM polarity code: %u", *this->pwm_pol_);
+  if (this->analog_start_.has_value())
+    ESP_LOGCONFIG(TAG, "  Analog start: %u", *this->analog_start_);
+  if (this->analog_stop_.has_value())
+    ESP_LOGCONFIG(TAG, "  Analog stop: %u", *this->analog_stop_);
+}
+
+bool MT6701I2CComponent::read_count(uint16_t &count) {
+  // Burst read both angle registers so the two bytes are consistent.
+  uint8_t data[2];
+  if (this->read_register(REG_ANGLE_H, data, 2) != i2c::ERROR_OK)
+    return false;
+  // 14-bit angle: D[13:6] in data[0], D[5:0] in the top 6 bits of data[1].
+  count = encode_uint16(data[0], data[1]) >> 2;
+  return true;
+}
+
+bool MT6701I2CComponent::update_register_(uint8_t reg, uint8_t mask, uint8_t value) {
+  uint8_t current;
+  if (this->read_register(reg, &current, 1) != i2c::ERROR_OK)
+    return false;
+  uint8_t updated = (current & ~mask) | (value & mask);
+  if (updated == current)
+    return true;
+  return this->write_register(reg, &updated, 1) == i2c::ERROR_OK;
+}
+
+void MT6701I2CComponent::apply_config_() {
+  // Collect the configured bits per register first, so registers shared by
+  // several options (e.g. 0x32 holds hysteresis, Z width and zero offset bits)
+  // are read-modify-written only once.
+  uint8_t masks[CONFIG_REG_COUNT] = {};
+  uint8_t values[CONFIG_REG_COUNT] = {};
+  auto add = [&masks, &values](uint8_t reg, uint8_t mask, uint8_t value) {
+    for (uint8_t i = 0; i < CONFIG_REG_COUNT; i++) {
+      if (CONFIG_REGS[i] == reg) {
+        masks[i] |= mask;
+        values[i] |= value & mask;
+        return;
+      }
+    }
+  };
+
+  if (this->direction_.has_value())
+    add(REG_ABZ_MUX_DIR, 0x02, *this->direction_ << 1);
+  if (this->output_mode_uvw_.has_value())
+    add(REG_ABZ_MUX_DIR, 0x40, *this->output_mode_uvw_ ? 0x40 : 0x00);
+  if (this->zero_offset_.has_value()) {
+    add(REG_CONFIG_H, 0x0F, *this->zero_offset_ >> 8);
+    add(REG_ZERO_L, 0xFF, *this->zero_offset_ & 0xFF);
+  }
+  if (this->hysteresis_.has_value()) {
+    add(REG_CONFIG_H, 0x80, (*this->hysteresis_ & 0x04) << 5);  // HYST[2] -> bit7
+    add(REG_HYST_L, 0xC0, (*this->hysteresis_ & 0x03) << 6);    // HYST[1:0] -> bits7:6
+  }
+  if (this->abz_ppr_.has_value()) {
+    // ABZ_RES is stored as (pulses per revolution - 1), 10 bits.
+    uint16_t res = *this->abz_ppr_ - 1;
+    add(REG_RES_H, 0x03, res >> 8);
+    add(REG_ABZ_RES_L, 0xFF, res & 0xFF);
+  }
+  if (this->z_pulse_width_.has_value())
+    add(REG_CONFIG_H, 0x70, (*this->z_pulse_width_ & 0x07) << 4);
+  if (this->uvw_pole_pairs_.has_value()) {
+    // UVW_RES is stored as (pole pairs - 1), 4 bits, in the high nibble.
+    add(REG_RES_H, 0xF0, (*this->uvw_pole_pairs_ - 1) << 4);
+  }
+  if (this->out_pin_pwm_.has_value())
+    add(REG_OUT, 0x20, *this->out_pin_pwm_ ? 0x20 : 0x00);
+  if (this->pwm_freq_.has_value())
+    add(REG_OUT, 0x80, (*this->pwm_freq_ & 0x01) << 7);
+  if (this->pwm_pol_.has_value())
+    add(REG_OUT, 0x40, (*this->pwm_pol_ & 0x01) << 6);
+  if (this->analog_start_.has_value()) {
+    add(REG_A_HIGH, 0x0F, *this->analog_start_ >> 8);
+    add(REG_A_START_L, 0xFF, *this->analog_start_ & 0xFF);
+  }
+  if (this->analog_stop_.has_value()) {
+    add(REG_A_HIGH, 0xF0, (*this->analog_stop_ >> 8) << 4);
+    add(REG_A_STOP_L, 0xFF, *this->analog_stop_ & 0xFF);
+  }
+
+  bool ok = true;
+  for (uint8_t i = 0; i < CONFIG_REG_COUNT; i++) {
+    if (masks[i] != 0)
+      ok &= this->update_register_(CONFIG_REGS[i], masks[i], values[i]);
+  }
+  if (!ok) {
+    // The chip may now be half-configured; surface it instead of just logging.
+    this->status_set_warning("configuration register write failed");
+  }
+}
+
+void MT6701I2CComponent::save_eeprom() {
+  if (this->is_failed()) {
+    // Timeouts are not delivered to failed components, so starting the
+    // sequence here would leave the bus suspended forever.
+    ESP_LOGW(TAG, "Not programming EEPROM: component is marked failed");
+    return;
+  }
+  if (this->suspend_sampling_) {
+    ESP_LOGW(TAG, "EEPROM programming already in progress");
+    return;
+  }
+  ESP_LOGW(TAG, "Programming MT6701 EEPROM. The EEPROM has a limited number of write "
+                "cycles, so avoid doing this repeatedly. Supply must be 4.5-5.5 V.");
+  this->suspend_sampling_ = true;
+
+  bool ok = this->write_byte(REG_EEPROM_KEY, EEPROM_KEY_VALUE) && this->write_byte(REG_EEPROM_CMD, EEPROM_CMD_VALUE);
+  if (!ok) {
+    ESP_LOGE(TAG, "Failed to start EEPROM programming");
+    this->suspend_sampling_ = false;
+    return;
+  }
+
+  this->set_timeout("eeprom", EEPROM_PROGRAM_DELAY_MS, [this]() {
+    this->suspend_sampling_ = false;
+    ESP_LOGI(TAG, "EEPROM programming complete");
+  });
+}
+
+}  // namespace esphome::mt6701_i2c

--- a/esphome/components/mt6701_i2c/mt6701_i2c.h
+++ b/esphome/components/mt6701_i2c/mt6701_i2c.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "esphome/components/mt6701/mt6701.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome::mt6701_i2c {
+
+// Angle output register (D[13:6] at 0x03, D[5:0] in bits 7:2 of 0x04). Both
+// bytes are read in a single burst starting here.
+static const uint8_t REG_ANGLE_H = 0x03;
+
+// EEPROM programming registers (see datasheet section 8.2).
+static const uint8_t REG_EEPROM_KEY = 0x09;  // write 0xB3
+static const uint8_t REG_EEPROM_CMD = 0x0A;  // write 0x05, then wait >= 600 ms
+static const uint8_t EEPROM_KEY_VALUE = 0xB3;
+static const uint8_t EEPROM_CMD_VALUE = 0x05;
+static const uint32_t EEPROM_PROGRAM_DELAY_MS = 600;
+
+// Configuration registers (writable over I2C only). Several of these also
+// contain manufacturer-reserved bits, so every write is read-modify-write.
+static const uint8_t REG_ABZ_MUX_DIR = 0x29;  // bit6 ABZ_MUX, bit1 DIR
+static const uint8_t REG_RES_H = 0x30;        // bits7:4 UVW_RES, bits1:0 ABZ_RES[9:8]
+static const uint8_t REG_ABZ_RES_L = 0x31;    // ABZ_RES[7:0]
+static const uint8_t REG_CONFIG_H = 0x32;     // bit7 HYST[2], bits6:4 Z_PULSE_WIDTH, bits3:0 ZERO[11:8]
+static const uint8_t REG_ZERO_L = 0x33;       // ZERO[7:0]
+static const uint8_t REG_HYST_L = 0x34;       // bits7:6 HYST[1:0]
+static const uint8_t REG_OUT = 0x38;          // bit7 PWM_FREQ, bit6 PWM_POL, bit5 OUT_MODE
+static const uint8_t REG_A_HIGH = 0x3E;       // bits7:4 A_STOP[11:8], bits3:0 A_START[11:8]
+static const uint8_t REG_A_START_L = 0x3F;    // A_START[7:0]
+static const uint8_t REG_A_STOP_L = 0x40;     // A_STOP[7:0]
+
+/// MT6701 driver over the I2C interface, with full configuration support.
+class MT6701I2CComponent final : public mt6701::MT6701Component, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+  // Configuration setters. Every option is optional: values that are not set in
+  // YAML are never written, so the chip keeps its factory / EEPROM defaults.
+  void set_direction(uint8_t dir_bit) { this->direction_ = dir_bit; }
+  void set_zero_offset(uint16_t raw12) { this->zero_offset_ = raw12; }
+  void set_hysteresis(uint8_t hyst) { this->hysteresis_ = hyst; }
+  void set_output_mode_uvw(bool uvw) { this->output_mode_uvw_ = uvw; }
+  void set_abz_pulses_per_revolution(uint16_t ppr) { this->abz_ppr_ = ppr; }
+  void set_z_pulse_width(uint8_t width) { this->z_pulse_width_ = width; }
+  void set_uvw_pole_pairs(uint8_t pole_pairs) { this->uvw_pole_pairs_ = pole_pairs; }
+  void set_out_pin_pwm(bool pwm) { this->out_pin_pwm_ = pwm; }
+  void set_pwm_frequency(uint8_t freq) { this->pwm_freq_ = freq; }
+  void set_pwm_polarity(uint8_t pol) { this->pwm_pol_ = pol; }
+  void set_analog_start(uint16_t raw12) { this->analog_start_ = raw12; }
+  void set_analog_stop(uint16_t raw12) { this->analog_stop_ = raw12; }
+
+  /// Persist the current register contents to the chip's EEPROM.
+  ///
+  /// Non-blocking: pauses sampling, sends the programming sequence and clears
+  /// the pause after the required delay. The EEPROM has a limited number of
+  /// write cycles, so this must only be triggered by an explicit user action.
+  void save_eeprom();
+
+ protected:
+  bool read_count(uint16_t &count) override;
+
+  /// Apply all configured options to the chip via read-modify-write.
+  void apply_config_();
+  /// Read-modify-write the given bits of a register, preserving the others.
+  bool update_register_(uint8_t reg, uint8_t mask, uint8_t value);
+
+  optional<uint8_t> direction_;
+  optional<uint16_t> zero_offset_;
+  optional<uint8_t> hysteresis_;
+  optional<bool> output_mode_uvw_;
+  optional<uint16_t> abz_ppr_;
+  optional<uint8_t> z_pulse_width_;
+  optional<uint8_t> uvw_pole_pairs_;
+  optional<bool> out_pin_pwm_;
+  optional<uint8_t> pwm_freq_;
+  optional<uint8_t> pwm_pol_;
+  optional<uint16_t> analog_start_;
+  optional<uint16_t> analog_stop_;
+};
+
+template<typename... Ts> class SaveEEPROMAction final : public Action<Ts...> {
+ public:
+  explicit SaveEEPROMAction(MT6701I2CComponent *parent) : parent_(parent) {}
+  void play(const Ts &...x) override { this->parent_->save_eeprom(); }
+
+ protected:
+  MT6701I2CComponent *parent_;
+};
+
+}  // namespace esphome::mt6701_i2c

--- a/esphome/components/mt6701_spi/__init__.py
+++ b/esphome/components/mt6701_spi/__init__.py
@@ -1,0 +1,40 @@
+import esphome.codegen as cg
+from esphome.components import spi
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+from ..mt6701 import MT6701Component
+
+CODEOWNERS = ["@slimcdk"]
+AUTO_LOAD = ["mt6701"]
+DEPENDENCIES = ["spi"]
+MULTI_CONF = True
+
+mt6701_spi_ns = cg.esphome_ns.namespace("mt6701_spi")
+MT6701SPIComponent = mt6701_spi_ns.class_(
+    "MT6701SPIComponent", MT6701Component, spi.SPIDevice
+)
+
+CONF_MT6701_SPI_ID = "mt6701_spi_id"
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(MT6701SPIComponent),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(
+        spi.spi_device_schema(
+            cs_pin_required=True,
+            default_data_rate=1_000_000,
+            default_mode="MODE1",
+        )
+    )
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await spi.register_spi_device(var, config)

--- a/esphome/components/mt6701_spi/binary_sensor/__init__.py
+++ b/esphome/components/mt6701_spi/binary_sensor/__init__.py
@@ -1,0 +1,31 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, DEVICE_CLASS_PROBLEM, ENTITY_CATEGORY_DIAGNOSTIC
+
+from .. import CONF_MT6701_SPI_ID, MT6701SPIComponent
+
+DEPENDENCIES = ["mt6701_spi"]
+
+CONF_PUSH_BUTTON = "push_button"
+CONF_TRACK_LOSS = "track_loss"
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
+    cv.GenerateID(CONF_MT6701_SPI_ID): cv.use_id(MT6701SPIComponent),
+    cv.Optional(CONF_PUSH_BUTTON): binary_sensor.binary_sensor_schema(),
+    cv.Optional(CONF_TRACK_LOSS): binary_sensor.binary_sensor_schema(
+        device_class=DEVICE_CLASS_PROBLEM,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+}
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_MT6701_SPI_ID])
+    if push_button_config := config.get(CONF_PUSH_BUTTON):
+        sens = await binary_sensor.new_binary_sensor(push_button_config)
+        cg.add(hub.set_push_button_binary_sensor(sens))
+    if track_loss_config := config.get(CONF_TRACK_LOSS):
+        sens = await binary_sensor.new_binary_sensor(track_loss_config)
+        cg.add(hub.set_track_loss_binary_sensor(sens))

--- a/esphome/components/mt6701_spi/mt6701_spi.cpp
+++ b/esphome/components/mt6701_spi/mt6701_spi.cpp
@@ -1,0 +1,98 @@
+#include "mt6701_spi.h"
+#include "esphome/core/log.h"
+
+namespace esphome::mt6701_spi {
+
+static const char *const TAG = "mt6701_spi";
+
+void MT6701SPIComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Running setup");
+  this->spi_setup();
+  // Probe: require several CRC-valid frames, at least one of them non-zero.
+  // Random noise passes the 6-bit CRC ~1/64 of the time, and a dead or
+  // stuck-low data line reads all-zero frames which pass trivially
+  // (crc6(0) == 0) - neither may count as a present encoder. A real encoder
+  // sitting at exactly count 0 with zero jitter would be misdetected here, but
+  // that is a 1-in-16384 alignment and the angle LSBs always jitter in
+  // practice.
+  uint8_t valid = 0;
+  bool nonzero = false;
+  for (uint8_t i = 0; i < 10 && (valid < 3 || !nonzero); i++) {
+    uint16_t count;
+    if (this->read_count(count)) {
+      valid++;
+      if (count != 0)
+        nonzero = true;
+    }
+  }
+  if (valid < 3 || !nonzero) {
+    ESP_LOGE(TAG, "No valid MT6701 frame received (check wiring / CS pin)");
+    this->mark_failed();
+    return;
+  }
+  this->setup_complete_ = true;
+}
+
+void MT6701SPIComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "MT6701 (SSI/SPI):");
+  LOG_PIN("  CS Pin: ", this->cs_);
+  LOG_UPDATE_INTERVAL(this);
+  if (this->is_failed())
+    ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
+}
+
+bool MT6701SPIComponent::read_count(uint16_t &count) {
+  // The SSI frame is 24 bits: 14-bit angle, 4-bit status, 6-bit CRC.
+  uint8_t buffer[3] = {0, 0, 0};
+  this->enable();
+  this->read_array(buffer, 3);
+  this->disable();
+
+  // Frame layout: 14-bit angle, 4-bit status, 6-bit CRC (most significant
+  // first). The CRC covers the top 18 bits (angle + status).
+  uint32_t frame = encode_uint24(buffer[0], buffer[1], buffer[2]);
+  uint32_t data18 = frame >> 6;
+  uint8_t crc = frame & 0x3F;
+  if (mt6701::crc6_mt6701(data18) != crc)
+    return false;
+
+  count = data18 >> 4;
+  uint8_t status = data18 & 0x0F;  // bit3 track loss, bit2 push button, bits1:0 field strength
+
+  // Publish only after the setup probe confirmed the device: noise frames that
+  // happen to pass the CRC during probing must not emit entity states. The
+  // 0xFF sentinel stays untouched until then, so the first post-setup read
+  // publishes the initial states.
+  if (this->setup_complete_ && status != this->last_status_) {
+    this->last_status_ = status;
+#ifdef USE_BINARY_SENSOR
+    if (this->push_button_binary_sensor_ != nullptr)
+      this->push_button_binary_sensor_->publish_state((status & 0x04) != 0);
+    if (this->track_loss_binary_sensor_ != nullptr)
+      this->track_loss_binary_sensor_->publish_state((status & 0x08) != 0);
+#endif
+#ifdef USE_TEXT_SENSOR
+    if (this->field_status_text_sensor_ != nullptr) {
+      const char *text;
+      switch (status & 0x03) {
+        case static_cast<uint8_t>(mt6701::MT6701FieldStatus::NORMAL):
+          text = "OK";
+          break;
+        case static_cast<uint8_t>(mt6701::MT6701FieldStatus::TOO_STRONG):
+          text = "TOO_STRONG";
+          break;
+        case static_cast<uint8_t>(mt6701::MT6701FieldStatus::TOO_WEAK):
+          text = "TOO_WEAK";
+          break;
+        default:  // 0b11 is reserved in the datasheet
+          text = "UNKNOWN";
+          break;
+      }
+      this->field_status_text_sensor_->publish_state(text);
+    }
+#endif
+  }
+  return true;
+}
+
+}  // namespace esphome::mt6701_spi

--- a/esphome/components/mt6701_spi/mt6701_spi.h
+++ b/esphome/components/mt6701_spi/mt6701_spi.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/mt6701/mt6701.h"
+#include "esphome/components/spi/spi.h"
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+
+namespace esphome::mt6701_spi {
+
+/// MT6701 driver over the SSI (SPI-compatible) interface.
+///
+/// SSI is read-only: it cannot write configuration registers, but it does
+/// report the magnetic-field status, push button and track-loss flags that the
+/// I2C interface does not expose. Each 24-bit frame is CRC-checked.
+class MT6701SPIComponent final : public mt6701::MT6701Component,
+                                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                                       spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_1MHZ> {
+#ifdef USE_BINARY_SENSOR
+  SUB_BINARY_SENSOR(push_button)
+  SUB_BINARY_SENSOR(track_loss)
+#endif
+#ifdef USE_TEXT_SENSOR
+  SUB_TEXT_SENSOR(field_status)
+#endif
+
+ public:
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  bool read_count(uint16_t &count) override;
+
+  // Last raw 4-bit status nibble published; 0xFF means "nothing published yet".
+  uint8_t last_status_{0xFF};
+  // Entity publishing from read_count() is held back until the setup probe has
+  // confirmed the encoder is present.
+  bool setup_complete_{false};
+};
+
+}  // namespace esphome::mt6701_spi

--- a/esphome/components/mt6701_spi/text_sensor/__init__.py
+++ b/esphome/components/mt6701_spi/text_sensor/__init__.py
@@ -1,0 +1,23 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_MAGNET
+
+from .. import CONF_MT6701_SPI_ID, MT6701SPIComponent
+
+DEPENDENCIES = ["mt6701_spi"]
+
+CONFIG_SCHEMA = text_sensor.text_sensor_schema(
+    icon=ICON_MAGNET,
+    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+).extend(
+    {
+        cv.GenerateID(CONF_MT6701_SPI_ID): cv.use_id(MT6701SPIComponent),
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_MT6701_SPI_ID])
+    var = await text_sensor.new_text_sensor(config)
+    cg.add(hub.set_field_status_text_sensor(var))

--- a/tests/component_tests/mt6701/config/mt6701_i2c_modes.yaml
+++ b/tests/component_tests/mt6701/config/mt6701_i2c_modes.yaml
@@ -1,0 +1,19 @@
+esphome:
+  name: mt6701-modes-test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+i2c:
+  - id: i2c_bus
+    sda: GPIO21
+    scl: GPIO22
+
+mt6701_i2c:
+  id: encoder_hub
+  i2c_id: i2c_bus
+  output_mode: ABZ
+  out_pin:
+    mode: ANALOG

--- a/tests/component_tests/mt6701/config/mt6701_i2c_modes_uvw_pwm.yaml
+++ b/tests/component_tests/mt6701/config/mt6701_i2c_modes_uvw_pwm.yaml
@@ -1,0 +1,21 @@
+esphome:
+  name: mt6701-modes-uvw-pwm-test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+i2c:
+  - id: i2c_bus
+    sda: GPIO21
+    scl: GPIO22
+
+mt6701_i2c:
+  id: encoder_hub
+  i2c_id: i2c_bus
+  output_mode: UVW
+  uvw:
+    pole_pairs: 7
+  out_pin:
+    mode: PWM

--- a/tests/component_tests/mt6701/test_mt6701.py
+++ b/tests/component_tests/mt6701/test_mt6701.py
@@ -1,0 +1,72 @@
+"""Config-validation tests for the mt6701 encoder component."""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome.components.mt6701 import position12
+from esphome.components.mt6701_i2c import DIRECTION, validate_hysteresis
+import esphome.config_validation as cv
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # raw 12-bit counts pass through unchanged
+        (0, 0),
+        (2048, 2048),
+        (4095, 4095),
+        # angles are converted to counts
+        ("0deg", 0),
+        ("45deg", 512),
+        ("90°", 1024),
+        # a full turn is not representable and must clamp to the max, not wrap to 0
+        ("360deg", 4095),
+        # percentages of a full revolution
+        ("25%", 1024),
+        ("50%", 2048),
+        ("100%", 4095),
+    ],
+)
+def test_position12_valid(value, expected: int) -> None:
+    assert position12(value) == expected
+
+
+@pytest.mark.parametrize("value", [-1, 4096, 5000, "400deg", "-10deg"])
+def test_position12_rejects_out_of_range(value) -> None:
+    with pytest.raises(cv.Invalid):
+        position12(value)
+
+
+@pytest.mark.parametrize(
+    ("lsb", "register_code"),
+    [(0, 4), (0.25, 5), (0.5, 6), (1, 0), (2, 1), (4, 2), (8, 3)],
+)
+def test_hysteresis_maps_lsb_to_register_code(lsb, register_code: int) -> None:
+    assert validate_hysteresis(lsb) == register_code
+
+
+@pytest.mark.parametrize("value", [3, 5, 16])
+def test_hysteresis_rejects_unsupported_step(value) -> None:
+    with pytest.raises(cv.Invalid):
+        validate_hysteresis(value)
+
+
+def test_direction_follows_datasheet_semantics() -> None:
+    # Datasheet section 8.1: DIR=1 makes the angle increase clockwise.
+    assert DIRECTION["CLOCKWISE"] == 1
+    assert DIRECTION["COUNTERCLOCKWISE"] == 0
+
+
+def test_enum_options_generate_register_codes_not_truthiness(
+    generate_main, component_config_path
+) -> None:
+    """cv.enum returns the (always truthy) key string; codegen must use the
+    register code, not bool(key). Regression test for output_mode/out_pin mode.
+    """
+    main_cpp = generate_main(component_config_path("mt6701_i2c_modes.yaml"))
+
+    # output_mode: ABZ (code 0) must generate false, not true
+    assert "set_output_mode_uvw(false)" in main_cpp
+    # out_pin mode: ANALOG (code 0) must generate false, not true
+    assert "set_out_pin_pwm(false)" in main_cpp

--- a/tests/component_tests/mt6701/test_mt6701.py
+++ b/tests/component_tests/mt6701/test_mt6701.py
@@ -58,15 +58,38 @@ def test_direction_follows_datasheet_semantics() -> None:
     assert DIRECTION["COUNTERCLOCKWISE"] == 0
 
 
+@pytest.mark.parametrize(
+    ("config_file", "output_mode_call", "out_pin_call"),
+    [
+        # code 0 keys must generate false, not true
+        (
+            "mt6701_i2c_modes.yaml",
+            "set_output_mode_uvw(false)",
+            "set_out_pin_pwm(false)",
+        ),
+        # code 1 keys must generate true, not false
+        (
+            "mt6701_i2c_modes_uvw_pwm.yaml",
+            "set_output_mode_uvw(true)",
+            "set_out_pin_pwm(true)",
+        ),
+    ],
+)
 def test_enum_options_generate_register_codes_not_truthiness(
-    generate_main, component_config_path
+    generate_main,
+    component_config_path,
+    config_file: str,
+    output_mode_call: str,
+    out_pin_call: str,
 ) -> None:
     """cv.enum returns the (always truthy) key string; codegen must use the
     register code, not bool(key). Regression test for output_mode/out_pin mode.
-    """
-    main_cpp = generate_main(component_config_path("mt6701_i2c_modes.yaml"))
 
-    # output_mode: ABZ (code 0) must generate false, not true
-    assert "set_output_mode_uvw(false)" in main_cpp
-    # out_pin mode: ANALOG (code 0) must generate false, not true
-    assert "set_out_pin_pwm(false)" in main_cpp
+    Both endpoints of the enum->bool mapping are pinned (code 0 -> false and
+    code 1 -> true) so that hardcoding a constant or reading a different
+    also-zero field is caught, not only the always-truthy regression.
+    """
+    main_cpp = generate_main(component_config_path(config_file))
+
+    assert output_mode_call in main_cpp
+    assert out_pin_call in main_cpp

--- a/tests/components/mt6701_i2c/common.yaml
+++ b/tests/components/mt6701_i2c/common.yaml
@@ -1,0 +1,34 @@
+mt6701_i2c:
+  id: mt6701_i2c_encoder
+  i2c_id: i2c_bus
+  address: 0x06
+  update_interval: 500ms
+  direction: CLOCKWISE
+  zero_offset: 45deg
+  hysteresis: 1
+  output_mode: ABZ
+  abz:
+    pulses_per_revolution: 1024
+    z_pulse_width: 1LSB
+  uvw:
+    pole_pairs: 8
+  out_pin:
+    mode: PWM
+    pwm_frequency: 994.4Hz
+    pwm_polarity: HIGH
+    analog_start: 0deg
+    analog_stop: 360deg
+
+sensor:
+  - platform: mt6701
+    mt6701_id: mt6701_i2c_encoder
+    name: MT6701 I2C Angle
+    update_interval: 100ms
+    raw_count:
+      name: MT6701 I2C Raw Count
+
+button:
+  - platform: template
+    name: MT6701 I2C Save EEPROM
+    on_press:
+      - mt6701_i2c.save_eeprom: mt6701_i2c_encoder

--- a/tests/components/mt6701_i2c/test.esp32-ard.yaml
+++ b/tests/components/mt6701_i2c/test.esp32-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-ard.yaml
+  mt6701_i2c: !include common.yaml

--- a/tests/components/mt6701_i2c/test.esp32-c3-idf.yaml
+++ b/tests/components/mt6701_i2c/test.esp32-c3-idf.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-c3-idf.yaml
+  mt6701_i2c: !include common.yaml

--- a/tests/components/mt6701_i2c/test.esp32-idf.yaml
+++ b/tests/components/mt6701_i2c/test.esp32-idf.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+  mt6701_i2c: !include common.yaml

--- a/tests/components/mt6701_i2c/test.esp8266-ard.yaml
+++ b/tests/components/mt6701_i2c/test.esp8266-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
+  mt6701_i2c: !include common.yaml

--- a/tests/components/mt6701_i2c/test.host.yaml
+++ b/tests/components/mt6701_i2c/test.host.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/host.yaml
+  mt6701_i2c: !include common.yaml

--- a/tests/components/mt6701_i2c/test.rp2040-ard.yaml
+++ b/tests/components/mt6701_i2c/test.rp2040-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
+  mt6701_i2c: !include common.yaml

--- a/tests/components/mt6701_spi/common.yaml
+++ b/tests/components/mt6701_spi/common.yaml
@@ -1,0 +1,26 @@
+mt6701_spi:
+  id: mt6701_spi_encoder
+  spi_id: spi_bus
+  cs_pin: ${cs_pin}
+  update_interval: 500ms
+
+sensor:
+  - platform: mt6701
+    mt6701_id: mt6701_spi_encoder
+    name: MT6701 SPI Angle
+    update_interval: 100ms
+    raw_count:
+      name: MT6701 SPI Raw Count
+
+binary_sensor:
+  - platform: mt6701_spi
+    mt6701_spi_id: mt6701_spi_encoder
+    push_button:
+      name: MT6701 SPI Button
+    track_loss:
+      name: MT6701 SPI Track Loss
+
+text_sensor:
+  - platform: mt6701_spi
+    mt6701_spi_id: mt6701_spi_encoder
+    name: MT6701 SPI Field Status

--- a/tests/components/mt6701_spi/test.esp32-ard.yaml
+++ b/tests/components/mt6701_spi/test.esp32-ard.yaml
@@ -1,0 +1,6 @@
+substitutions:
+  cs_pin: GPIO5
+
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-ard.yaml
+  mt6701_spi: !include common.yaml

--- a/tests/components/mt6701_spi/test.esp32-c3-idf.yaml
+++ b/tests/components/mt6701_spi/test.esp32-c3-idf.yaml
@@ -1,0 +1,6 @@
+substitutions:
+  cs_pin: GPIO7
+
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-c3-idf.yaml
+  mt6701_spi: !include common.yaml

--- a/tests/components/mt6701_spi/test.esp32-idf.yaml
+++ b/tests/components/mt6701_spi/test.esp32-idf.yaml
@@ -1,0 +1,6 @@
+substitutions:
+  cs_pin: GPIO5
+
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-idf.yaml
+  mt6701_spi: !include common.yaml

--- a/tests/components/mt6701_spi/test.esp8266-ard.yaml
+++ b/tests/components/mt6701_spi/test.esp8266-ard.yaml
@@ -1,0 +1,6 @@
+substitutions:
+  cs_pin: GPIO15
+
+packages:
+  spi: !include ../../test_build_components/common/spi/esp8266-ard.yaml
+  mt6701_spi: !include common.yaml

--- a/tests/components/mt6701_spi/test.rp2040-ard.yaml
+++ b/tests/components/mt6701_spi/test.rp2040-ard.yaml
@@ -1,0 +1,6 @@
+substitutions:
+  cs_pin: GPIO5
+
+packages:
+  spi: !include ../../test_build_components/common/spi/rp2040-ard.yaml
+  mt6701_spi: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Support for MagnTek MT6701 magnetic encoder. I've verified most of the implementation locally, but it's isolated to a single finished product and I haven't tested all its configuration options.

Documentation PR: esphome/esphome.io#7005

Datasheet: https://uploadcdn.oneyac.com/attachments/files/brand_pdf/magntek/F3/CA/MT6701QT-STD.pdf

<img width="1127" height="500" alt="image" src="https://github.com/user-attachments/assets/3c1e12d4-a6fa-439d-8b52-158f684cd093" />


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes: None

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7005

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
i2c:
  sda: GPIO21
  scl: GPIO22

mt6701_i2c:
  id: my_encoder
  direction: CLOCKWISE

sensor:
  - platform: mt6701
    mt6701_id: my_encoder
    name: Knob Angle
    update_interval: 100ms
    raw_count:
      name: Knob Raw Count
```
Full configuration reference: esphome/esphome.io#7005


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
