### PR TITLE
fix partial update bug

### DIFF
--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -423,7 +423,7 @@ class MipiSpi : public display::Display,
     ptr += y_offset * (x_offset + w + x_pad) + x_offset;
     if constexpr (BUFFERPIXEL == DISPLAYPIXEL) {
       this->write_display_data_(reinterpret_cast<const uint8_t *>(ptr), w * sizeof(BUFFERTYPE), h,
-                                x_pad * sizeof(BUFFERTYPE));
+                                (x_offset + x_pad) * sizeof(BUFFERTYPE));
     } else {
       // type conversion required, do it in chunks
       uint8_t dbuffer[DISPLAYPIXEL * 48];


### PR DESCRIPTION
# What does this implement/fix?

`MipiSpi::write_to_display_()` computes the pointer for the *first* row of
a buffer flush using stride `x_offset + w + x_pad` (matching how
`draw_pixel_at()`/`fill()` index the buffer), but only passes `x_pad` as
the per-row padding to `write_display_data_()`, which advances the pointer
by `w + pad` between rows. Every row after the first is therefore read
`x_offset` pixels too early, and the error compounds down the rows.

This is invisible whenever a flush's dirty rectangle starts at `x == 0`
(the common case with `auto_clear_enabled: true`, or single-row buffers),
since the missing term is zero — but as soon as a partial (dirty-rect)
flush starts at `x > 0` and spans more than one row, the panel shows
corrupted/shifted pixels that pull in stale buffer content.

Fix: pass `x_offset + x_pad` as the per-row padding, so the stride used to
advance between rows matches the stride used to compute the starting
offset.

Note: this is a different bug from #15787 (fixed in #15802). That PR fixed
the padding value computed at the *call site* in `update()`
(`round_buffer(width) - w - x_low_`); this bug is inside
`write_to_display_()` itself and is unaffected by that fix — reproduced on
2026.7.0 and confirmed still present on `dev`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- (no issue filed separately; fix and root-cause analysis submitted directly as this PR)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A — bugfix only, no user-facing configuration change

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Reproduces the bug: a partial redraw whose dirty rectangle doesn't start
# at x=0 and spans more than one row gets corrupted before this fix.
display:
  - platform: mipi_spi
    id: my_display
    model: ESP32-2432S028   # any model with a 16-bit native panel reproduces this
    rotation: 90°
    update_interval: never
    auto_clear_enabled: false   # keeps the dirty rect narrow instead of full-screen
    buffer_size: 0.5
    lambda: |-
      static int frame = 0;
      frame++;
      if (frame == 1) {
        // full frame, dirty rect = [0, W): establishes a baseline
        it.fill(Color(0, 0, 0));
        it.filled_rectangle(0, 0, 320, 40, Color(0, 0, 255));
      } else {
        // partial frame: box does NOT start at x=0 and is >1 row tall.
        // Before the fix: rows below the first are built from the wrong
        // buffer offset (shifted/garbled pixels). After the fix: a clean
        // solid-red 100x100 box.
        it.filled_rectangle(150, 60, 100, 100, Color(255, 0, 0));
      }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
