### PR TITLE
[bq76972] Add BQ76972 BMS chip monitoring component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -96,6 +96,7 @@ esphome/components/bmp581_i2c/* @danielkent-net @kahrendt
 esphome/components/bmp581_spi/* @danielkent-net @kahrendt
 esphome/components/bp1658cj/* @Cossid
 esphome/components/bp5758d/* @Cossid
+esphome/components/bq76972/* @limpkin
 esphome/components/bthome_mithermometer/* @nagyrobi
 esphome/components/button/* @esphome/core
 esphome/components/bytebuffer/* @clydebarrow

--- a/esphome/components/bq76972/__init__.py
+++ b/esphome/components/bq76972/__init__.py
@@ -1,0 +1,112 @@
+import esphome.codegen as cg
+from esphome.components import i2c, number, sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ADDRESS,
+    CONF_ID,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLTAGE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_VOLT,
+)
+
+DEPENDENCIES = ["i2c"]
+AUTO_LOAD = ["number"]
+
+bq76972_ns = cg.esphome_ns.namespace("bq76972")
+BQ76972Component = bq76972_ns.class_("BQ76972Component", cg.PollingComponent, i2c.I2CDevice)
+BQ76972AddressNumber = bq76972_ns.class_("BQ76972AddressNumber", number.Number)
+
+CONF_REG_DISABLED = "reg_disabled"
+CONF_CRC_ENABLED = "crc_enabled"
+CONF_STACK_VOLTAGE = "stack_voltage"
+CONF_I2C_ADDRESS_SETTER = "i2c_address_setter"
+
+TEMP_SENSORS = {
+    "internal_temperature": "set_internal_temp_sensor",
+    "cfetoff_temperature": "set_cfetoff_temp_sensor",
+    "dfetoff_temperature": "set_dfetoff_temp_sensor",
+    "alert_temperature": "set_alert_temp_sensor",
+    "ts1_temperature": "set_ts1_temp_sensor",
+    "ts2_temperature": "set_ts2_temp_sensor",
+    "ts3_temperature": "set_ts3_temp_sensor",
+    "hdq_temperature": "set_hdq_temp_sensor",
+    "dchg_temperature": "set_dchg_temp_sensor",
+    "ddsg_temperature": "set_ddsg_temp_sensor",
+}
+
+CONF_CELL_VOLTAGES = [f"cell_{i}_voltage" for i in range(1, 17)]
+
+voltage_sensor_schema = sensor.sensor_schema(
+    unit_of_measurement=UNIT_VOLT,
+    accuracy_decimals=3,
+    device_class=DEVICE_CLASS_VOLTAGE,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
+
+temp_sensor_schema = sensor.sensor_schema(
+    unit_of_measurement=UNIT_CELSIUS,
+    accuracy_decimals=1,
+    device_class=DEVICE_CLASS_TEMPERATURE,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.declare_id(BQ76972Component),
+            cv.Optional(CONF_CRC_ENABLED, default=False): cv.boolean,
+            cv.Optional(CONF_REG_DISABLED, default=True): cv.boolean,
+            cv.Optional(CONF_STACK_VOLTAGE): voltage_sensor_schema,
+            cv.Optional(CONF_I2C_ADDRESS_SETTER): number.number_schema(BQ76972AddressNumber),
+        }
+    )
+    .extend(
+        cv.Schema(
+            {cv.Optional(cell_key): voltage_sensor_schema for cell_key in CONF_CELL_VOLTAGES}
+        )
+    )
+    .extend(
+        cv.Schema(
+            {cv.Optional(temp_key): temp_sensor_schema for temp_key in TEMP_SENSORS}
+        )
+    )
+    .extend(i2c.i2c_device_schema(0x08))
+    .extend(cv.polling_component_schema("10s"))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    cg.add(var.set_address(config[CONF_ADDRESS]))
+    cg.add(var.set_crc_mode(config[CONF_CRC_ENABLED]))
+    cg.add(var.set_reg_disable(config[CONF_REG_DISABLED]))
+    cg.add(var.set_component_id(str(config[CONF_ID])))
+
+    if CONF_STACK_VOLTAGE in config:
+        sens = await sensor.new_sensor(config[CONF_STACK_VOLTAGE])
+        cg.add(var.set_stack_voltage_sensor(sens))
+
+    for temp_key, setter in TEMP_SENSORS.items():
+        if temp_key in config:
+            sens = await sensor.new_sensor(config[temp_key])
+            cg.add(getattr(var, setter)(sens))
+
+    for idx, cell_key in enumerate(CONF_CELL_VOLTAGES):
+        if cell_key in config:
+            sens = await sensor.new_sensor(config[cell_key])
+            cg.add(var.set_cell_sensor(idx, sens))
+
+    if CONF_I2C_ADDRESS_SETTER in config:
+        n_var = await number.new_number(
+            config[CONF_I2C_ADDRESS_SETTER],
+            min_value=8,
+            max_value=119,
+            step=1,
+        )
+        cg.add(n_var.set_hub(var))
+        cg.add(var.set_address_number(n_var))

--- a/esphome/components/bq76972/bq76972.cpp
+++ b/esphome/components/bq76972/bq76972.cpp
@@ -1,0 +1,543 @@
+#include "bq76972.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome::bq76972 {
+
+static const char *const TAG = "bq76972";
+static const uint8_t BQ76972_SUBCOMMAND_LSB_REG = 0x3E;
+static const uint8_t BQ76972_SUBCOMMAND_MSB_REG = 0x3F;
+static const uint8_t BQ76972_CMD_BAT_STATUS = 0x12;
+static const uint8_t BQ76972_GET_INT_TEMP = 0x68;
+static const uint8_t BQ76972_CMD_TEMP_START = 0x68;
+static const uint8_t BQ76972_CMD_CELL_START = 0x14;
+static const uint8_t BQ76972_CMD_STACK_VOLTAGE = 0x34;
+static const uint8_t BQ76972_SUBCMD_ENTER_CFG_UPDATE = 0x0090;
+static const uint8_t BQ76972_SUBCMD_EXIT_CFG_UPDATE = 0x0092;
+static const uint16_t BQ76972_MEM_REG0_CONFIG = 0x9237;
+static const uint16_t BQ76972_MEM_REG12_CONFIG = 0x9236;
+static const uint16_t BQ76972_MEM_I2C_ADDRESS = 0x923A;
+static const uint16_t BQ76972_MEM_SWAP_COMM_MODE = 0x29BC;
+
+struct ThermistorConfig {
+  sensor::Sensor *sensor;
+  uint16_t subcommand;
+  const char *name;
+};
+
+uint8_t BQ76972Component::compute_crc8(const uint8_t *data, size_t len) {
+  uint8_t crc = 0x00;  // Initial value is 0
+  for (size_t i = 0; i < len; ++i) {
+    crc ^= data[i];
+    for (int j = 0; j < 8; ++j) {
+      if (crc & 0x80) {
+        crc = (crc << 1) ^ 0x07;  // Polynomial x^8 + x^2 + x + 1
+      } else {
+        crc = (crc << 1);
+      }
+    }
+  }
+  return crc;
+}
+
+bool BQ76972Component::wait_for_subcommand(void) {
+  uint8_t reg_uint8;
+  while (true) {
+    if (!this->read_block(BQ76972_SUBCOMMAND_LSB_REG, &reg_uint8, 1))
+      return false;
+    if (reg_uint8 != 0xFF) {
+      break;
+    }
+  }
+  while (true) {
+    if (!this->read_block(BQ76972_SUBCOMMAND_MSB_REG, &reg_uint8, 1))
+      return false;
+    if (reg_uint8 != 0xFF) {
+      break;
+    }
+  }
+  return true;
+}
+
+bool BQ76972Component::wait_for_cfgupdate(void) {
+  uint16_t reg_uint16;
+  while (true) {
+    if (!this->bq76972_read_multi_16_le(BQ76972_CMD_BAT_STATUS, &reg_uint16, 1))
+      return false;
+    if ((reg_uint16 & 0x0001) == 0x0001) {
+      break;
+    }
+  }
+  return true;
+}
+
+bool BQ76972Component::read_block(uint8_t start_register, uint8_t *data, size_t len) {
+  if (!this->crc_mode_) {
+    return this->read_bytes(start_register, data, len);
+  }
+
+  // When CRC is enabled, every data byte is followed by a CRC byte
+  std::vector<uint8_t> buffer(len * 2);
+
+  if (!this->read_bytes(start_register, buffer.data(), len * 2)) {
+    ESP_LOGE(TAG, "I2C block read failed at register 0x%02X", start_register);
+    return false;
+  }
+
+  // Verify CRC for the FIRST data byte: Includes write address, register address, read address, and first data byte
+  uint8_t crc0_input[4] = {
+      static_cast<uint8_t>(this->i2c_address_ << 1),        // Write address
+      start_register,                                       // Register address
+      static_cast<uint8_t>((this->i2c_address_ << 1) | 1),  // Read address
+      buffer[0]                                             // First data byte
+  };
+
+  if (this->compute_crc8(crc0_input, 4) != buffer[1]) {
+    ESP_LOGE(TAG, "CRC mismatch on first byte of block read");
+    return false;
+  }
+  data[0] = buffer[0];
+
+  // Verify CRC for SUBSEQUENT data bytes: Calculated over the data byte only
+  for (size_t i = 1; i < len; ++i) {
+    uint8_t crc_sub[1] = {buffer[i * 2]};
+    if (this->compute_crc8(crc_sub, 1) != buffer[i * 2 + 1]) {
+      ESP_LOGE(TAG, "CRC mismatch on byte %d of block read", i);
+      return false;
+    }
+    data[i] = buffer[i * 2];
+  }
+
+  return true;
+}
+
+bool BQ76972Component::write_block(uint8_t start_register, const uint8_t *data, size_t len) {
+  if (!this->crc_mode_) {
+    return this->write_bytes(start_register, data, len);
+  }
+
+  // When CRC is enabled, every data byte is immediately followed by its CRC
+  std::vector<uint8_t> buffer(len * 2);
+
+  // Calculate CRC for the FIRST data byte: Includes responder write address, register address, and first data byte
+  uint8_t crc0_input[3] = {static_cast<uint8_t>(this->i2c_address_ << 1), start_register, data[0]};
+  buffer[0] = data[0];
+  buffer[1] = this->compute_crc8(crc0_input, 3);
+
+  // Calculate CRC for SUBSEQUENT data bytes: Includes ONLY the data byte itself
+  for (size_t i = 1; i < len; ++i) {
+    buffer[i * 2] = data[i];
+    uint8_t crc_sub[1] = {data[i]};
+    buffer[i * 2 + 1] = this->compute_crc8(crc_sub, 1);
+  }
+
+  return this->write_bytes(start_register, buffer.data(), buffer.size());
+}
+
+bool BQ76972Component::bq76972_read_multi_16_le(uint8_t a_register, uint16_t *data, size_t num_words) {
+  // destination and size sanity check
+  if (data == nullptr || num_words == 0) {
+    return false;
+  }
+
+  // With CRC: each uint16_t takes 4 bytes (Data0, CRC0, Data1, CRC1)
+  // Without CRC: each uint16_t takes 2 bytes (Data0, Data1)
+  size_t bytes_per_word = this->crc_mode_ ? 4 : 2;
+  size_t total_bytes_to_read = num_words * bytes_per_word;
+
+  // Use a dynamic buffer (vector) to cleanly handle variable length reads safely
+  std::vector<uint8_t> buffer(total_bytes_to_read);
+
+  if (!this->read_bytes(a_register, buffer.data(), total_bytes_to_read)) {
+    return false;  // Read failed
+  }
+
+  if (this->crc_mode_) {
+    for (size_t i = 0; i < num_words; i++) {
+      size_t offset = i * 4;
+      uint8_t data_lsb = buffer[offset + 0];
+      uint8_t crc_lsb = buffer[offset + 1];
+      uint8_t data_msb = buffer[offset + 2];
+      uint8_t crc_msb = buffer[offset + 3];
+
+      // 1. Check LSB CRC
+      if (i == 0) {
+        // The very first data byte CRC includes communication overhead addresses
+        uint8_t crc0_input[4] = {
+            static_cast<uint8_t>(this->i2c_address_ << 1),        // Write address
+            a_register,                                           // Register address
+            static_cast<uint8_t>((this->i2c_address_ << 1) | 1),  // Read address
+            data_lsb                                              // First data byte (LSB)
+        };
+        uint8_t crc0_calc = this->compute_crc8(crc0_input, 4);
+        if (crc0_calc != crc_lsb) {
+          ESP_LOGE(TAG, "CRC error on Word %d LSB. Expected 0x%02X, got 0x%02X", i, crc0_calc, crc_lsb);
+          return false;
+        }
+      } else {
+        // Subsequent sequential LSB bytes compute CRC only over the data byte itself
+        uint8_t crc_input[1] = {data_lsb};
+        uint8_t crc_calc = this->compute_crc8(crc_input, 1);
+        if (crc_calc != crc_lsb) {
+          ESP_LOGE(TAG, "CRC error on Word %d LSB. Expected 0x%02X, got 0x%02X", i, crc_calc, crc_lsb);
+          return false;
+        }
+      }
+
+      // 2. Check MSB CRC (Always calculated over the MSB data byte only)
+      uint8_t crc1_input[1] = {data_msb};
+      uint8_t crc1_calc = this->compute_crc8(crc1_input, 1);
+      if (crc1_calc != crc_msb) {
+        ESP_LOGE(TAG, "CRC error on Word %d MSB. Expected 0x%02X, got 0x%02X", i, crc1_calc, crc_msb);
+        return false;
+      }
+
+      // Store reconstituted value
+      data[i] = (static_cast<uint16_t>(data_msb) << 8) | data_lsb;
+    }
+  } else {
+    // Reconstitute words cleanly without CRC parsing
+    for (size_t i = 0; i < num_words; i++) {
+      size_t offset = i * 2;
+      data[i] = (static_cast<uint16_t>(buffer[offset + 1]) << 8) | buffer[offset + 0];
+    }
+  }
+
+  return true;
+}
+
+bool BQ76972Component::read_subcommand(uint16_t subcommand, uint8_t *data, size_t expected_len) {
+  // Write the 16-bit subcommand address to 0x3E (lower) and 0x3F (upper)
+  uint8_t sub_byte_l[1] = {
+      static_cast<uint8_t>(subcommand & 0xFF),
+  };
+  uint8_t sub_byte_h[1] = {static_cast<uint8_t>((subcommand >> 8) & 0xFF)};
+
+  if (!this->write_block(BQ76972_SUBCOMMAND_LSB_REG, sub_byte_l, 1))
+    return false;
+  if (!this->write_block(BQ76972_SUBCOMMAND_MSB_REG, sub_byte_h, 1))
+    return false;
+
+  // Wait for the device to process the command and populate the buffer.
+  if (!this->wait_for_subcommand())
+    return false;
+
+  // Read the populated data from the transfer buffer starting at 0x40
+  if (!this->read_block(0x40, data, expected_len))
+    return false;
+
+  return true;
+}
+
+bool BQ76972Component::write_subcommand(uint16_t subcommand, const uint8_t *data, size_t len) {
+  // Write the 16-bit subcommand address to 0x3E (lower) and 0x3F (upper)
+  uint8_t sub_byte_l[1] = {
+      static_cast<uint8_t>(subcommand & 0xFF),
+  };
+  uint8_t sub_byte_h[1] = {static_cast<uint8_t>((subcommand >> 8) & 0xFF)};
+
+  if (!this->write_block(BQ76972_SUBCOMMAND_LSB_REG, sub_byte_l, 1))
+    return false;
+  if (!this->write_block(BQ76972_SUBCOMMAND_MSB_REG, sub_byte_h, 1))
+    return false;
+
+  // Write the data into the transfer buffer starting at 0x40
+  if (len > 0) {
+    if (!this->write_block(0x40, data, len))
+      return false;
+
+    // Calculate checksum: 8-bit sum of 0x3E, 0x3F, and buffer data, then bitwise inverted
+    uint8_t sum = sub_byte_l[0] + sub_byte_h[0];
+    for (size_t i = 0; i < len; ++i) {
+      sum += data[i];
+    }
+    uint8_t checksum = ~sum;
+
+    // Calculate length: 4 (0x3E, 0x3F, 0x60, 0x61) + len of data
+    uint8_t data_length = 4 + len;
+
+    // Checksum and length must be written together as a word to 0x60 and 0x61
+    uint8_t tail[2] = {checksum, data_length};
+    if (!this->write_block(0x60, tail, 2))
+      return false;
+  }
+
+  return true;
+}
+
+bool BQ76972Component::store_int_temp() {
+  uint16_t internal_temp;
+  if (!this->bq76972_read_multi_16_le(BQ76972_GET_INT_TEMP, &internal_temp, 1)) {
+    return false;
+  }
+
+  // Internal temperature extraction
+  int16_t raw_temp = static_cast<int16_t>(internal_temp);
+  this->internal_temp_c_ = (raw_temp * 0.1f) - 273.15f;
+  this->internal_temp_f_ = (internal_temp_c_ * 9.0f / 5.0f) + 32.0f;
+
+  return true;
+}
+
+void BQ76972Component::setup() {
+  // Read internal temperature to check comms
+  if (!this->store_int_temp()) {
+    static std::string failure_reason = this->component_id_ + " failed to communicate over I2C";
+    this->mark_failed(failure_reason.c_str());
+    return;
+  }
+
+  if (this->address_number_ != nullptr) {
+    this->address_number_->publish_state(this->address_);
+  }
+
+  // Disable regulators if needed
+  if (this->reg_disable_) {
+    // See
+    // https://e2e.ti.com/support/power-management-group/power-management/f/power-management-forum/1583718/bq76972-undocumented-4-minute-config_update-auto-exit-timeout
+    bool reg_already_disabled = true;
+
+    // Check reg12 initial configuration
+    uint8_t reg_uint8;
+    if (!this->read_subcommand(BQ76972_MEM_REG12_CONFIG, &reg_uint8, 1)) {
+      static std::string failure_reason = this->component_id_ + ": couldn't read reg12 config";
+      this->mark_failed(failure_reason.c_str());
+      return;
+    }
+    if (reg_uint8 != 0)
+      reg_already_disabled = false;
+
+    // Check reg0 initial configuration
+    if (!this->read_subcommand(BQ76972_MEM_REG0_CONFIG, &reg_uint8, 1)) {
+      static std::string failure_reason = this->component_id_ + ": couldn't read reg0 config";
+      this->mark_failed(failure_reason.c_str());
+      return;
+    }
+    if ((reg_uint8 & 0x01) != 0)
+      reg_already_disabled = false;
+
+    if (!reg_already_disabled) {
+      // Enter CONFIG_UPDATE mode
+      if (!this->write_subcommand(BQ76972_SUBCMD_ENTER_CFG_UPDATE, nullptr, 0)) {
+        static std::string failure_reason = this->component_id_ + ": couldn't enter config update mode";
+        this->mark_failed(failure_reason.c_str());
+        return;
+      }
+      delay(10);
+
+      // Wait for config updatemode
+      if (!this->wait_for_cfgupdate()) {
+        static std::string failure_reason = this->component_id_ + ": couldn't wait for update mode";
+        this->mark_failed(failure_reason.c_str());
+        return;
+      }
+
+      // Send new configuration with reg1&2 disabled
+      uint8_t reg12_data[1] = {0x00};
+      if (!this->write_subcommand(BQ76972_MEM_REG12_CONFIG, reg12_data, 1)) {
+        static std::string failure_reason = this->component_id_ + ": couldn't set reg12 regiser";
+        this->mark_failed(failure_reason.c_str());
+        return;
+      }
+
+      // Send new configuration with reg0 disabled
+      uint8_t reg0_data[1] = {0x00};
+      if (!this->write_subcommand(BQ76972_MEM_REG0_CONFIG, reg0_data, 1)) {
+        static std::string failure_reason = this->component_id_ + ": couldn't set reg0 regiser";
+        this->mark_failed(failure_reason.c_str());
+        return;
+      }
+
+      // Exit CONFIG_UPDATE mode
+      if (!this->write_subcommand(BQ76972_SUBCMD_EXIT_CFG_UPDATE, nullptr, 0)) {
+        static std::string failure_reason = this->component_id_ + ": couldn't exit config update mode";
+        this->mark_failed(failure_reason.c_str());
+        return;
+      }
+
+      // Check success: reg12
+      if (!this->read_subcommand(BQ76972_MEM_REG12_CONFIG, &reg_uint8, 1) || (reg_uint8 != 0)) {
+        static std::string failure_reason = this->component_id_ + ": couldn't disable reg12";
+        this->mark_failed(failure_reason.c_str());
+        return;
+      }
+
+      // Check success
+      if (!this->read_subcommand(BQ76972_MEM_REG0_CONFIG, &reg_uint8, 1) || ((reg_uint8 & 0x01) != 0)) {
+        static std::string failure_reason = this->component_id_ + ": couldn't disable pre-regulator";
+        this->mark_failed(failure_reason.c_str());
+        return;
+      }
+    }
+  }
+
+  // Thermistor configuration
+  uint8_t register_for_thermistor_mes = 0x07;
+  const ThermistorConfig thermistors[] = {
+      {this->ts2_temp_sensor_, 0x92FE, "TS2"},         {this->ts3_temp_sensor_, 0x92FF, "TS3"},
+      {this->hdq_temp_sensor_, 0x9300, "HDQ"},         {this->dchg_temp_sensor_, 0x9301, "DCHG"},
+      {this->ddsg_temp_sensor_, 0x9302, "DDSG"},       {this->cfetoff_temp_sensor_, 0x92FA, "CFETOFF"},
+      {this->dfetoff_temp_sensor_, 0x92FB, "DFETOFF"}, {this->alert_temp_sensor_, 0x92FC, "ALERT"},
+  };
+
+  // Enter CONFIG_UPDATE mode
+  if (!this->write_subcommand(BQ76972_SUBCMD_ENTER_CFG_UPDATE, nullptr, 0)) {
+    static std::string failure_reason = this->component_id_ + ": couldn't enter config update mode";
+    this->mark_failed(failure_reason.c_str());
+    return;
+  }
+  delay(10);
+
+  // Wait for config updatemode
+  if (!this->wait_for_cfgupdate()) {
+    static std::string failure_reason = this->component_id_ + ": couldn't wait for update mode";
+    this->mark_failed(failure_reason.c_str());
+    return;
+  }
+
+  // Program registers if needed
+  for (const auto &t : thermistors) {
+    if (t.sensor != nullptr) {
+      if (!this->write_subcommand(t.subcommand, &register_for_thermistor_mes, 1)) {
+        std::string failure_reason = this->component_id_ + ": couldn't program " + t.name + " pin input for thermistor";
+        this->mark_failed(failure_reason.c_str());
+        return;
+      }
+    }
+  }
+
+  // Exit CONFIG_UPDATE mode
+  if (!this->write_subcommand(BQ76972_SUBCMD_EXIT_CFG_UPDATE, nullptr, 0)) {
+    static std::string failure_reason = this->component_id_ + ": couldn't exit config update mode";
+    this->mark_failed(failure_reason.c_str());
+    return;
+  }
+
+  // Delayed debug info
+  this->set_timeout(7000, [this]() {
+    ESP_LOGI(TAG, "%s: Init completed without issues", this->component_id_.c_str());
+    ESP_LOGI(TAG, "%s: Internal temperature of %.2f°C, %.2f°F", this->component_id_.c_str(), this->internal_temp_c_,
+             this->internal_temp_f_);
+  });
+}
+
+void BQ76972Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "BQ76972 (ID: %s):", this->component_id_.c_str());
+  LOG_I2C_DEVICE(this);
+  LOG_UPDATE_INTERVAL(this);
+  ESP_LOGCONFIG(TAG, "  CRC Mode: %s", this->crc_mode_ ? "Enabled" : "Disabled");
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
+  }
+}
+
+void BQ76972Component::program_address_from_number() {
+  if (this->address_number_ != nullptr) {
+    // Enter CONFIG_UPDATE mode
+    if (!this->write_subcommand(BQ76972_SUBCMD_ENTER_CFG_UPDATE, nullptr, 0)) {
+      ESP_LOGE(TAG, "%s: Couldn't enter config update mode", this->component_id_.c_str());
+      return;
+    }
+    delay(10);
+
+    // Wait for config updatemode
+    if (!this->wait_for_cfgupdate()) {
+      ESP_LOGE(TAG, "%s: Couldn't wait for update mode", this->component_id_.c_str());
+      return;
+    }
+
+    // Program new I²C address
+    uint8_t new_i2c_address_for_bq = (static_cast<uint8_t>(this->address_number_->state) << 1);
+    if (!this->write_subcommand(BQ76972_MEM_I2C_ADDRESS, &new_i2c_address_for_bq, 1)) {
+      ESP_LOGE(TAG, "%s: Couldn't program new I2C address", this->component_id_.c_str());
+      return;
+    }
+
+    // Issue swap comm mode
+    if (!this->write_subcommand(BQ76972_MEM_SWAP_COMM_MODE, nullptr, 0)) {
+      ESP_LOGE(TAG, "%s: Couldn't issue swap comm mode", this->component_id_.c_str());
+      return;
+    }
+    delay(10);
+
+    // Update our I²C internal logic
+    this->i2c_address_ = static_cast<uint8_t>(this->address_number_->state);
+    this->set_i2c_address(this->i2c_address_);
+
+    // Exit CONFIG_UPDATE mode
+    if (!this->write_subcommand(BQ76972_SUBCMD_EXIT_CFG_UPDATE, nullptr, 0)) {
+      ESP_LOGE(TAG, "%s: Couldn't exit config update mode", this->component_id_.c_str());
+      return;
+    }
+  }
+}
+
+void BQ76972Component::publish_temperature_from_buffer_(const uint16_t temperature_uint16t, sensor::Sensor *sens) {
+  if (sens == nullptr) {
+    return;  // Skip sensors that were not declared in YAML
+  }
+
+  // Combine Little-Endian byte pair into a signed 16-bit raw integer
+  int16_t raw_signed = static_cast<int16_t>(temperature_uint16t);
+
+  // Convert raw value (0.1 Kelvin) to Celsius: (Raw / 10.0) - 273.15
+  float temp_celsius = (raw_signed / 10.0f) - 273.15f;
+
+  sens->publish_state(temp_celsius);
+}
+
+void BQ76972Component::update() {
+  // Stack Voltage (1 LSB = 10mV -> convert to Volts)
+  uint16_t raw_stack;
+  if (!this->bq76972_read_multi_16_le(BQ76972_CMD_STACK_VOLTAGE, &raw_stack, 1)) {
+    ESP_LOGE(TAG, "%s: Couldn't fetch stack voltage", this->component_id_.c_str());
+    return;
+  }
+  this->pack_voltage_mv_ = raw_stack * 10;
+  if (this->stack_voltage_sensor_ != nullptr && raw_stack != 0) {
+    this->stack_voltage_sensor_->publish_state((float) raw_stack * 0.01f);
+  }
+
+  // Sequential Block Read for all 16 cell voltages
+  uint16_t cell_buffer[16];
+
+  // Issue a single I2C request starting from Cell 1's memory address
+  if (!this->bq76972_read_multi_16_le(BQ76972_CMD_CELL_START, cell_buffer, 16)) {
+    ESP_LOGE(TAG, "%s: Couldn't fetch cell voltages", this->component_id_.c_str());
+    return;
+  }
+
+  // Parse the retrieved block from local memory
+  for (size_t i = 0; i < 16; i++) {
+    this->cell_voltages_mv_[i] = cell_buffer[i];
+    if (this->cell_sensors_[i] == nullptr)
+      continue;
+
+    if (cell_buffer[i] != 0) {
+      this->cell_sensors_[i]->publish_state((float) cell_buffer[i] * 0.001f);
+    }
+  }
+
+  // Sequential Block Read for all 10 temperature sensors
+  uint16_t temperature_buffer[10];
+
+  // Issue a single I2C request
+  if (!this->bq76972_read_multi_16_le(BQ76972_CMD_TEMP_START, temperature_buffer, 10)) {
+    ESP_LOGE(TAG, "%s: Couldn't fetch temperatures", this->component_id_.c_str());
+    return;
+  }
+
+  // Publish state if needed
+  this->publish_temperature_from_buffer_(temperature_buffer[0], this->internal_temp_sensor_);
+  this->publish_temperature_from_buffer_(temperature_buffer[1], this->cfetoff_temp_sensor_);
+  this->publish_temperature_from_buffer_(temperature_buffer[2], this->dfetoff_temp_sensor_);
+  this->publish_temperature_from_buffer_(temperature_buffer[3], this->alert_temp_sensor_);
+  this->publish_temperature_from_buffer_(temperature_buffer[4], this->ts1_temp_sensor_);
+  this->publish_temperature_from_buffer_(temperature_buffer[5], this->ts2_temp_sensor_);
+  this->publish_temperature_from_buffer_(temperature_buffer[6], this->ts3_temp_sensor_);
+  this->publish_temperature_from_buffer_(temperature_buffer[7], this->hdq_temp_sensor_);
+  this->publish_temperature_from_buffer_(temperature_buffer[8], this->dchg_temp_sensor_);
+  this->publish_temperature_from_buffer_(temperature_buffer[9], this->ddsg_temp_sensor_);
+}
+
+}  // namespace esphome::bq76972

--- a/esphome/components/bq76972/bq76972.h
+++ b/esphome/components/bq76972/bq76972.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/core/component.h"
+
+#include <vector>
+#include <string>
+
+namespace esphome::bq76972 {
+
+class BQ76972AddressNumber;
+
+class BQ76972Component final : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void update();
+  void setup() override;
+  void dump_config() override;
+
+  // HARDWARE_LATE setup priority
+  void set_crc_mode(bool crc_mode) { this->crc_mode_ = crc_mode; }
+  void set_reg_disable(bool reg_disable) { this->reg_disable_ = reg_disable; }
+  void set_component_id(const std::string &id) { this->component_id_ = id; }
+  void set_address(uint8_t i2c_address) { this->i2c_address_ = i2c_address; }
+
+  // Custom I²C routines
+  bool wait_for_cfgupdate(void);
+  bool wait_for_subcommand(void);
+  uint8_t compute_crc8(const uint8_t *data, size_t len);
+  bool read_block(uint8_t start_register, uint8_t *data, size_t len);
+  bool write_block(uint8_t start_register, const uint8_t *data, size_t len);
+  bool write_subcommand(uint16_t subcommand, const uint8_t *data, size_t len);
+  bool read_subcommand(uint16_t subcommand, uint8_t *data, size_t expected_len);
+  bool bq76972_read_multi_16_le(uint8_t a_register, uint16_t *data, size_t num_words);
+
+  // I2C reprogramming
+  void set_address_number(BQ76972AddressNumber *num) { this->address_number_ = num; }
+  void program_address_from_number();
+
+  // Device related stuff
+  bool store_int_temp();
+
+  // Temperature Sensor Setters
+  void publish_temperature_from_buffer_(const uint16_t temperature_uint16t, sensor::Sensor *sens);
+  void set_internal_temp_sensor(sensor::Sensor *s) { this->internal_temp_sensor_ = s; }
+  void set_cfetoff_temp_sensor(sensor::Sensor *s) { this->cfetoff_temp_sensor_ = s; }
+  void set_dfetoff_temp_sensor(sensor::Sensor *s) { this->dfetoff_temp_sensor_ = s; }
+  void set_alert_temp_sensor(sensor::Sensor *s) { this->alert_temp_sensor_ = s; }
+  void set_ts1_temp_sensor(sensor::Sensor *s) { this->ts1_temp_sensor_ = s; }
+  void set_ts2_temp_sensor(sensor::Sensor *s) { this->ts2_temp_sensor_ = s; }
+  void set_ts3_temp_sensor(sensor::Sensor *s) { this->ts3_temp_sensor_ = s; }
+  void set_hdq_temp_sensor(sensor::Sensor *s) { this->hdq_temp_sensor_ = s; }
+  void set_dchg_temp_sensor(sensor::Sensor *s) { this->dchg_temp_sensor_ = s; }
+  void set_ddsg_temp_sensor(sensor::Sensor *s) { this->ddsg_temp_sensor_ = s; }
+
+  // Other setters
+  void set_stack_voltage_sensor(sensor::Sensor *s) { this->stack_voltage_sensor_ = s; }
+  void set_cell_sensor(size_t cell_idx, sensor::Sensor *s) {
+    if (cell_idx < 16) {
+      this->cell_sensors_[cell_idx] = s;
+    }
+  }
+
+ protected:
+  std::string component_id_;
+  uint8_t i2c_address_;
+  bool reg_disable_;
+  bool crc_mode_;
+
+  // local raw data copies
+  uint16_t cell_voltages_mv_[16];
+  uint16_t pack_voltage_mv_;
+  float internal_temp_f_;
+  float internal_temp_c_;
+
+  // Temperature sensors
+  sensor::Sensor *internal_temp_sensor_{nullptr};
+  sensor::Sensor *cfetoff_temp_sensor_{nullptr};
+  sensor::Sensor *dfetoff_temp_sensor_{nullptr};
+  sensor::Sensor *alert_temp_sensor_{nullptr};
+  sensor::Sensor *ts1_temp_sensor_{nullptr};
+  sensor::Sensor *ts2_temp_sensor_{nullptr};
+  sensor::Sensor *ts3_temp_sensor_{nullptr};
+  sensor::Sensor *hdq_temp_sensor_{nullptr};
+  sensor::Sensor *dchg_temp_sensor_{nullptr};
+  sensor::Sensor *ddsg_temp_sensor_{nullptr};
+
+  // sensor stuff
+  BQ76972AddressNumber *address_number_{nullptr};
+  sensor::Sensor *stack_voltage_sensor_{nullptr};
+  std::vector<sensor::Sensor *> cell_sensors_{std::vector<sensor::Sensor *>(16, nullptr)};
+};
+
+class BQ76972AddressNumber final : public number::Number {
+ public:
+  void set_hub(BQ76972Component *hub) { this->hub_ = hub; }
+
+ protected:
+  void control(float value) override { this->publish_state(value); }
+  BQ76972Component *hub_{nullptr};
+};
+
+}  // namespace esphome::bq76972

--- a/tests/components/bq76972/common.yaml
+++ b/tests/components/bq76972/common.yaml
@@ -1,0 +1,61 @@
+bq76972:
+  id: bq76972_id
+  address: 0x08           # Optional, set to 0x08 (default value) by default)
+  crc_enabled: true       # Optional, set to false by default (beware that the BQ7697202 has CRC enabled by default)
+  update_interval: 10s    # Optional, set to 10s by default
+  stack_voltage:
+    name: "Pack Total Voltage"
+  internal_temperature:
+    name: "Temperature - Internal"
+  ts1_temperature:
+    name: "Temperature - Pin TS1"
+  ts2_temperature:
+    name: "Temperature - Pin TS2"
+  ts3_temperature:
+    name: "Temperature - Pin TS3"
+  hdq_temperature:
+    name: "Temperature - Pin HDQ"
+  cell_1_voltage:
+    name: "Cell 1 Voltage"
+  cell_2_voltage:
+    name: "Cell 2 Voltage"
+  cell_3_voltage:
+    name: "Cell 3 Voltage"
+  cell_4_voltage:
+    name: "Cell 4 Voltage"
+  cell_5_voltage:
+    name: "Cell 5 Voltage"
+  cell_6_voltage:
+    name: "Cell 6 Voltage"
+  cell_7_voltage:
+    name: "Cell 7 Voltage"
+  cell_8_voltage:
+    name: "Cell 8 Voltage"
+  cell_9_voltage:
+    name: "Cell 9 Voltage"
+  cell_10_voltage:
+    name: "Cell 10 Voltage"
+  cell_11_voltage:
+    name: "Cell 11 Voltage"
+  cell_12_voltage:
+    name: "Cell 12 Voltage"
+  cell_13_voltage:
+    name: "Cell 13 Voltage"
+  cell_14_voltage:
+    name: "Cell 14 Voltage"
+  cell_15_voltage:
+    name: "Cell 15 Voltage"
+  cell_16_voltage:
+    name: "Cell 16 Voltage"
+  i2c_address_setter:
+    name: "New I2C Address"
+    mode: box
+    
+button:
+  - platform: template
+    name: "Program BQ I2C Address"
+    icon: "mdi:chip"
+    on_press:
+      then:
+        - lambda: |-
+            id(bq76972_id).program_address_from_number();

--- a/tests/components/bq76972/test.esp32-idf.yaml
+++ b/tests/components/bq76972/test.esp32-idf.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+  bq76972: !include common.yaml

--- a/tests/components/bq76972/test.esp8266-ard.yaml
+++ b/tests/components/bq76972/test.esp8266-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
+  bq76972: !include common.yaml

--- a/tests/components/bq76972/test.rp2040-ard.yaml
+++ b/tests/components/bq76972/test.rp2040-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
+  bq76972: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds support to the bq76972 BMS chip from ti, in **monitoring mode only**: the goal here is being able to monitor cell voltages and temperatures, not to operate a full battery with protection transistors.
It therefore allows reporting of the pack voltage, cell voltages and thermistor temperatures.
It also supports CRC mode and programming of the I2C address.
For context, I'm using it to monitor several ICs (hence why I wanted to reprogram the I2C address).
All bq76972 register changes **are not made permanent**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:
  id: i2c_bus
  scl: GPIO9
  sda: GPIO8

bq76972:
  id: bq76972_id
  address: 0x08           # Optional, set to 0x08 (default value) by default)
  crc_enabled: true       # Optional, set to false by default (beware that the BQ7697202 has CRC enabled by default)
  update_interval: 10s    # Optional, set to 10s by default
  stack_voltage:
    name: "Pack Total Voltage"
  internal_temperature:
    name: "Temperature - Internal"
  ts1_temperature:
    name: "Temperature - Pin TS1"
  ts2_temperature:
    name: "Temperature - Pin TS2"
  ts3_temperature:
    name: "Temperature - Pin TS3"
  hdq_temperature:
    name: "Temperature - Pin HDQ"
  cell_1_voltage:
    name: "Cell 1 Voltage"
  cell_2_voltage:
    name: "Cell 2 Voltage"
  cell_3_voltage:
    name: "Cell 3 Voltage"
  cell_4_voltage:
    name: "Cell 4 Voltage"
  cell_5_voltage:
    name: "Cell 5 Voltage"
  cell_6_voltage:
    name: "Cell 6 Voltage"
  cell_7_voltage:
    name: "Cell 7 Voltage"
  cell_8_voltage:
    name: "Cell 8 Voltage"
  cell_9_voltage:
    name: "Cell 9 Voltage"
  cell_10_voltage:
    name: "Cell 10 Voltage"
  cell_11_voltage:
    name: "Cell 11 Voltage"
  cell_12_voltage:
    name: "Cell 12 Voltage"
  cell_13_voltage:
    name: "Cell 13 Voltage"
  cell_14_voltage:
    name: "Cell 14 Voltage"
  cell_15_voltage:
    name: "Cell 15 Voltage"
  cell_16_voltage:
    name: "Cell 16 Voltage"
  i2c_address_setter:
    name: "New I2C Address"
    mode: box
    
button:
  - platform: template
    name: "Program BQ I2C Address"
    icon: "mdi:chip"
    on_press:
      then:
        - lambda: |-
            id(bq76972_id).program_address_from_number();
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
