### PR TITLE
[remote_base] support haier short IR message

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -2012,7 +2012,7 @@ HaierData, HaierBinarySensor, HaierTrigger, HaierAction, HaierDumper = declare_p
 HaierAction = ns.class_("HaierAction", RemoteTransmitterActionBase)
 HAIER_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_CODE): cv.All([cv.hex_uint8_t], cv.Length(min=13, max=13)),
+        cv.Required(CONF_CODE): cv.All([cv.hex_uint8_t], cv.Length(min=8, max=8)),
     }
 )
 

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -2012,7 +2012,9 @@ HaierData, HaierBinarySensor, HaierTrigger, HaierAction, HaierDumper = declare_p
 HaierAction = ns.class_("HaierAction", RemoteTransmitterActionBase)
 HAIER_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_CODE): cv.All([cv.hex_uint8_t], cv.Length(min=8, max=8)),
+        cv.Required(CONF_CODE): cv.All(
+            [cv.hex_uint8_t], cv.Any(cv.Length(min=8, max=8), cv.Length(min=13, max=13))
+        ),
     }
 )
 

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -2014,8 +2014,11 @@ HAIER_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_CODE): cv.All(
             [cv.hex_uint8_t],
-            cv.Any(cv.Length(min=8, max=8), cv.Length(min=13, max=13)),
-            msg="must be a list of length 8 or 13",
+            cv.Any(
+                cv.Length(min=8, max=8),
+                cv.Length(min=13, max=13),
+                msg="must be a list of length 8 or 13",
+            ),
         ),
     }
 )

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -2013,7 +2013,9 @@ HaierAction = ns.class_("HaierAction", RemoteTransmitterActionBase)
 HAIER_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_CODE): cv.All(
-            [cv.hex_uint8_t], cv.Any(cv.Length(min=8, max=8), cv.Length(min=13, max=13))
+            [cv.hex_uint8_t],
+            cv.Any(cv.Length(min=8, max=8), cv.Length(min=13, max=13)),
+            msg="must be a list of length 8 or 13",
         ),
     }
 )

--- a/esphome/components/remote_base/haier_protocol.cpp
+++ b/esphome/components/remote_base/haier_protocol.cpp
@@ -11,9 +11,12 @@ constexpr uint32_t HEADER_HIGH_US = 4400;
 constexpr uint32_t BIT_MARK_US = 540;
 constexpr uint32_t BIT_ONE_SPACE_US = 1650;
 constexpr uint32_t BIT_ZERO_SPACE_US = 580;
-constexpr unsigned int HAIER_IR_PACKET_BIT_SIZE = 72;  // 112;
+// 8 bytes + checksum
+constexpr unsigned int HAIER_IR_PACKET_BIT_SIZE_SHORT = 72;
+// 13 bytes + checksum
+constexpr unsigned int HAIER_IR_PACKET_BIT_SIZE_LONG = 112;
 // Max data bytes in packet (excluding checksum)
