### PR TITLE
add D01 pm2.5 sensor support

### DIFF
--- a/esphome/components/d01/__init__.py
+++ b/esphome/components/d01/__init__.py
@@ -1,0 +1,7 @@
+import esphome.codegen as cg
+
+CODEOWNERS = ["@ch604"]
+
+d01_ns = cg.esphome_ns.namespace("d01")
+D01Component = d01_ns.class_("D01Component", cg.PollingComponent)
+

--- a/esphome/components/d01/d01.cpp
+++ b/esphome/components/d01/d01.cpp
@@ -1,0 +1,46 @@
+#include "d01.h"
+#include "esphome/core/log.h"
+
+// uart specification for d01 sensor from https://manuals.plus/ae/1005006417362019:
+//
+// A frame of serial output data includes 4 bytes, formatted as follows:
+//  Characteristic byte: Fixed value 0xA5.
+//  Data byte: DATAH is the high 7 bits of the concentration value, and DATAL is the low 7 bits of the concentration value.
+//  Check byte: The low 7 bits of the sum of all bytes before the check byte.
+//
+// If the serial output is 4 bytes of data: 0*A5 0*01 0*2C 0*52, then DATAH = 0*01 = 1, DATAL = 0*2C = 44.
+// Concentration value = 1*128 + 44 = 172 µg/m³.
+//
+// The PM2.5 dust concentration value obtained from the dust sensor needs to be calibrated with a K value coefficient based on the TSI instrument's photometric method. It is generally recommended to use 0.4.
+
+namespace esphome {
+namespace d01 {
+
+static const char *const TAG = "d01";
+static const uint8_t D01_FRAME_HEADER = 0xA5;
+
+void D01Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "D01 PM2.5 Sensor:");
+  LOG_SENSOR("  ", "PM2.5", this->pm25_sensor_);
+  this->check_uart_settings(9600);
+}
+
+void D01Component::update() {
+  uint8_t buf[4];
+  while (this->available() >= 4) {
+    if (this->peek() != D01_FRAME_HEADER) { this->read(); continue; }
+    this->read_array(buf, 4);
+    uint8_t sum = (buf[0] + buf[1] + buf[2]) & 0x7F;
+    if (sum != buf[3]) {
+      ESP_LOGW(TAG, "D01 checksum mismatch");
+      continue;
+    }
+    int concentration = (buf[1] & 0x7F) * 128 + (buf[2] & 0x7F);
+    ESP_LOGD(TAG, "Got PM2.5 Concentration: %d µg/m³", (int) concentration);
+    if (this->pm25_sensor_ != nullptr)
+      this->pm25_sensor_->publish_state(concentration);
+  }
+}
+
+}
+}

--- a/esphome/components/d01/d01.h
+++ b/esphome/components/d01/d01.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/uart/uart.h"
+
+namespace esphome {
+namespace d01 {
+
+class D01Component final : public PollingComponent, public uart::UARTDevice {
+ public:
+  void set_pm25_sensor(sensor::Sensor *s) { this->pm25_sensor_ = s; }
+  void dump_config() override;
+  void update() override;
+
+ protected:
+  sensor::Sensor *pm25_sensor_{nullptr};
+};
+
+}
+}

--- a/esphome/components/d01/sensor.py
+++ b/esphome/components/d01/sensor.py
@@ -1,0 +1,33 @@
+import esphome.codegen as cg
+from esphome.components import sensor, uart
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_PM_2_5,
+    DEVICE_CLASS_PM25,
+    UNIT_MICROGRAMS_PER_CUBIC_METER,
+)
+
+from . import D01Component
+
+DEPENDENCIES = ["uart"]
+
+CONFIG_SCHEMA = (cv.Schema({
+    cv.GenerateID():
+    cv.declare_id(D01Component),
+    cv.Required(CONF_PM_2_5):
+    sensor.sensor_schema(
+        unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_PM25,
+    ),
+}).extend(cv.polling_component_schema("10s")).extend(uart.UART_DEVICE_SCHEMA))
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+    sens = await sensor.new_sensor(config[CONF_PM_2_5])
+    cg.add(var.set_pm25_sensor(sens))

--- a/tests/components/d01/common.yaml
+++ b/tests/components/d01/common.yaml
@@ -1,0 +1,4 @@
+sensor:
+  - platform: d01
+    pm_2_5:
+      name: D01 PM2.5 Concentration

--- a/tests/components/d01/test.esp32-idf.yaml
+++ b/tests/components/d01/test.esp32-idf.yaml
@@ -1,0 +1,8 @@
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+packages:
+  uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/d01/test.esp8266-ard.yaml
+++ b/tests/components/d01/test.esp8266-ard.yaml
@@ -1,0 +1,8 @@
+substitutions:
+  tx_pin: GPIO0
+  rx_pin: GPIO2
+
+packages:
+  uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/d01/test.rp2040-ard.yaml
+++ b/tests/components/d01/test.rp2040-ard.yaml
@@ -1,0 +1,8 @@
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+packages:
+  uart: !include ../../test_build_components/common/uart/rp2040-ard.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the D01 pm2.5 particulate sensor. I got this as a replacement for a pm1006 which was not working correctly, and found that they did not have the same communication format at all, though they are the same form factor, same connector, same pinout, etc.

There is no UART TX pin required for this sensor; it will automatically broadcast its packets every 1.4 seconds upon receiving power.

There is a correction factor advised of 0.4 in the component documentation (https://manuals.plus/ae/1005006417362019) which I expose as a filter.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp8266:
  board: d1_mini

uart:
  rx_pin: GPIO4 #D2
  baud_rate: 9600

sensor:
  - platform: d01
    pm_2_5:
      name: "PM2.5"
      filters:
        - multiply: 0.4   # manufacturer-recommended correction factor
        - sliding_window_moving_average:
            window_size: 5
            send_every: 10
            send_first_at: 1
    update_interval: 2s    # device updates UART every 1.4 seconds, this provides a sufficient window
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
