### PR TITLE
[modbus_server] Support byte-swapped word types U_WORD_S and S_WORD_S

### DIFF
--- a/esphome/components/modbus_server/modbus_server.h
+++ b/esphome/components/modbus_server/modbus_server.h
@@ -61,6 +61,7 @@ class ServerRegister {
   const char *format_value(int64_t value, char *buf, size_t buf_size) const {
     switch (this->value_type) {
       case SensorValueType::U_WORD:
+      case SensorValueType::U_WORD_S:
       case SensorValueType::U_DWORD:
       case SensorValueType::U_DWORD_R:
       case SensorValueType::U_QWORD:
@@ -68,6 +69,7 @@ class ServerRegister {
         buf_append_printf(buf, buf_size, 0, "%" PRIu64, static_cast<uint64_t>(value));
         return buf;
       case SensorValueType::S_WORD:
+      case SensorValueType::S_WORD_S:
       case SensorValueType::S_DWORD:
       case SensorValueType::S_DWORD_R:
       case SensorValueType::S_QWORD:


### PR DESCRIPTION
This PR is part of a series for byte-swapped Modbus word types (`U_WORD_S` / `S_WORD_S`).

**Stacked base (#17469 / #17831) already merged into `dev`.** This PR is only `format_value` polish and is ready to merge on current `dev` (no remaining stack dependency).

esphome/esphome:
- #17469 (closed; feature landed via #17831)
- #17829 (this PR — merge on `dev`)
- #17831 (merged)
- #17832 (merge after #17829)

esphome/esphome.io:
- esphome/esphome.io#6949
- esphome/esphome.io#7042 (merge after 6949)
- esphome/esphome.io#7043 (merge after 6949; depends on this polish + docs)

---

# What does this implement/fix?

Polish `ServerRegister::format_value` so byte-swapped word types `U_WORD_S` and `S_WORD_S` use the same unsigned vs signed logging/dump formatting as `U_WORD` / `S_WORD`.

Schema acceptance of `U_WORD_S` / `S_WORD_S` in `modbus_server` already landed with #17831 via the shared `SENSOR_VALUE_TYPE` map. This PR only adds the two `format_value` cases.

Related discussion: https://github.com/orgs/esphome/discussions/3659

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/orgs/esphome/discussions/3659

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6949
- esphome/esphome.io#7043 (merge after 6949)

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Types accepted via SENSOR_VALUE_TYPE from #17831; this PR polishes format_value logging/dump
modbus_server:
  - address: 1
    holding_registers:
      - start_address: 0x0000
        value_type: U_WORD_S
      - start_address: 0x0001
        value_type: S_WORD_S
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).