-constexpr size_t HAIER_MAX_DATA_BYTES = (HAIER_IR_PACKET_BIT_SIZE / 8);
+constexpr size_t HAIER_MAX_DATA_BYTES = 13;
 
 void HaierProtocol::encode_byte_(RemoteTransmitData *dst, uint8_t item) {
   for (uint8_t mask = 1 << 7; mask != 0; mask >>= 1) {
@@ -50,9 +53,8 @@ optional<HaierData> HaierProtocol::decode(RemoteReceiveData src) {
     return {};
   }
   size_t size = src.size() - src.get_index() - 1;
-  if (size < HAIER_IR_PACKET_BIT_SIZE * 2)
+  if ((size != HAIER_IR_PACKET_BIT_SIZE_LONG * 2) && (size != HAIER_IR_PACKET_BIT_SIZE_SHORT * 2))
     return {};
-  size = HAIER_IR_PACKET_BIT_SIZE * 2;
   uint8_t checksum = 0;
   HaierData out;
   while (size > 0) {

--- a/esphome/components/remote_base/haier_protocol.cpp
+++ b/esphome/components/remote_base/haier_protocol.cpp
@@ -62,7 +62,7 @@ optional<HaierData> HaierProtocol::decode(RemoteReceiveData src) {
   }
   uint8_t checksum = 0;
   HaierData out;
-  out.data.reserve(size / 8 - 1);
+  out.data.reserve(size / 16 - 1);
   while (size > 0) {
     uint8_t data = 0;
     for (uint8_t mask = 0x80; mask != 0; mask >>= 1) {

--- a/esphome/components/remote_base/haier_protocol.cpp
+++ b/esphome/components/remote_base/haier_protocol.cpp
@@ -11,7 +11,7 @@ constexpr uint32_t HEADER_HIGH_US = 4400;
 constexpr uint32_t BIT_MARK_US = 540;
 constexpr uint32_t BIT_ONE_SPACE_US = 1650;
 constexpr uint32_t BIT_ZERO_SPACE_US = 580;
-constexpr unsigned int HAIER_IR_PACKET_BIT_SIZE = 112;
+constexpr unsigned int HAIER_IR_PACKET_BIT_SIZE = 72;  // 112;
 // Max data bytes in packet (excluding checksum)
 constexpr size_t HAIER_MAX_DATA_BYTES = (HAIER_IR_PACKET_BIT_SIZE / 8);
 

--- a/esphome/components/remote_base/haier_protocol.cpp
+++ b/esphome/components/remote_base/haier_protocol.cpp
@@ -16,7 +16,7 @@ constexpr unsigned int HAIER_IR_PACKET_BIT_SIZE_SHORT = 72;
 // 13 bytes + checksum
 constexpr unsigned int HAIER_IR_PACKET_BIT_SIZE_LONG = 112;
 // Max data bytes in packet (excluding checksum)
-constexpr size_t HAIER_MAX_DATA_BYTES = 13;
+constexpr size_t HAIER_MAX_DATA_BYTES = HAIER_IR_PACKET_BIT_SIZE_LONG / 8 - 1;
 
 void HaierProtocol::encode_byte_(RemoteTransmitData *dst, uint8_t item) {
   for (uint8_t mask = 1 << 7; mask != 0; mask >>= 1) {
@@ -31,7 +31,7 @@ void HaierProtocol::encode_byte_(RemoteTransmitData *dst, uint8_t item) {
 
 void HaierProtocol::encode(RemoteTransmitData *dst, const HaierData &data) {
   dst->set_carrier_frequency(38000);
-  dst->reserve(5 + ((data.data.size() + 1) * 2));
+  dst->reserve(5 + ((data.data.size() + 1) * 16));
   dst->mark(HEADER_LOW_US);
   dst->space(HEADER_LOW_US);
   dst->mark(HEADER_LOW_US);
@@ -53,10 +53,16 @@ optional<HaierData> HaierProtocol::decode(RemoteReceiveData src) {
     return {};
   }
   size_t size = src.size() - src.get_index() - 1;
-  if ((size != HAIER_IR_PACKET_BIT_SIZE_LONG * 2) && (size != HAIER_IR_PACKET_BIT_SIZE_SHORT * 2))
+  if (size >= HAIER_IR_PACKET_BIT_SIZE_LONG * 2) {
+    size = HAIER_IR_PACKET_BIT_SIZE_LONG * 2;
+  } else if (size >= HAIER_IR_PACKET_BIT_SIZE_SHORT * 2) {
+    size = HAIER_IR_PACKET_BIT_SIZE_SHORT * 2;
+  } else {
     return {};
+  }
   uint8_t checksum = 0;
   HaierData out;
+  out.data.reserve(size / 8 - 1);
   while (size > 0) {
     uint8_t data = 0;
     for (uint8_t mask = 0x80; mask != 0; mask >>= 1) {

--- a/tests/components/remote_transmitter/common-buttons.yaml
+++ b/tests/components/remote_transmitter/common-buttons.yaml
@@ -198,7 +198,7 @@ button:
             0xFF,
           ]
   - platform: template
-    name: Haier
+    name: Haier Long
     on_press:
       remote_transmitter.transmit_haier:
         code:
@@ -217,6 +217,23 @@ button:
             0x00,
             0x05,
           ]
+  - platform: template
+    name: Haier Short
+    on_press:
+      remote_transmitter.transmit_haier:
+        code:
+          [
+            0xA6,
+            0xDA,
+            0x00,
+            0x00,
+            0x40,
+            0x40,
+            0x00,
+            0x80,
+          ]
+  - platform: template
+    name: Mirage
   - platform: template
     name: Mirage
     on_press:

--- a/tests/components/remote_transmitter/common-buttons.yaml
+++ b/tests/components/remote_transmitter/common-buttons.yaml
@@ -234,8 +234,6 @@ button:
           ]
   - platform: template
     name: Mirage
-  - platform: template
-    name: Mirage
     on_press:
       remote_transmitter.transmit_mirage:
         code: [0x56, 0x77, 0x00, 0x00, 0x22, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]


### PR DESCRIPTION
# What does this implement/fix?

The Haier IR protocol has two formats with either 9 bytes or 14 bytes.  The current code only supports the 14 byte version, so this adds support for the 9 byte version.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7040

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
