### PR TITLE
[espidf] Prune tool download cache after install to shrink the ESP-IDF cache

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -679,6 +679,10 @@ def _check_esphome_idf_framework_install(
                 )
             raise RuntimeError(f"ESP-IDF {version} framework installation failure")
 
+        # idf_tools.py extracts tool archives from <IDF_TOOLS_PATH>/dist into tools/; the
+        # archives are not needed afterward and, already compressed, dominate the cached install
+        rmdir(get_idf_tools_path() / "dist", msg="Remove ESP-IDF tool download cache")
+
         _write_stamp(env_stamp_file, stamp_info)
 
     return framework_path, install

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -680,8 +680,14 @@ def _check_esphome_idf_framework_install(
             raise RuntimeError(f"ESP-IDF {version} framework installation failure")
 
         # idf_tools.py extracts tool archives from <IDF_TOOLS_PATH>/dist into tools/; the
-        # archives are not needed afterward and, already compressed, dominate the cached install
-        rmdir(get_idf_tools_path() / "dist", msg="Remove ESP-IDF tool download cache")
+        # archives are not needed afterward and, already compressed, dominate the cached install.
+        # Best-effort: a failure to prune must not fail an otherwise successful install.
+        try:
+            rmdir(
+                get_idf_tools_path() / "dist", msg="Remove ESP-IDF tool download cache"
+            )
+        except RuntimeError as err:
+            _LOGGER.debug("Could not remove ESP-IDF tool download cache: %s", err)
 
         _write_stamp(env_stamp_file, stamp_info)
 

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -365,6 +365,23 @@ def test_check_esp_idf_install_fresh(espidf_mocks: SimpleNamespace) -> None:
     )
 
 
+def test_check_esp_idf_install_dist_prune_failure_ignored(
+    espidf_mocks: SimpleNamespace,
+) -> None:
+    """A failure to prune the tool download cache must not fail the install."""
+    tools_dist = get_idf_tools_path() / "dist"
+
+    def rmdir_side_effect(directory: Path, msg: str | None = None) -> None:
+        if directory == tools_dist:
+            raise RuntimeError("cannot remove dist")
+
+    espidf_mocks.rmdir.side_effect = rmdir_side_effect
+
+    # install still succeeds despite the failed prune
+    framework_path, _ = check_esp_idf_install(_IDF_VERSION, force=True)
+    assert framework_path == _get_framework_path(_IDF_VERSION)
+
+
 def test_check_esp_idf_install_git_source(espidf_mocks: SimpleNamespace) -> None:
     """A git source_url clones instead of downloading; explicit tools skip discovery."""
     check_esp_idf_install(

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -317,7 +317,7 @@ def espidf_mocks(setup_core: Path):
     # extracted-marker touch writes into.
     _get_framework_path(_IDF_VERSION).mkdir(parents=True, exist_ok=True)
     with (
-        patch("esphome.espidf.framework.rmdir"),
+        patch("esphome.espidf.framework.rmdir") as rmdir_mock,
         patch(
             "esphome.espidf.framework.download_from_mirrors",
             return_value="https://example.com/idf.tar.xz",
@@ -344,6 +344,7 @@ def espidf_mocks(setup_core: Path):
             run_ok=run_ok,
             tool_paths=tool_paths,
             clone=clone,
+            rmdir=rmdir_mock,
         )
 
 
@@ -358,6 +359,11 @@ def test_check_esp_idf_install_fresh(espidf_mocks: SimpleNamespace) -> None:
     espidf_mocks.extract.assert_called_once()
     espidf_mocks.venv.assert_called_once()
     espidf_mocks.clone.assert_not_called()
+    # the tool download cache (<IDF_TOOLS_PATH>/dist) is pruned after install
+    assert any(
+        call.args and Path(call.args[0]).name == "dist"
+        for call in espidf_mocks.rmdir.call_args_list
+    )
 
 
 def test_check_esp_idf_install_git_source(espidf_mocks: SimpleNamespace) -> None:

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -360,9 +360,8 @@ def test_check_esp_idf_install_fresh(espidf_mocks: SimpleNamespace) -> None:
     espidf_mocks.venv.assert_called_once()
     espidf_mocks.clone.assert_not_called()
     # the tool download cache (<IDF_TOOLS_PATH>/dist) is pruned after install
-    assert any(
-        call.args and Path(call.args[0]).name == "dist"
-        for call in espidf_mocks.rmdir.call_args_list
+    espidf_mocks.rmdir.assert_any_call(
+        get_idf_tools_path() / "dist", msg="Remove ESP-IDF tool download cache"
     )
 
 


### PR DESCRIPTION
# What does this implement/fix?

`idf_tools.py` downloads each toolchain/tool archive into `<IDF_TOOLS_PATH>/dist` and extracts it into `<IDF_TOOLS_PATH>/tools`. The archives are never read again after extraction, but they stay on disk and get written into the cached ESP-IDF install — and because they are already-compressed `.tar.xz`/`.tar.gz` files, they are essentially incompressible, so they dominate the *compressed* CI cache far more than their share of the uncompressed tree.

Measured on a current native install:

| | uncompressed | compressed (zstd, as GH Actions caches) |
|---|---|---|
| whole install | 5.8 GB | ~1.4 GB |
| `dist/` alone | 662 MB | ~662 MB (already compressed) |

So `dist/` is ~11% of the uncompressed tree but ~47% of the compressed cache. Dropping it takes the cached ESP-IDF install from ~1.4 GB to ~0.74 GB.

This removes `<IDF_TOOLS_PATH>/dist` after a successful `idf_tools.py install`. It is pure download scratch — nothing reads it after extraction, and a later install (e.g. after a version bump / cache miss) simply re-downloads and re-prunes. Doing it in `framework.py` (rather than a workflow step) means it benefits every install — local developer machines and every CI job — from one place, without touching the cache action's post-save hook.

Verified: `test_check_esp_idf_install_fresh` now asserts `dist` is pruned; full `test_espidf_framework.py` passes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Build-tooling change, no configuration impact
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).