### PR TITLE
[i2s_audio] Implemented I2S PDM Microphone DSR selection

### DIFF
--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -29,6 +29,7 @@ DEPENDENCIES = ["esp32"]
 MULTI_CONF = True
 
 CONF_PDM = "pdm"
+CONF_PDM_DSR = "pdm_dsr"
 CONF_ADC_TYPE = "adc_type"
 
 CONF_I2S_DOUT_PIN = "i2s_dout_pin"

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -118,7 +118,7 @@ CONFIG_SCHEMA = cv.All(
                 {
                     cv.Required(CONF_I2S_DIN_PIN): pins.internal_gpio_input_pin_number,
                     cv.Optional(CONF_PDM, default=False): cv.boolean,
-                    cv.Optional(CONF_PDM_DSR, default=8): cv.enum(I2S_PDM_DSR),
+                    cv.Optional(CONF_PDM_DSR, default=8): cv.enum(I2S_PDM_DSR, int=True),
                 }
             ),
         },

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -118,7 +118,7 @@ CONFIG_SCHEMA = cv.All(
                 {
                     cv.Required(CONF_I2S_DIN_PIN): pins.internal_gpio_input_pin_number,
                     cv.Optional(CONF_PDM, default=False): cv.boolean,
-                    cv.Optional(CONF_PDM_DSR, default=8): cv.one_of(*I2S_PDM_DSR),
+                    cv.Optional(CONF_PDM_DSR, default=8): cv.enum(I2S_PDM_DSR),
                 }
             ),
         },
@@ -150,6 +150,7 @@ async def to_code(config):
 
     cg.add(var.set_din_pin(config[CONF_I2S_DIN_PIN]))
     cg.add(var.set_pdm(config[CONF_PDM]))
-    cg.add(var.set_pdm_dsr(I2S_PDM_DSR[config[CONF_PDM_DSR]]))
+    if esp32.get_esp32_variant() in PDM_VARIANTS:
+        cg.add(var.set_pdm_dsr(config[CONF_PDM_DSR]))
 
     cg.add(var.set_correct_dc_offset(config[CONF_CORRECT_DC_OFFSET]))

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -41,8 +41,8 @@ PDM_VARIANTS = [esp32.VARIANT_ESP32, esp32.VARIANT_ESP32S3, esp32.VARIANT_ESP32P
 
 i2s_pdm_dsr_t = cg.global_ns.enum("i2s_pdm_dsr_t")
 I2S_PDM_DSR = {
-	8: i2s_pdm_dsr_t.I2S_PDM_DSR_8S,
-	16: i2s_pdm_dsr_t.I2S_PDM_DSR_16S,
+    8: i2s_pdm_dsr_t.I2S_PDM_DSR_8S,
+    16: i2s_pdm_dsr_t.I2S_PDM_DSR_16S,
 }
 
 

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -17,6 +17,7 @@ from .. import (
     CONF_LEFT,
     CONF_MONO,
     CONF_PDM,
+    CONF_PDM_DSR,
     CONF_RIGHT,
     I2SAudioIn,
     i2s_audio_component_schema,
@@ -37,6 +38,12 @@ I2SAudioMicrophone = i2s_audio_ns.class_(
 
 INTERNAL_ADC_VARIANTS = [esp32.VARIANT_ESP32]
 PDM_VARIANTS = [esp32.VARIANT_ESP32, esp32.VARIANT_ESP32S3, esp32.VARIANT_ESP32P4]
+
+i2s_pdm_dsr_t = cg.global_ns.enum("i2s_pdm_dsr_t")
+I2S_PDM_DSR = {
+	8: i2s_pdm_dsr_t.I2S_PDM_DSR_8S,
+	16: i2s_pdm_dsr_t.I2S_PDM_DSR_16S,
+}
 
 
 def _validate_esp32_variant(config):
@@ -111,6 +118,7 @@ CONFIG_SCHEMA = cv.All(
                 {
                     cv.Required(CONF_I2S_DIN_PIN): pins.internal_gpio_input_pin_number,
                     cv.Optional(CONF_PDM, default=False): cv.boolean,
+                    cv.Optional(CONF_PDM_DSR, default=8): cv.one_of(*I2S_PDM_DSR),
                 }
             ),
         },
@@ -142,5 +150,6 @@ async def to_code(config):
 
     cg.add(var.set_din_pin(config[CONF_I2S_DIN_PIN]))
     cg.add(var.set_pdm(config[CONF_PDM]))
+    cg.add(var.set_pdm_dsr(I2S_PDM_DSR[config[CONF_PDM_DSR]]))
 
     cg.add(var.set_correct_dc_offset(config[CONF_CORRECT_DC_OFFSET]))

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -118,7 +118,9 @@ CONFIG_SCHEMA = cv.All(
                 {
                     cv.Required(CONF_I2S_DIN_PIN): pins.internal_gpio_input_pin_number,
                     cv.Optional(CONF_PDM, default=False): cv.boolean,
-                    cv.Optional(CONF_PDM_DSR, default=8): cv.enum(I2S_PDM_DSR, int=True),
+                    cv.Optional(CONF_PDM_DSR, default=8): cv.enum(
+                        I2S_PDM_DSR, int=True
+                    ),
                 }
             ),
         },

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -128,7 +128,7 @@ bool I2SAudioMicrophone::start_driver_() {
         .sample_rate_hz = this->sample_rate_,
         .clk_src = clk_src,
         .mclk_multiple = this->mclk_multiple_,
-        .dn_sample_mode = I2S_PDM_DSR_8S,
+        .dn_sample_mode = this->pdm_dsr_,
     };
 
     i2s_pdm_rx_slot_config_t slot_cfg = I2S_PDM_RX_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, this->slot_mode_);

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -62,7 +62,7 @@ class I2SAudioMicrophone final : public I2SAudioIn, public microphone::Microphon
   i2s_chan_handle_t rx_handle_;
   bool pdm_{false};
 #if SOC_I2S_SUPPORTS_PDM_RX
