### PR TITLE
[ch422g] Fix boot-time initialization race

### DIFF
--- a/esphome/components/ch422g/ch422g.cpp
+++ b/esphome/components/ch422g/ch422g.cpp
@@ -13,22 +13,37 @@ static const uint8_t CH422G_REG_OUT_UPPER = 0x23;    // write reg for output bit
 static const char *const TAG = "ch422g";
 
 void CH422GComponent::setup() {
-  // set outputs before mode
-  this->write_outputs_();
-  // Set mode and check for errors
-  if (!this->set_mode_(this->mode_value_) || !this->read_inputs_()) {
-    ESP_LOGE(TAG, "CH422G not detected at 0x%02X", this->address_);
-    this->mark_failed();
-    return;
-  }
-
-  ESP_LOGCONFIG(TAG, "Initialization complete. Warning: %d, Error: %d", this->status_has_warning(),
-                this->status_has_error());
+  // Depending on board init order, the I2C bus (or the device itself) may
+  // not be ready yet on this very first attempt. Do not mark_failed() here;
+  // loop() below keeps retrying until ensure_initialized_() succeeds.
+  this->ensure_initialized_();
 }
 
 void CH422GComponent::loop() {
   // Clear all the previously read flags.
   this->pin_read_flags_ = 0x00;
+
+  if (!this->initialized_) {
+    this->ensure_initialized_();
+  }
+}
+
+bool CH422GComponent::ensure_initialized_() {
+  if (this->initialized_) {
+    return true;
+  }
+  // set outputs before mode
+  this->write_outputs_();
+  // Set mode and check for errors
+  if (!this->set_mode_(this->mode_value_) || !this->read_inputs_()) {
+    ESP_LOGW(TAG, "CH422G not detected yet at 0x%02X, will retry", this->address_);
+    return false;
+  }
+
+  this->initialized_ = true;
+  ESP_LOGCONFIG(TAG, "Initialization complete. Warning: %d, Error: %d", this->status_has_warning(),
+                this->status_has_error());
+  return true;
 }
 
 void CH422GComponent::dump_config() {

--- a/esphome/components/ch422g/ch422g.h
+++ b/esphome/components/ch422g/ch422g.h
@@ -25,6 +25,9 @@ class CH422GComponent final : public Component, public i2c::I2CDevice {
   void dump_config() override;
 
  protected:
+  /// Attempts the register handshake once. Safe to call repeatedly; returns
+  /// true immediately if already initialized.
+  bool ensure_initialized_();
   bool write_reg_(uint8_t reg, uint8_t value);
   uint8_t read_reg_(uint8_t reg);
   bool set_mode_(uint8_t mode);
@@ -39,6 +42,8 @@ class CH422GComponent final : public Component, public i2c::I2CDevice {
   uint8_t input_bits_ = {0x00};
   /// Copy of the mode value
   uint8_t mode_value_{};
+  /// True once the initial register handshake with the chip has succeeded
+  bool initialized_{false};
 };
 
 /// Helper class to expose a CH422G pin as a GPIO pin.


### PR DESCRIPTION
# What does this implement/fix?

Fixes a boot-order race where the I2C bus/device isn't ready on the first `setup()` attempt, which currently calls `mark_failed()` and gives up permanently. This retries the register handshake from `loop()` until it succeeds instead, tracked via a new `initialized_` flag.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:
  sda: GPIO8
  scl: GPIO9

ch422g:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).