### PR TITLE
[sen5x] Add model option to override autodetection

### DIFF
--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -264,7 +264,8 @@ void SEN5XComponent::dump_config() {
                 "  Type: %s%s\n"
                 "  Firmware version: %d\n"
                 "  Serial number: %s",
-                LOG_STR_ARG(type_to_string(this->type_)), this->model_override_.has_value() ? " (overridden)" : "",
+                LOG_STR_ARG(type_to_string(this->type_)),
+                LOG_STR_ARG(this->model_override_.has_value() ? LOG_STR(" (overridden)") : LOG_STR("")),
                 this->firmware_version_, this->serial_number_);
   if (this->auto_cleaning_interval_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Auto cleaning interval: %" PRId32 "s", this->auto_cleaning_interval_.value());

--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -265,7 +265,7 @@ void SEN5XComponent::dump_config() {
                 "  Firmware version: %d\n"
                 "  Serial number: %s",
                 LOG_STR_ARG(type_to_string(this->type_)),
-                LOG_STR_ARG(this->model_override_.has_value() ? LOG_STR(" (overridden)") : LOG_STR("")),
+                this->model_override_.has_value() ? LOG_STR_LITERAL(" (overridden)") : LOG_STR_LITERAL(""),
                 this->firmware_version_, this->serial_number_);
   if (this->auto_cleaning_interval_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Auto cleaning interval: %" PRId32 "s", this->auto_cleaning_interval_.value());

--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -119,17 +119,8 @@ void SEN5XComponent::setup() {
       }
 
       if (this->model_override_.has_value()) {
-        if (product_name_read_ok && detected_type != Sen5xType::UNKNOWN &&
-            detected_type != this->model_override_.value()) {
-          ESP_LOGW(TAG,
-                   "Detected %s but model is configured as %s; using configured model. Sensor data for "
-                   "capabilities not present on the physical device may be invalid",
-                   LOG_STR_ARG(type_to_string(detected_type)),
-                   LOG_STR_ARG(type_to_string(this->model_override_.value())));
-        } else if (!product_name_read_ok || detected_type == Sen5xType::UNKNOWN) {
-          ESP_LOGW(TAG,
-                   "Could not determine sensor model; using configured model %s. Sensor data for "
-                   "capabilities not present on the physical device may be invalid",
+        if (detected_type != this->model_override_.value()) {
+          ESP_LOGW(TAG, "Detected %s, using %s", LOG_STR_ARG(type_to_string(detected_type)),
                    LOG_STR_ARG(type_to_string(this->model_override_.value())));
         }
         this->type_ = this->model_override_.value();

--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -102,8 +102,7 @@ void SEN5XComponent::setup() {
 
       uint16_t raw_product_name[16];
       Sen5xType detected_type = Sen5xType::UNKNOWN;
-      bool product_name_read_ok = this->get_register(SEN5X_CMD_GET_PRODUCT_NAME, raw_product_name, 16, 20);
-      if (product_name_read_ok) {
+      if (this->get_register(SEN5X_CMD_GET_PRODUCT_NAME, raw_product_name, 16, 20)) {
         const char *product_name = sensirion_convert_to_string_in_place(raw_product_name, 16);
         if (strncmp(product_name, "SEN50", 5) == 0) {
           detected_type = Sen5xType::SEN50;
@@ -111,11 +110,7 @@ void SEN5XComponent::setup() {
           detected_type = Sen5xType::SEN54;
         } else if (strncmp(product_name, "SEN55", 5) == 0) {
           detected_type = Sen5xType::SEN55;
-        } else if (!this->model_override_.has_value()) {
-          ESP_LOGE(TAG, "Unknown product name: %.32s", product_name);
         }
-      } else if (!this->model_override_.has_value()) {
-        ESP_LOGE(TAG, "Failed to read product name");
       }
 
       if (this->model_override_.has_value()) {
@@ -124,10 +119,6 @@ void SEN5XComponent::setup() {
                    LOG_STR_ARG(type_to_string(this->model_override_.value())));
         }
         this->type_ = this->model_override_.value();
-      } else if (!product_name_read_ok) {
-        this->error_code_ = PRODUCT_NAME_FAILED;
-        this->mark_failed();
-        return;
       } else if (detected_type == Sen5xType::UNKNOWN) {
         this->type_ = Sen5xType::UNKNOWN;
         this->error_code_ = PRODUCT_NAME_FAILED;

--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -101,25 +101,49 @@ void SEN5XComponent::setup() {
       ESP_LOGV(TAG, "Serial number %s", this->serial_number_);
 
       uint16_t raw_product_name[16];
-      if (!this->get_register(SEN5X_CMD_GET_PRODUCT_NAME, raw_product_name, 16, 20)) {
+      Sen5xType detected_type = Sen5xType::UNKNOWN;
+      bool product_name_read_ok = this->get_register(SEN5X_CMD_GET_PRODUCT_NAME, raw_product_name, 16, 20);
+      if (product_name_read_ok) {
+        const char *product_name = sensirion_convert_to_string_in_place(raw_product_name, 16);
+        if (strncmp(product_name, "SEN50", 5) == 0) {
+          detected_type = Sen5xType::SEN50;
+        } else if (strncmp(product_name, "SEN54", 5) == 0) {
+          detected_type = Sen5xType::SEN54;
+        } else if (strncmp(product_name, "SEN55", 5) == 0) {
+          detected_type = Sen5xType::SEN55;
+        } else if (!this->model_override_.has_value()) {
+          ESP_LOGE(TAG, "Unknown product name: %.32s", product_name);
+        }
+      } else if (!this->model_override_.has_value()) {
         ESP_LOGE(TAG, "Failed to read product name");
-        this->error_code_ = PRODUCT_NAME_FAILED;
-        this->mark_failed();
-        return;
       }
-      const char *product_name = sensirion_convert_to_string_in_place(raw_product_name, 16);
-      if (strncmp(product_name, "SEN50", 5) == 0) {
-        this->type_ = Sen5xType::SEN50;
-      } else if (strncmp(product_name, "SEN54", 5) == 0) {
-        this->type_ = Sen5xType::SEN54;
-      } else if (strncmp(product_name, "SEN55", 5) == 0) {
-        this->type_ = Sen5xType::SEN55;
-      } else {
-        this->type_ = Sen5xType::UNKNOWN;
-        ESP_LOGE(TAG, "Unknown product name: %.32s", product_name);
+
+      if (this->model_override_.has_value()) {
+        if (product_name_read_ok && detected_type != Sen5xType::UNKNOWN &&
+            detected_type != this->model_override_.value()) {
+          ESP_LOGW(TAG,
+                   "Detected %s but model is configured as %s; using configured model. Sensor data for "
+                   "capabilities not present on the physical device may be invalid",
+                   LOG_STR_ARG(type_to_string(detected_type)),
+                   LOG_STR_ARG(type_to_string(this->model_override_.value())));
+        } else if (!product_name_read_ok || detected_type == Sen5xType::UNKNOWN) {
+          ESP_LOGW(TAG,
+                   "Could not determine sensor model; using configured model %s. Sensor data for "
+                   "capabilities not present on the physical device may be invalid",
+                   LOG_STR_ARG(type_to_string(this->model_override_.value())));
+        }
+        this->type_ = this->model_override_.value();
+      } else if (!product_name_read_ok) {
         this->error_code_ = PRODUCT_NAME_FAILED;
         this->mark_failed();
         return;
+      } else if (detected_type == Sen5xType::UNKNOWN) {
+        this->type_ = Sen5xType::UNKNOWN;
+        this->error_code_ = PRODUCT_NAME_FAILED;
+        this->mark_failed();
+        return;
+      } else {
+        this->type_ = detected_type;
       }
 
       ESP_LOGD(TAG, "Type: %s", LOG_STR_ARG(type_to_string(this->type_)));
@@ -255,10 +279,11 @@ void SEN5XComponent::dump_config() {
     }
   }
   ESP_LOGCONFIG(TAG,
-                "  Type: %s\n"
+                "  Type: %s%s\n"
                 "  Firmware version: %d\n"
                 "  Serial number: %s",
-                LOG_STR_ARG(type_to_string(this->type_)), this->firmware_version_, this->serial_number_);
+                LOG_STR_ARG(type_to_string(this->type_)), this->model_override_.has_value() ? " (overridden)" : "",
+                this->firmware_version_, this->serial_number_);
   if (this->auto_cleaning_interval_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Auto cleaning interval: %" PRId32 "s", this->auto_cleaning_interval_.value());
   }

--- a/esphome/components/sen5x/sen5x.h
+++ b/esphome/components/sen5x/sen5x.h
@@ -95,6 +95,7 @@ class SEN5XComponent final : public PollingComponent, public sensirion_common::S
     temp_comp.time_constant = time_constant;
     this->temperature_compensation_ = temp_comp;
   }
+  void set_model(Sen5xType model) { this->model_override_ = model; }
   bool start_fan_cleaning();
 
  protected:
@@ -126,6 +127,7 @@ class SEN5XComponent final : public PollingComponent, public sensirion_common::S
   optional<GasTuning> voc_tuning_params_;
   optional<GasTuning> nox_tuning_params_;
   optional<TemperatureCompensation> temperature_compensation_;
+  optional<Sen5xType> model_override_;
   ESPPreferenceObject pref_;
 };
 

--- a/esphome/components/sen5x/sensor.py
+++ b/esphome/components/sen5x/sensor.py
@@ -12,6 +12,7 @@ from esphome.const import (
     CONF_INDEX_OFFSET,
     CONF_LEARNING_TIME_GAIN_HOURS,
     CONF_LEARNING_TIME_OFFSET_HOURS,
+    CONF_MODEL,
     CONF_NORMALIZED_OFFSET_SLOPE,
     CONF_NOX,
     CONF_OFFSET,
@@ -39,6 +40,7 @@ from esphome.const import (
     UNIT_MICROGRAMS_PER_CUBIC_METER,
     UNIT_PERCENT,
 )
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@martgras"]
 DEPENDENCIES = ["i2c"]
@@ -49,6 +51,7 @@ SEN5XComponent = sen5x_ns.class_(
     "SEN5XComponent", cg.PollingComponent, sensirion_common.SensirionI2CDevice
 )
 RhtAccelerationMode = sen5x_ns.enum("RhtAccelerationMode")
+Sen5xType = sen5x_ns.enum("Sen5xType", is_class=True)
 
 CONF_ACCELERATION_MODE = "acceleration_mode"
 CONF_AUTO_CLEANING_INTERVAL = "auto_cleaning_interval"
@@ -61,6 +64,12 @@ ACCELERATION_MODES = {
     "low": RhtAccelerationMode.LOW_ACCELERATION,
     "medium": RhtAccelerationMode.MEDIUM_ACCELERATION,
     "high": RhtAccelerationMode.HIGH_ACCELERATION,
+}
+
+MODELS = {
+    "SEN50": Sen5xType.SEN50,
+    "SEN54": Sen5xType.SEN54,
+    "SEN55": Sen5xType.SEN55,
 }
 
 
@@ -186,6 +195,7 @@ CONFIG_SCHEMA = (
                 }
             ),
             cv.Optional(CONF_ACCELERATION_MODE): cv.enum(ACCELERATION_MODES),
+            cv.Optional(CONF_MODEL): cv.enum(MODELS, upper=True),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -210,7 +220,7 @@ SETTING_MAP = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
@@ -218,6 +228,9 @@ async def to_code(config):
     for key, funcName in SETTING_MAP.items():
         if cfg := config.get(key):
             cg.add(getattr(var, funcName)(cfg))
+
+    if CONF_MODEL in config:
+        cg.add(var.set_model(config[CONF_MODEL]))
 
     for key, funcName in SENSOR_MAP.items():
         if cfg := config.get(key):

--- a/esphome/components/sen5x/sensor.py
+++ b/esphome/components/sen5x/sensor.py
@@ -229,8 +229,8 @@ async def to_code(config: ConfigType) -> None:
         if cfg := config.get(key):
             cg.add(getattr(var, funcName)(cfg))
 
-    if CONF_MODEL in config:
-        cg.add(var.set_model(config[CONF_MODEL]))
+    if (model := config.get(CONF_MODEL)) is not None:
+        cg.add(var.set_model(model))
 
     for key, funcName in SENSOR_MAP.items():
         if cfg := config.get(key):

--- a/tests/components/sen5x/common.yaml
+++ b/tests/components/sen5x/common.yaml
@@ -42,4 +42,5 @@ sensor:
     auto_cleaning_interval: 604800s
     acceleration_mode: low
     store_baseline: true
+    model: sen55
     address: 0x69


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression introduced in #13489: a product name the component does not recognize now sets `PRODUCT_NAME_FAILED` and marks the whole component failed, where it was previously tolerated. Devices that were publishing sensor data before 2026.2.0 lose every sensor on the device after updating.

This adds an optional `model` config key (`sen50`/`sen54`/`sen55`) that overrides product name autodetection, restoring operation for those devices. The underlying problem is that model detection from the product name register (0xD014) is not always accurate and cannot be trusted on its own: reads can fail intermittently, and field units exist whose register misreports the model entirely, reporting `SEN54` while being a labeled SEN55 with a present, functional NOx element (the component disables NOx on them with `NOx requires a SEN55`). For such hardware a manual override is strictly needed. Autodetection remains the default as a best effort; with `model:` set, capability gating follows the configured model and a mismatch logs a warning. Without the option, behavior is unchanged.

Verified on affected hardware: a SEN54-reporting unit produced valid NOx measurements with the override.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/pull/13489

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome.io#7028

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: sen5x
    model: sen55
    nox:
      name: NOx
    address: 0x69
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
