### PR TITLE
[dallas_temp][ds2484] Fix one_wire test configs for grouped CI batches

### DIFF
--- a/tests/components/dallas_temp/common.yaml
+++ b/tests/components/dallas_temp/common.yaml
@@ -1,14 +1,18 @@
 one_wire:
   - platform: gpio
+    id: ow_dallas_temp
     pin: ${one_wire_pin}
 
 sensor:
   - platform: dallas_temp
+    one_wire_id: ow_dallas_temp
     address: 0x1C0000031EDD2A28
     name: Dallas Temperature 1
     resolution: 9
   - platform: dallas_temp
+    one_wire_id: ow_dallas_temp
     name: Dallas Temperature 2
   - platform: dallas_temp
+    one_wire_id: ow_dallas_temp
     name: Dallas Temperature 3
     index: 2

--- a/tests/components/ds2484/common.yaml
+++ b/tests/components/ds2484/common.yaml
@@ -1,6 +1,7 @@
 one_wire:
-  platform: ds2484
-  i2c_id: i2c_bus
-  address: 0x18
-  active_pullup: true
-  strong_pullup: false
+  - platform: ds2484
+    id: ow_ds2484
+    i2c_id: i2c_bus
+    address: 0x18
+    active_pullup: true
+    strong_pullup: false


### PR DESCRIPTION
# What does this implement/fix?

Full component matrix runs (any PR touching core files) currently fail config validation in the batch that groups `dallas_temp` with the new `ds248x`/`ds2484` components:

```
sensor.dallas_temp: Too many candidates found for 'one_wire_id' type 'one_wire::OneWireBus'
Some are 'ow_100', 'ow_101', 'ow_800_0', ..., 'ow_800_7', 'ow_2484'.
```

Two problems combine to cause this:

- The `ds2484` test defines `one_wire:` as a single dict instead of a list. ESPHome's `merge_config` (used by the CI test grouping) replaces a list with a dict wholesale, so every `one_wire` bus merged before `ds2484` is dropped, and buses merged after replace the dict again. In the failing batch this silently deleted `dallas_temp`'s gpio bus (and `ds2484`'s own bus), leaving only the eleven `ds248x` buses.
- The `dallas_temp` test sensors don't specify `one_wire_id`, which is ambiguous as soon as any other one_wire provider ends up in the same merged config.

This converts the `ds2484` bus to list form with an explicit id, and pins the `dallas_temp` test sensors to their own bus id.

Not reproducible on normal PRs since `dallas_temp` and `ds248x` are only batched together in full matrix runs; `ds248x` merged July 18 (#12717) after the last full run, so the first core-touching PR since then hits it.

Verified locally with all three failing batch repro commands from the CI log (esp32-idf, esp8266-ard, rp2040-ard) — all pass now — plus the three components individually with `--no-grouping`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Test-only change, no user-facing configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).