### PR TITLE
[ssd1306] Fix offset_x being ignored on SH1106/SH1107 displays

### DIFF
--- a/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
+++ b/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
@@ -41,17 +41,17 @@ void I2CSSD1306::command(uint8_t value) { this->write_byte(0x00, value); }
 void HOT I2CSSD1306::write_display_data() {
   if (this->is_sh1106_() || this->is_sh1107_()) {
     uint32_t i = 0;
+    // Some panels wire their visible columns to a window of the controller RAM
+    // that does not start at column 0 (e.g. SH1107 M5Stack Unit OLED needs offset_x: 32).
+    // SH1106 keeps its historical 0x02 base column on top of any offset.
+    uint8_t start_column = this->offset_x_;
+    if (this->is_sh1106_()) {
+      start_column += 0x02;
+    }
     for (uint8_t page = 0; page < (uint8_t) this->get_height_internal() / 8; page++) {
-      this->command(0xB0 + page);  // row
-      if (this->is_sh1106_()) {
-        this->command(0x02);  // lower column - 0x02 is historical SH1106 value
-      } else {
-        // Other SH1107 drivers use 0x00
-        // Column values dont change and it seems they can be set only once,
-        // but we follow SH1106 implementation and resend them
-        this->command(0x00);
-      }
-      this->command(0x10);  // higher column
+      this->command(0xB0 + page);                 // row
+      this->command(start_column & 0x0F);         // lower column
+      this->command(0x10 | (start_column >> 4));  // higher column
       for (uint8_t x = 0; x < (uint8_t) this->get_width_internal() / 16; x++) {
         uint8_t data[16];
         for (uint8_t &j : data)

--- a/esphome/components/ssd1306_spi/ssd1306_spi.cpp
+++ b/esphome/components/ssd1306_spi/ssd1306_spi.cpp
@@ -38,14 +38,17 @@ void SPISSD1306::command(uint8_t value) {
 }
 void HOT SPISSD1306::write_display_data() {
   if (this->is_sh1106_() || this->is_sh1107_()) {
+    // Some panels wire their visible columns to a window of the controller RAM
+    // that does not start at column 0 (e.g. SH1107 M5Stack Unit OLED needs offset_x: 32).
+    // SH1106 keeps its historical 0x02 base column on top of any offset.
+    uint8_t start_column = this->offset_x_;
+    if (this->is_sh1106_()) {
+      start_column += 0x02;
+    }
     for (uint8_t y = 0; y < (uint8_t) this->get_height_internal() / 8; y++) {
       this->command(0xB0 + y);
-      if (this->is_sh1106_()) {
-        this->command(0x02);
-      } else {
-        this->command(0x00);
-      }
-      this->command(0x10);
+      this->command(start_column & 0x0F);         // lower column
+      this->command(0x10 | (start_column >> 4));  // higher column
       this->dc_pin_->digital_write(true);
       for (uint8_t x = 0; x < (uint8_t) this->get_width_internal(); x++) {
         this->enable();


### PR DESCRIPTION
# What does this implement/fix?

The `offset_x` config option was accepted by validation but silently ignored for SH1106 and SH1107 displays. The non-SH110x models apply it in `SSD1306::display()`, but the SH1106/SH1107 code path in `write_display_data()` (both I2C and SPI variants) hardcoded the per-page column pointer, so the offset never reached the panel.

Some SH1107 panels wire their visible columns to a window of the controller RAM that does not start at column 0. The M5Stack Unit OLED (U119, 64x128) maps its 64 visible columns to RAM columns 32..95, so without the offset half the glass shows unwritten-RAM noise and the content sits shifted into the other half.

The column pointer is now computed from `offset_x`. Defaults are byte-identical to before: SH1106 keeps its historical `0x02` base column (with `offset_x` added on top), and SH1107 with `offset_x: 0` still sends column 0. The only behavioural change is that a non-zero `offset_x` now works.

Verified on real hardware: an M5Stack Unit OLED with `offset_x: 32` now renders correctly across the full panel.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: ssd1306_i2c
    model: SH1107 128x64
    offset_x: 32
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).