### PR TITLE
[epaper_spi] Do not yield on the final row of a T133A01 transfer phase

### DIFF
--- a/esphome/components/epaper_spi/epaper_spi_t133a01.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_t133a01.cpp
@@ -310,12 +310,12 @@ bool HOT EPaperT133A01::transfer_data() {
       half++;
       this->current_data_index_ = half;
 
-      // Only yield if there are rows left in this phase. Yielding on the final row would
-      // leave the phase complete but reported as unfinished, so the next call would skip
-      // the epilogue below and never release the bus.
-      if (half < total_rows && millis() - start_time > MAX_TRANSFER_TIME) {
-        return false;
+      if (millis() - start_time > MAX_TRANSFER_TIME) {
+        break;
       }
+    }
+    if (half < total_rows) {
+      return false;
     }
     ESP_LOGD(TAG, "CS phase done");
     this->disable();
@@ -348,11 +348,12 @@ bool HOT EPaperT133A01::transfer_data() {
       half++;
       this->current_data_index_ = half;
 
-      // Same as the CS phase: a yield on the final row would strand the open transaction,
-      // and here the function would go on to report the whole transfer complete.
-      if (half < total_rows * 2 && millis() - start_time > MAX_TRANSFER_TIME) {
-        return false;
+      if (millis() - start_time > MAX_TRANSFER_TIME) {
+        break;
       }
+    }
+    if (half < total_rows * 2) {
+      return false;
     }
     ESP_LOGD(TAG, "CS1 phase done");
     this->disable();

--- a/esphome/components/epaper_spi/epaper_spi_t133a01.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_t133a01.cpp
@@ -310,7 +310,10 @@ bool HOT EPaperT133A01::transfer_data() {
       half++;
       this->current_data_index_ = half;
 
-      if (millis() - start_time > MAX_TRANSFER_TIME) {
+      // Only yield if there are rows left in this phase. Yielding on the final row would
+      // leave the phase complete but reported as unfinished, so the next call would skip
+      // the epilogue below and never release the bus.
+      if (half < total_rows && millis() - start_time > MAX_TRANSFER_TIME) {
         return false;
       }
     }
@@ -345,7 +348,9 @@ bool HOT EPaperT133A01::transfer_data() {
       half++;
       this->current_data_index_ = half;
 
-      if (millis() - start_time > MAX_TRANSFER_TIME) {
+      // Same as the CS phase: a yield on the final row would strand the open transaction,
+      // and here the function would go on to report the whole transfer complete.
+      if (half < total_rows * 2 && millis() - start_time > MAX_TRANSFER_TIME) {
         return false;
       }
     }

--- a/tests/components/epaper_spi/common.h
+++ b/tests/components/epaper_spi/common.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "esphome/components/spi/spi.h"
+#include "esphome/core/hal.h"
+
+namespace esphome::epaper_spi::testing {
+
+/// SPI delegate that records transaction boundaries and burns wall-clock time on each
+/// row write, so a transfer can be driven past its MAX_TRANSFER_TIME yield deadline.
+class TimedSPIDelegate : public spi::SPIDelegate {
+ public:
+  explicit TimedSPIDelegate(uint32_t row_transfer_ms) : row_transfer_ms_(row_transfer_ms) {}
+
+  uint8_t transfer(uint8_t data) override { return 0; }
+
+  void write_array(const uint8_t *ptr, size_t length) override {
+    // A row of pixel data is one "slow" write; single-byte writes are commands.
+    if (length > 1) {
+      const uint32_t until = millis() + this->row_transfer_ms_;
+      while (millis() < until) {
+      }
+    }
+  }
+
+  void begin_transaction() override { this->begin_count++; }
+  void end_transaction() override { this->end_count++; }
+
+  int begin_count{0};
+  int end_count{0};
+
+ protected:
+  uint32_t row_transfer_ms_;
+};
+
+/// GPIO pin that just remembers the last level written to it.
+class RecordingPin : public GPIOPin {
+ public:
+  void setup() override {}
+  void pin_mode(gpio::Flags flags) override {}
+  gpio::Flags get_flags() const override { return gpio::Flags::FLAG_NONE; }
+  bool digital_read() override { return false; }
+  void digital_write(bool value) override { this->level = value; }
+  size_t dump_summary(char *buffer, size_t len) const override { return snprintf(buffer, len, "recording"); }
+
+  bool level{true};
+};
+
+}  // namespace esphome::epaper_spi::testing

--- a/tests/components/epaper_spi/display/test_t133a01_transfer.cpp
+++ b/tests/components/epaper_spi/display/test_t133a01_transfer.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include "../common.h"
+#include "esphome/components/epaper_spi/epaper_spi_t133a01.h"
+
+namespace esphome::epaper_spi::testing {
+
+/// Exposes the protected transfer machinery so the yield behaviour can be driven directly.
+class TestableT133A01 : public EPaperT133A01 {
+ public:
+  TestableT133A01(uint16_t width, uint16_t height) : EPaperT133A01("test", width, height, nullptr, 0) {}
+
+  void install(spi::SPIDelegate *delegate) {
+    this->delegate_ = delegate;
+    this->set_dc_pin(&this->dc);
+    this->set_cs_pins(&this->cs, &this->cs1);
+    ASSERT_TRUE(this->init_buffer_(this->buffer_length_));
+  }
+
+  using EPaperT133A01::transfer_data;
+
+  RecordingPin dc, cs, cs1;
+};
+
+/// Regression test for the T133A01 transfer deadlock (issue #17668).
+///
+/// `transfer_data()` evaluates its yield deadline *after* incrementing the row counter, so the
+/// deadline can expire on a phase's final row. The phase is then complete but the function
+/// reports "not done"; on the next call the phase guard is false, so the `disable()` /
+/// CS-deassert epilogue is skipped permanently. The SPI transaction is never closed and the
+/// next `enable()` blocks forever, tripping the task watchdog.
+///
+/// Here the CS phase is two rows and every row write overruns the deadline, so the second call
+/// completes the phase exactly as the deadline expires, which is the failing alignment. The completed
+/// phase must still run its epilogue: end the transaction and deassert CS.
+TEST(EPaperT133A01, CompletedPhaseRunsEpilogueWhenDeadlineExpiresOnFinalRow) {
+  // width 8 -> 4 bytes per row, 2 per half-row; height 2 -> a two-row CS phase
+  TestableT133A01 display(8, 2);
+  TimedSPIDelegate delegate(MAX_TRANSFER_TIME + 5);
+  display.install(&delegate);
+
+  // First call performs the one-off CCSET setup (which opens and closes a transaction of its
+  // own) and then writes row 0 of the CS phase before yielding on the deadline.
+  ASSERT_FALSE(display.transfer_data()) << "transfer should have yielded after the first row";
+  ASSERT_FALSE(display.cs.level) << "CS must stay asserted across a yield mid-phase";
+  const int closed_after_setup = delegate.end_count;
+
+  // Second call writes the final row of the CS phase; the deadline expires as it lands.
+  display.transfer_data();
+
+  EXPECT_EQ(delegate.end_count, closed_after_setup + 1)
+      << "completed CS phase skipped disable() -- SPI transaction left open";
+  EXPECT_TRUE(display.cs.level) << "completed CS phase left CS asserted";
+}
+
+/// The CS1 phase has the same off-by-one, but fails worse: after the skipped epilogue the
+/// function falls through to `return true`, reporting the transfer complete while the SPI
+/// transaction is still open and CS1 is still asserted. The next command's `enable()` then
+/// blocks forever. A transfer that reports done must have released the bus.
+TEST(EPaperT133A01, TransferReportsDoneOnlyAfterReleasingTheBus) {
+  TestableT133A01 display(8, 2);
+  TimedSPIDelegate delegate(MAX_TRANSFER_TIME + 5);
+  display.install(&delegate);
+
+  // Both phases are two rows each and every row overruns the deadline, so the transfer needs
+  // one call per row plus the setup call. Bound the loop so a regression fails rather than hangs.
+  int calls = 0;
+  while (!display.transfer_data()) {
+    ASSERT_LT(++calls, 10) << "transfer never reported completion";
+  }
+
+  EXPECT_TRUE(display.cs1.level) << "transfer reported done with CS1 still asserted";
+  EXPECT_EQ(delegate.begin_count, delegate.end_count)
+      << "transfer reported done with an SPI transaction still open -- the next enable() would deadlock";
+}
+
+}  // namespace esphome::epaper_spi::testing


### PR DESCRIPTION
# What does this implement/fix?

Fixes an intermittent deadlock and watchdog reboot on T133A01 e-paper panels (Seeed reTerminal E1004).

`transfer_data()` checked its 10 ms yield deadline **after** incrementing the row counter, so the deadline could expire on a phase's final row. The phase was then complete, but the function returned "not done". On the next call the phase guard (`half < total_rows`, and the CS1 equivalent) was already false, so the `disable()` and CS-deassert epilogue was skipped permanently. The SPI transaction was left open and the next `enable()` blocked forever, which tripped the esp-idf task watchdog and rebooted the device mid-update.

The CS1 phase failed worse: after skipping its epilogue the function fell through to `return true`, reporting the whole transfer complete while still holding the bus.

Whether the deadline lands on a phase's final row depends on how row timing aligns against the 10 ms budget, so it is probabilistic per update and config-dependent, which is presumably why it was not caught earlier.

The fix is to only yield when rows remain in the phase, so a completed phase always falls through to its epilogue:

```cpp
if (half < total_rows && millis() - start_time > MAX_TRANSFER_TIME) {      // CS phase
if (half < total_rows * 2 && millis() - start_time > MAX_TRANSFER_TIME) {  // CS1 phase
```

This is the fix proposed by the reporter in #17668, who verified it on hardware over 10+ consecutive updates. They stated in the issue that they were not submitting it as a PR themselves.

### Tests

Added `tests/components/epaper_spi/display/test_t133a01_transfer.cpp` with shared fixtures in `tests/components/epaper_spi/common.h`. A `SPIDelegate` stub records transaction begin/end and burns slightly more than `MAX_TRANSFER_TIME` per row write, so an 8x2 panel deterministically hits the deadline on each phase's final row. Two tests:

- `CompletedPhaseRunsEpilogueWhenDeadlineExpiresOnFinalRow` — a completed CS phase must close its transaction and deassert CS.
- `TransferReportsDoneOnlyAfterReleasingTheBus` — a transfer that returns `true` must have released the bus and deasserted CS1.

Both fail on `dev` and pass with this change:

```
# before
[  FAILED  ] EPaperT133A01.CompletedPhaseRunsEpilogueWhenDeadlineExpiresOnFinalRow
[  FAILED  ] EPaperT133A01.TransferReportsDoneOnlyAfterReleasingTheBus
  delegate.end_count Which is: 1 / closed_after_setup + 1 Which is: 2
  completed CS phase skipped disable() -- SPI transaction left open
  Value of: display.cs.level  Actual: false  Expected: true

# after
[       OK ] EPaperT133A01.CompletedPhaseRunsEpilogueWhenDeadlineExpiresOnFinalRow (57 ms)
[       OK ] EPaperT133A01.TransferReportsDoneOnlyAfterReleasingTheBus (71 ms)
[  PASSED  ] 2 tests.
```

`script/cpp_unit_test.py epaper_spi` passes, `esphome config tests/components/epaper_spi/validate-e1004.esp32-s3-idf.yaml` is valid, and `clang-format` is clean.

Note: this adds the first C++ unit tests for `epaper_spi`, so the component now has a `display/` subdirectory under `tests/components/epaper_spi/` to pull the display platform into the test build.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17668

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A — no user-facing configuration or documented behaviour changes.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

I do not have a reTerminal E1004 to test on, so no hardware box is ticked. Verification here is the host-platform unit tests above plus config validation. The reporter of #17668 ran this exact change on the affected hardware for 10+ consecutive updates without a watchdog reboot, where the stock driver hung on the first update.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: epaper_spi
    spi_id: epaper_spi_bus
    model: seeed-reterminal-e1004
    update_interval: 60s
    lambda: |-
      it.fill(Color::WHITE);
      it.filled_circle(200, 300, 80, Color(255, 0, 0));
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

---

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.
