### PR TITLE
[zigbee] fix apptype attribute for sensor

### DIFF
--- a/esphome/components/zigbee/zigbee_esp32.py
+++ b/esphome/components/zigbee/zigbee_esp32.py
@@ -189,7 +189,7 @@ def validate_sensor_esp32(config: ConfigType) -> ConfigType:
         ep[CONF_CLUSTERS][0][CONF_ATTRIBUTES].append(
             {
                 CONF_ATTRIBUTE_ID: 0x100,
-                CONF_VALUE: (apptype << 16) | 0xFFFF,
+                CONF_VALUE: (apptype << 16) & 0xFFFF,
                 CONF_TYPE: "UINT32",
             },
         )


### PR DESCRIPTION
# What does this implement/fix?

Apptype was always set to 0xFFFF.  Set it to the actual value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
