### PR TITLE
[opentherm] Restore idle output when stopped

### DIFF
--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -114,6 +114,7 @@ bool OpenTherm::get_protocol_error(OpenThermError &error) {
 void OpenTherm::stop() {
   this->stop_timer_();
   this->mode_ = OperationMode::IDLE;
+  this->out_pin_->digital_write(true);
 }
 
 void IRAM_ATTR OpenTherm::read_() {


### PR DESCRIPTION
# What does this implement/fix?

Restore the OpenTherm output pin to its idle-high state when `OpenTherm::stop()` is called.

`initialize()` sets the output high, but `stop()` previously only stopped the timer and changed the software mode. If shutdown interrupts a transmission while the output is low, the GPIO can otherwise remain at that last Manchester half-bit instead of returning to the component's idle state.

This is deliberately limited to restoring the physical idle level. It does not claim that a final OpenTherm request, such as a CH-disable request, was transmitted or acknowledged before shutdown.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A; no user-facing configuration or documentation changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
opentherm:
  in_pin: 4
  out_pin: 5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

The existing OpenTherm component tests compile successfully for ESP32 IDF and ESP8266. No new automated test was added because this change concerns the physical GPIO level during the shutdown lifecycle.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
