### PR TITLE
[nextion] Limit TFT upload to ESP32/ESP8266, dropping unbuildable LibreTiny support

### DIFF
--- a/esphome/components/nextion/__init__.py
+++ b/esphome/components/nextion/__init__.py
@@ -19,9 +19,6 @@ FILTER_SOURCE_FILES = filter_source_files_from_platform(
         },
         "nextion_upload_arduino.cpp": {
             PlatformFramework.ESP8266_ARDUINO,
-            PlatformFramework.BK72XX_ARDUINO,
-            PlatformFramework.RTL87XX_ARDUINO,
-            PlatformFramework.LN882X_ARDUINO,
         },
     }
 )

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -9,11 +9,8 @@ from esphome.const import (
     CONF_ID,
     CONF_LAMBDA,
     CONF_ON_TOUCH,
-    PLATFORM_BK72XX,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
-    PLATFORM_LN882X,
-    PLATFORM_RTL87XX,
 )
 from esphome.core import CORE, TimePeriod
 
@@ -153,9 +150,6 @@ CONFIG_SCHEMA = cv.All(
                     [
                         PLATFORM_ESP32,
                         PLATFORM_ESP8266,
-                        PLATFORM_BK72XX,
-                        PLATFORM_RTL87XX,
-                        PLATFORM_LN882X,
                     ]
                 ),
             ),

--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -1,7 +1,7 @@
 #include "nextion.h"
 
 #ifdef USE_NEXTION_TFT_UPLOAD
-#if defined(USE_ESP8266) || defined(USE_LIBRETINY)
+#ifdef USE_ESP8266
 
 #include <cinttypes>
 #include "esphome/components/network/util.h"
@@ -378,5 +378,5 @@ WiFiClient *Nextion::get_wifi_client_() {
 
 }  // namespace esphome::nextion
 
-#endif  // USE_ESP8266 || USE_LIBRETINY
+#endif  // USE_ESP8266
 #endif  // USE_NEXTION_TFT_UPLOAD


### PR DESCRIPTION
# What does this implement/fix?

The Nextion TFT upload path (`nextion_upload_arduino.cpp`) is declared as supported on the LibreTiny platforms (bk72xx / rtl87xx / ln882x) — via `FILTER_SOURCE_FILES`, the `tft_url` `only_on` list, and the `#if defined(USE_ESP8266) || defined(USE_LIBRETINY)` guard — but it does not actually compile there. The code uses `EspClass::getFreeHeap()`, which is a static-style call valid on the ESP8266 Arduino core but a **non-static member** on the LibreTiny Arduino core, so a LibreTiny build fails with:

```
nextion_upload_arduino.cpp:31:45: error: call to non-static member function without an object argument
   31 |   ESP_LOGV(TAG, "Heap: %" PRIu32, EspClass::getFreeHeap());
```

There is no LibreTiny test that compiles `tft_url`, so the broken build was never exercised in CI. It was surfaced by the upcoming LibreTiny clang-tidy scans (#17491), which analyze this file under the LibreTiny toolchain because its guard string contains `USE_LIBRETINY`.

This limits TFT upload to the platforms where it actually builds — ESP32 (via `nextion_upload_idf.cpp`) and ESP8266 (via `nextion_upload_arduino.cpp`) — by removing the LibreTiny platforms from the `tft_url` `only_on`, from `nextion_upload_arduino.cpp`'s `FILTER_SOURCE_FILES`, and from the file's `#if` guard (which also removes the `USE_LIBRETINY` string that the clang-tidy scan keys on — the same guard/filter alignment as #17638 did for RP2). LibreTiny users now get a clear config error instead of a compile failure. If someone wants to add real LibreTiny support later, the `getFreeHeap()` call needs to be made portable (e.g. `ESP.getFreeHeap()`) and a compile test added.

Verified: `tft_url` on bk72xx now fails validation with "This feature is only available on [esp32, esp8266]"; nextion still compiles on esp8266.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
display:
  - platform: nextion
    tft_url: http://example.com/display.tft  # esp32 / esp8266 only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).