-  i2s_pdm_dsr_t pdm_dsr_;
+  i2s_pdm_dsr_t pdm_dsr_{I2S_PDM_DSR_8S};
 #endif
 
   bool correct_dc_offset_;

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -29,6 +29,8 @@ class I2SAudioMicrophone final : public I2SAudioIn, public microphone::Microphon
 
   void set_pdm(bool pdm) { this->pdm_ = pdm; }
 
+  void set_pdm_dsr(i2s_pdm_dsr_t pdm_dsr) { this->pdm_dsr_ = pdm_dsr; }
+
  protected:
   /// @brief Starts the I2S driver. Updates the ``audio_stream_info_`` member variable with the current setttings.
   /// @return True if succesful, false otherwise
@@ -57,6 +59,7 @@ class I2SAudioMicrophone final : public I2SAudioIn, public microphone::Microphon
   gpio_num_t din_pin_{I2S_GPIO_UNUSED};
   i2s_chan_handle_t rx_handle_;
   bool pdm_{false};
+  i2s_pdm_dsr_t pdm_dsr_;
 
   bool correct_dc_offset_;
   bool locked_driver_{false};

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -29,7 +29,9 @@ class I2SAudioMicrophone final : public I2SAudioIn, public microphone::Microphon
 
   void set_pdm(bool pdm) { this->pdm_ = pdm; }
 
+#if SOC_I2S_SUPPORTS_PDM_RX
   void set_pdm_dsr(i2s_pdm_dsr_t pdm_dsr) { this->pdm_dsr_ = pdm_dsr; }
+#endif
 
  protected:
   /// @brief Starts the I2S driver. Updates the ``audio_stream_info_`` member variable with the current setttings.
