### PR TITLE
[platformio] Include cache path in invalid library error

### DIFF
--- a/esphome/platformio/library.py
+++ b/esphome/platformio/library.py
@@ -651,7 +651,7 @@ def convert_libraries(
         else:
             raise RuntimeError(
                 f"Invalid PIO library {key}: missing library.json and "
-                "library.properties"
+                f"library.properties in {component.path}"
             )
 
         try:

--- a/tests/unit_tests/test_platformio_library.py
+++ b/tests/unit_tests/test_platformio_library.py
@@ -139,6 +139,8 @@ def _patch_download_with_manifests(monkeypatch, tmp_path, manifests, *, properti
     def fake_download(self, force=False, salt="", namespace=""):
         self.path = tmp_path / self.get_sanitized_name().replace("/", "__")
         self.path.mkdir(parents=True, exist_ok=True)
+        if self.name not in manifests:
+            return
         if self.name in properties:
             (self.path / "library.properties").write_text(manifests[self.name])
         else:
@@ -210,6 +212,19 @@ def test_convert_libraries_handles_unparsable_dependency_version(tmp_path, monke
     top = convert_libraries([Library("esphome/A", "1.0.0", None)], _backend())
 
     assert [d.name for d in top[0].dependencies] == ["C"]
+
+
+def test_convert_libraries_error_for_missing_manifest_includes_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The error must name the cache directory so users can find the broken
+    # entry instead of guessing where the library was unpacked.
+    _patch_download_with_manifests(monkeypatch, tmp_path, {})
+
+    with pytest.raises(RuntimeError, match="Invalid PIO library") as excinfo:
+        convert_libraries([Library("esphome/A", "1.0.0", None)], _backend())
+
+    assert str(tmp_path / "esphome__A") in str(excinfo.value)
 
 
 def test_convert_libraries_skips_incompatible_dependency(tmp_path, monkeypatch):


### PR DESCRIPTION
# What does this implement/fix?

The `Invalid PIO library ...: missing library.json and library.properties` error never says where the broken cache entry lives, so users cannot find or remove it; see the confusion in https://github.com/esphome/esphome/issues/17670. This adds the on disk path of the library to the error message.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/17670

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
