### PR TITLE
[ld6002b] Add LD6002B 60GHz presence radar (1/5)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -287,6 +287,7 @@ esphome/components/ld2412/* @Rihan9
 esphome/components/ld2420/* @descipher
 esphome/components/ld2450/* @hareeshmu
 esphome/components/ld24xx/* @kbx81
+esphome/components/ld6002b/* @hepter
 esphome/components/ledc/* @OttoWinter
 esphome/components/libretiny/* @kuba2k2
 esphome/components/libretiny_pwm/* @kuba2k2

--- a/esphome/components/ld6002b/__init__.py
+++ b/esphome/components/ld6002b/__init__.py
@@ -4,7 +4,7 @@ from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_WAKEUP_PIN
 
-from .const import CONF_AUTO_WAKE, CONF_MAX_DATA_LEN, CONF_WAKEUP_PULSE_MS
+from .const import CONF_AUTO_WAKE, CONF_WAKEUP_PULSE
 
 CODEOWNERS = ["@hepter"]
 DEPENDENCIES = ["uart"]
@@ -13,20 +13,37 @@ MULTI_CONF = True
 ld6002b_ns = cg.esphome_ns.namespace("ld6002b")
 LD6002BComponent = ld6002b_ns.class_("LD6002BComponent", cg.Component, uart.UARTDevice)
 
+
+def _validate_wakeup_options(config):
+    """Reject wake options that would silently do nothing.
+
+    Runs before the schema so the defaults for the keys below have not been
+    filled in yet and an explicit user value is still distinguishable from one.
+    """
+    if CONF_WAKEUP_PIN in config:
+        return config
+    for key in (CONF_AUTO_WAKE, CONF_WAKEUP_PULSE):
+        if key in config:
+            raise cv.Invalid(
+                f"'{key}' requires '{CONF_WAKEUP_PIN}' to be configured", path=[key]
+            )
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
+    _validate_wakeup_options,
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(LD6002BComponent),
             cv.Optional(CONF_WAKEUP_PIN): pins.gpio_output_pin_schema,
             cv.Optional(
-                CONF_WAKEUP_PULSE_MS, default="50ms"
+                CONF_WAKEUP_PULSE, default="50ms"
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_AUTO_WAKE, default=True): cv.boolean,
-            cv.Optional(CONF_MAX_DATA_LEN): cv.int_range(min=256, max=65535),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
-    .extend(cv.COMPONENT_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA),
 )
 
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
@@ -47,9 +64,6 @@ async def to_code(config):
         pin = await cg.gpio_pin_expression(wakeup_pin_config)
         cg.add(var.set_wakeup_pin(pin))
 
-    if wakeup_pulse_config := config.get(CONF_WAKEUP_PULSE_MS):
-        cg.add(var.set_wakeup_pulse_ms(wakeup_pulse_config.total_milliseconds))
+    cg.add(var.set_wakeup_pulse_ms(config[CONF_WAKEUP_PULSE].total_milliseconds))
 
     cg.add(var.set_auto_wake(config[CONF_AUTO_WAKE]))
-    if max_data_len_config := config.get(CONF_MAX_DATA_LEN):
-        cg.add(var.set_max_data_len(max_data_len_config))

--- a/esphome/components/ld6002b/__init__.py
+++ b/esphome/components/ld6002b/__init__.py
@@ -1,0 +1,55 @@
+from esphome import pins
+import esphome.codegen as cg
+from esphome.components import uart
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_WAKEUP_PIN
+
+from .const import CONF_AUTO_WAKE, CONF_MAX_DATA_LEN, CONF_WAKEUP_PULSE_MS
+
+CODEOWNERS = ["@hepter"]
+DEPENDENCIES = ["uart"]
+MULTI_CONF = True
+
+ld6002b_ns = cg.esphome_ns.namespace("ld6002b")
+LD6002BComponent = ld6002b_ns.class_("LD6002BComponent", cg.Component, uart.UARTDevice)
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(LD6002BComponent),
+            cv.Optional(CONF_WAKEUP_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(
+                CONF_WAKEUP_PULSE_MS, default="50ms"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_AUTO_WAKE, default=True): cv.boolean,
+            cv.Optional(CONF_MAX_DATA_LEN): cv.int_range(min=256, max=65535),
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "ld6002b",
+    require_tx=True,
+    require_rx=True,
+    parity="NONE",
+    stop_bits=1,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+    if wakeup_pin_config := config.get(CONF_WAKEUP_PIN):
+        pin = await cg.gpio_pin_expression(wakeup_pin_config)
+        cg.add(var.set_wakeup_pin(pin))
+
+    if wakeup_pulse_config := config.get(CONF_WAKEUP_PULSE_MS):
+        cg.add(var.set_wakeup_pulse_ms(wakeup_pulse_config.total_milliseconds))
+
+    cg.add(var.set_auto_wake(config[CONF_AUTO_WAKE]))
+    if max_data_len_config := config.get(CONF_MAX_DATA_LEN):
+        cg.add(var.set_max_data_len(max_data_len_config))

--- a/esphome/components/ld6002b/__init__.py
+++ b/esphome/components/ld6002b/__init__.py
@@ -20,6 +20,8 @@ def _validate_wakeup_options(config):
     Runs before the schema so the defaults for the keys below have not been
     filled in yet and an explicit user value is still distinguishable from one.
     """
+    if not isinstance(config, dict):
+        return config
     if CONF_WAKEUP_PIN in config:
         return config
     for key in (CONF_AUTO_WAKE, CONF_WAKEUP_PULSE):

--- a/esphome/components/ld6002b/__init__.py
+++ b/esphome/components/ld6002b/__init__.py
@@ -48,8 +48,10 @@ CONFIG_SCHEMA = cv.All(
 
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
     "ld6002b",
+    baud_rate=115200,
     require_tx=True,
     require_rx=True,
+    data_bits=8,
     parity="NONE",
     stop_bits=1,
 )

--- a/esphome/components/ld6002b/binary_sensor.py
+++ b/esphome/components/ld6002b/binary_sensor.py
@@ -1,0 +1,40 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_TARGET, DEVICE_CLASS_OCCUPANCY
+
+from . import LD6002BComponent
+from .const import CONF_LD6002B_ID
+
+DEPENDENCIES = ["ld6002b"]
+
+MAX_TARGETS = 3
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_LD6002B_ID): cv.use_id(LD6002BComponent),
+        cv.Optional(CONF_TARGET): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_OCCUPANCY,
+        ),
+    }
+).extend(
+    {
+        cv.Optional(f"target_{i + 1}"): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_OCCUPANCY,
+        )
+        for i in range(MAX_TARGETS)
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_LD6002B_ID])
+
+    if target_config := config.get(CONF_TARGET):
+        sens = await binary_sensor.new_binary_sensor(target_config)
+        cg.add(hub.set_presence_binary_sensor(sens))
+
+    for i in range(MAX_TARGETS):
+        if target_config := config.get(f"target_{i + 1}"):
+            sens = await binary_sensor.new_binary_sensor(target_config)
+            cg.add(hub.set_target_presence_binary_sensor(i, sens))

--- a/esphome/components/ld6002b/const.py
+++ b/esphome/components/ld6002b/const.py
@@ -1,0 +1,4 @@
+CONF_AUTO_WAKE = "auto_wake"
+CONF_LD6002B_ID = "ld6002b_id"
+CONF_MAX_DATA_LEN = "max_data_len"
+CONF_WAKEUP_PULSE_MS = "wakeup_pulse_ms"

--- a/esphome/components/ld6002b/const.py
+++ b/esphome/components/ld6002b/const.py
@@ -1,4 +1,3 @@
 CONF_AUTO_WAKE = "auto_wake"
 CONF_LD6002B_ID = "ld6002b_id"
-CONF_MAX_DATA_LEN = "max_data_len"
-CONF_WAKEUP_PULSE_MS = "wakeup_pulse_ms"
+CONF_WAKEUP_PULSE = "wakeup_pulse"

--- a/esphome/components/ld6002b/ld6002b.cpp
+++ b/esphome/components/ld6002b/ld6002b.cpp
@@ -147,11 +147,14 @@ void LD6002BComponent::parse_byte_(uint8_t byte) {
   switch (this->parse_state_) {
     case ParseState::DISCARD:
       // Only entered from HCK, with a verified and non-zero number of bytes to skip. The zero
-      // check is still part of the condition because discard_remaining_ is unsigned: should a
-      // later change ever reach this state with nothing left to skip, decrementing first would
-      // wrap to 4294967295 and silently swallow the next four gigabytes of stream instead of
+      // guard stays because discard_remaining_ is unsigned: should a later change ever reach
+      // this state with nothing left to skip, an unconditional decrement would wrap to
+      // 4294967295 and silently swallow the next four gigabytes of stream instead of
       // resynchronising on the following frame.
-      if (this->discard_remaining_ == 0 || --this->discard_remaining_ == 0) {
+      if (this->discard_remaining_ > 0) {
+        this->discard_remaining_--;
+      }
+      if (this->discard_remaining_ == 0) {
         this->reset_parser_();
       }
       return;
@@ -236,7 +239,7 @@ void LD6002BComponent::handle_frame_(uint16_t type, const uint8_t *data, uint16_
   // its reply past the retry period, and treating such a reply as a leftover duplicate would starve
   // the command through every attempt and report a timeout for a write the module did perform.
   if (len == 0 && this->stale_ack_count_ > 0 && this->stale_ack_type_ == type &&
-      !(this->command_active_ && type == this->active_command_.type)) {
+      (!this->command_active_ || type != this->active_command_.type)) {
     this->stale_ack_count_--;
     ESP_LOGV(TAG, "Ignoring ACK for command 0x%04X from an earlier attempt (module frame 0x%04X)", type,
              this->frame_id_);

--- a/esphome/components/ld6002b/ld6002b.cpp
+++ b/esphome/components/ld6002b/ld6002b.cpp
@@ -15,7 +15,6 @@ static constexpr uint32_t SETUP_DELAY_MS = 100;
 static constexpr uint16_t TYPE_CONTROL = 0x0201;
 
 static constexpr uint16_t TYPE_REPORT_TARGET = 0x0A04;
-static constexpr uint16_t TYPE_REPORT_AREA_PRESENCE = 0x0A0A;
 
 // Control command values for TYPE_CONTROL
 static constexpr uint32_t CMD_POINT_CLOUD_ON = 0x06;
@@ -24,15 +23,6 @@ static constexpr uint32_t CMD_TARGET_DISPLAY_ON = 0x08;
 static constexpr uint32_t CMD_TARGET_DISPLAY_OFF = 0x09;
 
 static constexpr uint16_t TARGET_DATA_LEN = 20;  // x,y,z,dop_idx,cluster_id
-
-static uint32_t read_control_command_value(const uint8_t *data, uint8_t len) {
-  if (data == nullptr || len < 4) {
-    return 0;
-  }
-
-  return static_cast<uint32_t>(data[0]) | (static_cast<uint32_t>(data[1]) << 8) |
-         (static_cast<uint32_t>(data[2]) << 16) | (static_cast<uint32_t>(data[3]) << 24);
-}
 
 #ifdef ESPHOME_LOG_HAS_VERBOSE
 static const char *control_command_name(uint32_t command) {
@@ -66,15 +56,9 @@ void LD6002BComponent::write_u32_le(uint8_t *data, uint32_t value) {
 }
 
 void LD6002BComponent::setup() {
-  size_t desired_data_len = this->max_data_len_;
-  if (!this->max_data_len_overridden_) {
-    desired_data_len = DEFAULT_MAX_DATA_LEN;
-  }
-  this->max_data_len_ = desired_data_len;
-  // One allocation for the component lifetime: the parser reuses this buffer
-  // for the six byte header and for every payload up to max_data_len_.
+  // One allocation for the component lifetime; the parser reuses it for the header and every payload.
   RAMAllocator<uint8_t> allocator;
-  this->data_buf_ = allocator.allocate(std::max<size_t>(desired_data_len, 6));
+  this->data_buf_ = allocator.allocate(DEFAULT_MAX_DATA_LEN);
   if (this->data_buf_ == nullptr) {
     this->mark_failed(LOG_STR("Failed to allocate frame buffer"));
     return;
@@ -109,9 +93,8 @@ void LD6002BComponent::setup() {
 void LD6002BComponent::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "HLK-LD6002B:\n"
-                "  Auto wake: %s\n"
-                "  Max data length: %u",
-                this->auto_wake_ ? "true" : "false", static_cast<unsigned>(this->max_data_len_));
+                "  Auto wake: %s",
+                this->auto_wake_ ? "true" : "false");
   if (this->wakeup_pin_ != nullptr) {
     LOG_PIN("  Wake-up Pin: ", this->wakeup_pin_);
     ESP_LOGCONFIG(TAG, "  Wake Pulse: %ums", this->wakeup_pulse_ms_);
@@ -146,11 +129,7 @@ void LD6002BComponent::reset_parser_() {
 void LD6002BComponent::parse_byte_(uint8_t byte) {
   switch (this->parse_state_) {
     case ParseState::DISCARD:
-      // Only entered from HCK, with a verified and non-zero number of bytes to skip. The zero
-      // guard stays because discard_remaining_ is unsigned: should a later change ever reach
-      // this state with nothing left to skip, an unconditional decrement would wrap to
-      // 4294967295 and silently swallow the next four gigabytes of stream instead of
-      // resynchronising on the following frame.
+      // discard_remaining_ is unsigned: an unguarded decrement at zero would swallow 4 GB of stream.
       if (this->discard_remaining_ > 0) {
         this->discard_remaining_--;
       }
@@ -177,7 +156,7 @@ void LD6002BComponent::parse_byte_(uint8_t byte) {
           this->frame_type_ = read_u16_be(this->data_buf_ + 4);
           // The length is only trustworthy once the header checksum has been verified, so just
           // remember that the frame is oversized and let the HCK state act on it.
-          this->frame_oversize_ = this->data_len_ > this->max_data_len_;
+          this->frame_oversize_ = this->data_len_ > DEFAULT_MAX_DATA_LEN;
           this->parse_state_ = ParseState::HCK;
         }
       }
@@ -227,19 +206,9 @@ void LD6002BComponent::parse_byte_(uint8_t byte) {
 }
 
 void LD6002BComponent::handle_frame_(uint16_t type, const uint8_t *data, uint16_t len) {
-  // The module acknowledges a command with an empty frame of the same type. It does not echo our
-  // frame id: that field is a per-peer send counter (MSB 1 for us, 0 for the module) which the
-  // protocol only reuses in a reply for message types supporting a bidirectional exchange, and
-  // every type sent here is documented as unidirectional. ACKs of one type can therefore only be
-  // told apart by transmission order, so the duplicates a retried command leaves behind are
-  // swallowed instead of completing whatever command runs next.
-  //
-  // That swallowing only applies while no matching command is waiting. An ACK that arrives for the
-  // command still on the wire always completes it, however late: waking a sleeping module pushes
-  // its reply past the retry period, and treating such a reply as a leftover duplicate would starve
-  // the command through every attempt and report a timeout for a write the module did perform.
-  if (len == 0 && this->stale_ack_count_ > 0 && this->stale_ack_type_ == type &&
-      (!this->command_active_ || type != this->active_command_.type)) {
+  this->last_traffic_ms_ = millis();
+  // ACKs carry no id and arrive in send order: debt from earlier attempts is paid before the active command.
+  if (len == 0 && this->stale_ack_count_ > 0 && this->stale_ack_type_ == type) {
     this->stale_ack_count_--;
     ESP_LOGV(TAG, "Ignoring ACK for command 0x%04X from an earlier attempt (module frame 0x%04X)", type,
              this->frame_id_);
@@ -247,11 +216,10 @@ void LD6002BComponent::handle_frame_(uint16_t type, const uint8_t *data, uint16_
   }
   if (len == 0 && this->command_active_ && type == this->active_command_.type) {
     ESP_LOGV(TAG, "ACK for command 0x%04X (module frame 0x%04X)", type, this->frame_id_);
-    // Every frame transmitted for this command is answered, and this ACK settles exactly one of
-    // them, so the remaining attempts are still owed replies. Those become the guard debt for the
-    // window after this command finishes.
+    // This settles one expected reply; the rest stay owed and become the debt for the next command.
+    this->send_generation_++;
     this->stale_ack_type_ = type;
-    this->stale_ack_count_ = this->attempts_sent_ > 0 ? static_cast<uint8_t>(this->attempts_sent_ - 1) : 0;
+    this->stale_ack_count_ = this->acks_expected_ > 0 ? static_cast<uint8_t>(this->acks_expected_ - 1) : 0;
     this->command_active_ = false;
     this->command_sent_ = false;
     this->last_send_ms_ = 0;
@@ -262,9 +230,6 @@ void LD6002BComponent::handle_frame_(uint16_t type, const uint8_t *data, uint16_
   switch (type) {
     case TYPE_REPORT_TARGET:
       this->handle_target_report_(data, len);
-      break;
-    case TYPE_REPORT_AREA_PRESENCE:
-      this->handle_area_presence_(data, len);
       break;
     default:
       break;
@@ -277,48 +242,24 @@ void LD6002BComponent::handle_target_report_(const uint8_t *data, uint16_t len) 
 
   uint32_t target_num = read_u32_le(data);
   uint16_t available = (len - 4) / TARGET_DATA_LEN;
-  // Keep the un-narrowed value for the presence test: a report of e.g. 256
-  // targets must not truncate to 0 and read as "absent".
+  // Un-narrowed: a report of e.g. 256 targets must not truncate to 0 and read as "absent".
   const uint32_t reported = std::min<uint32_t>(target_num, available);
-  uint8_t count = static_cast<uint8_t>(std::min<uint32_t>(reported, MAX_TARGETS));
 
   this->target_presence_any_ = (reported > 0);
-  bool presence = this->target_presence_any_ || this->area_presence_any_;
 #ifdef USE_BINARY_SENSOR
   if (this->presence_binary_sensor_ != nullptr) {
-    this->presence_binary_sensor_->publish_state(presence);
+    this->presence_binary_sensor_->publish_state(this->target_presence_any_);
   }
 #endif
 
   for (uint8_t i = 0; i < MAX_TARGETS; i++) {
-    bool has_target = i < count;
 #ifdef USE_BINARY_SENSOR
     if (this->target_presence_[i] != nullptr) {
       // publish_state() already skips unchanged states, no manual de-dup needed.
-      this->target_presence_[i]->publish_state(has_target);
+      this->target_presence_[i]->publish_state(i < reported);
     }
 #endif
-    this->last_target_presence_[i] = has_target;
   }
-}
-
-void LD6002BComponent::handle_area_presence_(const uint8_t *data, uint16_t len) {
-  if (len < 16)
-    return;
-
-  this->area_presence_any_ = false;
-  for (uint8_t i = 0; i < AREA_COUNT; i++) {
-    uint32_t state = read_u32_le(data + (i * 4));
-    bool present = state != 0;
-    this->area_presence_any_ = this->area_presence_any_ || present;
-  }
-
-  bool presence = this->target_presence_any_ || this->area_presence_any_;
-#ifdef USE_BINARY_SENSOR
-  if (this->presence_binary_sensor_ != nullptr) {
-    this->presence_binary_sensor_->publish_state(presence);
-  }
-#endif
 }
 
 void LD6002BComponent::queue_command_(uint16_t type, const uint8_t *data, uint8_t len) {
@@ -346,15 +287,12 @@ void LD6002BComponent::queue_command_(uint16_t type, const uint8_t *data, uint8_
 void LD6002BComponent::process_command_queue_() {
   uint32_t now = millis();
   if (this->command_active_) {
-    // The opening attempt may be the frame that wakes a sleeping module, which consumes it rather
-    // than answering it; the retry that follows is acked 100-175ms later. The wider budget for that
-    // first attempt keeps the wake from cascading into further retries, while later attempts keep
-    // the normal period.
+    // A sleeping module consumes the opening attempt as its wake-up instead of answering it.
     const uint32_t ack_timeout = this->attempts_sent_ <= 1 ? CMD_FIRST_ACK_TIMEOUT_MS : CMD_ACK_TIMEOUT_MS;
     if (this->command_sent_ && now - this->last_send_ms_ >= ack_timeout) {
       const uint32_t active_control_command =
-          this->active_command_.type == TYPE_CONTROL
-              ? read_control_command_value(this->active_command_.data.data(), this->active_command_.len)
+          (this->active_command_.type == TYPE_CONTROL && this->active_command_.len >= 4)
+              ? read_u32_le(this->active_command_.data.data())
               : 0;
       if (this->retries_left_ > 0) {
 #ifdef ESPHOME_LOG_HAS_VERBOSE
@@ -362,8 +300,7 @@ void LD6002BComponent::process_command_queue_() {
           ESP_LOGV(TAG, "Retrying %s (0x%02" PRIX32 "), %u attempt(s) remaining",
                    control_command_name(active_control_command), active_control_command, this->retries_left_);
         } else {
-          // Writes such as the hold delay and z-range carry no control subcommand, so without this
-          // branch their retries were invisible and only the eventual timeout showed up.
+          // Writes without a control subcommand (hold delay, z-range) had no retry trace at all.
           ESP_LOGV(TAG, "Retrying command 0x%04X, %u attempt(s) remaining", this->active_command_.type,
                    this->retries_left_);
         }
@@ -379,8 +316,15 @@ void LD6002BComponent::process_command_queue_() {
         } else {
           ESP_LOGW(TAG, "Command 0x%04X timed out", this->active_command_.type);
         }
-        // No attempt was answered, so the module owes no ACK for this command any more.
-        this->stale_ack_count_ = 0;
+        // A reply may still be in flight for the attempt we just gave up on, so carry one over as
+        // debt rather than clearing the ledger, or that late ACK would retire the successor. Only
+        // one: reaching this point means nothing was answered at all, so the older attempts are
+        // speculative, and carrying them would swallow the successor's own replies.
+        const uint16_t owed = (this->stale_ack_type_ == this->active_command_.type ? this->stale_ack_count_ : 0) +
+                              (this->acks_expected_ > 0 ? 1 : 0);
+        this->stale_ack_type_ = this->active_command_.type;
+        this->stale_ack_count_ = static_cast<uint8_t>(std::min<uint16_t>(owed, 255));
+        this->send_generation_++;
         this->command_active_ = false;
         this->command_sent_ = false;
         this->last_send_ms_ = 0;
@@ -396,11 +340,13 @@ void LD6002BComponent::process_command_queue_() {
   this->cmd_head_ = (this->cmd_head_ + 1) % CMD_QUEUE_SIZE;
   this->cmd_count_--;
 
+  this->send_generation_++;
   this->retries_left_ = CMD_MAX_RETRIES;
   this->command_active_ = true;
   this->command_sent_ = false;
   this->last_send_ms_ = 0;
   this->attempts_sent_ = 0;
+  this->acks_expected_ = 0;
   if (this->stale_ack_type_ != this->active_command_.type) {
     this->stale_ack_count_ = 0;
   }
@@ -415,8 +361,7 @@ void LD6002BComponent::send_command_internal_(uint16_t type, const uint8_t *data
   if (len > CMD_MAX_DATA_LEN) {
     ESP_LOGW(TAG, "Command data too large: %u", len);
     if (track) {
-      // Release the slot: this command is never written, so it would neither be
-      // acked nor time out and the queue would stall behind it.
+      // Release the slot: an unwritten command is never acked and never times out.
       this->command_active_ = false;
       this->command_sent_ = false;
       this->last_send_ms_ = 0;
@@ -424,18 +369,24 @@ void LD6002BComponent::send_command_internal_(uint16_t type, const uint8_t *data
     return;
   }
 
-  if (this->auto_wake_ && this->wakeup_pin_ != nullptr) {
-    // Capture no payload: tracked commands are always sent from
-    // active_command_.data, which stays valid until the ack or the timeout,
-    // and untracked ones are staged in wake_scratch_ instead.
-    if (!track && len > 0 && data != nullptr) {
+  // Anonymous timeouts never replace each other; with a pulse already pending the module is waking anyway.
+  if (this->auto_wake_ && this->wakeup_pin_ != nullptr && !this->wake_pulse_pending_) {
+    // Snapshot the payload: the deferred write must not depend on state a completing command changes.
+    if (len > 0 && data != nullptr) {
       std::memcpy(this->wake_scratch_.data(), data, len);
     }
+    this->wake_pulse_pending_ = true;
     this->wakeup_pin_->digital_write(false);
-    this->set_timeout(this->wakeup_pulse_ms_, [this, type, len, track]() {
+    const uint8_t generation = this->send_generation_;
+    this->set_timeout(this->wakeup_pulse_ms_, [this, type, len, track, generation]() {
       this->wakeup_pin_->digital_write(true);
-      const uint8_t *payload = track ? this->active_command_.data.data() : this->wake_scratch_.data();
-      this->write_frame_(type, (len > 0) ? payload : nullptr, len, track);
+      this->wake_pulse_pending_ = false;
+      // Anonymous timeouts are never cancelled, so a tracked pulse whose command has since been
+      // retired must not transmit: the frame would land after its successor and be booked to it.
+      if (track && generation != this->send_generation_) {
+        return;
+      }
+      this->write_frame_(type, (len > 0) ? this->wake_scratch_.data() : nullptr, len, track);
     });
     return;
   }
@@ -471,11 +422,17 @@ void LD6002BComponent::write_frame_(uint16_t type, const uint8_t *data, uint8_t 
     }
     this->write_byte(static_cast<uint8_t>(~data_xor));
   }
+  const uint32_t now = millis();
   if (track) {
-    this->last_send_ms_ = millis();
+    // A frame sent to a module that has had time to fall asleep is its wake-up, and goes unanswered.
+    if (this->last_traffic_ms_ != 0 && now - this->last_traffic_ms_ < MODULE_AWAKE_MS) {
+      this->acks_expected_++;
+    }
+    this->last_send_ms_ = now;
     this->command_sent_ = true;
     this->attempts_sent_++;
   }
+  this->last_traffic_ms_ = now;
 }
 
 void LD6002BComponent::send_control_command_(uint32_t command) {

--- a/esphome/components/ld6002b/ld6002b.cpp
+++ b/esphome/components/ld6002b/ld6002b.cpp
@@ -244,6 +244,42 @@ void LD6002BComponent::handle_target_report_(const uint8_t *data, uint16_t len) 
   uint16_t available = (len - 4) / TARGET_DATA_LEN;
   // Un-narrowed: a report of e.g. 256 targets must not truncate to 0 and read as "absent".
   const uint32_t reported = std::min<uint32_t>(target_num, available);
+  uint8_t count = static_cast<uint8_t>(std::min<uint32_t>(reported, MAX_TARGETS));
+
+  // The module re-sorts its array by cluster id, so slots key on the id to track the person.
+  std::array<int32_t, MAX_TARGETS> wire_cluster{};
+  std::array<bool, MAX_TARGETS> wire_placed{};
+  std::array<bool, MAX_TARGETS> slot_seen{};
+  for (uint8_t i = 0; i < count; i++) {
+    uint16_t cluster_offset = 4 + (i * TARGET_DATA_LEN) + 16;
+    wire_cluster[i] = static_cast<int32_t>(read_u32_le(data + cluster_offset));
+  }
+  for (uint8_t i = 0; i < count; i++) {
+    for (uint8_t s = 0; s < MAX_TARGETS; s++) {
+      if (this->slot_occupied_[s] && !slot_seen[s] && this->slot_cluster_[s] == wire_cluster[i]) {
+        slot_seen[s] = true;
+        wire_placed[i] = true;
+        break;
+      }
+    }
+  }
+  for (uint8_t s = 0; s < MAX_TARGETS; s++) {
+    if (!slot_seen[s]) {
+      this->slot_occupied_[s] = false;
+    }
+  }
+  for (uint8_t i = 0; i < count; i++) {
+    if (wire_placed[i]) {
+      continue;
+    }
+    for (uint8_t s = 0; s < MAX_TARGETS; s++) {
+      if (!this->slot_occupied_[s]) {
+        this->slot_occupied_[s] = true;
+        this->slot_cluster_[s] = wire_cluster[i];
+        break;
+      }
+    }
+  }
 
   this->target_presence_any_ = (reported > 0);
 #ifdef USE_BINARY_SENSOR
@@ -256,7 +292,7 @@ void LD6002BComponent::handle_target_report_(const uint8_t *data, uint16_t len) 
 #ifdef USE_BINARY_SENSOR
     if (this->target_presence_[i] != nullptr) {
       // publish_state() already skips unchanged states, no manual de-dup needed.
-      this->target_presence_[i]->publish_state(i < reported);
+      this->target_presence_[i]->publish_state(this->slot_occupied_[i]);
     }
 #endif
   }

--- a/esphome/components/ld6002b/ld6002b.cpp
+++ b/esphome/components/ld6002b/ld6002b.cpp
@@ -1,0 +1,480 @@
+#include "ld6002b.h"
+#include "esphome/core/log.h"
+#include <algorithm>
+#include <cinttypes>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+namespace esphome::ld6002b {
+
+static const char *const TAG = "ld6002b";
+
+static constexpr uint8_t TF_SOF = 0x01;
+static constexpr uint32_t SETUP_DELAY_MS = 100;
+
+// Command/message types
+static constexpr uint16_t TYPE_CONTROL = 0x0201;
+
+static constexpr uint16_t TYPE_REPORT_TARGET = 0x0A04;
+static constexpr uint16_t TYPE_REPORT_AREA_PRESENCE = 0x0A0A;
+
+// Control command values for TYPE_CONTROL
+static constexpr uint32_t CMD_POINT_CLOUD_ON = 0x06;
+static constexpr uint32_t CMD_POINT_CLOUD_OFF = 0x07;
+static constexpr uint32_t CMD_TARGET_DISPLAY_ON = 0x08;
+static constexpr uint32_t CMD_TARGET_DISPLAY_OFF = 0x09;
+
+static constexpr uint16_t TARGET_DATA_LEN = 20;  // x,y,z,dop_idx,cluster_id
+
+static uint32_t read_control_command_value(const uint8_t *data, uint8_t len) {
+  if (data == nullptr || len < 4) {
+    return 0;
+  }
+
+  return static_cast<uint32_t>(data[0]) | (static_cast<uint32_t>(data[1]) << 8) |
+         (static_cast<uint32_t>(data[2]) << 16) | (static_cast<uint32_t>(data[3]) << 24);
+}
+
+#ifdef ESPHOME_LOG_HAS_VERBOSE
+static const char *control_command_name(uint32_t command) {
+  switch (command) {
+    case CMD_POINT_CLOUD_ON:
+      return "point_cloud_on";
+    case CMD_POINT_CLOUD_OFF:
+      return "point_cloud_off";
+    case CMD_TARGET_DISPLAY_ON:
+      return "target_display_on";
+    case CMD_TARGET_DISPLAY_OFF:
+      return "target_display_off";
+    default:
+      return "unknown";
+  }
+}
+#endif
+
+uint16_t LD6002BComponent::read_u16_be(const uint8_t *data) { return (static_cast<uint16_t>(data[0]) << 8) | data[1]; }
+
+uint32_t LD6002BComponent::read_u32_le(const uint8_t *data) {
+  return static_cast<uint32_t>(data[0]) | (static_cast<uint32_t>(data[1]) << 8) |
+         (static_cast<uint32_t>(data[2]) << 16) | (static_cast<uint32_t>(data[3]) << 24);
+}
+
+int32_t LD6002BComponent::read_int32_le(const uint8_t *data) {
+  uint32_t raw = read_u32_le(data);
+  int32_t value;
+  std::memcpy(&value, &raw, sizeof(value));
+  return value;
+}
+
+float LD6002BComponent::read_f32_le(const uint8_t *data) {
+  uint32_t raw = read_u32_le(data);
+  float value;
+  std::memcpy(&value, &raw, sizeof(value));
+  return value;
+}
+
+void LD6002BComponent::write_u32_le(uint8_t *data, uint32_t value) {
+  data[0] = value & 0xFF;
+  data[1] = (value >> 8) & 0xFF;
+  data[2] = (value >> 16) & 0xFF;
+  data[3] = (value >> 24) & 0xFF;
+}
+
+void LD6002BComponent::set_max_data_len(size_t max_data_len) {
+  this->max_data_len_overridden_ = true;
+  this->max_data_len_ = max_data_len;
+  this->data_buf_ = std::make_unique<uint8_t[]>(std::max<size_t>(max_data_len, 6));
+}
+
+void LD6002BComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up HLK-LD6002B...");
+  size_t desired_data_len = this->max_data_len_;
+  if (!this->max_data_len_overridden_) {
+    bool point_cloud_configured = false;
+    desired_data_len = point_cloud_configured ? DEFAULT_MAX_DATA_LEN_POINT_CLOUD : DEFAULT_MAX_DATA_LEN;
+  }
+  this->max_data_len_ = desired_data_len;
+  this->data_buf_ = std::make_unique<uint8_t[]>(std::max<size_t>(desired_data_len, 6));
+  if (this->wakeup_pin_ != nullptr) {
+    this->wakeup_pin_->setup();
+    this->wakeup_pin_->digital_write(true);
+  }
+
+  this->set_timeout(SETUP_DELAY_MS, [this]() {
+    bool want_target_stream = false;
+#ifdef USE_BINARY_SENSOR
+    want_target_stream = want_target_stream || this->presence_binary_sensor_ != nullptr;
+    if (!want_target_stream) {
+      for (auto *sensor : this->target_presence_) {
+        if (sensor != nullptr) {
+          want_target_stream = true;
+          break;
+        }
+      }
+    }
+#endif
+    if (want_target_stream) {
+      this->send_control_command_(CMD_TARGET_DISPLAY_ON);
+    }
+
+    bool want_point_cloud_stream = false;
+    this->send_control_command_(want_point_cloud_stream ? CMD_POINT_CLOUD_ON : CMD_POINT_CLOUD_OFF);
+  });
+}
+
+void LD6002BComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "HLK-LD6002B:");
+  ESP_LOGCONFIG(TAG, "  Auto wake: %s", this->auto_wake_ ? "true" : "false");
+#ifdef USE_BINARY_SENSOR
+  LOG_BINARY_SENSOR("  ", "Presence", this->presence_binary_sensor_);
+#endif
+}
+
+void LD6002BComponent::loop() {
+  while (this->available()) {
+    uint8_t byte = this->read();
+    this->parse_byte_(byte);
+  }
+  this->process_command_queue_();
+}
+
+void LD6002BComponent::reset_parser_() {
+  this->parse_state_ = ParseState::SOF;
+  this->header_pos_ = 0;
+  this->header_xor_ = 0;
+  this->data_len_ = 0;
+  this->data_pos_ = 0;
+  this->data_xor_ = 0;
+  this->discard_remaining_ = 0;
+}
+
+void LD6002BComponent::parse_byte_(uint8_t byte) {
+  switch (this->parse_state_) {
+    case ParseState::DISCARD:
+      if (this->discard_remaining_ > 0) {
+        this->discard_remaining_--;
+        if (this->discard_remaining_ == 0) {
+          this->reset_parser_();
+        }
+      } else {
+        this->reset_parser_();
+      }
+      return;
+    case ParseState::SOF:
+      if (byte != TF_SOF)
+        return;
+      this->header_pos_ = 0;
+      this->header_xor_ = 0;
+      this->header_xor_ ^= byte;
+      this->parse_state_ = ParseState::HEADER;
+      return;
+    case ParseState::HEADER:
+      if (this->header_pos_ < 6) {
+        this->data_buf_[this->header_pos_] = byte;
+        this->header_xor_ ^= byte;
+        this->header_pos_++;
+        if (this->header_pos_ == 6) {
+          this->frame_id_ = read_u16_be(this->data_buf_.get());
+          this->data_len_ = read_u16_be(this->data_buf_.get() + 2);
+          this->frame_type_ = read_u16_be(this->data_buf_.get() + 4);
+          if (this->data_len_ > this->max_data_len_) {
+            ESP_LOGW(TAG, "Frame too large: %u", this->data_len_);
+            // Discard the remaining bytes in this frame: header checksum + payload + data checksum (if any)
+            this->discard_remaining_ = 1 + this->data_len_ + (this->data_len_ > 0 ? 1 : 0);
+            this->parse_state_ = ParseState::DISCARD;
+            return;
+          }
+          this->parse_state_ = ParseState::HCK;
+        }
+      }
+      return;
+    case ParseState::HCK: {
+      uint8_t expected = static_cast<uint8_t>(~this->header_xor_);
+      if (byte != expected) {
+        ESP_LOGV(TAG, "Header checksum mismatch");
+        this->reset_parser_();
+        return;
+      }
+      if (this->data_len_ == 0) {
+        this->handle_frame_(this->frame_type_, nullptr, 0);
+        this->reset_parser_();
+      } else {
+        this->data_pos_ = 0;
+        this->data_xor_ = 0;
+        this->parse_state_ = ParseState::DATA;
+      }
+      return;
+    }
+    case ParseState::DATA:
+      this->data_buf_[this->data_pos_++] = byte;
+      this->data_xor_ ^= byte;
+      if (this->data_pos_ >= this->data_len_) {
+        this->parse_state_ = ParseState::DCK;
+      }
+      return;
+    case ParseState::DCK: {
+      uint8_t expected = static_cast<uint8_t>(~this->data_xor_);
+      if (byte == expected) {
+        this->handle_frame_(this->frame_type_, this->data_buf_.get(), this->data_len_);
+      } else {
+        ESP_LOGV(TAG, "Data checksum mismatch");
+      }
+      this->reset_parser_();
+      return;
+    }
+  }
+}
+
+void LD6002BComponent::handle_frame_(uint16_t type, const uint8_t *data, uint16_t len) {
+  const bool matching_ack_type = len == 0 && this->command_active_ && type == this->active_command_.type;
+  const bool matching_ack_frame_id =
+      ((this->frame_id_ & 0x7FFF) == (this->active_frame_id_ & 0x7FFF)) || this->active_command_.type == TYPE_CONTROL;
+  const bool matching_ack = matching_ack_type && matching_ack_frame_id;
+  if (matching_ack) {
+#ifdef ESPHOME_LOG_HAS_VERBOSE
+    const uint32_t active_control_command =
+        this->active_command_.type == TYPE_CONTROL
+            ? read_control_command_value(this->active_command_.data.data(), this->active_command_.len)
+            : 0;
+    if (active_control_command != 0 && ((this->frame_id_ & 0x7FFF) != (this->active_frame_id_ & 0x7FFF))) {
+      ESP_LOGV(TAG, "Accepting %s (0x%02" PRIX32 ") ACK with device frame 0x%04X while active frame is 0x%04X",
+               control_command_name(active_control_command), active_control_command, this->frame_id_,
+               this->active_frame_id_);
+    }
+    if (active_control_command != 0) {
+      ESP_LOGV(TAG, "ACK for %s (0x%02" PRIX32 ") matched frame 0x%04X", control_command_name(active_control_command),
+               active_control_command, this->frame_id_);
+    }
+#endif
+    this->command_active_ = false;
+    this->command_sent_ = false;
+    this->active_frame_id_ = 0;
+    this->last_send_ms_ = 0;
+    this->process_command_queue_();
+    return;
+  }
+
+#ifdef ESPHOME_LOG_HAS_VERBOSE
+  const uint32_t active_control_command =
+      this->command_active_ && this->active_command_.type == TYPE_CONTROL
+          ? read_control_command_value(this->active_command_.data.data(), this->active_command_.len)
+          : 0;
+  if (len == 0 && this->command_active_ && type == this->active_command_.type &&
+      this->frame_id_ != this->active_frame_id_ && this->active_command_.type != TYPE_CONTROL) {
+    ESP_LOGV(TAG, "Ignoring ACK for %s (0x%02" PRIX32 "): frame 0x%04X did not match active 0x%04X",
+             control_command_name(active_control_command), active_control_command, this->frame_id_,
+             this->active_frame_id_);
+  }
+#endif
+
+  switch (type) {
+    case TYPE_REPORT_TARGET:
+      this->handle_target_report_(data, len);
+      break;
+    case TYPE_REPORT_AREA_PRESENCE:
+      this->handle_area_presence_(data, len);
+      break;
+    default:
+      break;
+  }
+}
+
+void LD6002BComponent::handle_target_report_(const uint8_t *data, uint16_t len) {
+  if (len < 4)
+    return;
+
+  uint32_t target_num = read_u32_le(data);
+  uint16_t available = (len - 4) / TARGET_DATA_LEN;
+  uint8_t count = static_cast<uint8_t>(std::min<uint32_t>(target_num, available));
+
+  this->target_presence_any_ = (count > 0);
+  bool presence = this->target_presence_any_ || this->area_presence_any_;
+#ifdef USE_BINARY_SENSOR
+  if (this->presence_binary_sensor_ != nullptr) {
+    this->presence_binary_sensor_->publish_state(presence);
+  }
+#endif
+
+  for (uint8_t i = 0; i < MAX_TARGETS; i++) {
+    bool has_target = i < count;
+#ifdef USE_BINARY_SENSOR
+    if (this->target_presence_[i] != nullptr) {
+      if (!this->target_presence_initialized_[i] || has_target != this->last_target_presence_[i]) {
+        this->target_presence_[i]->publish_state(has_target);
+        this->target_presence_initialized_[i] = true;
+      }
+    }
+#endif
+    this->last_target_presence_[i] = has_target;
+  }
+}
+
+void LD6002BComponent::handle_area_presence_(const uint8_t *data, uint16_t len) {
+  if (len < 16)
+    return;
+
+  this->area_presence_any_ = false;
+  for (uint8_t i = 0; i < AREA_COUNT; i++) {
+    uint32_t state = read_u32_le(data + (i * 4));
+    bool present = state != 0;
+    this->area_presence_any_ = this->area_presence_any_ || present;
+#ifdef USE_BINARY_SENSOR
+    if (this->area_presence_[i] != nullptr) {
+      this->area_presence_[i]->publish_state(present);
+    }
+#endif
+  }
+
+  bool presence = this->target_presence_any_ || this->area_presence_any_;
+#ifdef USE_BINARY_SENSOR
+  if (this->presence_binary_sensor_ != nullptr) {
+    this->presence_binary_sensor_->publish_state(presence);
+  }
+#endif
+}
+
+void LD6002BComponent::queue_command_(uint16_t type, const uint8_t *data, uint8_t len) {
+  if (len > CMD_MAX_DATA_LEN) {
+    ESP_LOGW(TAG, "Command data too large: %u", len);
+    return;
+  }
+  if (this->cmd_count_ >= CMD_QUEUE_SIZE) {
+    ESP_LOGW(TAG, "Command queue full, dropping command 0x%04X", type);
+    return;
+  }
+
+  PendingCommand &cmd = this->cmd_queue_[this->cmd_tail_];
+  cmd.type = type;
+  cmd.len = len;
+  if (len > 0 && data != nullptr) {
+    std::memcpy(cmd.data.data(), data, len);
+  }
+
+  this->cmd_tail_ = (this->cmd_tail_ + 1) % CMD_QUEUE_SIZE;
+  this->cmd_count_++;
+  this->process_command_queue_();
+}
+
+void LD6002BComponent::process_command_queue_() {
+  uint32_t now = millis();
+  if (this->command_active_) {
+    if (this->command_sent_ && now - this->last_send_ms_ >= CMD_ACK_TIMEOUT_MS) {
+      const uint32_t active_control_command =
+          this->active_command_.type == TYPE_CONTROL
+              ? read_control_command_value(this->active_command_.data.data(), this->active_command_.len)
+              : 0;
+      if (this->retries_left_ > 0) {
+#ifdef ESPHOME_LOG_HAS_VERBOSE
+        if (active_control_command != 0) {
+          ESP_LOGV(TAG, "Retrying %s (0x%02" PRIX32 "), %u attempt(s) remaining",
+                   control_command_name(active_control_command), active_control_command, this->retries_left_);
+        }
+#endif
+        this->command_sent_ = false;
+        this->last_send_ms_ = 0;
+        this->send_command_(this->active_command_.type, this->active_command_.data.data(), this->active_command_.len);
+        this->retries_left_--;
+      } else {
+        if (active_control_command != 0) {
+          ESP_LOGW(TAG, "Command 0x%04X subcommand 0x%02" PRIX32 " timed out", this->active_command_.type,
+                   active_control_command);
+        } else {
+          ESP_LOGW(TAG, "Command 0x%04X timed out", this->active_command_.type);
+        }
+        this->command_active_ = false;
+        this->command_sent_ = false;
+        this->active_frame_id_ = 0;
+        this->last_send_ms_ = 0;
+      }
+    }
+    return;
+  }
+
+  if (this->cmd_count_ == 0)
+    return;
+
+  this->active_command_ = this->cmd_queue_[this->cmd_head_];
+  this->cmd_head_ = (this->cmd_head_ + 1) % CMD_QUEUE_SIZE;
+  this->cmd_count_--;
+
+  this->retries_left_ = CMD_MAX_RETRIES;
+  this->command_active_ = true;
+  this->command_sent_ = false;
+  this->active_frame_id_ = 0;
+  this->last_send_ms_ = 0;
+  this->send_command_(this->active_command_.type, this->active_command_.data.data(), this->active_command_.len);
+}
+
+void LD6002BComponent::send_command_(uint16_t type, const uint8_t *data, uint8_t len) {
+  this->send_command_internal_(type, data, len, true);
+}
+
+void LD6002BComponent::send_command_untracked_(uint16_t type, const uint8_t *data, uint8_t len) {
+  this->send_command_internal_(type, data, len, false);
+}
+
+void LD6002BComponent::send_command_internal_(uint16_t type, const uint8_t *data, uint8_t len, bool track) {
+  if (this->auto_wake_ && this->wakeup_pin_ != nullptr) {
+    if (len > CMD_MAX_DATA_LEN) {
+      ESP_LOGW(TAG, "Command data too large: %u", len);
+      return;
+    }
+    std::array<uint8_t, CMD_MAX_DATA_LEN> data_copy{};
+    if (len > 0 && data != nullptr) {
+      std::memcpy(data_copy.data(), data, len);
+    }
+    this->wakeup_pin_->digital_write(false);
+    this->set_timeout(this->wakeup_pulse_ms_, [this, type, len, data_copy, track]() {
+      this->wakeup_pin_->digital_write(true);
+      const uint8_t *payload = (len > 0) ? data_copy.data() : nullptr;
+      this->write_frame_(type, payload, len, track);
+    });
+    return;
+  }
+
+  this->write_frame_(type, data, len, track);
+}
+
+void LD6002BComponent::write_frame_(uint16_t type, const uint8_t *data, uint8_t len, bool track) {
+  uint16_t frame_id = this->next_frame_id_++ & 0x7FFF;
+  frame_id |= 0x8000;
+
+  uint8_t header_xor = 0;
+  auto write_header = [&](uint8_t b) {
+    this->write_byte(b);
+    header_xor ^= b;
+  };
+
+  write_header(TF_SOF);
+  write_header((frame_id >> 8) & 0xFF);
+  write_header(frame_id & 0xFF);
+  write_header((len >> 8) & 0xFF);
+  write_header(len & 0xFF);
+  write_header((type >> 8) & 0xFF);
+  write_header(type & 0xFF);
+
+  this->write_byte(static_cast<uint8_t>(~header_xor));
+
+  if (len > 0 && data != nullptr) {
+    uint8_t data_xor = 0;
+    for (uint8_t i = 0; i < len; i++) {
+      this->write_byte(data[i]);
+      data_xor ^= data[i];
+    }
+    this->write_byte(static_cast<uint8_t>(~data_xor));
+  }
+  if (track) {
+    this->active_frame_id_ = frame_id;
+    this->last_send_ms_ = millis();
+    this->command_sent_ = true;
+  }
+}
+
+void LD6002BComponent::send_control_command_(uint32_t command) {
+  uint8_t data[4];
+  write_u32_le(data, command);
+  this->queue_command_(TYPE_CONTROL, data, sizeof(data));
+}
+
+}  // namespace esphome::ld6002b

--- a/esphome/components/ld6002b/ld6002b.cpp
+++ b/esphome/components/ld6002b/ld6002b.cpp
@@ -214,7 +214,7 @@ void LD6002BComponent::handle_frame_(uint16_t type, const uint8_t *data, uint16_
              this->frame_id_);
     return;
   }
-  if (len == 0 && this->command_active_ && type == this->active_command_.type) {
+  if (len == 0 && this->command_active_ && this->command_sent_ && type == this->active_command_.type) {
     ESP_LOGV(TAG, "ACK for command 0x%04X (module frame 0x%04X)", type, this->frame_id_);
     // This settles one expected reply; the rest stay owed and become the debt for the next command.
     this->send_generation_++;

--- a/esphome/components/ld6002b/ld6002b.cpp
+++ b/esphome/components/ld6002b/ld6002b.cpp
@@ -207,6 +207,9 @@ void LD6002BComponent::parse_byte_(uint8_t byte) {
 
 void LD6002BComponent::handle_frame_(uint16_t type, const uint8_t *data, uint16_t len) {
   this->last_traffic_ms_ = millis();
+  if (this->stale_ack_count_ > 0 && millis() - this->stale_ack_ms_ > STALE_ACK_MAX_AGE_MS) {
+    this->stale_ack_count_ = 0;
+  }
   // ACKs carry no id and arrive in send order: debt from earlier attempts is paid before the active command.
   if (len == 0 && this->stale_ack_count_ > 0 && this->stale_ack_type_ == type) {
     this->stale_ack_count_--;
@@ -220,6 +223,7 @@ void LD6002BComponent::handle_frame_(uint16_t type, const uint8_t *data, uint16_
     this->send_generation_++;
     this->stale_ack_type_ = type;
     this->stale_ack_count_ = this->acks_expected_ > 0 ? static_cast<uint8_t>(this->acks_expected_ - 1) : 0;
+    this->stale_ack_ms_ = millis();
     this->command_active_ = false;
     this->command_sent_ = false;
     this->last_send_ms_ = 0;
@@ -360,6 +364,7 @@ void LD6002BComponent::process_command_queue_() {
                               (this->acks_expected_ > 0 ? 1 : 0);
         this->stale_ack_type_ = this->active_command_.type;
         this->stale_ack_count_ = static_cast<uint8_t>(std::min<uint16_t>(owed, 255));
+        this->stale_ack_ms_ = now;
         this->send_generation_++;
         this->command_active_ = false;
         this->command_sent_ = false;

--- a/esphome/components/ld6002b/ld6002b.cpp
+++ b/esphome/components/ld6002b/ld6002b.cpp
@@ -2,8 +2,6 @@
 #include "esphome/core/log.h"
 #include <algorithm>
 #include <cinttypes>
-#include <cmath>
-#include <cstdio>
 #include <cstring>
 
 namespace esphome::ld6002b {
@@ -60,20 +58,6 @@ uint32_t LD6002BComponent::read_u32_le(const uint8_t *data) {
          (static_cast<uint32_t>(data[2]) << 16) | (static_cast<uint32_t>(data[3]) << 24);
 }
 
-int32_t LD6002BComponent::read_int32_le(const uint8_t *data) {
-  uint32_t raw = read_u32_le(data);
-  int32_t value;
-  std::memcpy(&value, &raw, sizeof(value));
-  return value;
-}
-
-float LD6002BComponent::read_f32_le(const uint8_t *data) {
-  uint32_t raw = read_u32_le(data);
-  float value;
-  std::memcpy(&value, &raw, sizeof(value));
-  return value;
-}
-
 void LD6002BComponent::write_u32_le(uint8_t *data, uint32_t value) {
   data[0] = value & 0xFF;
   data[1] = (value >> 8) & 0xFF;
@@ -81,21 +65,20 @@ void LD6002BComponent::write_u32_le(uint8_t *data, uint32_t value) {
   data[3] = (value >> 24) & 0xFF;
 }
 
-void LD6002BComponent::set_max_data_len(size_t max_data_len) {
-  this->max_data_len_overridden_ = true;
-  this->max_data_len_ = max_data_len;
-  this->data_buf_ = std::make_unique<uint8_t[]>(std::max<size_t>(max_data_len, 6));
-}
-
 void LD6002BComponent::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up HLK-LD6002B...");
   size_t desired_data_len = this->max_data_len_;
   if (!this->max_data_len_overridden_) {
-    bool point_cloud_configured = false;
-    desired_data_len = point_cloud_configured ? DEFAULT_MAX_DATA_LEN_POINT_CLOUD : DEFAULT_MAX_DATA_LEN;
+    desired_data_len = DEFAULT_MAX_DATA_LEN;
   }
   this->max_data_len_ = desired_data_len;
-  this->data_buf_ = std::make_unique<uint8_t[]>(std::max<size_t>(desired_data_len, 6));
+  // One allocation for the component lifetime: the parser reuses this buffer
+  // for the six byte header and for every payload up to max_data_len_.
+  RAMAllocator<uint8_t> allocator;
+  this->data_buf_ = allocator.allocate(std::max<size_t>(desired_data_len, 6));
+  if (this->data_buf_ == nullptr) {
+    this->mark_failed(LOG_STR("Failed to allocate frame buffer"));
+    return;
+  }
   if (this->wakeup_pin_ != nullptr) {
     this->wakeup_pin_->setup();
     this->wakeup_pin_->digital_write(true);
@@ -118,16 +101,26 @@ void LD6002BComponent::setup() {
       this->send_control_command_(CMD_TARGET_DISPLAY_ON);
     }
 
-    bool want_point_cloud_stream = false;
-    this->send_control_command_(want_point_cloud_stream ? CMD_POINT_CLOUD_ON : CMD_POINT_CLOUD_OFF);
+    // Point-cloud streaming is introduced in a later part; make sure it is off.
+    this->send_control_command_(CMD_POINT_CLOUD_OFF);
   });
 }
 
 void LD6002BComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "HLK-LD6002B:");
-  ESP_LOGCONFIG(TAG, "  Auto wake: %s", this->auto_wake_ ? "true" : "false");
+  ESP_LOGCONFIG(TAG,
+                "HLK-LD6002B:\n"
+                "  Auto wake: %s\n"
+                "  Max data length: %u",
+                this->auto_wake_ ? "true" : "false", static_cast<unsigned>(this->max_data_len_));
+  if (this->wakeup_pin_ != nullptr) {
+    LOG_PIN("  Wake-up Pin: ", this->wakeup_pin_);
+    ESP_LOGCONFIG(TAG, "  Wake Pulse: %ums", this->wakeup_pulse_ms_);
+  }
 #ifdef USE_BINARY_SENSOR
   LOG_BINARY_SENSOR("  ", "Presence", this->presence_binary_sensor_);
+  for (uint8_t i = 0; i < MAX_TARGETS; i++) {
+    LOG_BINARY_SENSOR("  ", "Target Presence", this->target_presence_[i]);
+  }
 #endif
 }
 
@@ -147,17 +140,18 @@ void LD6002BComponent::reset_parser_() {
   this->data_pos_ = 0;
   this->data_xor_ = 0;
   this->discard_remaining_ = 0;
+  this->frame_oversize_ = false;
 }
 
 void LD6002BComponent::parse_byte_(uint8_t byte) {
   switch (this->parse_state_) {
     case ParseState::DISCARD:
-      if (this->discard_remaining_ > 0) {
-        this->discard_remaining_--;
-        if (this->discard_remaining_ == 0) {
-          this->reset_parser_();
-        }
-      } else {
+      // Only entered from HCK, with a verified and non-zero number of bytes to skip. The zero
+      // check is still part of the condition because discard_remaining_ is unsigned: should a
+      // later change ever reach this state with nothing left to skip, decrementing first would
+      // wrap to 4294967295 and silently swallow the next four gigabytes of stream instead of
+      // resynchronising on the following frame.
+      if (this->discard_remaining_ == 0 || --this->discard_remaining_ == 0) {
         this->reset_parser_();
       }
       return;
@@ -175,16 +169,12 @@ void LD6002BComponent::parse_byte_(uint8_t byte) {
         this->header_xor_ ^= byte;
         this->header_pos_++;
         if (this->header_pos_ == 6) {
-          this->frame_id_ = read_u16_be(this->data_buf_.get());
-          this->data_len_ = read_u16_be(this->data_buf_.get() + 2);
-          this->frame_type_ = read_u16_be(this->data_buf_.get() + 4);
-          if (this->data_len_ > this->max_data_len_) {
-            ESP_LOGW(TAG, "Frame too large: %u", this->data_len_);
-            // Discard the remaining bytes in this frame: header checksum + payload + data checksum (if any)
-            this->discard_remaining_ = 1 + this->data_len_ + (this->data_len_ > 0 ? 1 : 0);
-            this->parse_state_ = ParseState::DISCARD;
-            return;
-          }
+          this->frame_id_ = read_u16_be(this->data_buf_);
+          this->data_len_ = read_u16_be(this->data_buf_ + 2);
+          this->frame_type_ = read_u16_be(this->data_buf_ + 4);
+          // The length is only trustworthy once the header checksum has been verified, so just
+          // remember that the frame is oversized and let the HCK state act on it.
+          this->frame_oversize_ = this->data_len_ > this->max_data_len_;
           this->parse_state_ = ParseState::HCK;
         }
       }
@@ -194,6 +184,13 @@ void LD6002BComponent::parse_byte_(uint8_t byte) {
       if (byte != expected) {
         ESP_LOGV(TAG, "Header checksum mismatch");
         this->reset_parser_();
+        return;
+      }
+      if (this->frame_oversize_) {
+        ESP_LOGW(TAG, "Frame too large: %u", this->data_len_);
+        // The header is verified, so the length can be trusted: skip the payload and its checksum.
+        this->discard_remaining_ = static_cast<uint32_t>(this->data_len_) + 1;
+        this->parse_state_ = ParseState::DISCARD;
         return;
       }
       if (this->data_len_ == 0) {
@@ -216,7 +213,7 @@ void LD6002BComponent::parse_byte_(uint8_t byte) {
     case ParseState::DCK: {
       uint8_t expected = static_cast<uint8_t>(~this->data_xor_);
       if (byte == expected) {
-        this->handle_frame_(this->frame_type_, this->data_buf_.get(), this->data_len_);
+        this->handle_frame_(this->frame_type_, this->data_buf_, this->data_len_);
       } else {
         ESP_LOGV(TAG, "Data checksum mismatch");
       }
@@ -227,46 +224,37 @@ void LD6002BComponent::parse_byte_(uint8_t byte) {
 }
 
 void LD6002BComponent::handle_frame_(uint16_t type, const uint8_t *data, uint16_t len) {
-  const bool matching_ack_type = len == 0 && this->command_active_ && type == this->active_command_.type;
-  const bool matching_ack_frame_id =
-      ((this->frame_id_ & 0x7FFF) == (this->active_frame_id_ & 0x7FFF)) || this->active_command_.type == TYPE_CONTROL;
-  const bool matching_ack = matching_ack_type && matching_ack_frame_id;
-  if (matching_ack) {
-#ifdef ESPHOME_LOG_HAS_VERBOSE
-    const uint32_t active_control_command =
-        this->active_command_.type == TYPE_CONTROL
-            ? read_control_command_value(this->active_command_.data.data(), this->active_command_.len)
-            : 0;
-    if (active_control_command != 0 && ((this->frame_id_ & 0x7FFF) != (this->active_frame_id_ & 0x7FFF))) {
-      ESP_LOGV(TAG, "Accepting %s (0x%02" PRIX32 ") ACK with device frame 0x%04X while active frame is 0x%04X",
-               control_command_name(active_control_command), active_control_command, this->frame_id_,
-               this->active_frame_id_);
-    }
-    if (active_control_command != 0) {
-      ESP_LOGV(TAG, "ACK for %s (0x%02" PRIX32 ") matched frame 0x%04X", control_command_name(active_control_command),
-               active_control_command, this->frame_id_);
-    }
-#endif
+  // The module acknowledges a command with an empty frame of the same type. It does not echo our
+  // frame id: that field is a per-peer send counter (MSB 1 for us, 0 for the module) which the
+  // protocol only reuses in a reply for message types supporting a bidirectional exchange, and
+  // every type sent here is documented as unidirectional. ACKs of one type can therefore only be
+  // told apart by transmission order, so the duplicates a retried command leaves behind are
+  // swallowed instead of completing whatever command runs next.
+  //
+  // That swallowing only applies while no matching command is waiting. An ACK that arrives for the
+  // command still on the wire always completes it, however late: waking a sleeping module pushes
+  // its reply past the retry period, and treating such a reply as a leftover duplicate would starve
+  // the command through every attempt and report a timeout for a write the module did perform.
+  if (len == 0 && this->stale_ack_count_ > 0 && this->stale_ack_type_ == type &&
+      !(this->command_active_ && type == this->active_command_.type)) {
+    this->stale_ack_count_--;
+    ESP_LOGV(TAG, "Ignoring ACK for command 0x%04X from an earlier attempt (module frame 0x%04X)", type,
+             this->frame_id_);
+    return;
+  }
+  if (len == 0 && this->command_active_ && type == this->active_command_.type) {
+    ESP_LOGV(TAG, "ACK for command 0x%04X (module frame 0x%04X)", type, this->frame_id_);
+    // Every frame transmitted for this command is answered, and this ACK settles exactly one of
+    // them, so the remaining attempts are still owed replies. Those become the guard debt for the
+    // window after this command finishes.
+    this->stale_ack_type_ = type;
+    this->stale_ack_count_ = this->attempts_sent_ > 0 ? static_cast<uint8_t>(this->attempts_sent_ - 1) : 0;
     this->command_active_ = false;
     this->command_sent_ = false;
-    this->active_frame_id_ = 0;
     this->last_send_ms_ = 0;
     this->process_command_queue_();
     return;
   }
-
-#ifdef ESPHOME_LOG_HAS_VERBOSE
-  const uint32_t active_control_command =
-      this->command_active_ && this->active_command_.type == TYPE_CONTROL
-          ? read_control_command_value(this->active_command_.data.data(), this->active_command_.len)
-          : 0;
-  if (len == 0 && this->command_active_ && type == this->active_command_.type &&
-      this->frame_id_ != this->active_frame_id_ && this->active_command_.type != TYPE_CONTROL) {
-    ESP_LOGV(TAG, "Ignoring ACK for %s (0x%02" PRIX32 "): frame 0x%04X did not match active 0x%04X",
-             control_command_name(active_control_command), active_control_command, this->frame_id_,
-             this->active_frame_id_);
-  }
-#endif
 
   switch (type) {
     case TYPE_REPORT_TARGET:
@@ -286,9 +274,12 @@ void LD6002BComponent::handle_target_report_(const uint8_t *data, uint16_t len) 
 
   uint32_t target_num = read_u32_le(data);
   uint16_t available = (len - 4) / TARGET_DATA_LEN;
-  uint8_t count = static_cast<uint8_t>(std::min<uint32_t>(target_num, available));
+  // Keep the un-narrowed value for the presence test: a report of e.g. 256
+  // targets must not truncate to 0 and read as "absent".
+  const uint32_t reported = std::min<uint32_t>(target_num, available);
+  uint8_t count = static_cast<uint8_t>(std::min<uint32_t>(reported, MAX_TARGETS));
 
-  this->target_presence_any_ = (count > 0);
+  this->target_presence_any_ = (reported > 0);
   bool presence = this->target_presence_any_ || this->area_presence_any_;
 #ifdef USE_BINARY_SENSOR
   if (this->presence_binary_sensor_ != nullptr) {
@@ -300,10 +291,8 @@ void LD6002BComponent::handle_target_report_(const uint8_t *data, uint16_t len) 
     bool has_target = i < count;
 #ifdef USE_BINARY_SENSOR
     if (this->target_presence_[i] != nullptr) {
-      if (!this->target_presence_initialized_[i] || has_target != this->last_target_presence_[i]) {
-        this->target_presence_[i]->publish_state(has_target);
-        this->target_presence_initialized_[i] = true;
-      }
+      // publish_state() already skips unchanged states, no manual de-dup needed.
+      this->target_presence_[i]->publish_state(has_target);
     }
 #endif
     this->last_target_presence_[i] = has_target;
@@ -319,11 +308,6 @@ void LD6002BComponent::handle_area_presence_(const uint8_t *data, uint16_t len) 
     uint32_t state = read_u32_le(data + (i * 4));
     bool present = state != 0;
     this->area_presence_any_ = this->area_presence_any_ || present;
-#ifdef USE_BINARY_SENSOR
-    if (this->area_presence_[i] != nullptr) {
-      this->area_presence_[i]->publish_state(present);
-    }
-#endif
   }
 
   bool presence = this->target_presence_any_ || this->area_presence_any_;
@@ -359,7 +343,12 @@ void LD6002BComponent::queue_command_(uint16_t type, const uint8_t *data, uint8_
 void LD6002BComponent::process_command_queue_() {
   uint32_t now = millis();
   if (this->command_active_) {
-    if (this->command_sent_ && now - this->last_send_ms_ >= CMD_ACK_TIMEOUT_MS) {
+    // The opening attempt may be the frame that wakes a sleeping module, which consumes it rather
+    // than answering it; the retry that follows is acked 100-175ms later. The wider budget for that
+    // first attempt keeps the wake from cascading into further retries, while later attempts keep
+    // the normal period.
+    const uint32_t ack_timeout = this->attempts_sent_ <= 1 ? CMD_FIRST_ACK_TIMEOUT_MS : CMD_ACK_TIMEOUT_MS;
+    if (this->command_sent_ && now - this->last_send_ms_ >= ack_timeout) {
       const uint32_t active_control_command =
           this->active_command_.type == TYPE_CONTROL
               ? read_control_command_value(this->active_command_.data.data(), this->active_command_.len)
@@ -369,6 +358,11 @@ void LD6002BComponent::process_command_queue_() {
         if (active_control_command != 0) {
           ESP_LOGV(TAG, "Retrying %s (0x%02" PRIX32 "), %u attempt(s) remaining",
                    control_command_name(active_control_command), active_control_command, this->retries_left_);
+        } else {
+          // Writes such as the hold delay and z-range carry no control subcommand, so without this
+          // branch their retries were invisible and only the eventual timeout showed up.
+          ESP_LOGV(TAG, "Retrying command 0x%04X, %u attempt(s) remaining", this->active_command_.type,
+                   this->retries_left_);
         }
 #endif
         this->command_sent_ = false;
@@ -382,9 +376,10 @@ void LD6002BComponent::process_command_queue_() {
         } else {
           ESP_LOGW(TAG, "Command 0x%04X timed out", this->active_command_.type);
         }
+        // No attempt was answered, so the module owes no ACK for this command any more.
+        this->stale_ack_count_ = 0;
         this->command_active_ = false;
         this->command_sent_ = false;
-        this->active_frame_id_ = 0;
         this->last_send_ms_ = 0;
       }
     }
@@ -401,8 +396,11 @@ void LD6002BComponent::process_command_queue_() {
   this->retries_left_ = CMD_MAX_RETRIES;
   this->command_active_ = true;
   this->command_sent_ = false;
-  this->active_frame_id_ = 0;
   this->last_send_ms_ = 0;
+  this->attempts_sent_ = 0;
+  if (this->stale_ack_type_ != this->active_command_.type) {
+    this->stale_ack_count_ = 0;
+  }
   this->send_command_(this->active_command_.type, this->active_command_.data.data(), this->active_command_.len);
 }
 
@@ -410,25 +408,31 @@ void LD6002BComponent::send_command_(uint16_t type, const uint8_t *data, uint8_t
   this->send_command_internal_(type, data, len, true);
 }
 
-void LD6002BComponent::send_command_untracked_(uint16_t type, const uint8_t *data, uint8_t len) {
-  this->send_command_internal_(type, data, len, false);
-}
-
 void LD6002BComponent::send_command_internal_(uint16_t type, const uint8_t *data, uint8_t len, bool track) {
-  if (this->auto_wake_ && this->wakeup_pin_ != nullptr) {
-    if (len > CMD_MAX_DATA_LEN) {
-      ESP_LOGW(TAG, "Command data too large: %u", len);
-      return;
+  if (len > CMD_MAX_DATA_LEN) {
+    ESP_LOGW(TAG, "Command data too large: %u", len);
+    if (track) {
+      // Release the slot: this command is never written, so it would neither be
+      // acked nor time out and the queue would stall behind it.
+      this->command_active_ = false;
+      this->command_sent_ = false;
+      this->last_send_ms_ = 0;
     }
-    std::array<uint8_t, CMD_MAX_DATA_LEN> data_copy{};
-    if (len > 0 && data != nullptr) {
-      std::memcpy(data_copy.data(), data, len);
+    return;
+  }
+
+  if (this->auto_wake_ && this->wakeup_pin_ != nullptr) {
+    // Capture no payload: tracked commands are always sent from
+    // active_command_.data, which stays valid until the ack or the timeout,
+    // and untracked ones are staged in wake_scratch_ instead.
+    if (!track && len > 0 && data != nullptr) {
+      std::memcpy(this->wake_scratch_.data(), data, len);
     }
     this->wakeup_pin_->digital_write(false);
-    this->set_timeout(this->wakeup_pulse_ms_, [this, type, len, data_copy, track]() {
+    this->set_timeout(this->wakeup_pulse_ms_, [this, type, len, track]() {
       this->wakeup_pin_->digital_write(true);
-      const uint8_t *payload = (len > 0) ? data_copy.data() : nullptr;
-      this->write_frame_(type, payload, len, track);
+      const uint8_t *payload = track ? this->active_command_.data.data() : this->wake_scratch_.data();
+      this->write_frame_(type, (len > 0) ? payload : nullptr, len, track);
     });
     return;
   }
@@ -465,9 +469,9 @@ void LD6002BComponent::write_frame_(uint16_t type, const uint8_t *data, uint8_t 
     this->write_byte(static_cast<uint8_t>(~data_xor));
   }
   if (track) {
-    this->active_frame_id_ = frame_id;
     this->last_send_ms_ = millis();
     this->command_sent_ = true;
+    this->attempts_sent_++;
   }
 }
 

--- a/esphome/components/ld6002b/ld6002b.h
+++ b/esphome/components/ld6002b/ld6002b.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/preferences.h"
+#include "esphome/core/gpio.h"
+#include "esphome/components/uart/uart.h"
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+
+#include <array>
+#include <memory>
+#include <cmath>
+
+namespace esphome::ld6002b {
+
+static constexpr uint8_t MAX_TARGETS = 3;
+static constexpr uint8_t AREA_COUNT = 4;
+static constexpr size_t DEFAULT_MAX_DATA_LEN = 1024;
+static constexpr size_t DEFAULT_MAX_DATA_LEN_POINT_CLOUD = 4096;
+static constexpr size_t CMD_MAX_DATA_LEN = 32;
+
+class LD6002BComponent : public Component, public uart::UARTDevice {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void set_wakeup_pin(GPIOPin *pin) { this->wakeup_pin_ = pin; }
+  void set_wakeup_pulse_ms(uint32_t ms) { this->wakeup_pulse_ms_ = ms; }
+  void set_auto_wake(bool enable) { this->auto_wake_ = enable; }
+
+#ifdef USE_BINARY_SENSOR
+  void set_presence_binary_sensor(binary_sensor::BinarySensor *sensor) { this->presence_binary_sensor_ = sensor; }
+  void set_target_presence_binary_sensor(uint8_t target, binary_sensor::BinarySensor *sensor) {
+    this->target_presence_[target] = sensor;
+  }
+#endif
+  void set_max_data_len(size_t max_data_len);
+
+ protected:
+  enum class ParseState : uint8_t { SOF, HEADER, HCK, DATA, DCK, DISCARD };
+
+  struct PendingCommand {
+    uint16_t type{0};
+    uint8_t len{0};
+    std::array<uint8_t, CMD_MAX_DATA_LEN> data{};
+  };
+
+  void parse_byte_(uint8_t byte);
+  void reset_parser_();
+  void handle_frame_(uint16_t type, const uint8_t *data, uint16_t len);
+  void handle_target_report_(const uint8_t *data, uint16_t len);
+  void handle_area_presence_(const uint8_t *data, uint16_t len);
+
+  void queue_command_(uint16_t type, const uint8_t *data, uint8_t len);
+  void process_command_queue_();
+  void send_command_(uint16_t type, const uint8_t *data, uint8_t len);
+  void send_command_untracked_(uint16_t type, const uint8_t *data, uint8_t len);
+  void send_command_internal_(uint16_t type, const uint8_t *data, uint8_t len, bool track);
+  void write_frame_(uint16_t type, const uint8_t *data, uint8_t len, bool track);
+  void send_control_command_(uint32_t command);
+
+  static uint16_t read_u16_be(const uint8_t *data);
+  static uint32_t read_u32_le(const uint8_t *data);
+  static int32_t read_int32_le(const uint8_t *data);
+  static float read_f32_le(const uint8_t *data);
+  static void write_u32_le(uint8_t *data, uint32_t value);
+
+#ifdef USE_BINARY_SENSOR
+  binary_sensor::BinarySensor *presence_binary_sensor_{nullptr};
+  std::array<binary_sensor::BinarySensor *, MAX_TARGETS> target_presence_{};
+  std::array<binary_sensor::BinarySensor *, AREA_COUNT> area_presence_{};
+#endif
+
+  GPIOPin *wakeup_pin_{nullptr};
+  uint32_t wakeup_pulse_ms_{50};
+  bool auto_wake_{true};
+
+  ParseState parse_state_{ParseState::SOF};
+  uint8_t header_pos_{0};
+  uint8_t header_xor_{0};
+  uint16_t data_len_{0};
+  uint16_t frame_type_{0};
+  uint16_t frame_id_{0};
+  uint16_t data_pos_{0};
+  uint8_t data_xor_{0};
+  uint32_t discard_remaining_{0};
+  size_t max_data_len_{0};
+  bool max_data_len_overridden_{false};
+  std::unique_ptr<uint8_t[]> data_buf_;
+  uint16_t next_frame_id_{0};
+
+  static constexpr uint8_t CMD_QUEUE_SIZE = 16;
+  static constexpr uint32_t CMD_ACK_TIMEOUT_MS = 300;
+  static constexpr uint8_t CMD_MAX_RETRIES = 3;
+
+  std::array<PendingCommand, CMD_QUEUE_SIZE> cmd_queue_{};
+  uint8_t cmd_head_{0};
+  uint8_t cmd_tail_{0};
+  uint8_t cmd_count_{0};
+  bool command_active_{false};
+  bool command_sent_{false};
+  PendingCommand active_command_{};
+  uint16_t active_frame_id_{0};
+  uint8_t retries_left_{0};
+  uint32_t last_send_ms_{0};
+
+  bool target_presence_any_{false};
+  bool area_presence_any_{false};
+
+  std::array<bool, MAX_TARGETS> last_target_presence_{};
+  std::array<bool, MAX_TARGETS> target_presence_initialized_{};
+};
+
+}  // namespace esphome::ld6002b

--- a/esphome/components/ld6002b/ld6002b.h
+++ b/esphome/components/ld6002b/ld6002b.h
@@ -119,6 +119,10 @@ class LD6002BComponent : public Component, public uart::UARTDevice {
   // Bumped whenever the active command changes, so a deferred send can tell it was retired.
   uint8_t send_generation_{0};
 
+  // Which person owns each target_N slot, so a slot survives the module re-sorting its array.
+  std::array<int32_t, MAX_TARGETS> slot_cluster_{};
+  std::array<bool, MAX_TARGETS> slot_occupied_{};
+
   bool target_presence_any_{false};
 };
 

--- a/esphome/components/ld6002b/ld6002b.h
+++ b/esphome/components/ld6002b/ld6002b.h
@@ -3,7 +3,6 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
-#include "esphome/core/preferences.h"
 #include "esphome/core/gpio.h"
 #include "esphome/components/uart/uart.h"
 #ifdef USE_BINARY_SENSOR
@@ -12,15 +11,14 @@
 
 #include <array>
 #include <memory>
-#include <cmath>
 
 namespace esphome::ld6002b {
 
 static constexpr uint8_t MAX_TARGETS = 3;
 static constexpr uint8_t AREA_COUNT = 4;
 static constexpr size_t DEFAULT_MAX_DATA_LEN = 1024;
-static constexpr size_t DEFAULT_MAX_DATA_LEN_POINT_CLOUD = 4096;
-static constexpr size_t CMD_MAX_DATA_LEN = 32;
+// Largest protocol payload is TYPE_SET_AREA: int32 area id + 6 floats = 28 bytes.
+static constexpr size_t CMD_MAX_DATA_LEN = 28;
 
 class LD6002BComponent : public Component, public uart::UARTDevice {
  public:
@@ -36,10 +34,11 @@ class LD6002BComponent : public Component, public uart::UARTDevice {
 #ifdef USE_BINARY_SENSOR
   void set_presence_binary_sensor(binary_sensor::BinarySensor *sensor) { this->presence_binary_sensor_ = sensor; }
   void set_target_presence_binary_sensor(uint8_t target, binary_sensor::BinarySensor *sensor) {
+    if (target >= MAX_TARGETS)
+      return;
     this->target_presence_[target] = sensor;
   }
 #endif
-  void set_max_data_len(size_t max_data_len);
 
  protected:
   enum class ParseState : uint8_t { SOF, HEADER, HCK, DATA, DCK, DISCARD };
@@ -59,21 +58,17 @@ class LD6002BComponent : public Component, public uart::UARTDevice {
   void queue_command_(uint16_t type, const uint8_t *data, uint8_t len);
   void process_command_queue_();
   void send_command_(uint16_t type, const uint8_t *data, uint8_t len);
-  void send_command_untracked_(uint16_t type, const uint8_t *data, uint8_t len);
   void send_command_internal_(uint16_t type, const uint8_t *data, uint8_t len, bool track);
   void write_frame_(uint16_t type, const uint8_t *data, uint8_t len, bool track);
   void send_control_command_(uint32_t command);
 
   static uint16_t read_u16_be(const uint8_t *data);
   static uint32_t read_u32_le(const uint8_t *data);
-  static int32_t read_int32_le(const uint8_t *data);
-  static float read_f32_le(const uint8_t *data);
   static void write_u32_le(uint8_t *data, uint32_t value);
 
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *presence_binary_sensor_{nullptr};
   std::array<binary_sensor::BinarySensor *, MAX_TARGETS> target_presence_{};
-  std::array<binary_sensor::BinarySensor *, AREA_COUNT> area_presence_{};
 #endif
 
   GPIOPin *wakeup_pin_{nullptr};
@@ -89,13 +84,22 @@ class LD6002BComponent : public Component, public uart::UARTDevice {
   uint16_t data_pos_{0};
   uint8_t data_xor_{0};
   uint32_t discard_remaining_{0};
+  bool frame_oversize_{false};
   size_t max_data_len_{0};
   bool max_data_len_overridden_{false};
-  std::unique_ptr<uint8_t[]> data_buf_;
+  uint8_t *data_buf_{nullptr};
   uint16_t next_frame_id_{0};
 
+  // Sized for the boot burst: with every platform configured, setup() enqueues
+  // roughly ten GET/config commands back to back before the first ack lands.
   static constexpr uint8_t CMD_QUEUE_SIZE = 16;
   static constexpr uint32_t CMD_ACK_TIMEOUT_MS = 300;
+  // The first command sent to a sleeping module doubles as its wake frame (protocol 1.3 note 2):
+  // the module consumes it to wake and never answers it, so the reply only comes for the attempt
+  // after it. One retry is therefore unavoidable without a wakeup_pin; the wider opening budget
+  // keeps it from stacking further ones while the module comes up. An awake module acks in about
+  // 30ms and never reaches this timeout.
+  static constexpr uint32_t CMD_FIRST_ACK_TIMEOUT_MS = 600;
   static constexpr uint8_t CMD_MAX_RETRIES = 3;
 
   std::array<PendingCommand, CMD_QUEUE_SIZE> cmd_queue_{};
@@ -105,15 +109,21 @@ class LD6002BComponent : public Component, public uart::UARTDevice {
   bool command_active_{false};
   bool command_sent_{false};
   PendingCommand active_command_{};
-  uint16_t active_frame_id_{0};
+  // Staging buffer for untracked wake-pulse sends; tracked sends read
+  // active_command_.data directly, so nothing is copied for them.
+  std::array<uint8_t, CMD_MAX_DATA_LEN> wake_scratch_{};
   uint8_t retries_left_{0};
   uint32_t last_send_ms_{0};
+  // Frames transmitted for the command in flight, including retries: every one of them is answered.
+  uint8_t attempts_sent_{0};
+  // ACKs the module still owes for superseded attempts; they carry no id to match them on.
+  uint16_t stale_ack_type_{0};
+  uint8_t stale_ack_count_{0};
 
   bool target_presence_any_{false};
   bool area_presence_any_{false};
 
-  std::array<bool, MAX_TARGETS> last_target_presence_{};
-  std::array<bool, MAX_TARGETS> target_presence_initialized_{};
+  std::array<bool, MAX_TARGETS> last_target_presence_{};  // one-shot NAN clear for target sensors
 };
 
 }  // namespace esphome::ld6002b

--- a/esphome/components/ld6002b/ld6002b.h
+++ b/esphome/components/ld6002b/ld6002b.h
@@ -10,12 +10,10 @@
 #endif
 
 #include <array>
-#include <memory>
 
 namespace esphome::ld6002b {
 
 static constexpr uint8_t MAX_TARGETS = 3;
-static constexpr uint8_t AREA_COUNT = 4;
 static constexpr size_t DEFAULT_MAX_DATA_LEN = 1024;
 // Largest protocol payload is TYPE_SET_AREA: int32 area id + 6 floats = 28 bytes.
 static constexpr size_t CMD_MAX_DATA_LEN = 28;
@@ -53,7 +51,6 @@ class LD6002BComponent : public Component, public uart::UARTDevice {
   void reset_parser_();
   void handle_frame_(uint16_t type, const uint8_t *data, uint16_t len);
   void handle_target_report_(const uint8_t *data, uint16_t len);
-  void handle_area_presence_(const uint8_t *data, uint16_t len);
 
   void queue_command_(uint16_t type, const uint8_t *data, uint8_t len);
   void process_command_queue_();
@@ -85,8 +82,6 @@ class LD6002BComponent : public Component, public uart::UARTDevice {
   uint8_t data_xor_{0};
   uint32_t discard_remaining_{0};
   bool frame_oversize_{false};
-  size_t max_data_len_{0};
-  bool max_data_len_overridden_{false};
   uint8_t *data_buf_{nullptr};
   uint16_t next_frame_id_{0};
 
@@ -94,12 +89,10 @@ class LD6002BComponent : public Component, public uart::UARTDevice {
   // roughly ten GET/config commands back to back before the first ack lands.
   static constexpr uint8_t CMD_QUEUE_SIZE = 16;
   static constexpr uint32_t CMD_ACK_TIMEOUT_MS = 300;
-  // The first command sent to a sleeping module doubles as its wake frame (protocol 1.3 note 2):
-  // the module consumes it to wake and never answers it, so the reply only comes for the attempt
-  // after it. One retry is therefore unavoidable without a wakeup_pin; the wider opening budget
-  // keeps it from stacking further ones while the module comes up. An awake module acks in about
-  // 30ms and never reaches this timeout.
+  // A sleeping module consumes the first frame to wake and answers only the one after it.
   static constexpr uint32_t CMD_FIRST_ACK_TIMEOUT_MS = 600;
+  // How long the module stays awake after any frame, and so still answers the next one.
+  static constexpr uint32_t MODULE_AWAKE_MS = 10000;
   static constexpr uint8_t CMD_MAX_RETRIES = 3;
 
   std::array<PendingCommand, CMD_QUEUE_SIZE> cmd_queue_{};
@@ -109,21 +102,24 @@ class LD6002BComponent : public Component, public uart::UARTDevice {
   bool command_active_{false};
   bool command_sent_{false};
   PendingCommand active_command_{};
-  // Staging buffer for untracked wake-pulse sends; tracked sends read
-  // active_command_.data directly, so nothing is copied for them.
+  // Frame a pending wake pulse will write, snapshotted because active_command_ may move on first.
   std::array<uint8_t, CMD_MAX_DATA_LEN> wake_scratch_{};
+  bool wake_pulse_pending_{false};
   uint8_t retries_left_{0};
   uint32_t last_send_ms_{0};
-  // Frames transmitted for the command in flight, including retries: every one of them is answered.
+  // Last frame seen in either direction; any traffic keeps the module awake.
+  uint32_t last_traffic_ms_{0};
+  // Frames transmitted for the command in flight, including retries; drives the retry budget.
   uint8_t attempts_sent_{0};
-  // ACKs the module still owes for superseded attempts; they carry no id to match them on.
+  // Subset of those the module can actually answer: a frame that woke it is consumed, not replied to.
+  uint8_t acks_expected_{0};
+  // ACKs still owed for superseded attempts; they carry no id, only their arrival order.
   uint16_t stale_ack_type_{0};
   uint8_t stale_ack_count_{0};
+  // Bumped whenever the active command changes, so a deferred send can tell it was retired.
+  uint8_t send_generation_{0};
 
   bool target_presence_any_{false};
-  bool area_presence_any_{false};
-
-  std::array<bool, MAX_TARGETS> last_target_presence_{};  // one-shot NAN clear for target sensors
 };
 
 }  // namespace esphome::ld6002b

--- a/esphome/components/ld6002b/ld6002b.h
+++ b/esphome/components/ld6002b/ld6002b.h
@@ -94,6 +94,8 @@ class LD6002BComponent : public Component, public uart::UARTDevice {
   // How long the module stays awake after any frame, and so still answers the next one.
   static constexpr uint32_t MODULE_AWAKE_MS = 10000;
   static constexpr uint8_t CMD_MAX_RETRIES = 3;
+  // A reply cannot trail the frame that earned it for longer than this; the field worst case is ~726ms.
+  static constexpr uint32_t STALE_ACK_MAX_AGE_MS = 1000;
 
   std::array<PendingCommand, CMD_QUEUE_SIZE> cmd_queue_{};
   uint8_t cmd_head_{0};
@@ -116,6 +118,8 @@ class LD6002BComponent : public Component, public uart::UARTDevice {
   // ACKs still owed for superseded attempts; they carry no id, only their arrival order.
   uint16_t stale_ack_type_{0};
   uint8_t stale_ack_count_{0};
+  // When that debt was booked, so a debt no reply can still settle expires instead of eating a live ACK.
+  uint32_t stale_ack_ms_{0};
   // Bumped whenever the active command changes, so a deferred send can tell it was retired.
   uint8_t send_generation_{0};
 

--- a/tests/components/ld6002b/common.yaml
+++ b/tests/components/ld6002b/common.yaml
@@ -1,0 +1,11 @@
+ld6002b:
+  id: ld6002b_radar
+  wakeup_pin: GPIO4
+
+binary_sensor:
+  - platform: ld6002b
+    ld6002b_id: ld6002b_radar
+    target:
+      name: Presence
+    target_1:
+      name: Target-1 Presence

--- a/tests/components/ld6002b/common.yaml
+++ b/tests/components/ld6002b/common.yaml
@@ -1,6 +1,6 @@
 ld6002b:
   id: ld6002b_radar
-  wakeup_pin: GPIO4
+  wakeup_pin: GPIO14
 
 binary_sensor:
   - platform: ld6002b

--- a/tests/components/ld6002b/test.esp32-idf.yaml
+++ b/tests/components/ld6002b/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/ld6002b/test.esp32-idf.yaml
+++ b/tests/components/ld6002b/test.esp32-idf.yaml
@@ -1,3 +1,3 @@
 packages:
-  uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
+  uart: !include ../../test_build_components/common/uart_115200/esp32-idf.yaml
   ld6002b: !include common.yaml

--- a/tests/components/ld6002b/test.esp32-idf.yaml
+++ b/tests/components/ld6002b/test.esp32-idf.yaml
@@ -1,3 +1,3 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_115200/esp32-idf.yaml
+  uart_115200: !include ../../test_build_components/common/uart_115200/esp32-idf.yaml
   ld6002b: !include common.yaml

--- a/tests/components/ld6002b/test.esp32-idf.yaml
+++ b/tests/components/ld6002b/test.esp32-idf.yaml
@@ -1,4 +1,3 @@
 packages:
   uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
-
-<<: !include common.yaml
+  ld6002b: !include common.yaml

--- a/tests/components/ld6002b/test.esp8266-ard.yaml
+++ b/tests/components/ld6002b/test.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/ld6002b/test.esp8266-ard.yaml
+++ b/tests/components/ld6002b/test.esp8266-ard.yaml
@@ -1,3 +1,3 @@
 packages:
-  uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
+  uart: !include ../../test_build_components/common/uart_115200/esp8266-ard.yaml
   ld6002b: !include common.yaml

--- a/tests/components/ld6002b/test.esp8266-ard.yaml
+++ b/tests/components/ld6002b/test.esp8266-ard.yaml
@@ -1,3 +1,3 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_115200/esp8266-ard.yaml
+  uart_115200: !include ../../test_build_components/common/uart_115200/esp8266-ard.yaml
   ld6002b: !include common.yaml

--- a/tests/components/ld6002b/test.esp8266-ard.yaml
+++ b/tests/components/ld6002b/test.esp8266-ard.yaml
@@ -1,4 +1,3 @@
 packages:
   uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
-
-<<: !include common.yaml
+  ld6002b: !include common.yaml

--- a/tests/components/ld6002b/test.rp2040-ard.yaml
+++ b/tests/components/ld6002b/test.rp2040-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  uart: !include ../../test_build_components/common/uart/rp2040-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/ld6002b/test.rp2040-ard.yaml
+++ b/tests/components/ld6002b/test.rp2040-ard.yaml
@@ -1,3 +1,3 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_115200/rp2040-ard.yaml
+  uart_115200: !include ../../test_build_components/common/uart_115200/rp2040-ard.yaml
   ld6002b: !include common.yaml

--- a/tests/components/ld6002b/test.rp2040-ard.yaml
+++ b/tests/components/ld6002b/test.rp2040-ard.yaml
@@ -1,4 +1,3 @@
 packages:
   uart: !include ../../test_build_components/common/uart/rp2040-ard.yaml
-
-<<: !include common.yaml
+  ld6002b: !include common.yaml

--- a/tests/components/ld6002b/test.rp2040-ard.yaml
+++ b/tests/components/ld6002b/test.rp2040-ard.yaml
@@ -1,3 +1,3 @@
 packages:
-  uart: !include ../../test_build_components/common/uart/rp2040-ard.yaml
+  uart: !include ../../test_build_components/common/uart_115200/rp2040-ard.yaml
   ld6002b: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the Hi-Link HLK-LD6002B 60GHz 3D presence radar (UART).

This is **part 1 of 5**. Following the size-bot feedback on #13532 and @kbx81's suggestion to break it down, the component is split into a hub PR plus follow-up platform PRs (same shape ld2410 used in #3919 → #4434). This part contains:

- the `ld6002b` hub: UART frame parser (SOF / header / XOR-checksum state machine), command queue with ACK tracking, timeout and retries, wake-up pin handling
- `binary_sensor` platform: overall presence and per-target presence

Follow-up parts (opened as drafts, each stacked on the previous):

- #17820 target & point cloud sensors
- #17821 switch / number / text_sensor platforms
- #17822 select / button platforms
- #17823 area & zone configuration The five parts together are byte-identical to the original #13532 diff rebased onto current dev, which has been running on my own hardware for months.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- supersedes #13532 (split into parts)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6875 (covers the full component; will be aligned as the parts land)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 115200

ld6002b:
  id: ld6002b_radar
  wakeup_pin: GPIO4

binary_sensor:
  - platform: ld6002b
    ld6002b_id: ld6002b_radar
    target:
      name: Presence
    target_1:
      name: Target-1 Presence
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
