### PR TITLE
[espidf] Include .cc, .cxx and .c++ sources in the app source glob

### DIFF
--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -210,15 +210,27 @@ def get_component_cmakelists() -> str:
 if(CMAKE_SCRIPT_MODE_FILE)
     file(GLOB_RECURSE app_sources
         "${{CMAKE_CURRENT_SOURCE_DIR}}/*.cpp"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/*.cc"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/*.cxx"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/*.c++"
         "${{CMAKE_CURRENT_SOURCE_DIR}}/*.c"
         "${{CMAKE_CURRENT_SOURCE_DIR}}/esphome/*.cpp"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/esphome/*.cc"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/esphome/*.cxx"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/esphome/*.c++"
         "${{CMAKE_CURRENT_SOURCE_DIR}}/esphome/*.c"
     )
 else()
     file(GLOB_RECURSE app_sources CONFIGURE_DEPENDS
         "${{CMAKE_CURRENT_SOURCE_DIR}}/*.cpp"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/*.cc"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/*.cxx"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/*.c++"
         "${{CMAKE_CURRENT_SOURCE_DIR}}/*.c"
         "${{CMAKE_CURRENT_SOURCE_DIR}}/esphome/*.cpp"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/esphome/*.cc"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/esphome/*.cxx"
+        "${{CMAKE_CURRENT_SOURCE_DIR}}/esphome/*.c++"
         "${{CMAKE_CURRENT_SOURCE_DIR}}/esphome/*.c"
     )
 endif()

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -184,6 +184,18 @@ def test_get_component_cmakelists_compile_flags_excluded_from_link_opts() -> Non
     assert "-Wl,--gc-sections" in content
 
 
+def test_get_component_cmakelists_globs_alternate_cpp_extensions() -> None:
+    """Both app_sources glob variants include .cc/.cxx/.c++ so vendored sources
+    are compiled, matching the extensions PlatformIO's builder globs by default."""
+    CORE.build_flags = set()
+    from esphome.build_gen.espidf import get_component_cmakelists
+
+    content = get_component_cmakelists()
+    for ext in ("cc", "cxx", "c++"):
+        assert content.count(f'"${{CMAKE_CURRENT_SOURCE_DIR}}/*.{ext}"') == 2
+        assert content.count(f'"${{CMAKE_CURRENT_SOURCE_DIR}}/esphome/*.{ext}"') == 2
+
+
 def test_get_project_cmakelists_emits_managed_components_property(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

External components that vendor third-party code using alternate C++ extensions build fine on the PlatformIO toolchain, whose SCons builder globs `.cc`/`.cxx`/`.c++` by default, but fail to link on the native ESP-IDF toolchain with undefined references: the generated ESP-IDF CMakeLists only globs `*.cpp` and `*.c`, so `.cc` translation units are silently never compiled.

A concrete affected case is the wM-Bus component family (SzczepanLeon/esphome-components#403), which vendors wmbusmeters sources as `.cc` — every native-toolchain build fails at link with undefined references to `extractDV`, `extractUnit`, `bin2hex`, etc.

This adds `*.cc`, `*.cxx` and `*.c++` to both `app_sources` glob variants (script mode and `CONFIGURE_DEPENDS`) in `esphome/build_gen/espidf.py`, matching PlatformIO's default C++ suffixes. `*.C` (capital) is deliberately left out: `GLOB_RECURSE` is case-sensitive on case-sensitive filesystems, and matching it would also pick up plain `.c` files on case-insensitive ones. A unit test asserts all three patterns are present in both glob branches.

Verified by building an ESP32-C6 wM-Bus configuration with the native ESP-IDF toolchain: link fails before this change and the build succeeds end to end with it. PlatformIO toolchain builds are unaffected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (under `tests/` folder) — n/a, template string change.
