### PR TITLE
[opentherm] Fix l/min unit capitalization to L/min

### DIFF
--- a/esphome/components/opentherm/schema.py
+++ b/esphome/components/opentherm/schema.py
@@ -91,7 +91,7 @@ SENSORS: dict[str, SensorSchema] = {
     ),
     "dhw_flow_rate": SensorSchema(
         description="Water flow rate in DHW circuit",
-        unit_of_measurement="l/min",
+        unit_of_measurement="L/min",
         accuracy_decimals=2,
         icon="mdi:waves-arrow-right",
         state_class=STATE_CLASS_MEASUREMENT,


### PR DESCRIPTION
# What does this implement/fix?

Corrects the DHW flow-rate unit string for the `opentherm` component from `l/min` to `L/min`, matching the SI convention for litre (capital `L`) used elsewhere in ESPHome.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)