### PR TITLE
[ezo_pmp] Fix ml/min and ml unit capitalization

### DIFF
--- a/esphome/components/ezo_pmp/sensor.py
+++ b/esphome/components/ezo_pmp/sensor.py
@@ -23,7 +23,7 @@ CONF_PUMP_VOLTAGE = "pump_voltage"
 CONF_LAST_VOLUME_REQUESTED = "last_volume_requested"
 CONF_MAX_FLOW_RATE = "max_flow_rate"
 
-UNIT_MILILITER = "ml"
+UNIT_MILILITER = "mL"
 UNIT_MILILITERS_PER_MINUTE = "mL/min"
 
 CONFIG_SCHEMA = cv.Schema(

--- a/esphome/components/ezo_pmp/sensor.py
+++ b/esphome/components/ezo_pmp/sensor.py
@@ -24,7 +24,7 @@ CONF_LAST_VOLUME_REQUESTED = "last_volume_requested"
 CONF_MAX_FLOW_RATE = "max_flow_rate"
 
 UNIT_MILILITER = "ml"
-UNIT_MILILITERS_PER_MINUTE = "ml/min"
+UNIT_MILILITERS_PER_MINUTE = "mL/min"
 
 CONFIG_SCHEMA = cv.Schema(
     {


### PR DESCRIPTION
# What does this implement/fix?

Corrects the litre-based unit strings for the `ezo_pmp` sensor to use the SI convention of a capital `L` for litre, matching usage elsewhere in ESPHome:

- flow rate: `ml/min` → `mL/min`
- volume: `ml` → `mL`

Open Question:
https://github.com/home-assistant/core/blob/dev/homeassistant/const.py#L679-L692
In HA there is no `mL/min` defined. Should we convert it here or add `mL/min` to HA definitions?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)