### PR TITLE
[ota] fix: captive portal silently enabled OTA via non-fallback web server

### DIFF
--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -26,6 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def AUTO_LOAD() -> list[str]:
+    CORE.data["captive_portal_auto_loaded_web_server_ota"] = True
     auto_load = ["web_server_base", "ota.web_server"]
     if CORE.is_esp32:
         auto_load.append("socket")

--- a/esphome/components/web_server/ota/__init__.py
+++ b/esphome/components/web_server/ota/__init__.py
@@ -38,6 +38,17 @@ def _web_server_ota_final_validate(config: ConfigType) -> None:
         else:
             other_ota_configs.append(ota_conf)
 
+    captive_portal_auto_loaded = CORE.data.get("captive_portal_auto_loaded_web_server_ota", False)
+
+    if captive_portal_auto_loaded:
+        if len(web_server_ota_configs) > 1:
+            # captive_portal auto-loaded it AND user explicitly configured it
+            CORE.data["web_server_ota_captive_only"] = False
+        elif len(web_server_ota_configs) == 1:
+            # Only the auto-loaded entry exists — user did not explicitly configure it
+            # Use setdefault so a prior False (set above on a first pass) is not overwritten
+            CORE.data.setdefault("web_server_ota_captive_only", True)
+
     if len(web_server_ota_configs) <= 1:
         return
 
@@ -84,6 +95,9 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ota_to_code(var, config)
     await cg.register_component(var, config)
-    cg.add_define("USE_WEBSERVER_OTA")
+    if CORE.data.get("web_server_ota_captive_only", False):
+        cg.add_define("USE_WEBSERVER_OTA_DISABLED")  # captive portal only
+    else:
+        cg.add_define("USE_WEBSERVER_OTA")            # full web OTA
     if CORE.is_esp32:
         add_idf_component(name="zorxx/multipart-parser", ref="1.0.1")

--- a/esphome/components/web_server/ota/__init__.py
+++ b/esphome/components/web_server/ota/__init__.py
@@ -38,7 +38,9 @@ def _web_server_ota_final_validate(config: ConfigType) -> None:
         else:
             other_ota_configs.append(ota_conf)
 
-    captive_portal_auto_loaded = CORE.data.get("captive_portal_auto_loaded_web_server_ota", False)
+    captive_portal_auto_loaded = CORE.data.get(
+        "captive_portal_auto_loaded_web_server_ota", False
+    )
 
     if captive_portal_auto_loaded:
         if len(web_server_ota_configs) > 1:
@@ -98,6 +100,6 @@ async def to_code(config):
     if CORE.data.get("web_server_ota_captive_only", False):
         cg.add_define("USE_WEBSERVER_OTA_DISABLED")  # captive portal only
     else:
-        cg.add_define("USE_WEBSERVER_OTA")            # full web OTA
+        cg.add_define("USE_WEBSERVER_OTA")  # full web OTA
     if CORE.is_esp32:
         add_idf_component(name="zorxx/multipart-parser", ref="1.0.1")


### PR DESCRIPTION
# What does this implement/fix?

use `USE_WEBSERVER_OTA_DISABLED` if `ota.platform` != `web_server`, but captive portal enabled.

This aligns the behavior again with the one described in the documentation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #17839