### PR TITLE
[esp32][mdns][runtime_image] Bump recommended Arduino to 3.3.11 and platform to 55.03.311

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -814,14 +814,15 @@ def _is_framework_url(source: str) -> bool:
 # The default/recommended arduino framework version
 #  - https://github.com/espressif/arduino-esp32/releases
 ARDUINO_FRAMEWORK_VERSION_LOOKUP = {
-    "recommended": cv.Version(3, 3, 10),
-    "latest": cv.Version(3, 3, 10),
-    "dev": cv.Version(3, 3, 10),
+    "recommended": cv.Version(3, 3, 11),
+    "latest": cv.Version(3, 3, 11),
+    "dev": cv.Version(3, 3, 11),
 }
 ARDUINO_PLATFORM_VERSION_LOOKUP = {
     cv.Version(
         4, 0, 0, "alpha1"
     ): "https://github.com/pioarduino/platform-espressif32.git#prep_IDF6",
+    cv.Version(3, 3, 11): cv.Version(55, 3, 311),
     cv.Version(3, 3, 10): cv.Version(55, 3, 39),
     cv.Version(3, 3, 9): cv.Version(55, 3, 39),
     cv.Version(3, 3, 8): cv.Version(55, 3, 38, "1"),
@@ -845,6 +846,7 @@ ARDUINO_PLATFORM_VERSION_LOOKUP = {
 # See: https://github.com/pioarduino/esp-idf/releases
 ARDUINO_IDF_VERSION_LOOKUP = {
     cv.Version(4, 0, 0, "alpha1"): cv.Version(6, 0, 1),
+    cv.Version(3, 3, 11): cv.Version(5, 5, 5),
     cv.Version(3, 3, 10): cv.Version(5, 5, 5),
     cv.Version(3, 3, 9): cv.Version(5, 5, 4),
     cv.Version(3, 3, 8): cv.Version(5, 5, 4),
@@ -879,7 +881,7 @@ ESP_IDF_PLATFORM_VERSION_LOOKUP = {
     cv.Version(
         6, 0, 0
     ): "https://github.com/pioarduino/platform-espressif32.git#prep_IDF6",
-    cv.Version(5, 5, 5): cv.Version(55, 3, 39),
+    cv.Version(5, 5, 5): cv.Version(55, 3, 311),
     cv.Version(5, 5, 4): cv.Version(55, 3, 39),
     cv.Version(5, 5, 3, "1"): cv.Version(55, 3, 37),
     cv.Version(5, 5, 3): cv.Version(55, 3, 37),
@@ -900,8 +902,8 @@ ESP_IDF_PLATFORM_VERSION_LOOKUP = {
 # The platform-espressif32 version
 #  - https://github.com/pioarduino/platform-espressif32/releases
 PLATFORM_VERSION_LOOKUP = {
-    "recommended": cv.Version(55, 3, 39),
-    "latest": cv.Version(55, 3, 39),
+    "recommended": cv.Version(55, 3, 311),
+    "latest": cv.Version(55, 3, 311),
     "dev": "https://github.com/pioarduino/platform-espressif32.git#develop",
 }
 

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -209,7 +209,7 @@ async def to_code(config):
                 ethernet.request_ethernet_ip_state_listener()
 
     if CORE.is_esp32:
-        add_idf_component(name="espressif/mdns", ref="1.11.0")
+        add_idf_component(name="espressif/mdns", ref="1.11.3")
 
     cg.add_define("USE_MDNS")
 

--- a/esphome/components/runtime_image/__init__.py
+++ b/esphome/components/runtime_image/__init__.py
@@ -82,7 +82,7 @@ class JPEGFormat(Format):
             # JPEGDEC uses ESP32-S3 SIMD optimizations (guarded by board-level
             # ARDUINO_ESP32S3_DEV define) that require esp-dsp headers.
             # On Arduino this overwrites the stub; on IDF it adds the component.
-            add_idf_component(name="espressif/esp-dsp", ref="1.7.1")
+            add_idf_component(name="espressif/esp-dsp", ref="1.8.2")
 
 
 class PNGFormat(Format):

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -18,7 +18,7 @@ dependencies:
   esphome/micro-wav:
     version: 0.2.0
   espressif/esp-dsp:
-    version: "1.7.1"
+    version: "1.8.2"
   espressif/esp-tflite-micro:
     version: 1.3.3~1
   espressif/esp32-camera:

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -24,7 +24,7 @@ dependencies:
   espressif/esp32-camera:
     version: 2.1.7
   espressif/mdns:
-    version: 1.11.0
+    version: 1.11.3
   espressif/esp_wifi_remote:
     version: 1.5.1
     rules:

--- a/platformio.ini
+++ b/platformio.ini
@@ -141,9 +141,9 @@ extra_scripts = post:esphome/components/esp8266/post_build.py.script
 ; This are common settings for the ESP32 (all variants) using Arduino.
 [common:esp32-arduino]
 extends = common:arduino
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip
 platform_packages =
-    pioarduino/framework-arduinoespressif32@https://github.com/espressif/arduino-esp32/releases/download/3.3.10/esp32-core-3.3.10.tar.xz
+    pioarduino/framework-arduinoespressif32@https://github.com/espressif/arduino-esp32/releases/download/3.3.11/esp32-core-3.3.11.tar.xz
     pioarduino/framework-espidf@https://github.com/pioarduino/esp-idf/releases/download/v5.5.5/esp-idf-v5.5.5.tar.xz
 
 framework = arduino, espidf  ; Arduino as an ESP-IDF component
@@ -178,7 +178,7 @@ extra_scripts =
 ; This are common settings for the ESP32 (all variants) using IDF.
 [common:esp32-idf]
 extends = common:idf
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip
 platform_packages =
     pioarduino/framework-espidf@https://github.com/pioarduino/esp-idf/releases/download/v5.5.5/esp-idf-v5.5.5.tar.xz
 


### PR DESCRIPTION
# What does this implement/fix?

Bumps the recommended ESP32 Arduino framework version:

- **Arduino 3.3.9 -> 3.3.11** (via 3.3.10), mapped to ESP-IDF 5.5.5. pioarduino published a matching platform release **55.03.311** ("Arduino Release v3.3.11 based on ESP-IDF v5.5.5"), so unlike the 3.3.10 bump the platform tables no longer need to pair the newest framework versions with an older platform release.
- The recommended ESP-IDF version stays at 5.5.5.

Details:

- `ARDUINO_PLATFORM_VERSION_LOOKUP` gains 3.3.11 -> 55.3.311 and `ARDUINO_IDF_VERSION_LOOKUP` gains 3.3.11 -> 5.5.5.
- `ESP_IDF_PLATFORM_VERSION_LOOKUP` moves 5.5.5 from 55.3.39 to 55.3.311 and `PLATFORM_VERSION_LOOKUP` recommended/latest move to 55.3.311.
- `platformio.ini` platform pins updated to 55.03.311 and the Arduino core tarball to 3.3.11.
- Managed component pins raised to satisfy Arduino 3.3.11's new dependency floors (caught by the clang-tidy Arduino CI job): `espressif/mdns` 1.11.0 -> 1.11.3 (Arduino needs `^1.11.2`) and `espressif/esp-dsp` 1.7.1 -> 1.8.2 (Arduino needs `^1.8.0`), each in both `esphome/idf_component.yml` and the component's `add_idf_component` ref. Cross-checked the full 3.3.11 dependency list from the registry against every ESPHome pin - no other conflicts (remaining overlaps are caret-compatible or target-gated). Verified the esp32-arduino-tidy environment configures cleanly and both toolchains build wifi+api+mdns configs.

Note: this was blocked until yesterday because the Espressif component registry (which the native ESP-IDF toolchain installs `espressif/arduino-esp32` from) was missing 3.3.11 - their registry upload workflow stopped triggering after a release-workflow rename, reported in espressif/arduino-esp32#12781 and since backfilled.

Verified locally: a default `arduino` build on the native ESP-IDF toolchain (managed component 3.3.11 resolves from the registry and compiles to complete firmware) and a default `arduino` build on the PlatformIO toolchain (platform 55.03.311 + core 3.3.11 tarball + IDF 5.5.5). Both compile with no warnings.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32dev
  framework:
    type: arduino
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

