### PR TITLE
[modbus] Add unit tests for U_WORD_S and S_WORD_S

### DIFF
--- a/esphome/components/modbus/helpers.py
+++ b/esphome/components/modbus/helpers.py
@@ -38,7 +38,9 @@ SensorValueType = SensorValueType_ns.enum("SensorValueType")
 SENSOR_VALUE_TYPE = {
     "RAW": SensorValueType.RAW,
     "U_WORD": SensorValueType.U_WORD,
+    "U_WORD_S": SensorValueType.U_WORD_S,
     "S_WORD": SensorValueType.S_WORD,
+    "S_WORD_S": SensorValueType.S_WORD_S,
     "U_DWORD": SensorValueType.U_DWORD,
     "U_DWORD_R": SensorValueType.U_DWORD_R,
     "S_DWORD": SensorValueType.S_DWORD,
@@ -54,7 +56,9 @@ SENSOR_VALUE_TYPE = {
 TYPE_REGISTER_MAP = {
     "RAW": 1,
     "U_WORD": 1,
+    "U_WORD_S": 1,
     "S_WORD": 1,
+    "S_WORD_S": 1,
     "U_DWORD": 2,
     "U_DWORD_R": 2,
     "S_DWORD": 2,
@@ -70,7 +74,9 @@ TYPE_REGISTER_MAP = {
 CPP_TYPE_REGISTER_MAP = {
     "RAW": cg.uint16,
     "U_WORD": cg.uint16,
+    "U_WORD_S": cg.uint16,
     "S_WORD": cg.int16,
+    "S_WORD_S": cg.int16,
     "U_DWORD": cg.uint32,
     "U_DWORD_R": cg.uint32,
     "S_DWORD": cg.int32,

--- a/esphome/components/modbus/modbus_helpers.cpp
+++ b/esphome/components/modbus/modbus_helpers.cpp
@@ -169,7 +169,9 @@ bool is_client_pdu_standard(const uint8_t *pdu, size_t size) {
 static size_t required_payload_size(SensorValueType sensor_value_type) {
   switch (sensor_value_type) {
     case SensorValueType::U_WORD:
+    case SensorValueType::U_WORD_S:
     case SensorValueType::S_WORD:
+    case SensorValueType::S_WORD_S:
       return 2;
     case SensorValueType::U_DWORD:
     case SensorValueType::FP32:
@@ -220,6 +222,12 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
     case SensorValueType::U_WORD:
       value = mask_and_shift_by_rightbit(get_data<uint16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
+    case SensorValueType::U_WORD_S: {
+      value = get_data<uint16_t>(data, offset);
+      value = static_cast<uint16_t>((value << 8) | (value >> 8));
+      value = mask_and_shift_by_rightbit(value, bitmask);
+      break;
+    }
     case SensorValueType::U_DWORD:
     case SensorValueType::FP32:
       value = get_data<uint32_t>(data, offset);
@@ -234,6 +242,12 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
     case SensorValueType::S_WORD:
       value = mask_and_shift_by_rightbit(get_data<int16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
+    case SensorValueType::S_WORD_S: {
+      value = get_data<uint16_t>(data, offset);
+      value = static_cast<uint16_t>((value << 8) | (value >> 8));
+      value = mask_and_shift_by_rightbit(static_cast<int16_t>(value), bitmask);
+      break;
+    }
     case SensorValueType::S_DWORD:
       value = mask_and_shift_by_rightbit(get_data<int32_t>(data, offset), bitmask);
       break;

--- a/esphome/components/modbus/modbus_helpers.cpp
+++ b/esphome/components/modbus/modbus_helpers.cpp
@@ -223,9 +223,9 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
       value = mask_and_shift_by_rightbit(get_data<uint16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
     case SensorValueType::U_WORD_S: {
-      value = get_data<uint16_t>(data, offset);
-      value = static_cast<uint16_t>((value << 8) | (value >> 8));
-      value = mask_and_shift_by_rightbit(value, bitmask);
+      uint16_t word = get_data<uint16_t>(data, offset);
+      word = static_cast<uint16_t>((word << 8) | (word >> 8));
+      value = mask_and_shift_by_rightbit(word, bitmask);
       break;
     }
     case SensorValueType::U_DWORD:
@@ -243,9 +243,9 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
       value = mask_and_shift_by_rightbit(get_data<int16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
     case SensorValueType::S_WORD_S: {
-      value = get_data<uint16_t>(data, offset);
-      value = static_cast<uint16_t>((value << 8) | (value >> 8));
-      value = mask_and_shift_by_rightbit(static_cast<int16_t>(value), bitmask);
+      uint16_t word = get_data<uint16_t>(data, offset);
+      word = static_cast<uint16_t>((word << 8) | (word >> 8));
+      value = mask_and_shift_by_rightbit(static_cast<int16_t>(word), bitmask);
       break;
     }
     case SensorValueType::S_DWORD:

--- a/esphome/components/modbus/modbus_helpers.cpp
+++ b/esphome/components/modbus/modbus_helpers.cpp
@@ -223,8 +223,7 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
       value = mask_and_shift_by_rightbit(get_data<uint16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
     case SensorValueType::U_WORD_S: {
-      uint16_t word = get_data<uint16_t>(data, offset);
-      word = static_cast<uint16_t>((word << 8) | (word >> 8));
+      uint16_t word = byteswap(get_data<uint16_t>(data, offset));
       value = mask_and_shift_by_rightbit(word, bitmask);
       break;
     }
@@ -243,8 +242,7 @@ std::optional<int64_t> payload_to_number(const uint8_t *data, size_t size, Senso
       value = mask_and_shift_by_rightbit(get_data<int16_t>(data, offset), bitmask);  // default is 0xFFFF ;
       break;
     case SensorValueType::S_WORD_S: {
-      uint16_t word = get_data<uint16_t>(data, offset);
-      word = static_cast<uint16_t>((word << 8) | (word >> 8));
+      uint16_t word = byteswap(get_data<uint16_t>(data, offset));
       value = mask_and_shift_by_rightbit(static_cast<int16_t>(word), bitmask);
       break;
     }

--- a/esphome/components/modbus/modbus_helpers.h
+++ b/esphome/components/modbus/modbus_helpers.h
@@ -119,7 +119,9 @@ enum class SensorValueType : uint8_t {
   U_QWORD_R = 0xA,
   S_QWORD_R = 0xB,
   FP32 = 0xC,
-  FP32_R = 0xD
+  FP32_R = 0xD,
+  U_WORD_S = 0xE,  // 1 Register unsigned, bytes swapped
+  S_WORD_S = 0xF,  // 1 Register signed, bytes swapped
 };
 
 inline bool value_type_is_float(SensorValueType v) {
@@ -284,6 +286,12 @@ template<typename Container> void number_to_payload(Container &data, int64_t val
     case SensorValueType::S_WORD:
       data.push_back(value & 0xFFFF);
       break;
+    case SensorValueType::U_WORD_S:
+    case SensorValueType::S_WORD_S: {
+      uint16_t word = value & 0xFFFF;
+      data.push_back(static_cast<uint16_t>((word << 8) | (word >> 8)));
+      break;
+    }
     case SensorValueType::U_DWORD:
     case SensorValueType::S_DWORD:
     case SensorValueType::FP32:

--- a/esphome/components/modbus/modbus_helpers.h
+++ b/esphome/components/modbus/modbus_helpers.h
@@ -287,11 +287,9 @@ template<typename Container> void number_to_payload(Container &data, int64_t val
       data.push_back(value & 0xFFFF);
       break;
     case SensorValueType::U_WORD_S:
-    case SensorValueType::S_WORD_S: {
-      uint16_t word = value & 0xFFFF;
-      data.push_back(static_cast<uint16_t>((word << 8) | (word >> 8)));
+    case SensorValueType::S_WORD_S:
+      data.push_back(byteswap(static_cast<uint16_t>(value & 0xFFFF)));
       break;
-    }
     case SensorValueType::U_DWORD:
     case SensorValueType::S_DWORD:
     case SensorValueType::FP32:

--- a/tests/components/modbus/modbus_helpers_test.cpp
+++ b/tests/components/modbus/modbus_helpers_test.cpp
@@ -331,6 +331,7 @@ TEST(ModbusCreateClientPdu, WriteCoilsUseTheCoilLimitNotTheRegisterLimit) {
   EXPECT_TRUE(create_client_pdu(FC::WRITE_MULTIPLE_COILS, 0x0000, 1969, big.data(), big.size()).empty());
 }
 
+// --- payload_to_number -----------------------------------------------------
 TEST(ModbusHelpersTest, PayloadToNumberRejectsOffsetAtEndOfBuffer) {
   const std::vector<uint8_t> data{0x12, 0x34};
   EXPECT_FALSE(payload_to_number(std::span<const uint8_t>(data), SensorValueType::U_WORD, 2, 0xFFFFFFFF).has_value());

--- a/tests/components/modbus/modbus_helpers_test.cpp
+++ b/tests/components/modbus/modbus_helpers_test.cpp
@@ -346,12 +346,27 @@ TEST(ModbusHelpersTest, PayloadToNumberDecodesValidWord) {
   EXPECT_EQ(payload_to_number(std::span<const uint8_t>(data), SensorValueType::U_WORD, 0, 0xFFFFFFFF), 0x1234);
 }
 
+TEST(ModbusHelpersTest, PayloadToNumberDecodesSwappedUnsignedWord) {
+  const std::vector<uint8_t> data{0x34, 0x12};
+  EXPECT_EQ(payload_to_number(std::span<const uint8_t>(data), SensorValueType::U_WORD_S, 0, 0xFFFFFFFF), 0x1234);
+}
+
+TEST(ModbusHelpersTest, PayloadToNumberDecodesSwappedSignedWord) {
+  const std::vector<uint8_t> data{0xFE, 0xFF};
+  EXPECT_EQ(payload_to_number(std::span<const uint8_t>(data), SensorValueType::S_WORD_S, 0, 0xFFFFFFFF), -2);
+}
+
 // --- registers_to_number ---------------------------------------------------
 // Register words are host byte order; results must match the byte-based payload_to_number.
 
 TEST(ModbusHelpersTest, RegistersToNumberDecodesWord) {
   const uint16_t registers[] = {0x1234};
   EXPECT_EQ(registers_to_number(registers, 1, SensorValueType::U_WORD), 0x1234);
+}
+
+TEST(ModbusHelpersTest, RegistersToNumberDecodesSwappedWord) {
+  const uint16_t registers[] = {0x3412};
+  EXPECT_EQ(registers_to_number(registers, 1, SensorValueType::U_WORD_S), 0x1234);
 }
 
 TEST(ModbusHelpersTest, RegistersToNumberDecodesDwordHighWordFirst) {

--- a/tests/components/modbus/modbus_helpers_test.cpp
+++ b/tests/components/modbus/modbus_helpers_test.cpp
@@ -364,9 +364,14 @@ TEST(ModbusHelpersTest, RegistersToNumberDecodesWord) {
   EXPECT_EQ(registers_to_number(registers, 1, SensorValueType::U_WORD), 0x1234);
 }
 
-TEST(ModbusHelpersTest, RegistersToNumberDecodesSwappedWord) {
+TEST(ModbusHelpersTest, RegistersToNumberDecodesSwappedUnsignedWord) {
   const uint16_t registers[] = {0x3412};
   EXPECT_EQ(registers_to_number(registers, 1, SensorValueType::U_WORD_S), 0x1234);
+}
+
+TEST(ModbusHelpersTest, RegistersToNumberDecodesSwappedSignedWord) {
+  const uint16_t registers[] = {0xFEFF};
+  EXPECT_EQ(registers_to_number(registers, 1, SensorValueType::S_WORD_S), -2);
 }
 
 TEST(ModbusHelpersTest, RegistersToNumberDecodesDwordHighWordFirst) {

--- a/tests/components/modbus/modbus_helpers_test.cpp
+++ b/tests/components/modbus/modbus_helpers_test.cpp
@@ -580,4 +580,26 @@ TEST(ModbusServerPduPayload, ExceptionOfWriteYieldsExceptionCode) {
   EXPECT_EQ(payload[0], 0x03);
 }
 
+TEST(ModbusHelpersTest, NumberToPayloadRoundTripsSwappedUnsignedWord) {
+  std::vector<uint16_t> regs;
+  number_to_payload(regs, 0x1234, SensorValueType::U_WORD_S);
+  ASSERT_EQ(regs.size(), 1u);
+  EXPECT_EQ(regs[0], 0x3412);
+  EXPECT_EQ(registers_to_number(regs.data(), regs.size(), SensorValueType::U_WORD_S), 0x1234);
+}
+
+TEST(ModbusHelpersTest, NumberToPayloadRoundTripsSwappedSignedWord) {
+  std::vector<uint16_t> regs;
+  number_to_payload(regs, -2, SensorValueType::S_WORD_S);
+  ASSERT_EQ(regs.size(), 1u);
+  EXPECT_EQ(regs[0], 0xFEFF);
+  EXPECT_EQ(registers_to_number(regs.data(), regs.size(), SensorValueType::S_WORD_S), -2);
+}
+
+TEST(ModbusHelpersTest, PayloadToNumberAppliesBitmaskAfterSwap) {
+  // Bytes {0x34,0x12} decode as U_WORD_S to 0x1234; mask 0xFF00 then right-shift by bit 8 -> 0x12
+  const std::vector<uint8_t> data{0x34, 0x12};
+  EXPECT_EQ(payload_to_number(std::span<const uint8_t>(data), SensorValueType::U_WORD_S, 0, 0xFF00), 0x12);
+}
+
 }  // namespace esphome::modbus::helpers

--- a/tests/components/modbus/modbus_helpers_test.cpp
+++ b/tests/components/modbus/modbus_helpers_test.cpp
@@ -356,6 +356,18 @@ TEST(ModbusHelpersTest, PayloadToNumberDecodesSwappedSignedWord) {
   EXPECT_EQ(payload_to_number(std::span<const uint8_t>(data), SensorValueType::S_WORD_S, 0, 0xFFFFFFFF), -2);
 }
 
+TEST(ModbusHelpersTest, PayloadToNumberAppliesBitmaskAfterSwap) {
+  // Bytes {0x34,0x12} decode as U_WORD_S to 0x1234; mask 0xFF00 then right-shift by bit 8 -> 0x12
+  const std::vector<uint8_t> data{0x34, 0x12};
+  EXPECT_EQ(payload_to_number(std::span<const uint8_t>(data), SensorValueType::U_WORD_S, 0, 0xFF00), 0x12);
+}
+
+TEST(ModbusHelpersTest, PayloadToNumberAppliesBitmaskAfterSwapSigned) {
+  // Bytes {0x34,0xFE} decode as S_WORD_S to 0xFE34 (negative); mask 0x00F0 then right-shift by bit 4 -> 0x3
+  const std::vector<uint8_t> data{0x34, 0xFE};
+  EXPECT_EQ(payload_to_number(std::span<const uint8_t>(data), SensorValueType::S_WORD_S, 0, 0x00F0), 0x3);
+}
+
 // --- registers_to_number ---------------------------------------------------
 // Register words are host byte order; results must match the byte-based payload_to_number.
 
@@ -452,6 +464,24 @@ TEST(ModbusTypedBuilders, FloatToPayloadAppendsToExistingContent) {
   ASSERT_EQ(data.size(), 2u);
   EXPECT_EQ(data[0], 0x1234);
   EXPECT_EQ(data[1], 0x0001);
+}
+
+// --- number_to_payload -----------------------------------------------------
+
+TEST(ModbusHelpersTest, NumberToPayloadRoundTripsSwappedUnsignedWord) {
+  std::vector<uint16_t> regs;
+  number_to_payload(regs, 0x1234, SensorValueType::U_WORD_S);
+  ASSERT_EQ(regs.size(), 1u);
+  EXPECT_EQ(regs[0], 0x3412);
+  EXPECT_EQ(registers_to_number(regs.data(), regs.size(), SensorValueType::U_WORD_S), 0x1234);
+}
+
+TEST(ModbusHelpersTest, NumberToPayloadRoundTripsSwappedSignedWord) {
+  std::vector<uint16_t> regs;
+  number_to_payload(regs, -2, SensorValueType::S_WORD_S);
+  ASSERT_EQ(regs.size(), 1u);
+  EXPECT_EQ(regs[0], 0xFEFF);
+  EXPECT_EQ(registers_to_number(regs.data(), regs.size(), SensorValueType::S_WORD_S), -2);
 }
 
 TEST(ModbusCreateClientPdu, ExceptionFlaggedWriteCodesRejected) {
@@ -578,28 +608,6 @@ TEST(ModbusServerPduPayload, ExceptionOfWriteYieldsExceptionCode) {
   auto payload = server_pdu_payload(pdu);
   ASSERT_EQ(payload.size(), 1u);
   EXPECT_EQ(payload[0], 0x03);
-}
-
-TEST(ModbusHelpersTest, NumberToPayloadRoundTripsSwappedUnsignedWord) {
-  std::vector<uint16_t> regs;
-  number_to_payload(regs, 0x1234, SensorValueType::U_WORD_S);
-  ASSERT_EQ(regs.size(), 1u);
-  EXPECT_EQ(regs[0], 0x3412);
-  EXPECT_EQ(registers_to_number(regs.data(), regs.size(), SensorValueType::U_WORD_S), 0x1234);
-}
-
-TEST(ModbusHelpersTest, NumberToPayloadRoundTripsSwappedSignedWord) {
-  std::vector<uint16_t> regs;
-  number_to_payload(regs, -2, SensorValueType::S_WORD_S);
-  ASSERT_EQ(regs.size(), 1u);
-  EXPECT_EQ(regs[0], 0xFEFF);
-  EXPECT_EQ(registers_to_number(regs.data(), regs.size(), SensorValueType::S_WORD_S), -2);
-}
-
-TEST(ModbusHelpersTest, PayloadToNumberAppliesBitmaskAfterSwap) {
-  // Bytes {0x34,0x12} decode as U_WORD_S to 0x1234; mask 0xFF00 then right-shift by bit 8 -> 0x12
-  const std::vector<uint8_t> data{0x34, 0x12};
-  EXPECT_EQ(payload_to_number(std::span<const uint8_t>(data), SensorValueType::U_WORD_S, 0, 0xFF00), 0x12);
 }
 
 }  // namespace esphome::modbus::helpers

--- a/tests/components/modbus_controller/common.yaml
+++ b/tests/components/modbus_controller/common.yaml
@@ -41,6 +41,13 @@ number:
       return x * 2.0;
     write_lambda: |-
       return x / 2.0;
+  # Covers Python value-type maps + read/write path for byte-swapped words
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller1
+    id: modbus_number3
+    name: Test Number Swapped Word
+    address: 0x9003
+    value_type: U_WORD_S
 
 output:
   - platform: modbus_controller


### PR DESCRIPTION
This PR is part of a series for byte-swapped Modbus word types (`U_WORD_S` / `S_WORD_S`).

esphome/esphome:
- #17469
- #17829 (merge after 17469; `format_value` polish only — schema via shared `SENSOR_VALUE_TYPE` from #17469)
- #17831 (merge after 17469)
- #17832 (merge after 17829)

esphome/esphome.io:
- esphome/esphome.io#6949
- esphome/esphome.io#7042 (merge after 6949; depends on esphome 17469)
- esphome/esphome.io#7043 (merge after 6949; depends on esphome 17469/17829)

---

This PR is part of a series — merge after #17469. Stacked on #17469.

Note: `U_WORD_S` / `S_WORD_S` schema acceptance in `modbus_server` is intentional via #17469’s shared `SENSOR_VALUE_TYPE` (after @exciton retracted the server objection). #17829 only polishes `format_value` logging/dump.

# What does this implement/fix?

Adds unit tests for the byte-swapped word types `U_WORD_S` and `S_WORD_S` in `modbus_helpers_test.cpp` (`payload_to_number` and `registers_to_number`).

Part of a stacked series for byte-swapped Modbus word support:
1. #17469 — add `U_WORD_S` / `S_WORD_S` types (base for this PR)
2. #17829 — `modbus_server` `format_value` polish for those types (not first schema enablement)
3. **This PR** — unit tests for the modbus helpers (merge after 17469; stacked on that branch)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- #17469

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (tests only)

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — unit tests only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
