### PR TITLE
[espidf] Honor compile_process_limit in native ESP-IDF builds

### DIFF
--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -172,7 +172,6 @@ def run_idf_py(
 
     env = _get_idf_env()
     if jobs is not None:
-        # idf.py translates IDF_PY_BUILD_JOBS into ninja -j N
         env = {**env, "IDF_PY_BUILD_JOBS": str(jobs)}
     python_executable = _get_idf_tool("python")
     idf_py = idf_path / "tools" / "idf.py"

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -163,7 +163,7 @@ def run_idf_py(
     *args,
     cwd: Path | None = None,
     capture_output: bool = False,
-    extra_env: dict[str, str] | None = None,
+    jobs: int | None = None,
 ) -> int | str:
     """Run idf.py with the given arguments."""
     idf_path = _get_idf_path()
@@ -171,8 +171,9 @@ def run_idf_py(
         raise EsphomeError("ESP-IDF not found")
 
     env = _get_idf_env()
-    if extra_env:
-        env = {**env, **extra_env}
+    if jobs is not None:
+        # idf.py translates IDF_PY_BUILD_JOBS into ninja -j N
+        env = {**env, "IDF_PY_BUILD_JOBS": str(jobs)}
     python_executable = _get_idf_tool("python")
     idf_py = idf_path / "tools" / "idf.py"
     # Dispatch idf.py through esphome.espidf.runner, which wraps
@@ -402,12 +403,7 @@ def run_compile(config, verbose: bool) -> int:
     args.append("build")
     args.append("size")
 
-    extra_env: dict[str, str] | None = None
-    if (limit := config[CONF_ESPHOME].get(CONF_COMPILE_PROCESS_LIMIT)) is not None:
-        # idf.py translates IDF_PY_BUILD_JOBS into ninja -j N
-        extra_env = {"IDF_PY_BUILD_JOBS": str(limit)}
-
-    rc = run_idf_py(*args, extra_env=extra_env)
+    rc = run_idf_py(*args, jobs=config[CONF_ESPHOME].get(CONF_COMPILE_PROCESS_LIMIT))
     if rc == 0:
         size_json = CORE.relative_build_path("build", "esp_idf_size.json")
         partitions = CORE.relative_build_path("partitions.csv")

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -10,7 +10,12 @@ import shutil
 import subprocess
 
 from esphome.components.esp32.const import KEY_ESP32, KEY_FLASH_SIZE, KEY_IDF_VERSION
-from esphome.const import CONF_FRAMEWORK, CONF_SOURCE
+from esphome.const import (
+    CONF_COMPILE_PROCESS_LIMIT,
+    CONF_ESPHOME,
+    CONF_FRAMEWORK,
+    CONF_SOURCE,
+)
 from esphome.core import CORE, EsphomeError
 from esphome.espidf.framework import check_esp_idf_install, get_framework_env
 from esphome.espidf.size_summary import print_summary
@@ -155,7 +160,10 @@ def _get_idf_tool(name: str) -> str:
 
 
 def run_idf_py(
-    *args, cwd: Path | None = None, capture_output: bool = False
+    *args,
+    cwd: Path | None = None,
+    capture_output: bool = False,
+    extra_env: dict[str, str] | None = None,
 ) -> int | str:
     """Run idf.py with the given arguments."""
     idf_path = _get_idf_path()
@@ -163,6 +171,8 @@ def run_idf_py(
         raise EsphomeError("ESP-IDF not found")
 
     env = _get_idf_env()
+    if extra_env:
+        env = {**env, **extra_env}
     python_executable = _get_idf_tool("python")
     idf_py = idf_path / "tools" / "idf.py"
     # Dispatch idf.py through esphome.espidf.runner, which wraps
@@ -392,7 +402,12 @@ def run_compile(config, verbose: bool) -> int:
     args.append("build")
     args.append("size")
 
-    rc = run_idf_py(*args)
+    extra_env: dict[str, str] | None = None
+    if (limit := config[CONF_ESPHOME].get(CONF_COMPILE_PROCESS_LIMIT)) is not None:
+        # idf.py translates IDF_PY_BUILD_JOBS into ninja -j N
+        extra_env = {"IDF_PY_BUILD_JOBS": str(limit)}
+
+    rc = run_idf_py(*args, extra_env=extra_env)
     if rc == 0:
         size_json = CORE.relative_build_path("build", "esp_idf_size.json")
         partitions = CORE.relative_build_path("partitions.csv")

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -314,8 +314,30 @@ def test_get_cmake_output_missing_build_does_not_resolve_idf_env(
     mock_run.assert_not_called()
 
 
+def test_run_idf_py_jobs_sets_build_jobs_env(setup_core: Path) -> None:
+    """The jobs argument is exported to idf.py as IDF_PY_BUILD_JOBS."""
+    _setup_build(setup_core)
+
+    with (
+        patch.object(toolchain, "_get_idf_path", return_value=Path("/idf")),
+        patch.object(toolchain, "_get_idf_env", return_value={"PATH": "/bin"}),
+        patch.object(toolchain, "_get_idf_tool", return_value="python"),
+        patch.object(toolchain.subprocess, "run") as mock_run,
+    ):
+        mock_run.return_value.returncode = 0
+
+        toolchain.run_idf_py("build", jobs=2)
+        env = mock_run.call_args.kwargs["env"]
+        assert env["IDF_PY_BUILD_JOBS"] == "2"
+        assert env["PATH"] == "/bin"
+
+        toolchain.run_idf_py("build")
+        env = mock_run.call_args.kwargs["env"]
+        assert "IDF_PY_BUILD_JOBS" not in env
+
+
 def test_run_compile_passes_compile_process_limit(setup_core: Path) -> None:
-    """compile_process_limit is forwarded to idf.py as IDF_PY_BUILD_JOBS."""
+    """compile_process_limit is forwarded to run_idf_py as the job limit."""
     _setup_build(setup_core)
     config = {CONF_ESPHOME: {CONF_COMPILE_PROCESS_LIMIT: 1}}
 
@@ -326,9 +348,7 @@ def test_run_compile_passes_compile_process_limit(setup_core: Path) -> None:
     ):
         assert toolchain.run_compile(config, verbose=False) == 0
 
-    mock_run.assert_called_once_with(
-        "build", "size", extra_env={"IDF_PY_BUILD_JOBS": "1"}
-    )
+    mock_run.assert_called_once_with("build", "size", jobs=1)
 
 
 def test_run_compile_without_compile_process_limit(setup_core: Path) -> None:
@@ -343,7 +363,7 @@ def test_run_compile_without_compile_process_limit(setup_core: Path) -> None:
     ):
         assert toolchain.run_compile(config, verbose=False) == 0
 
-    mock_run.assert_called_once_with("build", "size", extra_env=None)
+    mock_run.assert_called_once_with("build", "size", jobs=None)
 
 
 def test_get_core_framework_version_from_core_data():

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -10,7 +10,12 @@ from unittest.mock import patch
 
 import pytest
 
-from esphome.const import CONF_FRAMEWORK, CONF_SOURCE
+from esphome.const import (
+    CONF_COMPILE_PROCESS_LIMIT,
+    CONF_ESPHOME,
+    CONF_FRAMEWORK,
+    CONF_SOURCE,
+)
 from esphome.core import CORE, EsphomeError
 from esphome.espidf import toolchain
 
@@ -307,6 +312,38 @@ def test_get_cmake_output_missing_build_does_not_resolve_idf_env(
 
     mock_env.assert_not_called()
     mock_run.assert_not_called()
+
+
+def test_run_compile_passes_compile_process_limit(setup_core: Path) -> None:
+    """compile_process_limit is forwarded to idf.py as IDF_PY_BUILD_JOBS."""
+    _setup_build(setup_core)
+    config = {CONF_ESPHOME: {CONF_COMPILE_PROCESS_LIMIT: 1}}
+
+    with (
+        patch.object(toolchain, "need_reconfigure", return_value=False),
+        patch.object(toolchain, "run_idf_py", return_value=0) as mock_run,
+        patch.object(toolchain, "print_summary"),
+    ):
+        assert toolchain.run_compile(config, verbose=False) == 0
+
+    mock_run.assert_called_once_with(
+        "build", "size", extra_env={"IDF_PY_BUILD_JOBS": "1"}
+    )
+
+
+def test_run_compile_without_compile_process_limit(setup_core: Path) -> None:
+    """When no compile_process_limit is set, no job limit is passed to idf.py."""
+    _setup_build(setup_core)
+    config = {CONF_ESPHOME: {}}
+
+    with (
+        patch.object(toolchain, "need_reconfigure", return_value=False),
+        patch.object(toolchain, "run_idf_py", return_value=0) as mock_run,
+        patch.object(toolchain, "print_summary"),
+    ):
+        assert toolchain.run_compile(config, verbose=False) == 0
+
+    mock_run.assert_called_once_with("build", "size", extra_env=None)
 
 
 def test_get_core_framework_version_from_core_data():


### PR DESCRIPTION
# What does this implement/fix?

The native ESP-IDF build path ignored the `compile_process_limit` option, so ninja always ran at full default parallelism (~cores+2). On low-memory hosts (Home Assistant Green/Blue/Yellow, Raspberry Pi) the parallel compiler processes exhaust RAM and get OOM-killed, failing builds with `fatal error: Killed signal terminated program cc1plus`. This also made the HA add-on's **Default Compile Process Limit** setting and the automatic Raspberry Pi 3 limit no-ops, since those only set the default for the same unread option.

This passes the configured limit to `idf.py` via the `IDF_PY_BUILD_JOBS` environment variable, which `idf.py` translates to `ninja -j N`. The variable is read by ESP-IDF 5.5.5 (the current recommended version) and 6.1+; older versions (5.5.4 and below, 6.0.x) do not read it and ignore it harmlessly, matching the previous behavior there. This matches the behavior of the PlatformIO build path, which passes `-jN` to `pio run`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17816

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test
  compile_process_limit: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).