### PR TITLE
[git] Fix submodule update failure when cloning libraries on the esp-idf toolchain

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -411,7 +411,7 @@ def _clone_idf_with_submodules(
             ["git", "reset", "--hard", "FETCH_HEAD"],
             git_dir=framework_path,
         )
-    update_submodules(framework_path, [], key)
+    update_submodules(framework_path, key)
 
     # Sanity-check the resulting tree: a clone can exit 0 yet produce no
     # usable ESP-IDF checkout, which would otherwise be marked extracted and

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -415,8 +415,14 @@ def _clone_idf_with_submodules(
     # Sanity-check the resulting tree. run_git_command only raises when
     # stderr is non-empty, so a clone that silently produces no working
     # tree would otherwise be marked extracted and stuck until
-    # ``esphome clean``.
-    if not (framework_path / "tools" / "idf_tools.py").is_file():
+    # ``esphome clean``. A real ESP-IDF checkout always declares submodules;
+    # a missing .gitmodules means the clone is truncated and update_submodules
+    # above skipped the vendored components (mbedtls, openthread, ...), which
+    # would otherwise surface much later as an opaque CMake error.
+    if (
+        not (framework_path / "tools" / "idf_tools.py").is_file()
+        or not (framework_path / ".gitmodules").is_file()
+    ):
         raise RuntimeError(
             f"Clone of {git_url} produced no usable ESP-IDF tree at {framework_path}"
         )

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -397,7 +397,7 @@ def _clone_idf_with_submodules(
     handles branches, tags, and SHAs uniformly (mirrors the approach in
     ``esphome.git.clone_or_update``).
     """
-    from esphome.git import run_git_command
+    from esphome.git import run_git_command, update_submodules
 
     _LOGGER.info("Cloning ESP-IDF from %s%s", git_url, f"@{ref}" if ref else "")
     run_git_command(["git", "clone", "--depth=1", "--", git_url, str(framework_path)])
@@ -410,19 +410,7 @@ def _clone_idf_with_submodules(
             ["git", "reset", "--hard", "FETCH_HEAD"],
             git_dir=framework_path,
         )
-    # cwd instead of git_dir: the git submodule porcelain fails on some git
-    # installations when GIT_DIR/GIT_WORK_TREE are set (see run_git_command).
-    run_git_command(
-        [
-            "git",
-            "submodule",
-            "update",
-            "--init",
-            "--recursive",
-            "--depth=1",
-        ],
-        cwd=framework_path,
-    )
+    update_submodules(framework_path, [], git_url)
 
     # Sanity-check the resulting tree. run_git_command only raises when
     # stderr is non-empty, so a clone that silently produces no working

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -413,11 +413,9 @@ def _clone_idf_with_submodules(
         )
     update_submodules(framework_path, [], key)
 
-    # Sanity-check the resulting tree. run_git_command only raises when
-    # stderr is non-empty, so a clone that silently produces no working
-    # tree would otherwise be marked extracted and stuck until
-    # ``esphome clean``. Submodule initialization is verified by
-    # update_submodules itself.
+    # Sanity-check the resulting tree: a clone can exit 0 yet produce no
+    # usable ESP-IDF checkout, which would otherwise be marked extracted and
+    # stuck until ``esphome clean``.
     if not (framework_path / "tools" / "idf_tools.py").is_file():
         raise RuntimeError(
             f"Clone of {key} produced no usable ESP-IDF tree at {framework_path}"

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -410,6 +410,8 @@ def _clone_idf_with_submodules(
             ["git", "reset", "--hard", "FETCH_HEAD"],
             git_dir=framework_path,
         )
+    # cwd instead of git_dir: the git submodule porcelain fails on some git
+    # installations when GIT_DIR/GIT_WORK_TREE are set (see run_git_command).
     run_git_command(
         [
             "git",
@@ -419,7 +421,7 @@ def _clone_idf_with_submodules(
             "--recursive",
             "--depth=1",
         ],
-        git_dir=framework_path,
+        cwd=framework_path,
     )
 
     # Sanity-check the resulting tree. run_git_command only raises when

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -416,16 +416,24 @@ def _clone_idf_with_submodules(
     # Sanity-check the resulting tree. run_git_command only raises when
     # stderr is non-empty, so a clone that silently produces no working
     # tree would otherwise be marked extracted and stuck until
-    # ``esphome clean``. A real ESP-IDF checkout always declares submodules;
-    # a missing .gitmodules means the clone is truncated and update_submodules
-    # above skipped the vendored components (mbedtls, openthread, ...), which
-    # would otherwise surface much later as an opaque CMake error.
-    if (
-        not (framework_path / "tools" / "idf_tools.py").is_file()
-        or not (framework_path / ".gitmodules").is_file()
-    ):
+    # ``esphome clean``.
+    if not (framework_path / "tools" / "idf_tools.py").is_file():
         raise RuntimeError(
             f"Clone of {key} produced no usable ESP-IDF tree at {framework_path}"
+        )
+    # Separately verify the vendored components actually materialized; the
+    # mbedtls submodule is present in every ESP-IDF release. This catches a
+    # truncated clone as well as a submodule init that silently did nothing,
+    # both of which would otherwise surface much later as an opaque CMake
+    # error. A fork that vendors the components in-tree instead of as
+    # submodules passes this check like a regular checkout.
+    if not (
+        framework_path / "components" / "mbedtls" / "mbedtls" / "CMakeLists.txt"
+    ).is_file():
+        raise RuntimeError(
+            f"Clone of {key} at {framework_path} is missing its vendored "
+            "components; the submodule checkout did not complete. Delete the "
+            "directory and retry."
         )
 
 

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -416,24 +416,11 @@ def _clone_idf_with_submodules(
     # Sanity-check the resulting tree. run_git_command only raises when
     # stderr is non-empty, so a clone that silently produces no working
     # tree would otherwise be marked extracted and stuck until
-    # ``esphome clean``.
+    # ``esphome clean``. Submodule initialization is verified by
+    # update_submodules itself.
     if not (framework_path / "tools" / "idf_tools.py").is_file():
         raise RuntimeError(
             f"Clone of {key} produced no usable ESP-IDF tree at {framework_path}"
-        )
-    # Separately verify the vendored components actually materialized; the
-    # mbedtls submodule is present in every ESP-IDF release. This catches a
-    # truncated clone as well as a submodule init that silently did nothing,
-    # both of which would otherwise surface much later as an opaque CMake
-    # error. A fork that vendors the components in-tree instead of as
-    # submodules passes this check like a regular checkout.
-    if not (
-        framework_path / "components" / "mbedtls" / "mbedtls" / "CMakeLists.txt"
-    ).is_file():
-        raise RuntimeError(
-            f"Clone of {key} at {framework_path} is missing its vendored "
-            "components; the submodule checkout did not complete. Delete the "
-            "directory and retry."
         )
 
 

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -399,7 +399,8 @@ def _clone_idf_with_submodules(
     """
     from esphome.git import run_git_command, update_submodules
 
-    _LOGGER.info("Cloning ESP-IDF from %s%s", git_url, f"@{ref}" if ref else "")
+    key = f"{git_url}@{ref}" if ref else git_url
+    _LOGGER.info("Cloning ESP-IDF from %s", key)
     run_git_command(["git", "clone", "--depth=1", "--", git_url, str(framework_path)])
     if ref:
         run_git_command(
@@ -410,7 +411,7 @@ def _clone_idf_with_submodules(
             ["git", "reset", "--hard", "FETCH_HEAD"],
             git_dir=framework_path,
         )
-    update_submodules(framework_path, [], git_url)
+    update_submodules(framework_path, [], key)
 
     # Sanity-check the resulting tree. run_git_command only raises when
     # stderr is non-empty, so a clone that silently produces no working
@@ -424,7 +425,7 @@ def _clone_idf_with_submodules(
         or not (framework_path / ".gitmodules").is_file()
     ):
         raise RuntimeError(
-            f"Clone of {git_url} produced no usable ESP-IDF tree at {framework_path}"
+            f"Clone of {key} produced no usable ESP-IDF tree at {framework_path}"
         )
 
 

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -26,6 +26,22 @@ NEVER_REFRESH = TimePeriodSeconds(seconds=-1)
 # it does not pollute the worktree.
 _CLONE_COMPLETE_MARKER = "esphome_clone_complete"
 
+# Environment variables that scope git to a specific repository. Git hooks and
+# some CI wrappers export these; if they leak into the git commands run here,
+# git binds to the caller's repository instead of the one being managed. The
+# effects range from loud (`git clone` producing a bare-style directory with
+# no working tree) to silent (an ambient GIT_INDEX_FILE makes
+# `git submodule update --init` exit 0 without initializing anything).
+_GIT_REPO_SCOPING_ENV = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_NAMESPACE",
+)
+
 
 class GitException(cv.Invalid):
     """Base exception for git-related errors."""
@@ -64,38 +80,36 @@ def run_git_command(
             "Running git command: %s%s", " ".join(cmd), f" (cwd={cwd})" if cwd else ""
         )
 
-    # Set up environment for repository isolation if git_dir is provided
-    # Force git to only operate on this specific repository by setting
-    # GIT_DIR and GIT_WORK_TREE. This prevents git from walking up the
-    # directory tree to find parent repositories when the target repo's
-    # .git directory is corrupt. Without this, commands like 'git stash'
-    # could accidentally operate on parent repositories (e.g., the main
-    # ESPHome repo) instead of failing, causing data loss.
+    # Every invocation starts from an environment with the repository-scoping
+    # variables stripped (see _GIT_REPO_SCOPING_ENV) so a git hook or CI
+    # wrapper invoking ESPHome can never redirect these commands to its own
+    # repository or index.
+    #
+    # ``git_dir`` then re-adds GIT_DIR and GIT_WORK_TREE pointing at the
+    # managed repository. This prevents git from walking up the directory
+    # tree to find parent repositories when the target repo's .git directory
+    # is corrupt. Without this, commands like 'git stash' could accidentally
+    # operate on parent repositories (e.g., the main ESPHome repo) instead of
+    # failing, causing data loss.
     #
     # ``cwd`` (without ``git_dir``) runs the command in that directory
     # without GIT_DIR/GIT_WORK_TREE. The ``git submodule`` porcelain needs
     # this: on some installations (e.g. Windows setups where a shim hands
     # git untranslated paths) it refuses to run when GIT_DIR/GIT_WORK_TREE
-    # are set, failing with "cannot be used without a working tree". Ambient
-    # GIT_DIR/GIT_WORK_TREE from the caller's environment (a git hook, a CI
-    # wrapper) are stripped for the same reason, and GIT_CEILING_DIRECTORIES
-    # keeps the parent-repo-walk protection: if the repo's .git is missing
-    # or corrupt, git fails instead of discovering an enclosing repository.
-    env: dict[str, str] | None = None
+    # are set, failing with "cannot be used without a working tree".
+    # GIT_CEILING_DIRECTORIES (which git only honors as an absolute path)
+    # keeps the parent-repo-walk protection instead: if the repo's .git is
+    # missing or corrupt, git fails rather than discovering an enclosing
+    # repository.
+    env = {
+        k: v for k, v in subprocess.os.environ.items() if k not in _GIT_REPO_SCOPING_ENV
+    }
     if git_dir is not None:
-        env = {
-            **subprocess.os.environ,
-            "GIT_DIR": str(Path(git_dir) / ".git"),
-            "GIT_WORK_TREE": str(git_dir),
-        }
+        env["GIT_DIR"] = str(Path(git_dir) / ".git")
+        env["GIT_WORK_TREE"] = str(git_dir)
         cwd = git_dir
     elif cwd is not None:
-        env = {
-            k: v
-            for k, v in subprocess.os.environ.items()
-            if k not in ("GIT_DIR", "GIT_WORK_TREE")
-        }
-        env["GIT_CEILING_DIRECTORIES"] = str(Path(cwd).parent)
+        env["GIT_CEILING_DIRECTORIES"] = str(Path(cwd).absolute().parent)
 
     try:
         ret = subprocess.run(

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -141,7 +141,10 @@ def run_git_command(
             if lines[-1].startswith("fatal:"):
                 raise GitCommandError(lines[-1][len("fatal: ") :])
             raise GitCommandError(err_str)
-        raise GitCommandError(f"git exited with code {ret.returncode}: {' '.join(cmd)}")
+        raise GitCommandError(
+            f"git exited with code {ret.returncode}: "
+            f"{_redact_url_credentials(' '.join(cmd))}"
+        )
 
     return ret.stdout.decode("utf-8").strip()
 
@@ -361,7 +364,7 @@ def clone_or_update(
             )
         except EsphomeError as err:
             _LOGGER.warning(
-                "Could not write clone completion marker for %s: %s", key, err
+                "Could not write clone completion marker for %s: %s", safe_key, err
             )
 
     else:

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -49,8 +49,9 @@ def run_git_command(
     """Run a git command and return its stdout.
 
     ``git_dir`` runs the command in that repository with GIT_DIR/GIT_WORK_TREE
-    isolation; ``cwd`` runs it in that directory without isolation. The two
-    are mutually exclusive and ``git_dir`` wins when both are given.
+    isolation; ``cwd`` runs it in that directory with those variables stripped
+    from the environment instead. The two are mutually exclusive and
+    ``git_dir`` wins when both are given.
     """
     if git_dir is not None:
         _LOGGER.debug(
@@ -71,11 +72,15 @@ def run_git_command(
     # could accidentally operate on parent repositories (e.g., the main
     # ESPHome repo) instead of failing, causing data loss.
     #
-    # ``cwd`` (without ``git_dir``) runs the command in that directory with
-    # no environment override. The ``git submodule`` porcelain needs this:
-    # on some installations (e.g. Windows setups where a shim hands git
-    # untranslated paths) it refuses to run when GIT_DIR/GIT_WORK_TREE are
-    # set, failing with "cannot be used without a working tree".
+    # ``cwd`` (without ``git_dir``) runs the command in that directory
+    # without GIT_DIR/GIT_WORK_TREE. The ``git submodule`` porcelain needs
+    # this: on some installations (e.g. Windows setups where a shim hands
+    # git untranslated paths) it refuses to run when GIT_DIR/GIT_WORK_TREE
+    # are set, failing with "cannot be used without a working tree". Ambient
+    # GIT_DIR/GIT_WORK_TREE from the caller's environment (a git hook, a CI
+    # wrapper) are stripped for the same reason, and GIT_CEILING_DIRECTORIES
+    # keeps the parent-repo-walk protection: if the repo's .git is missing
+    # or corrupt, git fails instead of discovering an enclosing repository.
     env: dict[str, str] | None = None
     if git_dir is not None:
         env = {
@@ -84,6 +89,13 @@ def run_git_command(
             "GIT_WORK_TREE": str(git_dir),
         }
         cwd = git_dir
+    elif cwd is not None:
+        env = {
+            k: v
+            for k, v in subprocess.os.environ.items()
+            if k not in ("GIT_DIR", "GIT_WORK_TREE")
+        }
+        env["GIT_CEILING_DIRECTORIES"] = str(Path(cwd).parent)
 
     try:
         ret = subprocess.run(

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -169,7 +169,7 @@ def update_submodules(repo_dir: Path, submodules: list[str] | None, key: str) ->
     if not submodules and not (repo_dir / ".gitmodules").is_file():
         return
     _LOGGER.info(
-        "Initializing submodules (%s) for %s",
+        "Updating submodules (%s) for %s",
         ", ".join(submodules) if submodules else "all",
         key,
     )

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -162,6 +162,34 @@ def _remove_repo_dir(repo_dir: Path) -> None:
         rmtree(repo_dir)
 
 
+def _update_none_paths(repo_dir: Path) -> set[str]:
+    """Return the paths of submodules the repo declares with ``update = none``.
+
+    Git skips these on purpose during ``git submodule update --init`` (and
+    exits 0), so they must not be reported as failed initializations.
+    """
+    # --get-regexp exits 1 with empty stderr when nothing matches, which
+    # run_git_command treats as success with empty output.
+    config = run_git_command(
+        ["git", "config", "-f", ".gitmodules", "--get-regexp", r"^submodule\."],
+        cwd=repo_dir,
+    )
+    paths: dict[str, str] = {}
+    updates: dict[str, str] = {}
+    for line in config.splitlines():
+        config_key, _, value = line.partition(" ")
+        name, _, prop = config_key.removeprefix("submodule.").rpartition(".")
+        if prop == "path":
+            paths[name] = value
+        elif prop == "update":
+            updates[name] = value
+    return {
+        paths[name]
+        for name, mode in updates.items()
+        if mode == "none" and name in paths
+    }
+
+
 def update_submodules(repo_dir: Path, submodules: list[str] | None, key: str) -> None:
     """Initialize/update submodules of a freshly cloned or updated repo.
 
@@ -203,8 +231,10 @@ def update_submodules(repo_dir: Path, submodules: list[str] | None, key: str) ->
     if missing := [
         line.split()[1] for line in status.splitlines() if line.startswith("-")
     ]:
+        missing = [path for path in missing if path not in _update_none_paths(repo_dir)]
+    if missing:
         raise GitRepositoryError(
-            f"Submodules ({', '.join(missing)}) for {key} failed to initialize"
+            f"Submodules ({', '.join(missing)}) for {key} were left uninitialized"
         )
 
 

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -162,12 +162,16 @@ def _remove_repo_dir(repo_dir: Path) -> None:
         rmtree(repo_dir)
 
 
-def _update_none_paths(repo_dir: Path) -> set[str]:
-    """Return the paths of submodules the repo declares with ``update = none``.
+def _update_none_paths(repo_dir: Path, prefix: str = "") -> set[str]:
+    """Return the paths of submodules ``repo_dir`` declares with ``update = none``.
 
     Git skips these on purpose during ``git submodule update --init`` (and
     exits 0), so they must not be reported as failed initializations.
+    ``prefix`` is prepended to each returned path so declarations read from a
+    nested submodule's ``.gitmodules`` come back relative to the superproject.
     """
+    if not (repo_dir / ".gitmodules").is_file():
+        return set()
     # --get-regexp exits 1 with empty stderr when nothing matches, which
     # run_git_command treats as success with empty output.
     config = run_git_command(
@@ -184,7 +188,7 @@ def _update_none_paths(repo_dir: Path) -> set[str]:
         elif prop == "update":
             updates[name] = value
     return {
-        paths[name]
+        f"{prefix}{paths[name]}"
         for name, mode in updates.items()
         if mode == "none" and name in paths
     }
@@ -231,7 +235,15 @@ def update_submodules(repo_dir: Path, submodules: list[str] | None, key: str) ->
     if missing := [
         line.split()[1] for line in status.splitlines() if line.startswith("-")
     ]:
-        missing = [path for path in missing if path not in _update_none_paths(repo_dir)]
+        # `update = none` declarations can live at any level: in the
+        # superproject's .gitmodules or in that of any initialized nested
+        # submodule. Collect them all before deciding anything failed.
+        skipped = _update_none_paths(repo_dir)
+        for line in status.splitlines():
+            if line and not line.startswith("-"):
+                path = line.split()[1]
+                skipped |= _update_none_paths(repo_dir / path, prefix=f"{path}/")
+        missing = [path for path in missing if path not in skipped]
     if missing:
         raise GitRepositoryError(
             f"Submodules ({', '.join(missing)}) for {key} were left uninitialized"

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -125,12 +125,14 @@ def run_git_command(
             "for installation instructions."
         ) from err
 
-    if ret.returncode != 0 and ret.stderr:
-        err_str = ret.stderr.decode("utf-8")
-        lines = [x.strip() for x in err_str.splitlines()]
-        if lines[-1].startswith("fatal:"):
-            raise GitCommandError(lines[-1][len("fatal: ") :])
-        raise GitCommandError(err_str)
+    if ret.returncode != 0:
+        if ret.stderr:
+            err_str = ret.stderr.decode("utf-8")
+            lines = [x.strip() for x in err_str.splitlines()]
+            if lines[-1].startswith("fatal:"):
+                raise GitCommandError(lines[-1][len("fatal: ") :])
+            raise GitCommandError(err_str)
+        raise GitCommandError(f"git exited with code {ret.returncode}: {' '.join(cmd)}")
 
     return ret.stdout.decode("utf-8").strip()
 
@@ -162,36 +164,28 @@ def _remove_repo_dir(repo_dir: Path) -> None:
         rmtree(repo_dir)
 
 
-def _update_none_paths(repo_dir: Path, prefix: str = "") -> set[str]:
+def _update_none_paths(repo_dir: Path) -> set[str]:
     """Return the paths of submodules ``repo_dir`` declares with ``update = none``.
 
     Git skips these on purpose during ``git submodule update --init`` (and
     exits 0), so they must not be reported as failed initializations.
-    ``prefix`` is prepended to each returned path so declarations read from a
-    nested submodule's ``.gitmodules`` come back relative to the superproject.
     """
     if not (repo_dir / ".gitmodules").is_file():
         return set()
-    # --get-regexp exits 1 with empty stderr when nothing matches, which
-    # run_git_command treats as success with empty output.
     config = run_git_command(
-        ["git", "config", "-f", ".gitmodules", "--get-regexp", r"^submodule\."],
+        ["git", "config", "-f", ".gitmodules", "--list"],
         cwd=repo_dir,
     )
     paths: dict[str, str] = {}
-    updates: dict[str, str] = {}
+    skipped_names: set[str] = set()
     for line in config.splitlines():
-        config_key, _, value = line.partition(" ")
+        config_key, _, value = line.partition("=")
         name, _, prop = config_key.removeprefix("submodule.").rpartition(".")
         if prop == "path":
             paths[name] = value
-        elif prop == "update":
-            updates[name] = value
-    return {
-        f"{prefix}{paths[name]}"
-        for name, mode in updates.items()
-        if mode == "none" and name in paths
-    }
+        elif prop == "update" and value == "none":
+            skipped_names.add(name)
+    return {paths[name] for name in skipped_names & paths.keys()}
 
 
 def update_submodules(repo_dir: Path, submodules: list[str] | None, key: str) -> None:
@@ -203,7 +197,13 @@ def update_submodules(repo_dir: Path, submodules: list[str] | None, key: str) ->
     Most repositories declare no submodules, so the "every submodule" case
     does nothing when there is no ``.gitmodules`` file. An explicit list is
     always passed through so a path that does not exist in the repository
-    surfaces as a git error instead of being silently ignored.
+    surfaces as a git error instead of being silently ignored, and each named
+    path is verified afterwards: a path left uninitialized (other than by an
+    ``update = none`` declaration, which git honors even for named paths)
+    raises ``GitRepositoryError``. Which submodules the "every submodule"
+    case populates is git's own policy (``update = none``,
+    ``submodule.active``, sparse checkouts); git's exit code is the error
+    signal there.
 
     Runs with plain ``cwd`` rather than ``git_dir`` isolation, which the
     ``git submodule`` porcelain does not tolerate (see ``run_git_command``).
@@ -223,27 +223,23 @@ def update_submodules(repo_dir: Path, submodules: list[str] | None, key: str) ->
         + submodules,
         cwd=repo_dir,
     )
-    # Verify the update actually initialized what it was asked to; a status
-    # line starting with "-" is a declared but uninitialized submodule. The
-    # porcelain can exit 0 without doing anything, and the resulting empty
-    # directories would otherwise only surface much later as opaque build
-    # errors.
+    if not submodules:
+        return
+    # The caller named these paths; verify each was actually initialized. A
+    # status line starting with "-" is a declared but uninitialized
+    # submodule. Uninitialized lines carry no describe suffix, so everything
+    # after the SHA is the path (which may contain spaces).
     status = run_git_command(
-        ["git", "submodule", "status", *recursive, "--"] + submodules,
+        ["git", "submodule", "status", "--"] + submodules,
         cwd=repo_dir,
     )
-    if missing := [
-        line.split()[1] for line in status.splitlines() if line.startswith("-")
-    ]:
-        # `update = none` declarations can live at any level: in the
-        # superproject's .gitmodules or in that of any initialized nested
-        # submodule. Collect them all before deciding anything failed.
-        skipped = _update_none_paths(repo_dir)
-        for line in status.splitlines():
-            if line and not line.startswith("-"):
-                path = line.split()[1]
-                skipped |= _update_none_paths(repo_dir / path, prefix=f"{path}/")
-        missing = [path for path in missing if path not in skipped]
+    missing = [
+        line[1:].split(" ", 1)[1]
+        for line in status.splitlines()
+        if line.startswith("-")
+    ]
+    if missing:
+        missing = [path for path in missing if path not in _update_none_paths(repo_dir)]
     if missing:
         raise GitRepositoryError(
             f"Submodules ({', '.join(missing)}) for {key} were left uninitialized"

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -460,6 +460,12 @@ def clone_or_update(
                     ["git", "reset", "--hard", "FETCH_HEAD"],
                     git_dir=repo_dir,
                 )
+
+                # Inside the try so a submodule failure (including the
+                # named-path verification) routes through the recovery
+                # re-clone below instead of leaving a repo that the refresh
+                # window would silently accept on the next run.
+                update_submodules(repo_dir, submodules, key)
             except GitException as err:
                 # Repository is in a broken state or update failed
                 # Only attempt recovery once to prevent infinite recursion
@@ -494,8 +500,6 @@ def clone_or_update(
                 )
                 _LOGGER.info("Repository %s successfully recovered", key)
                 return result
-
-            update_submodules(repo_dir, submodules, key)
 
             def revert():
                 _LOGGER.info("Reverting changes to %s -> %s", key, old_sha)

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -62,6 +62,15 @@ class GitRepositoryError(GitException):
     """Exception raised when a git repository is in an invalid state."""
 
 
+def _redact_url_credentials(text: str) -> str:
+    """Mask userinfo in any URLs embedded in ``text``.
+
+    Users can put credentials directly in a git URL, and log output is
+    routinely pasted into public issues.
+    """
+    return re.sub(r"://[^/@\s]+@", "://***@", text)
+
+
 def run_git_command(
     cmd: list[str], git_dir: Path | None = None, *, cwd: Path | None = None
 ) -> str:
@@ -104,9 +113,7 @@ def run_git_command(
 
     _LOGGER.debug(
         "Running git command: %s (cwd=%s, isolated=%s)",
-        # Redact userinfo: clone URLs may embed credentials, and -v output is
-        # routinely pasted into public issues.
-        re.sub(r"://[^/@\s]+@", "://***@", " ".join(cmd)),
+        _redact_url_credentials(" ".join(cmd)),
         cwd,
         git_dir is not None,
     )
@@ -180,7 +187,7 @@ def update_submodules(repo_dir: Path, key: str) -> None:
     """
     if not (repo_dir / ".gitmodules").is_file():
         return
-    _LOGGER.info("Updating submodules for %s", key)
+    _LOGGER.info("Updating submodules for %s", _redact_url_credentials(key))
     run_git_command(
         ["git", "submodule", "update", "--init", "--recursive", "--depth=1"],
         cwd=repo_dir,
@@ -286,7 +293,14 @@ def clone_or_update(
     _recover_broken: bool = True,
 ) -> tuple[Path, Callable[[], None] | None]:
     key = f"{url}@{ref}"
+    # The user may have embedded credentials in the URL itself; log this
+    # instead of key.
+    safe_key = _redact_url_credentials(key)
 
+    # Keep the caller's URL for the recovery re-clone below: rewriting the
+    # rewritten URL would double the userinfo, and the recursive call must
+    # compute the same cache key as this one.
+    original_url = url
     if username is not None and password is not None:
         url = url.replace(
             "://", f"://{urllib.parse.quote(username)}:{urllib.parse.quote(password)}@"
@@ -302,12 +316,12 @@ def clone_or_update(
         # predates the marker; either way it cannot be trusted, especially
         # with NEVER_REFRESH where it would otherwise be reused forever.
         _LOGGER.warning(
-            "Removing incomplete clone of %s at %s, will re-clone", key, repo_dir
+            "Removing incomplete clone of %s at %s, will re-clone", safe_key, repo_dir
         )
         _remove_repo_dir(repo_dir)
 
     if not repo_dir.is_dir():
-        _LOGGER.info("Cloning %s", key)
+        _LOGGER.info("Cloning %s", safe_key)
         _LOGGER.debug("Location: %s", repo_dir)
         try:
             cmd = ["git", "clone", "--depth=1"]
@@ -352,7 +366,7 @@ def clone_or_update(
 
     else:
         if refresh == NEVER_REFRESH or CORE.skip_external_update:
-            _LOGGER.debug("Skipping update for %s (refresh disabled)", key)
+            _LOGGER.debug("Skipping update for %s (refresh disabled)", safe_key)
             return repo_dir, None
 
         file_timestamp = Path(repo_dir / ".git" / "FETCH_HEAD")
@@ -376,7 +390,7 @@ def clone_or_update(
                     ["git", "rev-parse", "HEAD"], git_dir=repo_dir
                 )
 
-                _LOGGER.info("Updating %s", key)
+                _LOGGER.info("Updating %s", safe_key)
                 _LOGGER.debug("Location: %s", repo_dir)
 
                 # Stash local changes (if any)
@@ -414,13 +428,13 @@ def clone_or_update(
                 if not _recover_broken:
                     _LOGGER.error(
                         "Repository %s recovery failed, cannot retry (already attempted once)",
-                        key,
+                        safe_key,
                     )
                     raise
 
                 _LOGGER.warning(
                     "Repository %s has issues (%s), attempting recovery",
-                    key,
+                    safe_key,
                     err,
                 )
                 _LOGGER.info("Removing broken repository at %s", repo_dir)
@@ -430,7 +444,7 @@ def clone_or_update(
                 # Recursively call clone_or_update to re-clone
                 # Set _recover_broken=False to prevent infinite recursion
                 result = clone_or_update(
-                    url=url,
+                    url=original_url,
                     ref=ref,
                     refresh=refresh,
                     domain=domain,
@@ -440,11 +454,11 @@ def clone_or_update(
                     subpath=subpath,
                     _recover_broken=False,
                 )
-                _LOGGER.info("Repository %s successfully recovered", key)
+                _LOGGER.info("Repository %s successfully recovered", safe_key)
                 return result
 
             def revert():
-                _LOGGER.info("Reverting changes to %s -> %s", key, old_sha)
+                _LOGGER.info("Reverting changes to %s -> %s", safe_key, old_sha)
                 run_git_command(["git", "reset", "--hard", old_sha], git_dir=repo_dir)
 
             return repo_dir, revert

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -104,7 +104,9 @@ def run_git_command(
 
     _LOGGER.debug(
         "Running git command: %s (cwd=%s, isolated=%s)",
-        " ".join(cmd),
+        # Redact userinfo: clone URLs may embed credentials, and -v output is
+        # routinely pasted into public issues.
+        re.sub(r"://[^/@\s]+@", "://***@", " ".join(cmd)),
         cwd,
         git_dir is not None,
     )
@@ -164,86 +166,25 @@ def _remove_repo_dir(repo_dir: Path) -> None:
         rmtree(repo_dir)
 
 
-def _update_none_paths(repo_dir: Path) -> set[str]:
-    """Return the paths of submodules ``repo_dir`` declares with ``update = none``.
+def update_submodules(repo_dir: Path, key: str) -> None:
+    """Initialize/update every submodule the repository declares, recursively,
+    matching how PlatformIO clones libraries.
 
-    Git skips these on purpose during ``git submodule update --init`` (and
-    exits 0), so they must not be reported as failed initializations.
-    """
-    if not (repo_dir / ".gitmodules").is_file():
-        return set()
-    config = run_git_command(
-        ["git", "config", "-f", ".gitmodules", "--list"],
-        cwd=repo_dir,
-    )
-    paths: dict[str, str] = {}
-    skipped_names: set[str] = set()
-    for line in config.splitlines():
-        config_key, _, value = line.partition("=")
-        name, _, prop = config_key.removeprefix("submodule.").rpartition(".")
-        if prop == "path":
-            paths[name] = value
-        elif prop == "update" and value == "none":
-            skipped_names.add(name)
-    return {paths[name] for name in skipped_names & paths.keys()}
-
-
-def update_submodules(repo_dir: Path, submodules: list[str] | None, key: str) -> None:
-    """Initialize/update submodules of a freshly cloned or updated repo.
-
-    ``submodules`` is ``None`` to skip submodule handling entirely, an empty
-    list for every submodule the repository declares (recursively, matching
-    how PlatformIO clones libraries), or a list of specific submodule paths.
-    Most repositories declare no submodules, so the "every submodule" case
-    does nothing when there is no ``.gitmodules`` file. An explicit list is
-    always passed through so a path that does not exist in the repository
-    surfaces as a git error instead of being silently ignored, and each named
-    path is verified afterwards: a path left uninitialized (other than by an
-    ``update = none`` declaration, which git honors even for named paths)
-    raises ``GitRepositoryError``. Which submodules the "every submodule"
-    case populates is git's own policy (``update = none``,
-    ``submodule.active``, sparse checkouts); git's exit code is the error
-    signal there.
+    Most repositories declare no submodules, so this does nothing when there
+    is no ``.gitmodules`` file. Which submodules get populated is git's own
+    policy (``update = none``, ``submodule.active``, sparse checkouts);
+    git's exit code is the error signal.
 
     Runs with plain ``cwd`` rather than ``git_dir`` isolation, which the
     ``git submodule`` porcelain does not tolerate (see ``run_git_command``).
     """
-    if submodules is None:
+    if not (repo_dir / ".gitmodules").is_file():
         return
-    if not submodules and not (repo_dir / ".gitmodules").is_file():
-        return
-    _LOGGER.info(
-        "Updating submodules (%s) for %s",
-        ", ".join(submodules) if submodules else "all",
-        key,
-    )
-    recursive = [] if submodules else ["--recursive"]
+    _LOGGER.info("Updating submodules for %s", key)
     run_git_command(
-        ["git", "submodule", "update", "--init", *recursive, "--depth=1", "--"]
-        + submodules,
+        ["git", "submodule", "update", "--init", "--recursive", "--depth=1"],
         cwd=repo_dir,
     )
-    if not submodules:
-        return
-    # The caller named these paths; verify each was actually initialized. A
-    # status line starting with "-" is a declared but uninitialized
-    # submodule. Uninitialized lines carry no describe suffix, so everything
-    # after the SHA is the path (which may contain spaces).
-    status = run_git_command(
-        ["git", "submodule", "status", "--"] + submodules,
-        cwd=repo_dir,
-    )
-    missing = [
-        line[1:].split(" ", 1)[1]
-        for line in status.splitlines()
-        if line.startswith("-")
-    ]
-    if missing:
-        missing = [path for path in missing if path not in _update_none_paths(repo_dir)]
-    if missing:
-        raise GitRepositoryError(
-            f"Submodules ({', '.join(missing)}) for {key} were left uninitialized"
-        )
 
 
 def resolve_symlink_stub(repo_dir: Path, file_path: Path) -> Path | None:
@@ -340,7 +281,7 @@ def clone_or_update(
     domain: str,
     username: str = None,
     password: str = None,
-    submodules: list[str] | None = None,
+    init_submodules: bool = False,
     subpath: Path | None = None,
     _recover_broken: bool = True,
 ) -> tuple[Path, Callable[[], None] | None]:
@@ -385,7 +326,8 @@ def clone_or_update(
                     ["git", "reset", "--hard", "FETCH_HEAD"], git_dir=repo_dir
                 )
 
-            update_submodules(repo_dir, submodules, key)
+            if init_submodules:
+                update_submodules(repo_dir, key)
 
         except GitException:
             # Remove incomplete clone to prevent stale state. Without this,
@@ -461,11 +403,11 @@ def clone_or_update(
                     git_dir=repo_dir,
                 )
 
-                # Inside the try so a submodule failure (including the
-                # named-path verification) routes through the recovery
-                # re-clone below instead of leaving a repo that the refresh
-                # window would silently accept on the next run.
-                update_submodules(repo_dir, submodules, key)
+                # Inside the try so a submodule failure routes through the
+                # recovery re-clone below instead of leaving a repo that the
+                # refresh window would silently accept on the next run.
+                if init_submodules:
+                    update_submodules(repo_dir, key)
             except GitException as err:
                 # Repository is in a broken state or update failed
                 # Only attempt recovery once to prevent infinite recursion
@@ -494,7 +436,7 @@ def clone_or_update(
                     domain=domain,
                     username=username,
                     password=password,
-                    submodules=submodules,
+                    init_submodules=init_submodules,
                     subpath=subpath,
                     _recover_broken=False,
                 )

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -43,13 +43,17 @@ class GitRepositoryError(GitException):
     """Exception raised when a git repository is in an invalid state."""
 
 
-def run_git_command(cmd: list[str], git_dir: Path | None = None) -> str:
+def run_git_command(
+    cmd: list[str], git_dir: Path | None = None, *, cwd: Path | None = None
+) -> str:
     if git_dir is not None:
         _LOGGER.debug(
             "Running git command with repository isolation: %s (git_dir=%s)",
             " ".join(cmd),
             git_dir,
         )
+    elif cwd is not None:
+        _LOGGER.debug("Running git command: %s (cwd=%s)", " ".join(cmd), cwd)
     else:
         _LOGGER.debug("Running git command: %s", " ".join(cmd))
 
@@ -60,20 +64,28 @@ def run_git_command(cmd: list[str], git_dir: Path | None = None) -> str:
     # .git directory is corrupt. Without this, commands like 'git stash'
     # could accidentally operate on parent repositories (e.g., the main
     # ESPHome repo) instead of failing, causing data loss.
+    #
+    # ``cwd`` (without ``git_dir``) runs the command in that directory with
+    # no environment override. The ``git submodule`` porcelain needs this:
+    # on some installations (e.g. Windows setups where a shim hands git
+    # untranslated paths) it refuses to run when GIT_DIR/GIT_WORK_TREE are
+    # set, failing with "cannot be used without a working tree".
     env: dict[str, str] | None = None
-    cwd: str | None = None
+    run_cwd: str | None = None
     if git_dir is not None:
         env = {
             **subprocess.os.environ,
             "GIT_DIR": str(Path(git_dir) / ".git"),
             "GIT_WORK_TREE": str(git_dir),
         }
-        cwd = str(git_dir)
+        run_cwd = str(git_dir)
+    elif cwd is not None:
+        run_cwd = str(cwd)
 
     try:
         ret = subprocess.run(
             cmd,
-            cwd=cwd,
+            cwd=run_cwd,
             capture_output=True,
             check=False,
             close_fds=False,
@@ -121,6 +133,35 @@ def _remove_repo_dir(repo_dir: Path) -> None:
         _LOGGER.debug("Could not delete clone completion marker first: %s", err)
     if repo_dir.is_dir():
         rmtree(repo_dir)
+
+
+def _update_submodules(repo_dir: Path, submodules: list[str], key: str) -> None:
+    """Initialize/update submodules of a freshly cloned or updated repo.
+
+    An empty ``submodules`` list means "every submodule the repository
+    declares". Most repositories declare none, so in that case skip the git
+    call entirely when there is no ``.gitmodules`` file — running it would do
+    nothing, and the ``git submodule`` porcelain fails outright on some git
+    installations (see ``run_git_command``'s ``cwd`` note).
+
+    An explicit submodule list is always passed through so a path that does
+    not exist in the repository surfaces as a git error instead of being
+    silently ignored.
+    """
+    if not submodules and not (repo_dir / ".gitmodules").is_file():
+        return
+    _LOGGER.info(
+        "Initializing submodules (%s) for %s",
+        ", ".join(submodules) if submodules else "all",
+        key,
+    )
+    cmd = ["git", "submodule", "update", "--init", "--depth=1"]
+    if not submodules:
+        # "All submodules" requests come from PlatformIO library conversion;
+        # PlatformIO clones libraries with --recursive, so nested submodules
+        # are part of what such a library may rely on.
+        cmd.append("--recursive")
+    run_git_command(cmd + ["--"] + submodules, cwd=repo_dir)
 
 
 def resolve_symlink_stub(repo_dir: Path, file_path: Path) -> Path | None:
@@ -263,14 +304,7 @@ def clone_or_update(
                 )
 
             if submodules is not None:
-                _LOGGER.info(
-                    "Initializing submodules (%s) for %s", ", ".join(submodules), key
-                )
-                run_git_command(
-                    ["git", "submodule", "update", "--init", "--depth=1", "--"]
-                    + submodules,
-                    git_dir=repo_dir,
-                )
+                _update_submodules(repo_dir, submodules, key)
 
         except GitException:
             # Remove incomplete clone to prevent stale state. Without this,
@@ -381,14 +415,7 @@ def clone_or_update(
                 return result
 
             if submodules is not None:
-                _LOGGER.info(
-                    "Updating submodules (%s) for %s", ", ".join(submodules), key
-                )
-                run_git_command(
-                    ["git", "submodule", "update", "--init", "--depth=1", "--"]
-                    + submodules,
-                    git_dir=repo_dir,
-                )
+                _update_submodules(repo_dir, submodules, key)
 
             def revert():
                 _LOGGER.info("Reverting changes to %s -> %s", key, old_sha)

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -46,16 +46,22 @@ class GitRepositoryError(GitException):
 def run_git_command(
     cmd: list[str], git_dir: Path | None = None, *, cwd: Path | None = None
 ) -> str:
+    """Run a git command and return its stdout.
+
+    ``git_dir`` runs the command in that repository with GIT_DIR/GIT_WORK_TREE
+    isolation; ``cwd`` runs it in that directory without isolation. The two
+    are mutually exclusive and ``git_dir`` wins when both are given.
+    """
     if git_dir is not None:
         _LOGGER.debug(
             "Running git command with repository isolation: %s (git_dir=%s)",
             " ".join(cmd),
             git_dir,
         )
-    elif cwd is not None:
-        _LOGGER.debug("Running git command: %s (cwd=%s)", " ".join(cmd), cwd)
     else:
-        _LOGGER.debug("Running git command: %s", " ".join(cmd))
+        _LOGGER.debug(
+            "Running git command: %s%s", " ".join(cmd), f" (cwd={cwd})" if cwd else ""
+        )
 
     # Set up environment for repository isolation if git_dir is provided
     # Force git to only operate on this specific repository by setting
@@ -71,21 +77,18 @@ def run_git_command(
     # untranslated paths) it refuses to run when GIT_DIR/GIT_WORK_TREE are
     # set, failing with "cannot be used without a working tree".
     env: dict[str, str] | None = None
-    run_cwd: str | None = None
     if git_dir is not None:
         env = {
             **subprocess.os.environ,
             "GIT_DIR": str(Path(git_dir) / ".git"),
             "GIT_WORK_TREE": str(git_dir),
         }
-        run_cwd = str(git_dir)
-    elif cwd is not None:
-        run_cwd = str(cwd)
+        cwd = git_dir
 
     try:
         ret = subprocess.run(
             cmd,
-            cwd=run_cwd,
+            cwd=str(cwd) if cwd is not None else None,
             capture_output=True,
             check=False,
             close_fds=False,
@@ -135,19 +138,22 @@ def _remove_repo_dir(repo_dir: Path) -> None:
         rmtree(repo_dir)
 
 
-def _update_submodules(repo_dir: Path, submodules: list[str], key: str) -> None:
+def update_submodules(repo_dir: Path, submodules: list[str] | None, key: str) -> None:
     """Initialize/update submodules of a freshly cloned or updated repo.
 
-    An empty ``submodules`` list means "every submodule the repository
-    declares". Most repositories declare none, so in that case skip the git
-    call entirely when there is no ``.gitmodules`` file — running it would do
-    nothing, and the ``git submodule`` porcelain fails outright on some git
-    installations (see ``run_git_command``'s ``cwd`` note).
+    ``submodules`` is ``None`` to skip submodule handling entirely, an empty
+    list for every submodule the repository declares (recursively, matching
+    how PlatformIO clones libraries), or a list of specific submodule paths.
+    Most repositories declare no submodules, so the "every submodule" case
+    does nothing when there is no ``.gitmodules`` file. An explicit list is
+    always passed through so a path that does not exist in the repository
+    surfaces as a git error instead of being silently ignored.
 
-    An explicit submodule list is always passed through so a path that does
-    not exist in the repository surfaces as a git error instead of being
-    silently ignored.
+    Runs with plain ``cwd`` rather than ``git_dir`` isolation, which the
+    ``git submodule`` porcelain does not tolerate (see ``run_git_command``).
     """
+    if submodules is None:
+        return
     if not submodules and not (repo_dir / ".gitmodules").is_file():
         return
     _LOGGER.info(
@@ -155,13 +161,12 @@ def _update_submodules(repo_dir: Path, submodules: list[str], key: str) -> None:
         ", ".join(submodules) if submodules else "all",
         key,
     )
-    cmd = ["git", "submodule", "update", "--init", "--depth=1"]
-    if not submodules:
-        # "All submodules" requests come from PlatformIO library conversion;
-        # PlatformIO clones libraries with --recursive, so nested submodules
-        # are part of what such a library may rely on.
-        cmd.append("--recursive")
-    run_git_command(cmd + ["--"] + submodules, cwd=repo_dir)
+    recursive = [] if submodules else ["--recursive"]
+    run_git_command(
+        ["git", "submodule", "update", "--init", *recursive, "--depth=1", "--"]
+        + submodules,
+        cwd=repo_dir,
+    )
 
 
 def resolve_symlink_stub(repo_dir: Path, file_path: Path) -> Path | None:
@@ -303,8 +308,7 @@ def clone_or_update(
                     ["git", "reset", "--hard", "FETCH_HEAD"], git_dir=repo_dir
                 )
 
-            if submodules is not None:
-                _update_submodules(repo_dir, submodules, key)
+            update_submodules(repo_dir, submodules, key)
 
         except GitException:
             # Remove incomplete clone to prevent stale state. Without this,
@@ -414,8 +418,7 @@ def clone_or_update(
                 _LOGGER.info("Repository %s successfully recovered", key)
                 return result
 
-            if submodules is not None:
-                _update_submodules(repo_dir, submodules, key)
+            update_submodules(repo_dir, submodules, key)
 
             def revert():
                 _LOGGER.info("Reverting changes to %s -> %s", key, old_sha)

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 import hashlib
 import logging
+import os
 from pathlib import Path
 import re
 import subprocess
@@ -11,7 +12,7 @@ import urllib.parse
 
 import esphome.config_validation as cv
 from esphome.core import CORE, EsphomeError, TimePeriodSeconds
-from esphome.helpers import rmtree, write_file
+from esphome.helpers import add_git_ceiling_directory, rmtree, write_file
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,14 +33,16 @@ _CLONE_COMPLETE_MARKER = "esphome_clone_complete"
 # effects range from loud (`git clone` producing a bare-style directory with
 # no working tree) to silent (an ambient GIT_INDEX_FILE makes
 # `git submodule update --init` exit 0 without initializing anything).
-_GIT_REPO_SCOPING_ENV = (
-    "GIT_DIR",
-    "GIT_WORK_TREE",
-    "GIT_INDEX_FILE",
-    "GIT_OBJECT_DIRECTORY",
-    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-    "GIT_COMMON_DIR",
-    "GIT_NAMESPACE",
+_GIT_REPO_SCOPING_ENV = frozenset(
+    {
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_NAMESPACE",
+    }
 )
 
 
@@ -64,22 +67,12 @@ def run_git_command(
 ) -> str:
     """Run a git command and return its stdout.
 
-    ``git_dir`` runs the command in that repository with GIT_DIR/GIT_WORK_TREE
-    isolation; ``cwd`` runs it in that directory with those variables stripped
-    from the environment instead. The two are mutually exclusive and
-    ``git_dir`` wins when both are given.
+    The repository-scoping environment variables in ``_GIT_REPO_SCOPING_ENV``
+    are always stripped. ``git_dir`` additionally pins GIT_DIR/GIT_WORK_TREE
+    to that repository and runs the command there; ``cwd`` alone runs the
+    command in that directory with GIT_CEILING_DIRECTORIES capping repository
+    discovery at its parent.
     """
-    if git_dir is not None:
-        _LOGGER.debug(
-            "Running git command with repository isolation: %s (git_dir=%s)",
-            " ".join(cmd),
-            git_dir,
-        )
-    else:
-        _LOGGER.debug(
-            "Running git command: %s%s", " ".join(cmd), f" (cwd={cwd})" if cwd else ""
-        )
-
     # Every invocation starts from an environment with the repository-scoping
     # variables stripped (see _GIT_REPO_SCOPING_ENV) so a git hook or CI
     # wrapper invoking ESPHome can never redirect these commands to its own
@@ -101,20 +94,25 @@ def run_git_command(
     # keeps the parent-repo-walk protection instead: if the repo's .git is
     # missing or corrupt, git fails rather than discovering an enclosing
     # repository.
-    env = {
-        k: v for k, v in subprocess.os.environ.items() if k not in _GIT_REPO_SCOPING_ENV
-    }
+    env = {k: v for k, v in os.environ.items() if k not in _GIT_REPO_SCOPING_ENV}
     if git_dir is not None:
         env["GIT_DIR"] = str(Path(git_dir) / ".git")
         env["GIT_WORK_TREE"] = str(git_dir)
         cwd = git_dir
     elif cwd is not None:
-        env["GIT_CEILING_DIRECTORIES"] = str(Path(cwd).absolute().parent)
+        add_git_ceiling_directory(env, Path(cwd).absolute().parent)
+
+    _LOGGER.debug(
+        "Running git command: %s (cwd=%s, isolated=%s)",
+        " ".join(cmd),
+        cwd,
+        git_dir is not None,
+    )
 
     try:
         ret = subprocess.run(
             cmd,
-            cwd=str(cwd) if cwd is not None else None,
+            cwd=cwd,
             capture_output=True,
             check=False,
             close_fds=False,
@@ -193,6 +191,21 @@ def update_submodules(repo_dir: Path, submodules: list[str] | None, key: str) ->
         + submodules,
         cwd=repo_dir,
     )
+    # Verify the update actually initialized what it was asked to; a status
+    # line starting with "-" is a declared but uninitialized submodule. The
+    # porcelain can exit 0 without doing anything, and the resulting empty
+    # directories would otherwise only surface much later as opaque build
+    # errors.
+    status = run_git_command(
+        ["git", "submodule", "status", *recursive, "--"] + submodules,
+        cwd=repo_dir,
+    )
+    if missing := [
+        line.split()[1] for line in status.splitlines() if line.startswith("-")
+    ]:
+        raise GitRepositoryError(
+            f"Submodules ({', '.join(missing)}) for {key} failed to initialize"
+        )
 
 
 def resolve_symlink_stub(repo_dir: Path, file_path: Path) -> Path | None:

--- a/esphome/platformio/library.py
+++ b/esphome/platformio/library.py
@@ -134,7 +134,7 @@ class GitSource(Source):
             ref=self.ref,
             refresh=git.NEVER_REFRESH if not force else None,
             domain=domain,
-            submodules=[],
+            init_submodules=True,
             subpath=Path(dir_suffix),
         )
         return path

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -144,6 +144,10 @@ def _make_idf_tree(framework_path: Path) -> None:
     # A real ESP-IDF checkout always declares submodules; update_submodules
     # skips the git call when this file is missing.
     (framework_path / ".gitmodules").write_text("# stub\n")
+    # Vendored submodule content the sanity check verifies.
+    mbedtls = framework_path / "components" / "mbedtls" / "mbedtls"
+    mbedtls.mkdir(parents=True)
+    (mbedtls / "CMakeLists.txt").write_text("# stub\n")
 
 
 def test_clone_idf_with_submodules_without_ref(tmp_path: Path) -> None:
@@ -217,34 +221,53 @@ def test_clone_idf_with_submodules_raises_when_tree_missing(
         )
 
 
-def test_clone_idf_with_submodules_raises_when_gitmodules_missing(
+def test_clone_idf_accepts_flattened_fork_without_gitmodules(
     tmp_path: Path,
 ) -> None:
-    """A truncated clone without .gitmodules must fail loudly.
+    """A fork that vendors components in-tree instead of as submodules is valid.
 
-    update_submodules silently skips when .gitmodules is absent, so without
-    the sanity check the missing vendored components would only surface much
-    later as an opaque CMake error.
+    No .gitmodules means the submodule step is skipped, and the sanity check
+    verifies the vendored content directly rather than requiring .gitmodules.
     """
     framework_path = tmp_path / "idf"
     framework_path.mkdir()
-    (framework_path / "tools").mkdir()
-    (framework_path / "tools" / "idf_tools.py").write_text("# stub\n")
-    # Deliberately no .gitmodules.
+    _make_idf_tree(framework_path)
+    (framework_path / ".gitmodules").unlink()
+
+    with patch("esphome.git.run_git_command", return_value="") as run_git_command_mock:
+        _clone_idf_with_submodules(
+            framework_path,
+            "https://github.com/example/flattened-esp-idf.git",
+            None,
+        )
+
+    calls = [c.args[0] for c in run_git_command_mock.call_args_list]
+    assert not any(c[1] == "submodule" for c in calls)
+
+
+def test_clone_idf_raises_when_vendored_components_missing(
+    tmp_path: Path,
+) -> None:
+    """A checkout without the vendored submodule content must fail loudly.
+
+    Covers both a truncated clone and a submodule init that silently did
+    nothing; either would otherwise surface much later as an opaque CMake
+    error, and the tree would stay broken until esphome clean.
+    """
+    framework_path = tmp_path / "idf"
+    framework_path.mkdir()
+    _make_idf_tree(framework_path)
+    (framework_path / "components" / "mbedtls" / "mbedtls" / "CMakeLists.txt").unlink()
 
     with (
-        patch("esphome.git.run_git_command", return_value="") as run_git_command_mock,
-        pytest.raises(RuntimeError, match="no usable ESP-IDF tree"),
+        patch("esphome.git.run_git_command", return_value=""),
+        pytest.raises(RuntimeError, match="missing its vendored components"),
     ):
         _clone_idf_with_submodules(
             framework_path,
             "https://github.com/espressif/esp-idf.git",
-            None,
+            "v5.5.4",
         )
-
-    # The submodule step was skipped rather than run against the broken tree.
-    calls = [c.args[0] for c in run_git_command_mock.call_args_list]
-    assert not any(c[1] == "submodule" for c in calls)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -141,6 +141,9 @@ def _make_idf_tree(framework_path: Path) -> None:
     """Create the minimum tree _clone_idf_with_submodules sanity-checks for."""
     (framework_path / "tools").mkdir(parents=True)
     (framework_path / "tools" / "idf_tools.py").write_text("# stub\n")
+    # A real ESP-IDF checkout always declares submodules; update_submodules
+    # skips the git call when this file is missing.
+    (framework_path / ".gitmodules").write_text("# stub\n")
 
 
 def test_clone_idf_with_submodules_without_ref(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -160,7 +160,7 @@ def test_clone_idf_with_submodules_without_ref(tmp_path: Path) -> None:
             framework_path, "https://github.com/espressif/esp-idf.git", None
         )
 
-    # No ref -> just clone + submodule update/status, no fetch/reset.
+    # No ref -> just clone + submodule update, no fetch/reset.
     calls = [c.args[0] for c in run_git_command_mock.call_args_list]
     assert calls[0] == [
         "git",
@@ -170,8 +170,7 @@ def test_clone_idf_with_submodules_without_ref(tmp_path: Path) -> None:
         "https://github.com/espressif/esp-idf.git",
         str(framework_path),
     ]
-    assert calls[-2][:5] == ["git", "submodule", "update", "--init", "--recursive"]
-    assert calls[-1][:3] == ["git", "submodule", "status"]
+    assert calls[-1][:5] == ["git", "submodule", "update", "--init", "--recursive"]
     assert not any(c[1] == "fetch" for c in calls)
     assert not any(c[1] == "reset" for c in calls)
 
@@ -189,7 +188,7 @@ def test_clone_idf_with_submodules_with_ref(tmp_path: Path) -> None:
         )
 
     calls = [c.args[0] for c in run_git_command_mock.call_args_list]
-    # clone, fetch ref, reset hard, submodule update, submodule status
+    # clone, fetch ref, reset hard, submodule update
     assert calls[0][:2] == ["git", "clone"]
     assert calls[1] == [
         "git",
@@ -201,7 +200,6 @@ def test_clone_idf_with_submodules_with_ref(tmp_path: Path) -> None:
     ]
     assert calls[2] == ["git", "reset", "--hard", "FETCH_HEAD"]
     assert calls[3][:5] == ["git", "submodule", "update", "--init", "--recursive"]
-    assert calls[4][:3] == ["git", "submodule", "status"]
 
 
 def test_clone_idf_with_submodules_raises_when_tree_missing(

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -217,6 +217,36 @@ def test_clone_idf_with_submodules_raises_when_tree_missing(
         )
 
 
+def test_clone_idf_with_submodules_raises_when_gitmodules_missing(
+    tmp_path: Path,
+) -> None:
+    """A truncated clone without .gitmodules must fail loudly.
+
+    update_submodules silently skips when .gitmodules is absent, so without
+    the sanity check the missing vendored components would only surface much
+    later as an opaque CMake error.
+    """
+    framework_path = tmp_path / "idf"
+    framework_path.mkdir()
+    (framework_path / "tools").mkdir()
+    (framework_path / "tools" / "idf_tools.py").write_text("# stub\n")
+    # Deliberately no .gitmodules.
+
+    with (
+        patch("esphome.git.run_git_command", return_value="") as run_git_command_mock,
+        pytest.raises(RuntimeError, match="no usable ESP-IDF tree"),
+    ):
+        _clone_idf_with_submodules(
+            framework_path,
+            "https://github.com/espressif/esp-idf.git",
+            None,
+        )
+
+    # The submodule step was skipped rather than run against the broken tree.
+    calls = [c.args[0] for c in run_git_command_mock.call_args_list]
+    assert not any(c[1] == "submodule" for c in calls)
+
+
 # ---------------------------------------------------------------------------
 # Helpers for _tar_extract_all hard-link prefix-stripping tests
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -137,17 +137,17 @@ def test_parse_git_source_rejected(source: str) -> None:
     assert _parse_git_source(source) is None
 
 
-def _make_idf_tree(framework_path: Path) -> None:
-    """Create the minimum tree _clone_idf_with_submodules sanity-checks for."""
+def _make_idf_tree(framework_path: Path, *, gitmodules: bool = True) -> None:
+    """Create the minimum tree _clone_idf_with_submodules sanity-checks for.
+
+    ``gitmodules=False`` simulates a fork that vendors components in-tree
+    instead of declaring submodules; update_submodules skips the git call
+    when that file is missing.
+    """
     (framework_path / "tools").mkdir(parents=True)
     (framework_path / "tools" / "idf_tools.py").write_text("# stub\n")
-    # A real ESP-IDF checkout always declares submodules; update_submodules
-    # skips the git call when this file is missing.
-    (framework_path / ".gitmodules").write_text("# stub\n")
-    # Vendored submodule content the sanity check verifies.
-    mbedtls = framework_path / "components" / "mbedtls" / "mbedtls"
-    mbedtls.mkdir(parents=True)
-    (mbedtls / "CMakeLists.txt").write_text("# stub\n")
+    if gitmodules:
+        (framework_path / ".gitmodules").write_text("# stub\n")
 
 
 def test_clone_idf_with_submodules_without_ref(tmp_path: Path) -> None:
@@ -160,7 +160,7 @@ def test_clone_idf_with_submodules_without_ref(tmp_path: Path) -> None:
             framework_path, "https://github.com/espressif/esp-idf.git", None
         )
 
-    # No ref -> just clone + submodule update, no fetch/reset.
+    # No ref -> just clone + submodule update/status, no fetch/reset.
     calls = [c.args[0] for c in run_git_command_mock.call_args_list]
     assert calls[0] == [
         "git",
@@ -170,7 +170,8 @@ def test_clone_idf_with_submodules_without_ref(tmp_path: Path) -> None:
         "https://github.com/espressif/esp-idf.git",
         str(framework_path),
     ]
-    assert calls[-1][:5] == ["git", "submodule", "update", "--init", "--recursive"]
+    assert calls[-2][:5] == ["git", "submodule", "update", "--init", "--recursive"]
+    assert calls[-1][:3] == ["git", "submodule", "status"]
     assert not any(c[1] == "fetch" for c in calls)
     assert not any(c[1] == "reset" for c in calls)
 
@@ -188,7 +189,7 @@ def test_clone_idf_with_submodules_with_ref(tmp_path: Path) -> None:
         )
 
     calls = [c.args[0] for c in run_git_command_mock.call_args_list]
-    # clone, fetch ref, reset hard, submodule update
+    # clone, fetch ref, reset hard, submodule update, submodule status
     assert calls[0][:2] == ["git", "clone"]
     assert calls[1] == [
         "git",
@@ -200,6 +201,7 @@ def test_clone_idf_with_submodules_with_ref(tmp_path: Path) -> None:
     ]
     assert calls[2] == ["git", "reset", "--hard", "FETCH_HEAD"]
     assert calls[3][:5] == ["git", "submodule", "update", "--init", "--recursive"]
+    assert calls[4][:3] == ["git", "submodule", "status"]
 
 
 def test_clone_idf_with_submodules_raises_when_tree_missing(
@@ -226,13 +228,11 @@ def test_clone_idf_accepts_flattened_fork_without_gitmodules(
 ) -> None:
     """A fork that vendors components in-tree instead of as submodules is valid.
 
-    No .gitmodules means the submodule step is skipped, and the sanity check
-    verifies the vendored content directly rather than requiring .gitmodules.
+    No .gitmodules means the submodule step is skipped entirely.
     """
     framework_path = tmp_path / "idf"
     framework_path.mkdir()
-    _make_idf_tree(framework_path)
-    (framework_path / ".gitmodules").unlink()
+    _make_idf_tree(framework_path, gitmodules=False)
 
     with patch("esphome.git.run_git_command", return_value="") as run_git_command_mock:
         _clone_idf_with_submodules(
@@ -243,31 +243,6 @@ def test_clone_idf_accepts_flattened_fork_without_gitmodules(
 
     calls = [c.args[0] for c in run_git_command_mock.call_args_list]
     assert not any(c[1] == "submodule" for c in calls)
-
-
-def test_clone_idf_raises_when_vendored_components_missing(
-    tmp_path: Path,
-) -> None:
-    """A checkout without the vendored submodule content must fail loudly.
-
-    Covers both a truncated clone and a submodule init that silently did
-    nothing; either would otherwise surface much later as an opaque CMake
-    error, and the tree would stay broken until esphome clean.
-    """
-    framework_path = tmp_path / "idf"
-    framework_path.mkdir()
-    _make_idf_tree(framework_path)
-    (framework_path / "components" / "mbedtls" / "mbedtls" / "CMakeLists.txt").unlink()
-
-    with (
-        patch("esphome.git.run_git_command", return_value=""),
-        pytest.raises(RuntimeError, match="missing its vendored components"),
-    ):
-        _clone_idf_with_submodules(
-            framework_path,
-            "https://github.com/espressif/esp-idf.git",
-            "v5.5.4",
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -240,7 +240,12 @@ def test_run_git_command_without_git_dir(mock_subprocess_run: Mock) -> None:
 def test_run_git_command_with_cwd_runs_in_dir_without_isolation(
     tmp_path: Path, mock_subprocess_run: Mock
 ) -> None:
-    """The cwd parameter sets the working directory without GIT_DIR/GIT_WORK_TREE."""
+    """The cwd parameter sets the working directory without GIT_DIR/GIT_WORK_TREE.
+
+    Ambient GIT_DIR/GIT_WORK_TREE (e.g. from a git hook or CI wrapper) must be
+    stripped too, and GIT_CEILING_DIRECTORIES must stop git from walking up to
+    an enclosing repository if the target repo's .git is missing or corrupt.
+    """
     repo_dir = tmp_path / "test_repo"
     repo_dir.mkdir()
 
@@ -250,13 +255,16 @@ def test_run_git_command_with_cwd_runs_in_dir_without_isolation(
         stderr=b"",
     )
 
-    result = git.run_git_command(["git", "submodule", "update"], cwd=repo_dir)
+    with patch.dict(
+        os.environ, {"GIT_DIR": "/ambient/.git", "GIT_WORK_TREE": "/ambient"}
+    ):
+        result = git.run_git_command(["git", "submodule", "update"], cwd=repo_dir)
 
     call_args = mock_subprocess_run.call_args
-    env = call_args[1].get("env")
-    if env is not None:
-        assert "GIT_DIR" not in env
-        assert "GIT_WORK_TREE" not in env
+    env = call_args[1]["env"]
+    assert "GIT_DIR" not in env
+    assert "GIT_WORK_TREE" not in env
+    assert env["GIT_CEILING_DIRECTORIES"] == str(repo_dir.parent)
     assert call_args[1]["cwd"] == str(repo_dir)
     assert result == "test output"
 

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -71,17 +71,38 @@ def _simulate_cloned_repo(repo_dir: Path) -> None:
     (repo_dir / ".git").mkdir(exist_ok=True)
 
 
-def _make_clone_side_effect(repo_dir: Path) -> Callable[..., str]:
-    """Return a run_git_command side effect whose clone creates the repo dir."""
+def _make_clone_side_effect(
+    repo_dir: Path, gitmodules: bool = False
+) -> Callable[..., str]:
+    """Return a run_git_command side effect whose clone creates the repo dir.
+
+    With ``gitmodules`` the cloned repo also declares submodules.
+    """
 
     def git_command_side_effect(
         cmd: list[str], cwd: str | None = None, **kwargs: Any
     ) -> str:
         if _get_git_command_type(cmd) == "clone":
             _simulate_cloned_repo(repo_dir)
+            if gitmodules:
+                (repo_dir / ".gitmodules").write_text("test")
         return ""
 
     return git_command_side_effect
+
+
+def _submodule_calls(mock: Mock) -> list[Any]:
+    """Return the mock's `git submodule` calls."""
+    return [
+        c for c in mock.call_args_list if _get_git_command_type(c[0][0]) == "submodule"
+    ]
+
+
+def _assert_submodule_runs_without_isolation(call: Any, repo_dir: Path) -> None:
+    """Assert a git submodule call ran with plain cwd, not GIT_DIR/GIT_WORK_TREE
+    isolation, which breaks the submodule porcelain on some installations."""
+    assert call.kwargs.get("git_dir") is None
+    assert call.kwargs.get("cwd") == repo_dir
 
 
 def test_run_git_command_success(tmp_path: Path) -> None:
@@ -1166,15 +1187,7 @@ def test_clone_with_submodules_uses_shallow_submodule_update(
     domain = "test"
     repo_dir = _compute_repo_dir(url, None, domain)
 
-    def git_command_side_effect(
-        cmd: list[str], cwd: str | None = None, **kwargs: Any
-    ) -> str:
-        if _get_git_command_type(cmd) == "clone":
-            repo_dir.mkdir(parents=True, exist_ok=True)
-            (repo_dir / ".git").mkdir(exist_ok=True)
-        return ""
-
-    mock_run_git_command.side_effect = git_command_side_effect
+    mock_run_git_command.side_effect = _make_clone_side_effect(repo_dir)
 
     git.clone_or_update(
         url=url,
@@ -1184,9 +1197,7 @@ def test_clone_with_submodules_uses_shallow_submodule_update(
         submodules=["components/foo"],
     )
 
-    submodule_calls = [
-        c for c in mock_run_git_command.call_args_list if "submodule" in c[0][0]
-    ]
+    submodule_calls = _submodule_calls(mock_run_git_command)
     assert len(submodule_calls) == 1
     cmd = submodule_calls[0][0][0]
     assert "--depth=1" in cmd
@@ -1194,10 +1205,7 @@ def test_clone_with_submodules_uses_shallow_submodule_update(
     # The `--` terminator must precede the submodule paths so a path
     # beginning with `-` cannot be parsed as an option.
     assert cmd.index("--") < cmd.index("components/foo")
-    # git submodule must run with plain cwd, not GIT_DIR/GIT_WORK_TREE
-    # isolation, which breaks the submodule porcelain on some installations.
-    assert submodule_calls[0].kwargs.get("git_dir") is None
-    assert submodule_calls[0].kwargs.get("cwd") == repo_dir
+    _assert_submodule_runs_without_isolation(submodule_calls[0], repo_dir)
 
 
 def test_refresh_fetch_is_shallow(tmp_path: Path, mock_run_git_command: Mock) -> None:
@@ -1245,20 +1253,20 @@ def test_refresh_submodule_update_is_shallow(
         submodules=["components/foo"],
     )
 
-    submodule_calls = [
-        c for c in mock_run_git_command.call_args_list if "submodule" in c[0][0]
-    ]
+    submodule_calls = _submodule_calls(mock_run_git_command)
     assert len(submodule_calls) == 1
     cmd = submodule_calls[0][0][0]
     assert "--depth=1" in cmd
     assert "components/foo" in cmd
     assert cmd.index("--") < cmd.index("components/foo")
-    assert submodule_calls[0].kwargs.get("git_dir") is None
-    assert submodule_calls[0].kwargs.get("cwd") == repo_dir
+    _assert_submodule_runs_without_isolation(submodule_calls[0], repo_dir)
 
 
-def test_clone_all_submodules_skipped_without_gitmodules(
-    tmp_path: Path, mock_run_git_command: Mock
+@pytest.mark.parametrize(
+    "refresh", [None, TimePeriodSeconds(days=1)], ids=["clone", "refresh"]
+)
+def test_all_submodules_skipped_without_gitmodules(
+    tmp_path: Path, mock_run_git_command: Mock, refresh: TimePeriodSeconds | None
 ) -> None:
     """An empty submodule list ("all") is a no-op for repos with no .gitmodules.
 
@@ -1274,21 +1282,28 @@ def test_clone_all_submodules_skipped_without_gitmodules(
     domain = "test"
     repo_dir = _compute_repo_dir(url, None, domain)
 
-    mock_run_git_command.side_effect = _make_clone_side_effect(repo_dir)
+    if refresh is None:
+        mock_run_git_command.side_effect = _make_clone_side_effect(repo_dir)
+    else:
+        _setup_old_repo(repo_dir)
+        mock_run_git_command.return_value = "abc123"
 
     git.clone_or_update(
         url=url,
         ref=None,
-        refresh=None,
+        refresh=refresh,
         domain=domain,
         submodules=[],
     )
 
-    assert not any("submodule" in c[0][0] for c in mock_run_git_command.call_args_list)
+    assert not _submodule_calls(mock_run_git_command)
 
 
-def test_clone_all_submodules_updated_with_gitmodules(
-    tmp_path: Path, mock_run_git_command: Mock
+@pytest.mark.parametrize(
+    "refresh", [None, TimePeriodSeconds(days=1)], ids=["clone", "refresh"]
+)
+def test_all_submodules_updated_with_gitmodules(
+    tmp_path: Path, mock_run_git_command: Mock, refresh: TimePeriodSeconds | None
 ) -> None:
     """An empty submodule list initializes all submodules when .gitmodules exists."""
     CORE.config_path = tmp_path / "test.yaml"
@@ -1297,91 +1312,31 @@ def test_clone_all_submodules_updated_with_gitmodules(
     domain = "test"
     repo_dir = _compute_repo_dir(url, None, domain)
 
-    def git_command_side_effect(
-        cmd: list[str], cwd: str | None = None, **kwargs: Any
-    ) -> str:
-        if _get_git_command_type(cmd) == "clone":
-            _simulate_cloned_repo(repo_dir)
-            (repo_dir / ".gitmodules").write_text("test")
-        return ""
-
-    mock_run_git_command.side_effect = git_command_side_effect
+    if refresh is None:
+        mock_run_git_command.side_effect = _make_clone_side_effect(
+            repo_dir, gitmodules=True
+        )
+    else:
+        _setup_old_repo(repo_dir)
+        (repo_dir / ".gitmodules").write_text("test")
+        mock_run_git_command.return_value = "abc123"
 
     git.clone_or_update(
         url=url,
         ref=None,
-        refresh=None,
+        refresh=refresh,
         domain=domain,
         submodules=[],
     )
 
-    submodule_calls = [
-        c for c in mock_run_git_command.call_args_list if "submodule" in c[0][0]
-    ]
+    submodule_calls = _submodule_calls(mock_run_git_command)
     assert len(submodule_calls) == 1
     cmd = submodule_calls[0][0][0]
     assert "--depth=1" in cmd
     # "All submodules" mirrors PlatformIO's recursive library clones.
     assert "--recursive" in cmd
     assert cmd[-1] == "--"
-    assert submodule_calls[0].kwargs.get("git_dir") is None
-    assert submodule_calls[0].kwargs.get("cwd") == repo_dir
-
-
-def test_refresh_all_submodules_skipped_without_gitmodules(
-    tmp_path: Path, mock_run_git_command: Mock
-) -> None:
-    """The refresh path also skips the "all submodules" no-op."""
-    CORE.config_path = tmp_path / "test.yaml"
-
-    url = "https://github.com/test/repo"
-    domain = "test"
-    repo_dir = _compute_repo_dir(url, None, domain)
-
-    _setup_old_repo(repo_dir)
-    mock_run_git_command.return_value = "abc123"
-
-    git.clone_or_update(
-        url=url,
-        ref=None,
-        refresh=TimePeriodSeconds(days=1),
-        domain=domain,
-        submodules=[],
-    )
-
-    assert not any("submodule" in c[0][0] for c in mock_run_git_command.call_args_list)
-
-
-def test_refresh_all_submodules_updated_with_gitmodules(
-    tmp_path: Path, mock_run_git_command: Mock
-) -> None:
-    """The refresh path updates all submodules when .gitmodules exists."""
-    CORE.config_path = tmp_path / "test.yaml"
-
-    url = "https://github.com/test/repo"
-    domain = "test"
-    repo_dir = _compute_repo_dir(url, None, domain)
-
-    _setup_old_repo(repo_dir)
-    (repo_dir / ".gitmodules").write_text("test")
-    mock_run_git_command.return_value = "abc123"
-
-    git.clone_or_update(
-        url=url,
-        ref=None,
-        refresh=TimePeriodSeconds(days=1),
-        domain=domain,
-        submodules=[],
-    )
-
-    submodule_calls = [
-        c for c in mock_run_git_command.call_args_list if "submodule" in c[0][0]
-    ]
-    assert len(submodule_calls) == 1
-    cmd = submodule_calls[0][0][0]
-    assert "--recursive" in cmd
-    assert submodule_calls[0].kwargs.get("git_dir") is None
-    assert submodule_calls[0].kwargs.get("cwd") == repo_dir
+    _assert_submodule_runs_without_isolation(submodule_calls[0], repo_dir)
 
 
 def test_refresh_picks_up_new_remote_commits(

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -238,17 +238,28 @@ def test_run_git_command_without_git_dir(mock_subprocess_run: Mock) -> None:
     assert result == "Cloning into 'test_repo'..."
 
 
+@pytest.mark.parametrize("relative", [False, True], ids=["absolute", "relative"])
 def test_run_git_command_with_cwd_runs_in_dir_without_isolation(
-    tmp_path: Path, mock_subprocess_run: Mock
+    tmp_path: Path,
+    mock_subprocess_run: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    relative: bool,
 ) -> None:
     """The cwd parameter sets the working directory without GIT_DIR/GIT_WORK_TREE.
 
     Ambient GIT_DIR/GIT_WORK_TREE (e.g. from a git hook or CI wrapper) must be
     stripped too, and GIT_CEILING_DIRECTORIES must stop git from walking up to
     an enclosing repository if the target repo's .git is missing or corrupt.
+    Git silently ignores a relative ceiling entry, so the variable must come
+    out absolute even when the given cwd is relative.
     """
     repo_dir = tmp_path / "test_repo"
     repo_dir.mkdir()
+    if relative:
+        monkeypatch.chdir(tmp_path)
+        cwd_arg = Path("test_repo")
+    else:
+        cwd_arg = repo_dir
 
     mock_subprocess_run.return_value = Mock(
         returncode=0,
@@ -264,15 +275,17 @@ def test_run_git_command_with_cwd_runs_in_dir_without_isolation(
             "GIT_INDEX_FILE": "/ambient/.git/index",
         },
     ):
-        result = git.run_git_command(["git", "submodule", "update"], cwd=repo_dir)
+        result = git.run_git_command(["git", "submodule", "update"], cwd=cwd_arg)
 
     call_args = mock_subprocess_run.call_args
     env = call_args[1]["env"]
     assert "GIT_DIR" not in env
     assert "GIT_WORK_TREE" not in env
     assert "GIT_INDEX_FILE" not in env
-    assert env["GIT_CEILING_DIRECTORIES"] == str(repo_dir.parent)
-    assert call_args[1]["cwd"] == repo_dir
+    ceiling = Path(env["GIT_CEILING_DIRECTORIES"])
+    assert ceiling.is_absolute()
+    assert ceiling.samefile(tmp_path)
+    assert call_args[1]["cwd"] == cwd_arg
     assert result == "test output"
 
 
@@ -1489,6 +1502,56 @@ def test_clone_or_update_real_git_initializes_submodules(tmp_path: Path) -> None
         )
 
     assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
+
+
+def test_clone_or_update_real_git_honors_update_none_submodule(
+    tmp_path: Path,
+) -> None:
+    """End-to-end with real git: a submodule declared `update = none` is not
+    reported as a failed initialization.
+
+    Git deliberately skips such submodules during `git submodule update
+    --init` and leaves them uninitialized; the status verification must not
+    turn that into an error while still checking out the regular submodules.
+    """
+    CORE.config_path = tmp_path / "test.yaml"
+
+    sub_repo = tmp_path / "sub"
+    _make_real_repo(sub_repo, "sub_file.txt")
+
+    upstream = tmp_path / "upstream"
+    _make_real_repo(upstream, "README.md")
+    _real_git("submodule", "add", str(sub_repo), "vendor/sub", cwd=upstream)
+    _real_git("submodule", "add", str(sub_repo), "vendor/skipped", cwd=upstream)
+    _real_git(
+        "config",
+        "-f",
+        ".gitmodules",
+        "submodule.vendor/skipped.update",
+        "none",
+        cwd=upstream,
+    )
+    _real_git("add", ".gitmodules", cwd=upstream)
+    _real_git("commit", "-q", "-m", "add submodules", cwd=upstream)
+
+    with patch.dict(
+        os.environ,
+        {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "protocol.file.allow",
+            "GIT_CONFIG_VALUE_0": "always",
+        },
+    ):
+        repo_dir, _ = git.clone_or_update(
+            url=str(upstream),
+            ref=None,
+            refresh=None,
+            domain="test_e2e",
+            submodules=[],
+        )
+
+    assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
+    assert not (repo_dir / "vendor" / "skipped" / "sub_file.txt").exists()
 
 
 def test_refresh_picks_up_new_remote_commits(

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -1466,6 +1466,44 @@ def test_uninitialized_named_submodule_raises(
     assert not repo_dir.is_dir()
 
 
+def test_refresh_uninitialized_named_submodule_recovers_then_raises(
+    tmp_path: Path, mock_run_git_command: Mock
+) -> None:
+    """A refresh-path verification failure routes through the recovery re-clone.
+
+    The broken repo is removed and re-cloned; when verification fails again on
+    the fresh clone the cache entry is removed and the error propagates,
+    instead of leaving behind a repo the refresh window would silently accept
+    on the next run.
+    """
+    CORE.config_path = tmp_path / "test.yaml"
+
+    url = "https://github.com/test/repo"
+    domain = "test"
+    repo_dir = _compute_repo_dir(url, None, domain)
+
+    _setup_old_repo(repo_dir)
+    mock_run_git_command.side_effect = _make_uninitialized_submodule_side_effect(
+        repo_dir, gitmodules_config=""
+    )
+
+    with pytest.raises(git.GitRepositoryError, match="vendor/sub"):
+        git.clone_or_update(
+            url=url,
+            ref=None,
+            refresh=TimePeriodSeconds(days=1),
+            domain=domain,
+            submodules=["vendor/sub"],
+        )
+
+    assert not repo_dir.is_dir()
+    # Recovery removed the repo and re-cloned before failing again.
+    assert any(
+        _get_git_command_type(c[0][0]) == "clone"
+        for c in mock_run_git_command.call_args_list
+    )
+
+
 def test_named_submodule_with_update_none_not_reported(
     tmp_path: Path, mock_run_git_command: Mock
 ) -> None:
@@ -1618,14 +1656,14 @@ def test_clone_or_update_real_git_initializes_submodules(tmp_path: Path) -> None
 def test_clone_or_update_real_git_honors_update_none_submodule(
     tmp_path: Path,
 ) -> None:
-    """End-to-end with real git: submodules declared `update = none` are not
-    reported as failed initializations, at any nesting level.
+    """End-to-end with real git: submodules declared `update = none` stay skipped.
 
-    Git deliberately skips such submodules during `git submodule update
-    --init` and leaves them uninitialized; the status verification must not
-    turn that into an error while still checking out the regular submodules.
-    The nested case matters because the skipped submodule's declaration lives
-    in the intermediate submodule's .gitmodules, not the superproject's.
+    The all-submodules clone shows git itself skipping the declared paths at
+    both nesting levels while the regular submodules check out. The follow-up
+    call naming the skipped path exercises ESPHome's carve-out: the status
+    verification sees the path uninitialized and `_update_none_paths` (parsing
+    real `git config -f .gitmodules --list` output) excuses it instead of
+    raising.
     """
     CORE.config_path = tmp_path / "test.yaml"
 
@@ -1652,12 +1690,25 @@ def test_clone_or_update_real_git_honors_update_none_submodule(
             submodules=[],
         )
 
-    assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
+        assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
+        assert not (repo_dir / "vendor" / "skipped" / "sub_file.txt").exists()
+        assert (repo_dir / "vendor" / "mid" / "mid_file.txt").is_file()
+        assert not (
+            repo_dir / "vendor" / "mid" / "vendor" / "leaf" / "sub_file.txt"
+        ).exists()
+
+        # Naming the skipped path must not raise: the verification sees it
+        # uninitialized and the real .gitmodules parse excuses it.
+        repo_dir_again, _ = git.clone_or_update(
+            url=str(upstream),
+            ref=None,
+            refresh=None,
+            domain="test_e2e",
+            submodules=["vendor/skipped"],
+        )
+
+    assert repo_dir_again == repo_dir
     assert not (repo_dir / "vendor" / "skipped" / "sub_file.txt").exists()
-    assert (repo_dir / "vendor" / "mid" / "mid_file.txt").is_file()
-    assert not (
-        repo_dir / "vendor" / "mid" / "vendor" / "leaf" / "sub_file.txt"
-    ).exists()
 
 
 def test_refresh_picks_up_new_remote_commits(

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -124,16 +124,16 @@ def test_run_git_command_success(tmp_path: Path) -> None:
 
 
 def test_run_git_command_debug_log_redacts_credentials(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
+    tmp_path: Path, mock_subprocess_run: Mock, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Embedded URL credentials never reach the debug log; -v output is
-    routinely pasted into public issues."""
-    repo_dir = tmp_path / "repo"
-    repo_dir.mkdir()
+    routinely pasted into public issues. subprocess is mocked so no real
+    git ever sees the URL (the path is not creatable on Windows)."""
+    mock_subprocess_run.return_value = Mock(returncode=0, stdout=b"", stderr=b"")
     with caplog.at_level(logging.DEBUG, logger="esphome.git"):
         git.run_git_command(
-            ["git", "init", "https://user:hunter2@github.com/test/repo"],
-            str(repo_dir),
+            ["git", "clone", "https://user:hunter2@github.com/test/repo"],
+            cwd=tmp_path,
         )
     assert "hunter2" not in caplog.text
     assert "://***@github.com/test/repo" in caplog.text
@@ -155,10 +155,17 @@ def test_run_git_command_with_git_dir_isolation(
         stderr=b"",
     )
 
-    result = git.run_git_command(
-        ["git", "rev-parse", "HEAD"],
-        git_dir=repo_dir,
-    )
+    # Ambient repo-scoping vars simulate a git hook invoking ESPHome; an
+    # ambient GIT_INDEX_FILE surviving into a git_dir invocation fails
+    # silently (git operates on the caller's index and exits 0).
+    with patch.dict(
+        os.environ,
+        {"GIT_INDEX_FILE": "/caller/index", "GIT_OBJECT_DIRECTORY": "/caller/objects"},
+    ):
+        result = git.run_git_command(
+            ["git", "rev-parse", "HEAD"],
+            git_dir=repo_dir,
+        )
 
     # Verify subprocess.run was called
     assert mock_subprocess_run.called
@@ -170,6 +177,9 @@ def test_run_git_command_with_git_dir_isolation(
     assert "GIT_WORK_TREE" in env
     assert env["GIT_DIR"] == str(repo_dir / ".git")
     assert env["GIT_WORK_TREE"] == str(repo_dir)
+    # The ambient scoping vars must be stripped, not passed through.
+    assert "GIT_INDEX_FILE" not in env
+    assert "GIT_OBJECT_DIRECTORY" not in env
 
     assert result == "test output"
 
@@ -1379,6 +1389,58 @@ def test_all_submodules_updated_with_gitmodules(
     # Recursive, mirroring PlatformIO's recursive library clones.
     assert "--recursive" in cmd
     _assert_submodule_runs_without_isolation(submodule_calls[0], repo_dir)
+
+
+def test_recovery_reclone_keeps_credentials_and_cache_key(
+    tmp_path: Path, mock_run_git_command: Mock
+) -> None:
+    """The recovery re-clone must not re-apply credentials to the already
+    rewritten URL (no doubled userinfo) and must land in the same cache
+    directory, or a credentialed private repo re-clones on every run."""
+    CORE.config_path = tmp_path / "test.yaml"
+
+    url = "https://github.com/test/repo"
+    domain = "test"
+    repo_dir = _compute_repo_dir(url, None, domain)
+
+    _setup_old_repo(repo_dir)
+    (repo_dir / ".gitmodules").write_text("test")
+
+    calls = {"submodule": 0}
+
+    def git_command_side_effect(
+        cmd: list[str], cwd: str | None = None, **kwargs: Any
+    ) -> str:
+        if _get_git_command_type(cmd) == "clone":
+            _simulate_cloned_repo(repo_dir)
+        if _get_git_command_type(cmd) == "submodule":
+            calls["submodule"] += 1
+            if calls["submodule"] == 1:
+                raise git.GitCommandError("git submodule update exited with code 1")
+        return ""
+
+    mock_run_git_command.side_effect = git_command_side_effect
+
+    recovered_dir, _ = git.clone_or_update(
+        url=url,
+        ref=None,
+        refresh=TimePeriodSeconds(days=1),
+        domain=domain,
+        username="user",
+        password="hunter2",
+        init_submodules=True,
+    )
+
+    assert recovered_dir == repo_dir
+    clone_cmds = [
+        c[0][0]
+        for c in mock_run_git_command.call_args_list
+        if _get_git_command_type(c[0][0]) == "clone"
+    ]
+    assert clone_cmds
+    clone_url = clone_cmds[0][-2]
+    assert clone_url == "https://user:hunter2@github.com/test/repo"
+    assert clone_url.count("@") == 1
 
 
 def test_refresh_submodule_failure_recovers_then_raises(

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -1194,6 +1194,10 @@ def test_clone_with_submodules_uses_shallow_submodule_update(
     # The `--` terminator must precede the submodule paths so a path
     # beginning with `-` cannot be parsed as an option.
     assert cmd.index("--") < cmd.index("components/foo")
+    # git submodule must run with plain cwd, not GIT_DIR/GIT_WORK_TREE
+    # isolation, which breaks the submodule porcelain on some installations.
+    assert submodule_calls[0].kwargs.get("git_dir") is None
+    assert submodule_calls[0].kwargs.get("cwd") == repo_dir
 
 
 def test_refresh_fetch_is_shallow(tmp_path: Path, mock_run_git_command: Mock) -> None:
@@ -1249,6 +1253,135 @@ def test_refresh_submodule_update_is_shallow(
     assert "--depth=1" in cmd
     assert "components/foo" in cmd
     assert cmd.index("--") < cmd.index("components/foo")
+    assert submodule_calls[0].kwargs.get("git_dir") is None
+    assert submodule_calls[0].kwargs.get("cwd") == repo_dir
+
+
+def test_clone_all_submodules_skipped_without_gitmodules(
+    tmp_path: Path, mock_run_git_command: Mock
+) -> None:
+    """An empty submodule list ("all") is a no-op for repos with no .gitmodules.
+
+    This is the esp-idf toolchain library scenario from issue #17860: the
+    PlatformIO library converter requests "all submodules" for every git
+    library, and most libraries declare none. The git submodule porcelain
+    must not run at all in that case — it fails outright on some git
+    installations.
+    """
+    CORE.config_path = tmp_path / "test.yaml"
+
+    url = "https://github.com/test/repo"
+    domain = "test"
+    repo_dir = _compute_repo_dir(url, None, domain)
+
+    mock_run_git_command.side_effect = _make_clone_side_effect(repo_dir)
+
+    git.clone_or_update(
+        url=url,
+        ref=None,
+        refresh=None,
+        domain=domain,
+        submodules=[],
+    )
+
+    assert not any("submodule" in c[0][0] for c in mock_run_git_command.call_args_list)
+
+
+def test_clone_all_submodules_updated_with_gitmodules(
+    tmp_path: Path, mock_run_git_command: Mock
+) -> None:
+    """An empty submodule list initializes all submodules when .gitmodules exists."""
+    CORE.config_path = tmp_path / "test.yaml"
+
+    url = "https://github.com/test/repo"
+    domain = "test"
+    repo_dir = _compute_repo_dir(url, None, domain)
+
+    def git_command_side_effect(
+        cmd: list[str], cwd: str | None = None, **kwargs: Any
+    ) -> str:
+        if _get_git_command_type(cmd) == "clone":
+            _simulate_cloned_repo(repo_dir)
+            (repo_dir / ".gitmodules").write_text("test")
+        return ""
+
+    mock_run_git_command.side_effect = git_command_side_effect
+
+    git.clone_or_update(
+        url=url,
+        ref=None,
+        refresh=None,
+        domain=domain,
+        submodules=[],
+    )
+
+    submodule_calls = [
+        c for c in mock_run_git_command.call_args_list if "submodule" in c[0][0]
+    ]
+    assert len(submodule_calls) == 1
+    cmd = submodule_calls[0][0][0]
+    assert "--depth=1" in cmd
+    # "All submodules" mirrors PlatformIO's recursive library clones.
+    assert "--recursive" in cmd
+    assert cmd[-1] == "--"
+    assert submodule_calls[0].kwargs.get("git_dir") is None
+    assert submodule_calls[0].kwargs.get("cwd") == repo_dir
+
+
+def test_refresh_all_submodules_skipped_without_gitmodules(
+    tmp_path: Path, mock_run_git_command: Mock
+) -> None:
+    """The refresh path also skips the "all submodules" no-op."""
+    CORE.config_path = tmp_path / "test.yaml"
+
+    url = "https://github.com/test/repo"
+    domain = "test"
+    repo_dir = _compute_repo_dir(url, None, domain)
+
+    _setup_old_repo(repo_dir)
+    mock_run_git_command.return_value = "abc123"
+
+    git.clone_or_update(
+        url=url,
+        ref=None,
+        refresh=TimePeriodSeconds(days=1),
+        domain=domain,
+        submodules=[],
+    )
+
+    assert not any("submodule" in c[0][0] for c in mock_run_git_command.call_args_list)
+
+
+def test_refresh_all_submodules_updated_with_gitmodules(
+    tmp_path: Path, mock_run_git_command: Mock
+) -> None:
+    """The refresh path updates all submodules when .gitmodules exists."""
+    CORE.config_path = tmp_path / "test.yaml"
+
+    url = "https://github.com/test/repo"
+    domain = "test"
+    repo_dir = _compute_repo_dir(url, None, domain)
+
+    _setup_old_repo(repo_dir)
+    (repo_dir / ".gitmodules").write_text("test")
+    mock_run_git_command.return_value = "abc123"
+
+    git.clone_or_update(
+        url=url,
+        ref=None,
+        refresh=TimePeriodSeconds(days=1),
+        domain=domain,
+        submodules=[],
+    )
+
+    submodule_calls = [
+        c for c in mock_run_git_command.call_args_list if "submodule" in c[0][0]
+    ]
+    assert len(submodule_calls) == 1
+    cmd = submodule_calls[0][0][0]
+    assert "--recursive" in cmd
+    assert submodule_calls[0].kwargs.get("git_dir") is None
+    assert submodule_calls[0].kwargs.get("cwd") == repo_dir
 
 
 def test_refresh_picks_up_new_remote_commits(

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -237,6 +237,30 @@ def test_run_git_command_without_git_dir(mock_subprocess_run: Mock) -> None:
     assert result == "Cloning into 'test_repo'..."
 
 
+def test_run_git_command_with_cwd_runs_in_dir_without_isolation(
+    tmp_path: Path, mock_subprocess_run: Mock
+) -> None:
+    """The cwd parameter sets the working directory without GIT_DIR/GIT_WORK_TREE."""
+    repo_dir = tmp_path / "test_repo"
+    repo_dir.mkdir()
+
+    mock_subprocess_run.return_value = Mock(
+        returncode=0,
+        stdout=b"test output",
+        stderr=b"",
+    )
+
+    result = git.run_git_command(["git", "submodule", "update"], cwd=repo_dir)
+
+    call_args = mock_subprocess_run.call_args
+    env = call_args[1].get("env")
+    if env is not None:
+        assert "GIT_DIR" not in env
+        assert "GIT_WORK_TREE" not in env
+    assert call_args[1]["cwd"] == str(repo_dir)
+    assert result == "test output"
+
+
 def test_run_git_command_without_git_dir_raises_error(
     mock_subprocess_run: Mock,
 ) -> None:

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -1360,32 +1360,27 @@ def test_all_submodules_updated_with_gitmodules(
         submodules=[],
     )
 
-    update_cmd, status_cmd = (c[0][0] for c in _submodule_calls(mock_run_git_command))
-    assert update_cmd[2] == "update"
-    assert "--depth=1" in update_cmd
+    submodule_calls = _submodule_calls(mock_run_git_command)
+    # Which submodules the "all" mode populates is git's own policy, so no
+    # status verification follows the update in this mode.
+    assert len(submodule_calls) == 1
+    cmd = submodule_calls[0][0][0]
+    assert cmd[2] == "update"
+    assert "--depth=1" in cmd
     # "All submodules" mirrors PlatformIO's recursive library clones.
-    assert "--recursive" in update_cmd
-    assert update_cmd[-1] == "--"
-    assert status_cmd[2] == "status"
-    assert "--recursive" in status_cmd
-    for call in _submodule_calls(mock_run_git_command):
-        _assert_submodule_runs_without_isolation(call, repo_dir)
+    assert "--recursive" in cmd
+    assert cmd[-1] == "--"
+    _assert_submodule_runs_without_isolation(submodule_calls[0], repo_dir)
 
 
-def test_uninitialized_submodule_after_update_raises(
-    tmp_path: Path, mock_run_git_command: Mock
-) -> None:
-    """A submodule update that silently did nothing must fail loudly.
+def _make_uninitialized_submodule_side_effect(
+    repo_dir: Path, gitmodules_config: str
+) -> Callable[..., str]:
+    """Side effect where submodule update exits 0 but leaves a path empty.
 
-    `git submodule update --init` can exit 0 without initializing anything;
-    the status verification catches that, and the clone-path cleanup removes
-    the broken cache entry so the next run re-clones.
+    ``gitmodules_config`` is what ``git config -f .gitmodules --list``
+    returns for the cloned repo.
     """
-    CORE.config_path = tmp_path / "test.yaml"
-
-    url = "https://github.com/test/repo"
-    domain = "test"
-    repo_dir = _compute_repo_dir(url, None, domain)
 
     def git_command_side_effect(
         cmd: list[str], cwd: str | None = None, **kwargs: Any
@@ -1395,9 +1390,31 @@ def test_uninitialized_submodule_after_update_raises(
             (repo_dir / ".gitmodules").write_text("test")
         if _get_git_command_type(cmd) == "submodule" and "status" in cmd:
             return "-abc123 vendor/sub"
+        if _get_git_command_type(cmd) == "config":
+            return gitmodules_config
         return ""
 
-    mock_run_git_command.side_effect = git_command_side_effect
+    return git_command_side_effect
+
+
+def test_uninitialized_named_submodule_raises(
+    tmp_path: Path, mock_run_git_command: Mock
+) -> None:
+    """An explicitly named submodule left uninitialized must fail loudly.
+
+    `git submodule update --init` can exit 0 without initializing anything;
+    the status verification catches that for named paths, and the clone-path
+    cleanup removes the broken cache entry so the next run re-clones.
+    """
+    CORE.config_path = tmp_path / "test.yaml"
+
+    url = "https://github.com/test/repo"
+    domain = "test"
+    repo_dir = _compute_repo_dir(url, None, domain)
+
+    mock_run_git_command.side_effect = _make_uninitialized_submodule_side_effect(
+        repo_dir, gitmodules_config=""
+    )
 
     with pytest.raises(git.GitRepositoryError, match="vendor/sub"):
         git.clone_or_update(
@@ -1405,11 +1422,43 @@ def test_uninitialized_submodule_after_update_raises(
             ref=None,
             refresh=None,
             domain=domain,
-            submodules=[],
+            submodules=["vendor/sub"],
         )
 
     # The broken clone must not be left behind as a valid cache entry.
     assert not repo_dir.is_dir()
+
+
+def test_named_submodule_with_update_none_not_reported(
+    tmp_path: Path, mock_run_git_command: Mock
+) -> None:
+    """A named path the repo declares `update = none` is not a failure.
+
+    Git honors the declaration even for explicitly named paths and leaves
+    them uninitialized on purpose.
+    """
+    CORE.config_path = tmp_path / "test.yaml"
+
+    url = "https://github.com/test/repo"
+    domain = "test"
+    repo_dir = _compute_repo_dir(url, None, domain)
+
+    mock_run_git_command.side_effect = _make_uninitialized_submodule_side_effect(
+        repo_dir,
+        gitmodules_config=(
+            "submodule.vendor/sub.path=vendor/sub\nsubmodule.vendor/sub.update=none"
+        ),
+    )
+
+    git.clone_or_update(
+        url=url,
+        ref=None,
+        refresh=None,
+        domain=domain,
+        submodules=["vendor/sub"],
+    )
+
+    assert repo_dir.is_dir()
 
 
 def _real_git(*args: str, cwd: Path) -> None:
@@ -1433,6 +1482,16 @@ def _real_git(*args: str, cwd: Path) -> None:
     )
 
 
+# Git blocks file-protocol submodules by default (CVE-2022-39253); the e2e
+# tests allow them via GIT_CONFIG_* environment variables, which reach the
+# child git processes through run_git_command's filtered environment.
+_ALLOW_FILE_PROTOCOL_ENV = {
+    "GIT_CONFIG_COUNT": "1",
+    "GIT_CONFIG_KEY_0": "protocol.file.allow",
+    "GIT_CONFIG_VALUE_0": "always",
+}
+
+
 def _make_real_repo(path: Path, filename: str) -> None:
     """Create a real git repository containing one committed file."""
     path.mkdir()
@@ -1440,6 +1499,19 @@ def _make_real_repo(path: Path, filename: str) -> None:
     (path / filename).write_text("content")
     _real_git("add", filename, cwd=path)
     _real_git("commit", "-q", "-m", "init", cwd=path)
+
+
+def _add_submodule(
+    repo: Path, url: Path, path: str, *, update_none: bool = False
+) -> None:
+    """Add ``url`` as a submodule of ``repo`` at ``path`` and commit it."""
+    _real_git("submodule", "add", str(url), path, cwd=repo)
+    if update_none:
+        _real_git(
+            "config", "-f", ".gitmodules", f"submodule.{path}.update", "none", cwd=repo
+        )
+        _real_git("add", ".gitmodules", cwd=repo)
+    _real_git("commit", "-q", "-m", f"add submodule {path}", cwd=repo)
 
 
 def test_clone_or_update_real_git_without_submodules(tmp_path: Path) -> None:
@@ -1470,10 +1542,8 @@ def test_clone_or_update_real_git_initializes_submodules(tmp_path: Path) -> None
 
     Exercises the real `git submodule update` invocation, including the
     env handling in run_git_command that the mocked tests cannot cover.
-    The fixture uses local path repositories; git blocks file-protocol
-    submodules by default (CVE-2022-39253), so the test allows them via
-    GIT_CONFIG_* environment variables, which reach the child git processes
-    through run_git_command's filtered environment.
+    The explicit-list call afterwards exercises the real `git submodule
+    status` verification on the refresh path.
     """
     CORE.config_path = tmp_path / "test.yaml"
 
@@ -1482,17 +1552,9 @@ def test_clone_or_update_real_git_initializes_submodules(tmp_path: Path) -> None
 
     upstream = tmp_path / "upstream"
     _make_real_repo(upstream, "README.md")
-    _real_git("submodule", "add", str(sub_repo), "vendor/sub", cwd=upstream)
-    _real_git("commit", "-q", "-m", "add submodule", cwd=upstream)
+    _add_submodule(upstream, sub_repo, "vendor/sub")
 
-    with patch.dict(
-        os.environ,
-        {
-            "GIT_CONFIG_COUNT": "1",
-            "GIT_CONFIG_KEY_0": "protocol.file.allow",
-            "GIT_CONFIG_VALUE_0": "always",
-        },
-    ):
+    with patch.dict(os.environ, _ALLOW_FILE_PROTOCOL_ENV):
         repo_dir, _ = git.clone_or_update(
             url=str(upstream),
             ref=None,
@@ -1500,7 +1562,17 @@ def test_clone_or_update_real_git_initializes_submodules(tmp_path: Path) -> None
             domain="test_e2e",
             submodules=[],
         )
+        assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
 
+        repo_dir_again, _ = git.clone_or_update(
+            url=str(upstream),
+            ref=None,
+            refresh=None,
+            domain="test_e2e",
+            submodules=["vendor/sub"],
+        )
+
+    assert repo_dir_again == repo_dir
     assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
 
 
@@ -1524,42 +1596,15 @@ def test_clone_or_update_real_git_honors_update_none_submodule(
     # Intermediate submodule that itself declares a skipped nested submodule.
     mid_repo = tmp_path / "mid"
     _make_real_repo(mid_repo, "mid_file.txt")
-    _real_git("submodule", "add", str(sub_repo), "vendor/leaf", cwd=mid_repo)
-    _real_git(
-        "config",
-        "-f",
-        ".gitmodules",
-        "submodule.vendor/leaf.update",
-        "none",
-        cwd=mid_repo,
-    )
-    _real_git("add", ".gitmodules", cwd=mid_repo)
-    _real_git("commit", "-q", "-m", "add nested submodule", cwd=mid_repo)
+    _add_submodule(mid_repo, sub_repo, "vendor/leaf", update_none=True)
 
     upstream = tmp_path / "upstream"
     _make_real_repo(upstream, "README.md")
-    _real_git("submodule", "add", str(sub_repo), "vendor/sub", cwd=upstream)
-    _real_git("submodule", "add", str(sub_repo), "vendor/skipped", cwd=upstream)
-    _real_git("submodule", "add", str(mid_repo), "vendor/mid", cwd=upstream)
-    _real_git(
-        "config",
-        "-f",
-        ".gitmodules",
-        "submodule.vendor/skipped.update",
-        "none",
-        cwd=upstream,
-    )
-    _real_git("add", ".gitmodules", cwd=upstream)
-    _real_git("commit", "-q", "-m", "add submodules", cwd=upstream)
+    _add_submodule(upstream, sub_repo, "vendor/sub")
+    _add_submodule(upstream, sub_repo, "vendor/skipped", update_none=True)
+    _add_submodule(upstream, mid_repo, "vendor/mid")
 
-    with patch.dict(
-        os.environ,
-        {
-            "GIT_CONFIG_COUNT": "1",
-            "GIT_CONFIG_KEY_0": "protocol.file.allow",
-            "GIT_CONFIG_VALUE_0": "always",
-        },
-    ):
+    with patch.dict(os.environ, _ALLOW_FILE_PROTOCOL_ENV):
         repo_dir, _ = git.clone_or_update(
             url=str(upstream),
             ref=None,

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 import os
 from pathlib import Path
+import subprocess
 import time
 from typing import Any
 from unittest.mock import Mock, patch
@@ -1369,6 +1370,98 @@ def test_all_submodules_updated_with_gitmodules(
     assert "--recursive" in cmd
     assert cmd[-1] == "--"
     _assert_submodule_runs_without_isolation(submodule_calls[0], repo_dir)
+
+
+def _real_git(*args: str, cwd: Path) -> None:
+    """Run real git to build a test fixture repository."""
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=test@test.invalid",
+            "-c",
+            "user.name=test",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "protocol.file.allow=always",
+            *args,
+        ],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _make_real_repo(path: Path, filename: str) -> None:
+    """Create a real git repository containing one committed file."""
+    path.mkdir()
+    _real_git("init", "-q", cwd=path)
+    (path / filename).write_text("content")
+    _real_git("add", filename, cwd=path)
+    _real_git("commit", "-q", "-m", "init", cwd=path)
+
+
+def test_clone_or_update_real_git_without_submodules(tmp_path: Path) -> None:
+    """End-to-end with real git: a repo with no .gitmodules clones cleanly.
+
+    This is the issue #17860 scenario: requesting "all submodules" on a
+    submodule-less repository must not invoke the git submodule porcelain
+    and must produce a usable checkout.
+    """
+    CORE.config_path = tmp_path / "test.yaml"
+
+    upstream = tmp_path / "upstream"
+    _make_real_repo(upstream, "README.md")
+
+    repo_dir, _ = git.clone_or_update(
+        url=str(upstream),
+        ref=None,
+        refresh=None,
+        domain="test_e2e",
+        submodules=[],
+    )
+
+    assert (repo_dir / "README.md").is_file()
+
+
+def test_clone_or_update_real_git_initializes_submodules(tmp_path: Path) -> None:
+    """End-to-end with real git: submodules are actually checked out.
+
+    Exercises the real `git submodule update` invocation, including the
+    env handling in run_git_command that the mocked tests cannot cover.
+    The fixture uses local path repositories; git blocks file-protocol
+    submodules by default (CVE-2022-39253), so the test allows them via
+    GIT_CONFIG_* environment variables, which reach the child git processes
+    through run_git_command's filtered environment.
+    """
+    CORE.config_path = tmp_path / "test.yaml"
+
+    sub_repo = tmp_path / "sub"
+    _make_real_repo(sub_repo, "sub_file.txt")
+
+    upstream = tmp_path / "upstream"
+    _make_real_repo(upstream, "README.md")
+    _real_git("submodule", "add", str(sub_repo), "vendor/sub", cwd=upstream)
+    _real_git("commit", "-q", "-m", "add submodule", cwd=upstream)
+
+    with patch.dict(
+        os.environ,
+        {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "protocol.file.allow",
+            "GIT_CONFIG_VALUE_0": "always",
+        },
+    ):
+        repo_dir, _ = git.clone_or_update(
+            url=str(upstream),
+            ref=None,
+            refresh=None,
+            domain="test_e2e",
+            submodules=[],
+        )
+
+    assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
 
 
 def test_refresh_picks_up_new_remote_commits(

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -272,7 +272,7 @@ def test_run_git_command_with_cwd_runs_in_dir_without_isolation(
     assert "GIT_WORK_TREE" not in env
     assert "GIT_INDEX_FILE" not in env
     assert env["GIT_CEILING_DIRECTORIES"] == str(repo_dir.parent)
-    assert call_args[1]["cwd"] == str(repo_dir)
+    assert call_args[1]["cwd"] == repo_dir
     assert result == "test output"
 
 
@@ -1216,35 +1216,44 @@ def test_clone_with_ref_uses_shallow_fetch(
     assert ref in fetch_calls[0][0][0]
 
 
-def test_clone_with_submodules_uses_shallow_submodule_update(
-    tmp_path: Path, mock_run_git_command: Mock
+@pytest.mark.parametrize(
+    "refresh", [None, TimePeriodSeconds(days=1)], ids=["clone", "refresh"]
+)
+def test_explicit_submodule_update_is_shallow(
+    tmp_path: Path, mock_run_git_command: Mock, refresh: TimePeriodSeconds | None
 ) -> None:
-    """Submodule init on a fresh clone should use --depth=1."""
+    """An explicit submodule list is updated shallowly and then verified."""
     CORE.config_path = tmp_path / "test.yaml"
 
     url = "https://github.com/test/repo"
     domain = "test"
     repo_dir = _compute_repo_dir(url, None, domain)
 
-    mock_run_git_command.side_effect = _make_clone_side_effect(repo_dir)
+    if refresh is None:
+        mock_run_git_command.side_effect = _make_clone_side_effect(repo_dir)
+    else:
+        _setup_old_repo(repo_dir)
+        mock_run_git_command.return_value = "abc123"
 
     git.clone_or_update(
         url=url,
         ref=None,
-        refresh=None,
+        refresh=refresh,
         domain=domain,
         submodules=["components/foo"],
     )
 
-    submodule_calls = _submodule_calls(mock_run_git_command)
-    assert len(submodule_calls) == 1
-    cmd = submodule_calls[0][0][0]
-    assert "--depth=1" in cmd
-    assert "components/foo" in cmd
+    update_cmd, status_cmd = (c[0][0] for c in _submodule_calls(mock_run_git_command))
+    assert update_cmd[2] == "update"
+    assert "--depth=1" in update_cmd
+    assert "components/foo" in update_cmd
     # The `--` terminator must precede the submodule paths so a path
     # beginning with `-` cannot be parsed as an option.
-    assert cmd.index("--") < cmd.index("components/foo")
-    _assert_submodule_runs_without_isolation(submodule_calls[0], repo_dir)
+    assert update_cmd.index("--") < update_cmd.index("components/foo")
+    assert status_cmd[2] == "status"
+    assert "components/foo" in status_cmd
+    for call in _submodule_calls(mock_run_git_command):
+        _assert_submodule_runs_without_isolation(call, repo_dir)
 
 
 def test_refresh_fetch_is_shallow(tmp_path: Path, mock_run_git_command: Mock) -> None:
@@ -1269,36 +1278,6 @@ def test_refresh_fetch_is_shallow(tmp_path: Path, mock_run_git_command: Mock) ->
     assert "--depth=1" in cmd
     # Ref must still be in the refresh fetch so the right tip is updated.
     assert cmd[-1] == ref
-
-
-def test_refresh_submodule_update_is_shallow(
-    tmp_path: Path, mock_run_git_command: Mock
-) -> None:
-    """The refresh-path submodule update should use --depth=1."""
-    CORE.config_path = tmp_path / "test.yaml"
-
-    url = "https://github.com/test/repo"
-    domain = "test"
-    repo_dir = _compute_repo_dir(url, None, domain)
-
-    _setup_old_repo(repo_dir)
-    mock_run_git_command.return_value = "abc123"
-
-    git.clone_or_update(
-        url=url,
-        ref=None,
-        refresh=TimePeriodSeconds(days=1),
-        domain=domain,
-        submodules=["components/foo"],
-    )
-
-    submodule_calls = _submodule_calls(mock_run_git_command)
-    assert len(submodule_calls) == 1
-    cmd = submodule_calls[0][0][0]
-    assert "--depth=1" in cmd
-    assert "components/foo" in cmd
-    assert cmd.index("--") < cmd.index("components/foo")
-    _assert_submodule_runs_without_isolation(submodule_calls[0], repo_dir)
 
 
 @pytest.mark.parametrize(
@@ -1368,14 +1347,56 @@ def test_all_submodules_updated_with_gitmodules(
         submodules=[],
     )
 
-    submodule_calls = _submodule_calls(mock_run_git_command)
-    assert len(submodule_calls) == 1
-    cmd = submodule_calls[0][0][0]
-    assert "--depth=1" in cmd
+    update_cmd, status_cmd = (c[0][0] for c in _submodule_calls(mock_run_git_command))
+    assert update_cmd[2] == "update"
+    assert "--depth=1" in update_cmd
     # "All submodules" mirrors PlatformIO's recursive library clones.
-    assert "--recursive" in cmd
-    assert cmd[-1] == "--"
-    _assert_submodule_runs_without_isolation(submodule_calls[0], repo_dir)
+    assert "--recursive" in update_cmd
+    assert update_cmd[-1] == "--"
+    assert status_cmd[2] == "status"
+    assert "--recursive" in status_cmd
+    for call in _submodule_calls(mock_run_git_command):
+        _assert_submodule_runs_without_isolation(call, repo_dir)
+
+
+def test_uninitialized_submodule_after_update_raises(
+    tmp_path: Path, mock_run_git_command: Mock
+) -> None:
+    """A submodule update that silently did nothing must fail loudly.
+
+    `git submodule update --init` can exit 0 without initializing anything;
+    the status verification catches that, and the clone-path cleanup removes
+    the broken cache entry so the next run re-clones.
+    """
+    CORE.config_path = tmp_path / "test.yaml"
+
+    url = "https://github.com/test/repo"
+    domain = "test"
+    repo_dir = _compute_repo_dir(url, None, domain)
+
+    def git_command_side_effect(
+        cmd: list[str], cwd: str | None = None, **kwargs: Any
+    ) -> str:
+        if _get_git_command_type(cmd) == "clone":
+            _simulate_cloned_repo(repo_dir)
+            (repo_dir / ".gitmodules").write_text("test")
+        if _get_git_command_type(cmd) == "submodule" and "status" in cmd:
+            return "-abc123 vendor/sub"
+        return ""
+
+    mock_run_git_command.side_effect = git_command_side_effect
+
+    with pytest.raises(git.GitRepositoryError, match="vendor/sub"):
+        git.clone_or_update(
+            url=url,
+            ref=None,
+            refresh=None,
+            domain=domain,
+            submodules=[],
+        )
+
+    # The broken clone must not be left behind as a valid cache entry.
+    assert not repo_dir.is_dir()
 
 
 def _real_git(*args: str, cwd: Path) -> None:

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -1507,22 +1507,40 @@ def test_clone_or_update_real_git_initializes_submodules(tmp_path: Path) -> None
 def test_clone_or_update_real_git_honors_update_none_submodule(
     tmp_path: Path,
 ) -> None:
-    """End-to-end with real git: a submodule declared `update = none` is not
-    reported as a failed initialization.
+    """End-to-end with real git: submodules declared `update = none` are not
+    reported as failed initializations, at any nesting level.
 
     Git deliberately skips such submodules during `git submodule update
     --init` and leaves them uninitialized; the status verification must not
     turn that into an error while still checking out the regular submodules.
+    The nested case matters because the skipped submodule's declaration lives
+    in the intermediate submodule's .gitmodules, not the superproject's.
     """
     CORE.config_path = tmp_path / "test.yaml"
 
     sub_repo = tmp_path / "sub"
     _make_real_repo(sub_repo, "sub_file.txt")
 
+    # Intermediate submodule that itself declares a skipped nested submodule.
+    mid_repo = tmp_path / "mid"
+    _make_real_repo(mid_repo, "mid_file.txt")
+    _real_git("submodule", "add", str(sub_repo), "vendor/leaf", cwd=mid_repo)
+    _real_git(
+        "config",
+        "-f",
+        ".gitmodules",
+        "submodule.vendor/leaf.update",
+        "none",
+        cwd=mid_repo,
+    )
+    _real_git("add", ".gitmodules", cwd=mid_repo)
+    _real_git("commit", "-q", "-m", "add nested submodule", cwd=mid_repo)
+
     upstream = tmp_path / "upstream"
     _make_real_repo(upstream, "README.md")
     _real_git("submodule", "add", str(sub_repo), "vendor/sub", cwd=upstream)
     _real_git("submodule", "add", str(sub_repo), "vendor/skipped", cwd=upstream)
+    _real_git("submodule", "add", str(mid_repo), "vendor/mid", cwd=upstream)
     _real_git(
         "config",
         "-f",
@@ -1552,6 +1570,10 @@ def test_clone_or_update_real_git_honors_update_none_submodule(
 
     assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
     assert not (repo_dir / "vendor" / "skipped" / "sub_file.txt").exists()
+    assert (repo_dir / "vendor" / "mid" / "mid_file.txt").is_file()
+    assert not (
+        repo_dir / "vendor" / "mid" / "vendor" / "leaf" / "sub_file.txt"
+    ).exists()
 
 
 def test_refresh_picks_up_new_remote_commits(

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -289,6 +289,43 @@ def test_run_git_command_with_cwd_runs_in_dir_without_isolation(
     assert result == "test output"
 
 
+def test_run_git_command_raises_on_nonfatal_stderr(
+    tmp_path: Path, mock_subprocess_run: Mock
+) -> None:
+    """Nonzero exit with stderr lacking a fatal: prefix raises with full stderr."""
+    mock_subprocess_run.return_value = Mock(
+        returncode=1,
+        stdout=b"",
+        stderr=b"error: pathspec 'nope' did not match any file(s)\n",
+    )
+
+    with pytest.raises(GitCommandError, match="did not match"):
+        git.run_git_command(["git", "checkout", "nope"], git_dir=tmp_path)
+
+
+def test_run_git_command_raises_on_nonzero_exit_without_stderr(
+    tmp_path: Path, mock_subprocess_run: Mock
+) -> None:
+    """A nonzero exit must raise even when git printed nothing to stderr.
+
+    Silent nonzero exits were previously treated as success, which is how
+    broken checkouts could be cached as complete.
+    """
+    mock_subprocess_run.return_value = Mock(
+        returncode=1,
+        stdout=b"",
+        stderr=b"",
+    )
+
+    with pytest.raises(GitCommandError, match="exited with code 1"):
+        git.run_git_command(["git", "submodule", "update"], cwd=tmp_path)
+
+
+def test_update_none_paths_without_gitmodules(tmp_path: Path) -> None:
+    """A repo without .gitmodules declares nothing, so nothing is skipped."""
+    assert git._update_none_paths(tmp_path) == set()
+
+
 def test_run_git_command_without_git_dir_raises_error(
     mock_subprocess_run: Mock,
 ) -> None:
@@ -1446,7 +1483,9 @@ def test_named_submodule_with_update_none_not_reported(
     mock_run_git_command.side_effect = _make_uninitialized_submodule_side_effect(
         repo_dir,
         gitmodules_config=(
-            "submodule.vendor/sub.path=vendor/sub\nsubmodule.vendor/sub.update=none"
+            "submodule.vendor/sub.path=vendor/sub\n"
+            "submodule.vendor/sub.update=none\n"
+            "submodule.vendor/sub.branch=main"
         ),
     )
 

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -257,7 +257,12 @@ def test_run_git_command_with_cwd_runs_in_dir_without_isolation(
     )
 
     with patch.dict(
-        os.environ, {"GIT_DIR": "/ambient/.git", "GIT_WORK_TREE": "/ambient"}
+        os.environ,
+        {
+            "GIT_DIR": "/ambient/.git",
+            "GIT_WORK_TREE": "/ambient",
+            "GIT_INDEX_FILE": "/ambient/.git/index",
+        },
     ):
         result = git.run_git_command(["git", "submodule", "update"], cwd=repo_dir)
 
@@ -265,6 +270,7 @@ def test_run_git_command_with_cwd_runs_in_dir_without_isolation(
     env = call_args[1]["env"]
     assert "GIT_DIR" not in env
     assert "GIT_WORK_TREE" not in env
+    assert "GIT_INDEX_FILE" not in env
     assert env["GIT_CEILING_DIRECTORIES"] == str(repo_dir.parent)
     assert call_args[1]["cwd"] == str(repo_dir)
     assert result == "test output"

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -1,6 +1,7 @@
 """Tests for git.py module."""
 
 from collections.abc import Callable
+import logging
 import os
 from pathlib import Path
 import subprocess
@@ -120,6 +121,22 @@ def test_run_git_command_success(tmp_path: Path) -> None:
     result = git.run_git_command(["git", "status", "--porcelain"], str(repo_dir))
     # Empty repo should have empty status
     assert isinstance(result, str)
+
+
+def test_run_git_command_debug_log_redacts_credentials(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Embedded URL credentials never reach the debug log; -v output is
+    routinely pasted into public issues."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    with caplog.at_level(logging.DEBUG, logger="esphome.git"):
+        git.run_git_command(
+            ["git", "init", "https://user:hunter2@github.com/test/repo"],
+            str(repo_dir),
+        )
+    assert "hunter2" not in caplog.text
+    assert "://***@github.com/test/repo" in caplog.text
 
 
 def test_run_git_command_with_git_dir_isolation(
@@ -319,11 +336,6 @@ def test_run_git_command_raises_on_nonzero_exit_without_stderr(
 
     with pytest.raises(GitCommandError, match="exited with code 1"):
         git.run_git_command(["git", "submodule", "update"], cwd=tmp_path)
-
-
-def test_update_none_paths_without_gitmodules(tmp_path: Path) -> None:
-    """A repo without .gitmodules declares nothing, so nothing is skipped."""
-    assert git._update_none_paths(tmp_path) == set()
 
 
 def test_run_git_command_without_git_dir_raises_error(
@@ -1266,46 +1278,6 @@ def test_clone_with_ref_uses_shallow_fetch(
     assert ref in fetch_calls[0][0][0]
 
 
-@pytest.mark.parametrize(
-    "refresh", [None, TimePeriodSeconds(days=1)], ids=["clone", "refresh"]
-)
-def test_explicit_submodule_update_is_shallow(
-    tmp_path: Path, mock_run_git_command: Mock, refresh: TimePeriodSeconds | None
-) -> None:
-    """An explicit submodule list is updated shallowly and then verified."""
-    CORE.config_path = tmp_path / "test.yaml"
-
-    url = "https://github.com/test/repo"
-    domain = "test"
-    repo_dir = _compute_repo_dir(url, None, domain)
-
-    if refresh is None:
-        mock_run_git_command.side_effect = _make_clone_side_effect(repo_dir)
-    else:
-        _setup_old_repo(repo_dir)
-        mock_run_git_command.return_value = "abc123"
-
-    git.clone_or_update(
-        url=url,
-        ref=None,
-        refresh=refresh,
-        domain=domain,
-        submodules=["components/foo"],
-    )
-
-    update_cmd, status_cmd = (c[0][0] for c in _submodule_calls(mock_run_git_command))
-    assert update_cmd[2] == "update"
-    assert "--depth=1" in update_cmd
-    assert "components/foo" in update_cmd
-    # The `--` terminator must precede the submodule paths so a path
-    # beginning with `-` cannot be parsed as an option.
-    assert update_cmd.index("--") < update_cmd.index("components/foo")
-    assert status_cmd[2] == "status"
-    assert "components/foo" in status_cmd
-    for call in _submodule_calls(mock_run_git_command):
-        _assert_submodule_runs_without_isolation(call, repo_dir)
-
-
 def test_refresh_fetch_is_shallow(tmp_path: Path, mock_run_git_command: Mock) -> None:
     """The refresh-path fetch should use --depth=1."""
     CORE.config_path = tmp_path / "test.yaml"
@@ -1336,7 +1308,7 @@ def test_refresh_fetch_is_shallow(tmp_path: Path, mock_run_git_command: Mock) ->
 def test_all_submodules_skipped_without_gitmodules(
     tmp_path: Path, mock_run_git_command: Mock, refresh: TimePeriodSeconds | None
 ) -> None:
-    """An empty submodule list ("all") is a no-op for repos with no .gitmodules.
+    """init_submodules is a no-op for repos with no .gitmodules.
 
     This is the esp-idf toolchain library scenario from issue #17860: the
     PlatformIO library converter requests "all submodules" for every git
@@ -1361,7 +1333,7 @@ def test_all_submodules_skipped_without_gitmodules(
         ref=None,
         refresh=refresh,
         domain=domain,
-        submodules=[],
+        init_submodules=True,
     )
 
     assert not _submodule_calls(mock_run_git_command)
@@ -1373,7 +1345,7 @@ def test_all_submodules_skipped_without_gitmodules(
 def test_all_submodules_updated_with_gitmodules(
     tmp_path: Path, mock_run_git_command: Mock, refresh: TimePeriodSeconds | None
 ) -> None:
-    """An empty submodule list initializes all submodules when .gitmodules exists."""
+    """init_submodules initializes all submodules when .gitmodules exists."""
     CORE.config_path = tmp_path / "test.yaml"
 
     url = "https://github.com/test/repo"
@@ -1394,87 +1366,30 @@ def test_all_submodules_updated_with_gitmodules(
         ref=None,
         refresh=refresh,
         domain=domain,
-        submodules=[],
+        init_submodules=True,
     )
 
     submodule_calls = _submodule_calls(mock_run_git_command)
-    # Which submodules the "all" mode populates is git's own policy, so no
-    # status verification follows the update in this mode.
+    # Which submodules get populated is git's own policy, so no status
+    # verification follows the update.
     assert len(submodule_calls) == 1
     cmd = submodule_calls[0][0][0]
     assert cmd[2] == "update"
     assert "--depth=1" in cmd
-    # "All submodules" mirrors PlatformIO's recursive library clones.
+    # Recursive, mirroring PlatformIO's recursive library clones.
     assert "--recursive" in cmd
-    assert cmd[-1] == "--"
     _assert_submodule_runs_without_isolation(submodule_calls[0], repo_dir)
 
 
-def _make_uninitialized_submodule_side_effect(
-    repo_dir: Path, gitmodules_config: str
-) -> Callable[..., str]:
-    """Side effect where submodule update exits 0 but leaves a path empty.
-
-    ``gitmodules_config`` is what ``git config -f .gitmodules --list``
-    returns for the cloned repo.
-    """
-
-    def git_command_side_effect(
-        cmd: list[str], cwd: str | None = None, **kwargs: Any
-    ) -> str:
-        if _get_git_command_type(cmd) == "clone":
-            _simulate_cloned_repo(repo_dir)
-            (repo_dir / ".gitmodules").write_text("test")
-        if _get_git_command_type(cmd) == "submodule" and "status" in cmd:
-            return "-abc123 vendor/sub"
-        if _get_git_command_type(cmd) == "config":
-            return gitmodules_config
-        return ""
-
-    return git_command_side_effect
-
-
-def test_uninitialized_named_submodule_raises(
+def test_refresh_submodule_failure_recovers_then_raises(
     tmp_path: Path, mock_run_git_command: Mock
 ) -> None:
-    """An explicitly named submodule left uninitialized must fail loudly.
+    """A refresh-path submodule failure routes through the recovery re-clone.
 
-    `git submodule update --init` can exit 0 without initializing anything;
-    the status verification catches that for named paths, and the clone-path
-    cleanup removes the broken cache entry so the next run re-clones.
-    """
-    CORE.config_path = tmp_path / "test.yaml"
-
-    url = "https://github.com/test/repo"
-    domain = "test"
-    repo_dir = _compute_repo_dir(url, None, domain)
-
-    mock_run_git_command.side_effect = _make_uninitialized_submodule_side_effect(
-        repo_dir, gitmodules_config=""
-    )
-
-    with pytest.raises(git.GitRepositoryError, match="vendor/sub"):
-        git.clone_or_update(
-            url=url,
-            ref=None,
-            refresh=None,
-            domain=domain,
-            submodules=["vendor/sub"],
-        )
-
-    # The broken clone must not be left behind as a valid cache entry.
-    assert not repo_dir.is_dir()
-
-
-def test_refresh_uninitialized_named_submodule_recovers_then_raises(
-    tmp_path: Path, mock_run_git_command: Mock
-) -> None:
-    """A refresh-path verification failure routes through the recovery re-clone.
-
-    The broken repo is removed and re-cloned; when verification fails again on
-    the fresh clone the cache entry is removed and the error propagates,
-    instead of leaving behind a repo the refresh window would silently accept
-    on the next run.
+    The broken repo is removed and re-cloned; when the submodule update fails
+    again on the fresh clone the cache entry is removed and the error
+    propagates, instead of leaving behind a repo the refresh window would
+    silently accept on the next run.
     """
     CORE.config_path = tmp_path / "test.yaml"
 
@@ -1483,17 +1398,27 @@ def test_refresh_uninitialized_named_submodule_recovers_then_raises(
     repo_dir = _compute_repo_dir(url, None, domain)
 
     _setup_old_repo(repo_dir)
-    mock_run_git_command.side_effect = _make_uninitialized_submodule_side_effect(
-        repo_dir, gitmodules_config=""
-    )
+    (repo_dir / ".gitmodules").write_text("test")
 
-    with pytest.raises(git.GitRepositoryError, match="vendor/sub"):
+    def git_command_side_effect(
+        cmd: list[str], cwd: str | None = None, **kwargs: Any
+    ) -> str:
+        if _get_git_command_type(cmd) == "clone":
+            _simulate_cloned_repo(repo_dir)
+            (repo_dir / ".gitmodules").write_text("test")
+        if _get_git_command_type(cmd) == "submodule":
+            raise git.GitCommandError("git submodule update exited with code 1")
+        return ""
+
+    mock_run_git_command.side_effect = git_command_side_effect
+
+    with pytest.raises(git.GitCommandError, match="exited with code 1"):
         git.clone_or_update(
             url=url,
             ref=None,
             refresh=TimePeriodSeconds(days=1),
             domain=domain,
-            submodules=["vendor/sub"],
+            init_submodules=True,
         )
 
     assert not repo_dir.is_dir()
@@ -1502,40 +1427,6 @@ def test_refresh_uninitialized_named_submodule_recovers_then_raises(
         _get_git_command_type(c[0][0]) == "clone"
         for c in mock_run_git_command.call_args_list
     )
-
-
-def test_named_submodule_with_update_none_not_reported(
-    tmp_path: Path, mock_run_git_command: Mock
-) -> None:
-    """A named path the repo declares `update = none` is not a failure.
-
-    Git honors the declaration even for explicitly named paths and leaves
-    them uninitialized on purpose.
-    """
-    CORE.config_path = tmp_path / "test.yaml"
-
-    url = "https://github.com/test/repo"
-    domain = "test"
-    repo_dir = _compute_repo_dir(url, None, domain)
-
-    mock_run_git_command.side_effect = _make_uninitialized_submodule_side_effect(
-        repo_dir,
-        gitmodules_config=(
-            "submodule.vendor/sub.path=vendor/sub\n"
-            "submodule.vendor/sub.update=none\n"
-            "submodule.vendor/sub.branch=main"
-        ),
-    )
-
-    git.clone_or_update(
-        url=url,
-        ref=None,
-        refresh=None,
-        domain=domain,
-        submodules=["vendor/sub"],
-    )
-
-    assert repo_dir.is_dir()
 
 
 def _real_git(*args: str, cwd: Path) -> None:
@@ -1608,7 +1499,7 @@ def test_clone_or_update_real_git_without_submodules(tmp_path: Path) -> None:
         ref=None,
         refresh=None,
         domain="test_e2e",
-        submodules=[],
+        init_submodules=True,
     )
 
     assert (repo_dir / "README.md").is_file()
@@ -1619,8 +1510,6 @@ def test_clone_or_update_real_git_initializes_submodules(tmp_path: Path) -> None
 
     Exercises the real `git submodule update` invocation, including the
     env handling in run_git_command that the mocked tests cannot cover.
-    The explicit-list call afterwards exercises the real `git submodule
-    status` verification on the refresh path.
     """
     CORE.config_path = tmp_path / "test.yaml"
 
@@ -1637,19 +1526,9 @@ def test_clone_or_update_real_git_initializes_submodules(tmp_path: Path) -> None
             ref=None,
             refresh=None,
             domain="test_e2e",
-            submodules=[],
-        )
-        assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
-
-        repo_dir_again, _ = git.clone_or_update(
-            url=str(upstream),
-            ref=None,
-            refresh=None,
-            domain="test_e2e",
-            submodules=["vendor/sub"],
+            init_submodules=True,
         )
 
-    assert repo_dir_again == repo_dir
     assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
 
 
@@ -1658,12 +1537,8 @@ def test_clone_or_update_real_git_honors_update_none_submodule(
 ) -> None:
     """End-to-end with real git: submodules declared `update = none` stay skipped.
 
-    The all-submodules clone shows git itself skipping the declared paths at
-    both nesting levels while the regular submodules check out. The follow-up
-    call naming the skipped path exercises ESPHome's carve-out: the status
-    verification sees the path uninitialized and `_update_none_paths` (parsing
-    real `git config -f .gitmodules --list` output) excuses it instead of
-    raising.
+    Shows git itself skipping the declared paths at both nesting levels
+    (and exiting 0) while the regular submodules check out.
     """
     CORE.config_path = tmp_path / "test.yaml"
 
@@ -1687,28 +1562,15 @@ def test_clone_or_update_real_git_honors_update_none_submodule(
             ref=None,
             refresh=None,
             domain="test_e2e",
-            submodules=[],
+            init_submodules=True,
         )
 
-        assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
-        assert not (repo_dir / "vendor" / "skipped" / "sub_file.txt").exists()
-        assert (repo_dir / "vendor" / "mid" / "mid_file.txt").is_file()
-        assert not (
-            repo_dir / "vendor" / "mid" / "vendor" / "leaf" / "sub_file.txt"
-        ).exists()
-
-        # Naming the skipped path must not raise: the verification sees it
-        # uninitialized and the real .gitmodules parse excuses it.
-        repo_dir_again, _ = git.clone_or_update(
-            url=str(upstream),
-            ref=None,
-            refresh=None,
-            domain="test_e2e",
-            submodules=["vendor/skipped"],
-        )
-
-    assert repo_dir_again == repo_dir
+    assert (repo_dir / "vendor" / "sub" / "sub_file.txt").is_file()
     assert not (repo_dir / "vendor" / "skipped" / "sub_file.txt").exists()
+    assert (repo_dir / "vendor" / "mid" / "mid_file.txt").is_file()
+    assert not (
+        repo_dir / "vendor" / "mid" / "vendor" / "leaf" / "sub_file.txt"
+    ).exists()
 
 
 def test_refresh_picks_up_new_remote_commits(


### PR DESCRIPTION
# What does this implement/fix?

Since 2026.7.0 the esp-idf toolchain runs `git submodule update --init` after cloning every PlatformIO library from git, even when the repository has no submodules at all. On some git installations this command refuses to run with `GIT_DIR`/`GIT_WORK_TREE` set and the build fails with `git-submodule cannot be used without a working tree`; the platformio toolchain never had this problem because PlatformIO clones libraries with `--recursive` and never sets those variables.

This change skips the submodule step when the repository has no `.gitmodules` file, and runs `git submodule` with a plain working directory instead of `GIT_DIR`/`GIT_WORK_TREE` isolation, matching PlatformIO; the repository was already cloned or validated at that point. All git commands now start from an environment with the repository scoping variables stripped (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` and friends), so a git hook or CI wrapper invoking ESPHome can no longer redirect them to its own repository, and `GIT_CEILING_DIRECTORIES` keeps the protection against git walking up to a parent repository. When initializing all submodules we now also pass `--recursive` to match PlatformIO's library clones.

The submodule handling now lives in one shared helper, `update_submodules` in `esphome/git.py`, used by both `clone_or_update` paths and by the ESP-IDF from git clone. Callers opt in with `init_submodules=True` and every declared submodule is initialized recursively; the previous named submodule list mode was dropped since nothing calls it. Which submodules get populated is git's own policy (`update = none`, `submodule.active`, sparse checkouts), so git's exit code is the error signal, and `run_git_command` now raises on any nonzero exit instead of only when stderr is non-empty. The clone command debug log also redacts credentials embedded in URLs. One behavior widening to note: library submodules are now fetched recursively to match how PlatformIO clones them, where the previous conversion was not recursive.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17860

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: example
  libraries:
    - libsesame3bt=https://github.com/homy-newfs8/libsesame3bt#0.33.2

esp32:
  board: esp32dev
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

