### PR TITLE
Split multi-token build.flags entries when generating ESP-IDF component CMakeLists

### DIFF
--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -111,6 +111,18 @@ def generate_cmakelists_txt(component: IDFComponent) -> str:
     # same way; emitting such an entry as a single quoted compile option
     # hands the compiler one argv with an embedded space.
     build_flags = [token for entry in build_flags for token in shlex.split(entry)]
+    # Re-glue bare -I/-L/-l tokens to their argument ("-I foo" -> "-Ifoo") so
+    # the prefix classifiers below still route them to INCLUDE_DIRS and the
+    # link handling.
+    tokens, build_flags = build_flags, []
+    i = 0
+    while i < len(tokens):
+        if tokens[i] in ("-I", "-L", "-l") and i + 1 < len(tokens):
+            build_flags.append(tokens[i] + tokens[i + 1])
+            i += 2
+        else:
+            build_flags.append(tokens[i])
+            i += 1
 
     # List all sources files
     build_src_files = collect_filtered_files(

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -10,6 +10,7 @@ ESP-IDF platform/framework compatibility defaults.
 import logging
 import os
 from pathlib import Path
+import shlex
 
 from esphome.core import CORE, Library
 from esphome.helpers import write_file_if_changed
@@ -105,6 +106,11 @@ def generate_cmakelists_txt(component: IDFComponent) -> str:
     build_flags = ensure_list(
         component.data.get("build", {}).get("flags", DEFAULT_BUILD_FLAGS)
     )
+    # PlatformIO shell-lexes each build.flags entry, so one entry can carry a
+    # flag and its argument (e.g. "-include cp_custom_alloc.h"). Split the
+    # same way; emitting such an entry as a single quoted compile option
+    # hands the compiler one argv with an embedded space.
+    build_flags = [token for entry in build_flags for token in shlex.split(entry)]
 
     # List all sources files
     build_src_files = collect_filtered_files(

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -10,7 +10,6 @@ ESP-IDF platform/framework compatibility defaults.
 import logging
 import os
 from pathlib import Path
-import shlex
 
 from esphome.core import CORE, Library
 from esphome.helpers import write_file_if_changed
@@ -84,6 +83,10 @@ def generate_cmakelists_txt(component: IDFComponent) -> str:
     Returns:
         str: The complete CMakeLists.txt content as a string
     """
+    # Late import: this module loads with the esp32 platform on every
+    # validate/compile, but shlex is only needed when generating component
+    # CMakeLists.
+    import shlex
 
     def escape_entry(p: PathType) -> str:
         # In CMakeLists.txt, backslashes need to be escaped

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -165,6 +165,32 @@ def test_generate_cmakelists_txt_multi_token_flag(tmp_component):
     assert '  "-include"\n  "cp_custom_alloc.h"\n' in content
 
 
+def test_generate_cmakelists_txt_space_separated_classified_flags(tmp_component):
+    # Space-separated -I/-L/-l entries routed to INCLUDE_DIRS and the link
+    # handling before the shlex split was added; splitting must not leak
+    # them into raw compile options.
+    src_dir = tmp_component.path / "src"
+    src_dir.mkdir()
+    (src_dir / "main.c").write_text("int main() {}")
+    (tmp_component.path / "extra_inc").mkdir()
+
+    tmp_component.data = {
+        "build": {"flags": ["-I extra_inc", "-L extra_lib", "-l extralib", "-DTEST"]}
+    }
+
+    content = generate_cmakelists_txt(tmp_component)
+    assert 'INCLUDE_DIRS "src" "extra_inc"' in content
+    assert 'target_link_directories(${COMPONENT_LIB} INTERFACE\n  "extra_lib"\n)' in (
+        content
+    )
+    assert 'target_link_libraries(${COMPONENT_LIB} INTERFACE\n  "extralib"\n)' in (
+        content
+    )
+    assert '"-I"' not in content
+    assert '"-L"' not in content
+    assert '"-l"' not in content
+
+
 def test_generate_cmakelists_txt_references_project_managed_components_variable(
     tmp_component: IDFComponent,
 ) -> None:

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -150,6 +150,21 @@ target_link_libraries(${{COMPONENT_LIB}} INTERFACE
     )
 
 
+def test_generate_cmakelists_txt_multi_token_flag(tmp_component):
+    # PlatformIO shell-lexes each build.flags entry, so a single entry can
+    # carry a flag and its argument. The generated CMakeLists must emit them
+    # as separate compile options, not one argument with an embedded space.
+    src_dir = tmp_component.path / "src"
+    src_dir.mkdir()
+    (src_dir / "main.c").write_text("int main() {}")
+
+    tmp_component.data = {"build": {"flags": ["-include cp_custom_alloc.h", "-DTEST"]}}
+
+    content = generate_cmakelists_txt(tmp_component)
+    assert '"-include cp_custom_alloc.h"' not in content
+    assert '  "-include"\n  "cp_custom_alloc.h"\n' in content
+
+
 def test_generate_cmakelists_txt_references_project_managed_components_variable(
     tmp_component: IDFComponent,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

`generate_cmakelists_txt` emits each `library.json` `build.flags` entry as its own quoted `target_compile_options` argument. PlatformIO shell-lexes each entry, so manifests legitimately carry multi-token entries; chipmunk2d-platformio ships `"-include cp_custom_alloc.h"`. Emitted as one quoted option, that reaches gcc as a single argv with an embedded space:

```
<command-line>: fatal error: cp_custom_alloc.h: No such file or directory
```

Since 2026.7 converts PlatformIO libraries to IDF components, this breaks every ESP-IDF build pulling such a library (e.g. lvgl-canvas-fx, which powers pavlov-net/hub75-studio; its CI on main has been red on exactly this error).

The fix splits each entry with `shlex` before the `-I`/`-L`/`-l`/`-W` classification, matching the lexing the PlatformIO build path applies to the same manifest. Added a test with a multi-token entry: it fails before the fix (the malformed single-token option is emitted verbatim) and passes after.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes: none filed; bug demonstrated by the test in this PR

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (build-system fix, no user-facing configuration change)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Reproduces on any ESP32 esp-idf config with:
external_components:
  - source: github://pavlov-net/lvgl-canvas-fx
    components: [lvgl_canvas_fx]
# lvgl_canvas_fx pulls chipmunk2d-platformio, whose manifest has the
# multi-token flags entry "-include cp_custom_alloc.h".
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
