### PR TITLE
[core] Add optional deprecation warning to cv.rename_key

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -2718,13 +2718,24 @@ SOURCE_SCHEMA = Any(
 )
 
 
-def rename_key(old_key, new_key, *, removed_in: str | None = None):
+def rename_key(
+    old_key, new_key, *, removed_in: str | None = None, component: str | None = None
+):
+    """Rename a config key from ``old_key`` to ``new_key``.
+
+    When ``removed_in`` is set, a deprecation warning is logged if the old key is
+    present. Pass ``component`` (the platform/component name) alongside
+    ``removed_in`` so the warning identifies where it originates.
+    """
+
     def validator(config: dict) -> dict:
         config = config.copy()
         if old_key in config:
             if removed_in is not None:
+                prefix = f"[{component}] " if component else ""
                 _LOGGER.warning(
-                    "'%s' is deprecated, use '%s'. Will be removed in %s",
+                    "%s'%s' is deprecated, use '%s'. Will be removed in %s",
+                    prefix,
                     old_key,
                     new_key,
                     removed_in,

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -2718,10 +2718,17 @@ SOURCE_SCHEMA = Any(
 )
 
 
-def rename_key(old_key, new_key):
+def rename_key(old_key, new_key, *, removed_in: str | None = None):
     def validator(config: dict) -> dict:
         config = config.copy()
         if old_key in config:
+            if removed_in is not None:
+                _LOGGER.warning(
+                    "'%s' is deprecated, use '%s'. Will be removed in %s",
+                    old_key,
+                    new_key,
+                    removed_in,
+                )
             config[new_key] = config.pop(old_key)
         return config
 

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -2942,6 +2942,20 @@ def test_rename_key_removed_in_absent_key_no_warning(
     assert not caplog.records
 
 
+def test_rename_key_removed_in_with_component_prefixes_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="esphome.config_validation"):
+        result = cv.rename_key(
+            "old", "new", removed_in="2026.8.0", component="my_component"
+        )({"old": 5})
+    assert result == {"new": 5}
+    assert (
+        "[my_component] 'old' is deprecated, use 'new'. Will be removed in 2026.8.0"
+        in caplog.text
+    )
+
+
 def test_file__existing_relative_path(setup_core: Path) -> None:
     (setup_core / "partitions.csv").write_text("csv\n")
 

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 import string
 
@@ -2913,6 +2914,32 @@ def test_rename_key_present() -> None:
 
 def test_rename_key_absent() -> None:
     assert cv.rename_key("old", "new")({"other": 5}) == {"other": 5}
+
+
+def test_rename_key_no_removed_in_is_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="esphome.config_validation"):
+        assert cv.rename_key("old", "new")({"old": 5}) == {"new": 5}
+    assert not caplog.records
+
+
+def test_rename_key_removed_in_renames_and_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="esphome.config_validation"):
+        result = cv.rename_key("old", "new", removed_in="2026.8.0")({"old": 5})
+    assert result == {"new": 5}
+    assert "'old' is deprecated, use 'new'. Will be removed in 2026.8.0" in caplog.text
+
+
+def test_rename_key_removed_in_absent_key_no_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="esphome.config_validation"):
+        result = cv.rename_key("old", "new", removed_in="2026.8.0")({"other": 5})
+    assert result == {"other": 5}
+    assert not caplog.records
 
 
 def test_file__existing_relative_path(setup_core: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Adds an optional keyword argument `removed_in` to `cv.rename_key`. When set and the old key is present, the validator logs a deprecation warning before renaming, matching the phrasing of existing deprecations (e.g. cover's `on_open`): `'old' is deprecated, use 'new'. Will be removed in 2026.8.0`.

When `removed_in` is omitted, behavior is unchanged. The argument is keyword-only, so the existing `api` call sites (which pass no `removed_in`) are unaffected and stay silent. Covered by unit tests, including one asserting no warning is emitted without `removed_in`.

Requested by a maintainer so the sgp4x/sen5x/sen6x gas-index key-rename PRs (#17723, #17724, #17725) can share this one validator instead of each carrying a duplicated warn-and-rename helper.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Python-only validator change; verified via `pytest tests/unit_tests/test_config_validation.py`.

## Checklist:

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (under `tests/` folder).
