### PR TITLE
Multi-stage Docker build — reduce image size by ~34%

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,11 +2,17 @@ ARG BUILD_VERSION=dev
 ARG BUILD_BASE_VERSION=2026.06.1
 ARG BUILD_TYPE=docker
 
-FROM ghcr.io/esphome/docker-base:debian-${BUILD_BASE_VERSION} AS base-source-docker
-FROM ghcr.io/esphome/docker-base:debian-ha-addon-${BUILD_BASE_VERSION} AS base-source-ha-addon
+# Builder stages (with build-essential for compiling native Python extensions)
+FROM ghcr.io/esphome/docker-base:debian-${BUILD_BASE_VERSION} AS builder-source-docker
+FROM ghcr.io/esphome/docker-base:debian-ha-addon-${BUILD_BASE_VERSION} AS builder-source-ha-addon
 
+# Runtime stages (no build-essential)
+FROM ghcr.io/esphome/docker-base:debian-runtime-${BUILD_BASE_VERSION} AS runtime-source-docker
+FROM ghcr.io/esphome/docker-base:debian-ha-addon-runtime-${BUILD_BASE_VERSION} AS runtime-source-ha-addon
+
+# ======================= builder =======================
 ARG BUILD_TYPE
-FROM base-source-${BUILD_TYPE} AS base
+FROM builder-source-${BUILD_TYPE} AS builder
 
 RUN git config --system --add safe.directory "*" \
     && git config --system advice.detachedHead false
@@ -30,7 +36,35 @@ RUN \
     && mkdir -p /piolibs
 
 COPY script/platformio_install_deps.py platformio.ini /
-RUN /platformio_install_deps.py /platformio.ini --libraries
+RUN /platformio_install_deps.py /platformio.ini --libraries \
+    && rm -rf /root/.platformio/.cache
+
+# Install esphome itself
+COPY . /esphome
+RUN uv pip install --no-cache-dir -e /esphome
+
+
+# ======================= runtime base =======================
+ARG BUILD_TYPE
+FROM runtime-source-${BUILD_TYPE} AS runtime-base
+
+RUN git config --system --add safe.directory "*" \
+    && git config --system advice.detachedHead false
+
+# Copy Python packages from builder
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Copy PlatformIO libraries (pre-installed, no cache)
+COPY --from=builder /root/.platformio /root/.platformio
+
+# Copy PlatformIO config
+COPY --from=builder /platformio.ini /platformio.ini
+COPY --from=builder /platformio_install_deps.py /platformio_install_deps.py
+COPY --from=builder /piolibs /piolibs
+
+# Copy esphome source (installed in editable mode)
+COPY --from=builder /esphome /esphome
 
 ARG BUILD_VERSION
 
@@ -46,7 +80,7 @@ LABEL \
 
 
 # ======================= docker-type image =======================
-FROM base AS base-docker
+FROM runtime-base AS base-docker
 
 # Expose the dashboard to Docker
 EXPOSE 6052
@@ -68,7 +102,7 @@ CMD ["dashboard", "/config"]
 
 
 # ======================= ha-addon-type image =======================
-FROM base AS base-ha-addon
+FROM runtime-base AS base-ha-addon
 
 # Copy root filesystem
 COPY docker/ha-addon-rootfs/ /
@@ -83,7 +117,3 @@ LABEL \
 
 ARG BUILD_TYPE
 FROM base-${BUILD_TYPE} AS final
-
-# Copy esphome and install
-COPY . /esphome
-RUN uv pip install --no-cache-dir -e /esphome


### PR DESCRIPTION
# What does this implement/fix?

Reduce the Docker image size from ~940 MB to ~613 MB (34% smaller) by using a multi-stage build that separates build-time dependencies from the runtime image.

After investigating with `dive`, it turns out `build-essential` + GCC + sanitizer libraries account for ~250 MB but aren't needed at runtime — PlatformIO downloads its own cross-compilers (xtensa, arm-none-eabi) when it compiles firmware. The host GCC was only needed to compile Python C extensions during `pip install`.

This PR introduces a proper multi-stage build:

1. **Builder stage** (uses `docker-base:debian-*` with build-essential):
   - Installs pip/uv
   - Compiles Python native extensions (cryptography, aiohttp, etc.)
   - Installs PlatformIO libraries
   - Clears the PlatformIO download cache

2. **Runtime stage** (uses new `docker-base:debian-runtime-*` without build-essential):
   - COPYs only site-packages, binaries, PlatformIO libs, and esphome source from builder
   - No GCC, no uv, no pip, no build cache

| | Before | After | Saved |
|---|---|---|---|
| Image size | 940 MB | 613 MB | **327 MB (34%)** |

I was assisted by Claude (Anthropic) in investigating the image size and putting this together. This started as an experiment to reduce the ESPHome footprint on my Home Assistant installation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Depends on esphome/docker-base#89 (adds `runtime` and `ha-addon-runtime` image targets)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (no user-facing configuration change)

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No configuration change — this only affects the Docker image build
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A — no user-facing changes.