@@ -59,7 +61,9 @@ class I2SAudioMicrophone final : public I2SAudioIn, public microphone::Microphon
   gpio_num_t din_pin_{I2S_GPIO_UNUSED};
   i2s_chan_handle_t rx_handle_;
   bool pdm_{false};
+#if SOC_I2S_SUPPORTS_PDM_RX
   i2s_pdm_dsr_t pdm_dsr_;
+#endif
 
   bool correct_dc_offset_;
   bool locked_driver_{false};

--- a/tests/components/microphone/common-pdm.yaml
+++ b/tests/components/microphone/common-pdm.yaml
@@ -17,3 +17,9 @@ microphone:
           else:
             - microphone.mute:
                 id: mic_id_external
+  - platform: i2s_audio
+    id: mic_id_pdm
+    i2s_din_pin: ${i2s_din_pin2}
+    adc_type: external
+    pdm: true
+    pdm_dsr: 16

--- a/tests/components/microphone/common.yaml
+++ b/tests/components/microphone/common.yaml
@@ -27,3 +27,4 @@ microphone:
     i2s_din_pin: ${i2s_din_pin2}
     adc_type: external
     pdm: true
+    pdm_dsr: 16

--- a/tests/components/microphone/test.esp32-idf.yaml
+++ b/tests/components/microphone/test.esp32-idf.yaml
@@ -1,8 +1,8 @@
 substitutions:
-  i2s_bclk_pin: GPIO15
-  i2s_lrclk_pin: GPIO4
-  i2s_mclk_pin: GPIO5
   i2s_din_pin1: GPIO33
   i2s_din_pin2: GPIO34
 
-<<: !include common.yaml
+packages:
+  i2s_audio: !include ../../test_build_components/common/i2s_audio/esp32-idf.yaml
+
+<<: !include common-pdm.yaml

--- a/tests/components/microphone/test.esp32-s2-idf.yaml
+++ b/tests/components/microphone/test.esp32-s2-idf.yaml
@@ -3,6 +3,6 @@ substitutions:
   i2s_din_pin2: GPIO34
 
 packages:
-  i2s_audio: !include ../../test_build_components/common/i2s_audio/esp32-s3-idf.yaml
+  i2s_audio: !include ../../test_build_components/common/i2s_audio/esp32-s2-idf.yaml
 
 <<: !include common.yaml

--- a/tests/components/microphone/test.esp32-s3-idf.yaml
+++ b/tests/components/microphone/test.esp32-s3-idf.yaml
@@ -1,0 +1,8 @@
+substitutions:
+  i2s_din_pin1: GPIO33
+  i2s_din_pin2: GPIO34
+
+packages:
+  i2s_audio: !include ../../test_build_components/common/i2s_audio/esp32-s3-idf.yaml
+
+<<: !include common.yaml

--- a/tests/test_build_components/common/i2s_audio/esp32-s2-idf.yaml
+++ b/tests/test_build_components/common/i2s_audio/esp32-s2-idf.yaml
@@ -1,0 +1,14 @@
+# Common I2S audio bus configuration for ESP32-S2 IDF tests
+# Provides a shared i2s_audio bus that speaker/microphone components can use
+# Each consumer must give its speaker/microphone a unique data pin
+
+substitutions:
+  i2s_bclk_pin: GPIO5
+  i2s_lrclk_pin: GPIO4
+  i2s_mclk_pin: GPIO15
+
+i2s_audio:
+  - id: i2s_audio_bus
+    i2s_bclk_pin: ${i2s_bclk_pin}
+    i2s_lrclk_pin: ${i2s_lrclk_pin}
+    i2s_mclk_pin: ${i2s_mclk_pin}


### PR DESCRIPTION
# What does this implement/fix?

Allows custom selection of PDM downsampling rate instead of hard-coded `8S`.
Non-breaking as preserves it as the default.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7026

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
microphone:
  platform: i2s_audio
  adc_type: external
  pdm: true
  pdm_dsr: 16
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).