### PR TITLE
Pin cryptography to 48.0.1 on Intel macOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-cryptography==49.0.0
+# cryptography 49+ ships no Intel macOS wheels (arm64 only); esptool caps <49 there.
+# Keep 48.0.1, the last universal2 release, so esphome stays installable on Intel Macs.
+cryptography==49.0.0; platform_system != "Darwin" or platform_machine != "x86_64"
+cryptography==48.0.1; platform_system == "Darwin" and platform_machine == "x86_64"
 voluptuous==0.16.0
 PyYAML==6.0.3
 paho-mqtt==1.6.1


### PR DESCRIPTION
# What does this implement/fix?

TLDR: this is out of our control; the Python ecosystem we rely on is dropping support for Intel Macs, specifically [cryptography as of 49.0.0](https://cryptography.io/en/stable/changelog/#v49-0-0). We can work around it for now by holding Intel Macs on cryptography 48.0.1, but as soon as something breaking lands or a critical security issue hits cryptography we will be forced to drop macOS Intel support.

cryptography 49.0.0 [dropped Intel macOS](https://cryptography.io/en/stable/changelog/#v49-0-0); its macOS wheels are arm64 only and a source build needs Rust 1.83, which end users do not have. esptool 5.3.1 already caps `cryptography<49.0.0` on Darwin x86_64 for the same reason, so our `cryptography==49.0.0` pin makes esphome uninstallable on Intel Macs; pip fails with ResolutionImpossible, see the report below.

This splits the pin with environment markers, mirroring esptool's: everything keeps 49.0.0, Intel macOS gets 48.0.1, the last release with universal2 wheels. The only import site is `wifi/wpa2_eap.py`, which uses x509 APIs identical in both versions and gates on cryptography >= 2 only.

Verified with uv cross resolution on Python 3.13: `x86_64-apple-darwin` resolves and picks 48.0.1; `aarch64-apple-darwin` and `x86_64-unknown-linux-gnu` still pick 49.0.0.

This should ship in a 2026.7.x patch release so Intel Mac users can update again.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/327
- fixes https://github.com/esphome/esphome/issues/17704

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
