### PR TITLE
esp32_ble_tracker: warn when scan window equals interval (continuous scan starves Wi-Fi/active BLE connections)

### DIFF
--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -135,6 +135,17 @@ def validate_scan_parameters(config):
             f"Scan window ({window}) needs to be smaller than scan interval ({interval})"
         )
 
+    if window == interval:
+        _LOGGER.warning(
+            "Scan window (%s) equals scan interval (%s), so the radio scans "
+            "continuously with no idle time. On single-antenna ESP32 variants "
+            "this starves Wi-Fi and active BLE connections of radio time and can "
+            "cause Wi-Fi instability and dropped bluetooth_proxy connections. "
+            "Set a scan window smaller than the scan interval to leave idle time.",
+            window,
+            interval,
+        )
+
     if interval.total_milliseconds * 3 > duration.total_milliseconds:
         raise cv.Invalid(
             "Scan duration needs to be at least three times the scan interval to"

--- a/tests/component_tests/esp32_ble_tracker/test_esp32_ble_tracker.py
+++ b/tests/component_tests/esp32_ble_tracker/test_esp32_ble_tracker.py
@@ -1,0 +1,46 @@
+"""Tests for esp32_ble_tracker configuration helpers."""
+
+import logging
+
+import pytest
+
+from esphome.components.esp32_ble_tracker import (
+    CONF_DURATION,
+    CONF_INTERVAL,
+    CONF_WINDOW,
+    validate_scan_parameters,
+)
+import esphome.config_validation as cv
+
+
+def _scan_params(interval_ms: int, window_ms: int, duration_s: int = 300) -> dict:
+    """Build a scan_parameters config the way the schema would produce it."""
+    return {
+        CONF_DURATION: cv.positive_time_period_seconds(f"{duration_s}s"),
+        CONF_INTERVAL: cv.positive_time_period_milliseconds(f"{interval_ms}ms"),
+        CONF_WINDOW: cv.positive_time_period_milliseconds(f"{window_ms}ms"),
+    }
+
+
+def test_scan_window_smaller_than_interval_is_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A scan window below the interval leaves idle time and must not warn."""
+    with caplog.at_level(logging.WARNING):
+        validate_scan_parameters(_scan_params(interval_ms=320, window_ms=30))
+    assert "scans continuously" not in caplog.text
+
+
+def test_scan_window_equal_to_interval_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Window == interval means continuous scanning and must warn the user."""
+    with caplog.at_level(logging.WARNING):
+        validate_scan_parameters(_scan_params(interval_ms=1100, window_ms=1100))
+    assert "scans continuously" in caplog.text
+
+
+def test_scan_window_greater_than_interval_is_invalid() -> None:
+    """Window > interval is physically impossible and must be rejected."""
+    with pytest.raises(cv.Invalid, match="needs to be smaller"):
+        validate_scan_parameters(_scan_params(interval_ms=320, window_ms=400))


### PR DESCRIPTION
# What does this implement/fix?

`esp32_ble_tracker`'s scan-parameter validator rejects `window > interval` but silently accepts `window == interval`. A window equal to the interval means the BLE radio scans **continuously with no idle gaps** (100% duty cycle). On single-antenna ESP32 variants, that leaves no radio time for Wi-Fi coexistence or for **active BLE connections**, and in practice shows up as Wi-Fi instability and repeated `bluetooth_proxy` disconnect/reconnect loops on any device held in an active connection.

This adds a `_LOGGER.warning` (non-breaking — configs still compile) when `window == interval`, steering users toward a window smaller than the interval so the radio has idle time. It follows the existing warning precedent in the same file (`validate_max_connections_deprecated`) and matches the guidance already in the docs, which note that raising these values "typically provides no meaningful benefit while increasing CPU usage" and "can cause WiFi instability on wireless models."

I ran into this on a real Wi-Fi ESP32 acting as a `bluetooth_proxy` with active connections: a `scan_parameters` of `interval: 1100ms` / `window: 1100ms` produced an EcoFlow battery (active BLE connection) that reconnected roughly every 7–10 seconds, ~14k times/day. Restoring the default sub-interval window made the connection rock solid — but nothing in the config had warned that the aggressive value was the cause.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Developer breaking change
- [ ] Undocumented C++ API change
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (validation/UX gap; related in spirit to the class of active-connection stability issues such as #6701, which was a separate state-machine race already fixed by #8297)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- Not required — no config variables added or changed; this only adds a runtime validation warning for an already-valid (but discouraged) combination. The docs already advise against aggressive scan windows.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32_ble_tracker:
  scan_parameters:
    interval: 1100ms
    window: 1100ms   # == interval -> now emits a warning (continuous scan, starves Wi-Fi/active connections)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

Added `tests/component_tests/esp32_ble_tracker/test_esp32_ble_tracker.py` covering the three cases: `window < interval` (silent), `window == interval` (warns), `window > interval` (raises `cv.Invalid`). Locally green: `ruff check`, `ruff format --check`, `script/ci-custom.py`, and the new pytest (3 passed).
