### PR TITLE
[modbus] Turn the ModbusDevice alias into a working compatibility shim

### DIFF
--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -259,7 +259,7 @@ class ModbusClientDevice {
 // exists only on this deprecated path) and on_modbus_error() the function code and exception code.
 // Remove before 2027.2.0 (window restarted when the plain alias became a behavior shim in 2026.8.0)
 class ESPDEPRECATED("Subclass ModbusClientDevice and override on_response()/on_error() instead. Removed in 2027.2.0",
-                    "2026.6.0") ModbusDevice : public ModbusClientDevice {
+                    "2026.8.0") ModbusDevice : public ModbusClientDevice {
  public:
   using ModbusClientDevice::ModbusClientDevice;
   virtual void on_modbus_data(const std::vector<uint8_t> &data) {}

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -252,10 +252,27 @@ class ModbusClientDevice {
   uint8_t address_{0};
 };
 
-// This is for compatibility with external components using the former class name
-// Remove before 2026.12.0
-using ModbusDevice ESPDEPRECATED("Use ModbusClientDevice instead. Removed in 2026.12.0",
-                                 "2026.6.0") = ModbusClientDevice;
+// Compatibility shim for external components written against the pre-2026.8 API, which subclassed
+// ModbusDevice and overrode on_modbus_data()/on_modbus_error(). The name is free (nothing in-tree
+// uses it), so instead of a plain alias it adapts the new span-based hooks back to the old
+// signatures: on_modbus_data() receives the response payload as an owning vector (the heap copy
+// exists only on this deprecated path) and on_modbus_error() the function code and exception code.
+// Remove before 2027.2.0 (window restarted when the plain alias became a behavior shim in 2026.8.0)
+class ESPDEPRECATED("Subclass ModbusClientDevice and override on_response()/on_error() instead. Removed in 2027.2.0",
+                    "2026.6.0") ModbusDevice : public ModbusClientDevice {
+ public:
+  using ModbusClientDevice::ModbusClientDevice;
+  virtual void on_modbus_data(const std::vector<uint8_t> &data) {}
+  virtual void on_modbus_error(uint8_t function_code, uint8_t exception_code) {}
+
+  void on_response(std::span<const uint8_t> request_pdu, std::span<const uint8_t> response_pdu) override {
+    auto payload = helpers::server_pdu_payload(response_pdu);
+    this->on_modbus_data(std::vector<uint8_t>(payload.begin(), payload.end()));
+  }
+  void on_error(std::span<const uint8_t> request_pdu, ExceptionCode exception_code) override {
+    this->on_modbus_error(request_pdu.empty() ? 0 : request_pdu[0], static_cast<uint8_t>(exception_code));
+  }
+};
 
 // Register values exchanged with server handlers, in host byte order. Sized at the larger of the two protocol
 // maxima (read = 125 / 0x7D, write = 123 / 0x7B); the per-direction count limit is enforced by the hub, not by

--- a/tests/components/modbus/modbus_client_hub_test.cpp
+++ b/tests/components/modbus/modbus_client_hub_test.cpp
@@ -220,4 +220,48 @@ TEST(ModbusClientHub, OversizedPduIsRefusedWithNotSent) {
   EXPECT_TRUE(hub.tx_buffer_empty());
 }
 
+// --- ModbusDevice compatibility shim ------------------------------------------------------------
+// External components written against the pre-2026.8 API subclass ModbusDevice and override the
+// old callbacks; the shim adapts the span-based hooks back to those signatures.
+namespace {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+class LegacyApiDevice : public ModbusDevice {
+ public:
+  LegacyApiDevice(ModbusClientHub *hub, uint8_t address) : ModbusDevice(hub, address) {}
+  void on_modbus_data(const std::vector<uint8_t> &data) override { this->last_data_ = data; }
+  void on_modbus_error(uint8_t function_code, uint8_t exception_code) override {
+    this->last_error_fc_ = function_code;
+    this->last_error_code_ = exception_code;
+  }
+  std::vector<uint8_t> last_data_;
+  int last_error_fc_{-1};
+  int last_error_code_{-1};
+};
+#pragma GCC diagnostic pop
+}  // namespace
+
+TEST(ModbusDeviceShim, LegacyCallbacksReceiveTheOldShapes) {
+  NoResponseProbeHub hub;
+  LegacyApiDevice device(&hub, 0x02);
+
+  // Read response: on_modbus_data() historically received the payload after the function code and
+  // the byte-count byte, as an owning vector.
+  const uint8_t read_req[] = {0x03, 0x00, 0x10, 0x00, 0x02};
+  device.send_pdu(read_req);
+  hub.force_send_front();
+  const uint8_t response[] = {0x03, 0x04, 0x00, 0x2A, 0x01, 0x00};
+  hub.receive_frame_for_test(0x02, response);
+  const std::vector<uint8_t> expected{0x00, 0x2A, 0x01, 0x00};
+  EXPECT_EQ(device.last_data_, expected);
+
+  // Exception response: on_modbus_error() received the unmasked function code and the exception code.
+  device.send_pdu(read_req);
+  hub.force_send_front();
+  const uint8_t error[] = {0x83, 0x02};
+  hub.receive_frame_for_test(0x02, error);
+  EXPECT_EQ(device.last_error_fc_, 0x03);
+  EXPECT_EQ(device.last_error_code_, 0x02);
+}
+
 }  // namespace esphome::modbus::testing

--- a/tests/components/modbus/modbus_client_hub_test.cpp
+++ b/tests/components/modbus/modbus_client_hub_test.cpp
@@ -255,7 +255,15 @@ TEST(ModbusDeviceShim, LegacyCallbacksReceiveTheOldShapes) {
   const std::vector<uint8_t> expected{0x00, 0x2A, 0x01, 0x00};
   EXPECT_EQ(device.last_data_, expected);
 
-  // Exception response: on_modbus_error() received the unmasked function code and the exception code.
+  // Write echo: no byte-count byte, so the payload is everything after the function code.
+  const uint8_t write_req[] = {0x06, 0x00, 0x10, 0x00, 0x2A};
+  device.send_pdu(write_req);
+  hub.force_send_front();
+  hub.receive_frame_for_test(0x02, write_req);  // single-write responses echo the request
+  const std::vector<uint8_t> expected_echo{0x00, 0x10, 0x00, 0x2A};
+  EXPECT_EQ(device.last_data_, expected_echo);
+
+  // Exception response: on_modbus_error() received the masked function code and the exception code.
   device.send_pdu(read_req);
   hub.force_send_front();
   const uint8_t error[] = {0x83, 0x02};


### PR DESCRIPTION
This PR is part of a series of fixes for modbus and related components.

Core modbus architecture:
- #8032 -- in [2026.3.0](https://esphome.io/changelog/2026.3.0/)
- #15291 in [2026.4.0](https://esphome.io/changelog/2026.4.0/)
- #14172 in [2026.4.0](https://esphome.io/changelog/2026.4.0/)
- #15509 in [2026.5.0](https://esphome.io/changelog/2026.5.0/)
- #11969 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #11987 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #12376 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17378 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17282 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17434 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17377 (merged)
- #17844 (merged)
- #17846 (merged)
- #17854 (merge ready)
- #17848 (merge after 17846)
- #17435 (merge after 17848)
- #12612 (merge after 17435)
- #12421 (merge after 11781 & 12376)
- #12614 (merge after 12612)

Overhaul of modbus_controller
- #17677 (merge after 12612)
- #11781 (merge after 17435)

New features for server mode
- #17205 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17387 (merge ready)
- #17357 (merge ready)
- #17264 (merge ready)
- #17464 (merge after 17264)

New features for client mode
- #17467 (merge after 17434, 17387)
- #17676 (merge after 12612)

There are associated tests
- #14395 (tests 8032 above)
- #14845 (tests 11969 above)
- #17345 (tests 11781 above)
---

# What does this implement/fix?

Restores a deprecation window for external components written against the pre-2026.8 modbus callback API.

The callback overhaul renamed `on_modbus_data()`/`on_modbus_error()` to the span-based `on_response()`/`on_error()`.
Signature-identical renames (`on_modbus_not_sent()`, `on_modbus_no_response()`) got forwarding shims, but a signature change cannot be bridged that way: an external component overriding `on_modbus_data(const std::vector<uint8_t> &)` today silently stops being called, or fails to compile if it spelled `override`.

Nothing in-tree uses the old `ModbusDevice` name (all internal code says `ModbusClientDevice`), so the deprecated alias becomes a small derived class that adapts the new hooks back to the old signatures.
`on_modbus_data()` receives the response payload exactly as the released 2026.7 dispatch delivered it (the bytes after the function code, and after the byte-count byte for reads) as an owning vector; the heap copy exists only on this deprecated path.
`on_modbus_error()` receives the masked function code (exception bit stripped, matching the released dispatch) and the exception code.
Old external components that subclass `modbus::ModbusDevice` keep working, with the same deprecation warning the alias already emitted; migrated components are unaffected.
Externals that already renamed their base to `ModbusClientDevice` but still override `on_modbus_data()` cannot be shimmed there - the base's `on_response()` default is reserved for the typed dispatch introduced by #17435, which would consume standard responses before any fall-through could run.
Their migration path is a one-line base swap back to `modbus::ModbusDevice` for the deprecation window, or moving to `on_response()`.

One theoretical incompatibility: an external using `ModbusDevice *` as an interchangeable pointer type for plain `ModbusClientDevice` objects (rather than subclassing) no longer converts.
Subclassing is the pattern the old API required, so this should not occur in practice.

The removal window restarts at 2027.2.0, since the alias only became a behavior shim now.

A unit test drives a legacy subclass through the real hub dispatch and pins both old callback shapes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Restores the migration path for the developer breaking change shipped in the 2026.8 modbus overhaul

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No configuration change; C++ compatibility shim only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



