### PR TITLE
[ethernet] Set SPI CS hold time for ENC28J60

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -478,7 +478,7 @@ SPI_SCHEMA = _spi_schema()
 
 # The ENC28J60's SCK maximum is 20 MHz, so the shared 26.67 MHz default is out
 # of spec for it and makes the driver's CS hold time helper compute no hold
-ENC28J60_SPI_SCHEMA = _spi_schema(default_clock="20MHz", max_clock=int(20e6))
+SPI_SCHEMA_ENC28J60 = _spi_schema(default_clock="20MHz", max_clock=int(20e6))
 
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
@@ -494,7 +494,7 @@ CONFIG_SCHEMA = cv.All(
             "W5500": SPI_SCHEMA,
             "OPENETH": cv.All(BASE_SCHEMA, cv.only_on([Platform.ESP32])),
             "DM9051": SPI_SCHEMA,
-            "ENC28J60": ENC28J60_SPI_SCHEMA,
+            "ENC28J60": SPI_SCHEMA_ENC28J60,
             "W6100": cv.All(SPI_SCHEMA, cv.only_on([Platform.RP2])),
             "W6300": cv.All(SPI_SCHEMA, cv.only_on([Platform.RP2])),
             "LAN8670": RMII_SCHEMA,

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -437,37 +437,48 @@ GENERIC_SCHEMA = cv.All(
     cv.only_on([Platform.ESP32]),
 )
 
-SPI_SCHEMA = cv.All(
-    BASE_SCHEMA.extend(
-        cv.Schema(
-            {
-                cv.Required(CONF_CLK_PIN): pins.internal_gpio_output_pin_number,
-                cv.Required(CONF_MISO_PIN): pins.internal_gpio_input_pin_number,
-                cv.Required(CONF_MOSI_PIN): pins.internal_gpio_output_pin_number,
-                cv.Required(CONF_CS_PIN): pins.internal_gpio_output_pin_number,
-                cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_number,
-                cv.Optional(CONF_RESET_PIN): pins.internal_gpio_output_pin_number,
-                cv.SplitDefault(CONF_CLOCK_SPEED, esp32="26.67MHz"): cv.All(
-                    cv.only_on_esp32,
-                    cv.frequency,
-                    cv.int_range(int(8e6), int(80e6)),
-                ),
-                cv.Optional(CONF_INTERFACE): cv.All(
-                    cv.only_on_esp32,
-                    cv.one_of(*SPI_INTERFACE_MAP.keys(), lower=True),
-                ),
-                # Set default value (SPI_ETHERNET_DEFAULT_POLLING_INTERVAL) at _validate()
-                cv.Optional(CONF_POLLING_INTERVAL): cv.All(
-                    cv.only_on_esp32,
-                    cv.positive_time_period_milliseconds,
-                    cv.Range(min=TimePeriodMilliseconds(milliseconds=1)),
-                ),
-            }
+
+def _spi_schema(default_clock: str = "26.67MHz", max_clock: int = int(80e6)):
+    return cv.All(
+        BASE_SCHEMA.extend(
+            cv.Schema(
+                {
+                    cv.Required(CONF_CLK_PIN): pins.internal_gpio_output_pin_number,
+                    cv.Required(CONF_MISO_PIN): pins.internal_gpio_input_pin_number,
+                    cv.Required(CONF_MOSI_PIN): pins.internal_gpio_output_pin_number,
+                    cv.Required(CONF_CS_PIN): pins.internal_gpio_output_pin_number,
+                    cv.Optional(
+                        CONF_INTERRUPT_PIN
+                    ): pins.internal_gpio_input_pin_number,
+                    cv.Optional(CONF_RESET_PIN): pins.internal_gpio_output_pin_number,
+                    cv.SplitDefault(CONF_CLOCK_SPEED, esp32=default_clock): cv.All(
+                        cv.only_on_esp32,
+                        cv.frequency,
+                        cv.int_range(int(8e6), max_clock),
+                    ),
+                    cv.Optional(CONF_INTERFACE): cv.All(
+                        cv.only_on_esp32,
+                        cv.one_of(*SPI_INTERFACE_MAP.keys(), lower=True),
+                    ),
+                    # Set default value (SPI_ETHERNET_DEFAULT_POLLING_INTERVAL) at _validate()
+                    cv.Optional(CONF_POLLING_INTERVAL): cv.All(
+                        cv.only_on_esp32,
+                        cv.positive_time_period_milliseconds,
+                        cv.Range(min=TimePeriodMilliseconds(milliseconds=1)),
+                    ),
+                }
+            ),
         ),
-    ),
-    cv.only_on([Platform.ESP32, Platform.RP2]),
-    _validate_spi_interface,
-)
+        cv.only_on([Platform.ESP32, Platform.RP2]),
+        _validate_spi_interface,
+    )
+
+
+SPI_SCHEMA = _spi_schema()
+
+# The ENC28J60's SCK maximum is 20 MHz, so the shared 26.67 MHz default is out
+# of spec for it and makes the driver's CS hold time helper compute no hold
+ENC28J60_SPI_SCHEMA = _spi_schema(default_clock="20MHz", max_clock=int(20e6))
 
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
@@ -483,7 +494,7 @@ CONFIG_SCHEMA = cv.All(
             "W5500": SPI_SCHEMA,
             "OPENETH": cv.All(BASE_SCHEMA, cv.only_on([Platform.ESP32])),
             "DM9051": SPI_SCHEMA,
-            "ENC28J60": SPI_SCHEMA,
+            "ENC28J60": ENC28J60_SPI_SCHEMA,
             "W6100": cv.All(SPI_SCHEMA, cv.only_on([Platform.RP2])),
             "W6300": cv.All(SPI_SCHEMA, cv.only_on([Platform.RP2])),
             "LAN8670": RMII_SCHEMA,

--- a/esphome/components/ethernet/ethernet_component_esp32.cpp
+++ b/esphome/components/ethernet/ethernet_component_esp32.cpp
@@ -234,7 +234,7 @@ void EthernetComponent::ethernet_lazy_init_() {
 #elif defined(USE_ETHERNET_ENC28J60)
   // ENC28J60 does not support poll_period_ms. CS must stay asserted for the chip's CS hold
   // time (t10, 210 ns) after the last clock or MAC/MII register reads fail ("wrong chip ID")
-  enc28j60_config.spi_devcfg->cs_ena_posttrans = enc28j60_cal_spi_cs_hold_time(this->clock_speed_ / 1000000);
+  enc28j60_config.spi_devcfg->cs_ena_posttrans = enc28j60_cal_spi_cs_hold_time((this->clock_speed_ + 999999) / 1000000);
   enc28j60_config.int_gpio_num = this->interrupt_pin_;
 #endif
 

--- a/esphome/components/ethernet/ethernet_component_esp32.cpp
+++ b/esphome/components/ethernet/ethernet_component_esp32.cpp
@@ -233,9 +233,8 @@ void EthernetComponent::ethernet_lazy_init_() {
 #endif
 #elif defined(USE_ETHERNET_ENC28J60)
   enc28j60_config.int_gpio_num = this->interrupt_pin_;
-  // ENC28J60 does not support poll_period_ms
-  // CS must stay asserted for the chip's CS hold time (t10, 210 ns) after the
-  // last clock or MAC/MII register reads fail ("wrong chip ID" at driver init)
+  // ENC28J60 does not support poll_period_ms. CS must stay asserted for the chip's CS hold
+  // time (t10, 210 ns) after the last clock or MAC/MII register reads fail ("wrong chip ID")
   enc28j60_config.spi_devcfg->cs_ena_posttrans = enc28j60_cal_spi_cs_hold_time(this->clock_speed_ / 1000000);
 #endif
 

--- a/esphome/components/ethernet/ethernet_component_esp32.cpp
+++ b/esphome/components/ethernet/ethernet_component_esp32.cpp
@@ -232,10 +232,10 @@ void EthernetComponent::ethernet_lazy_init_() {
   dm9051_config.poll_period_ms = this->polling_interval_;
 #endif
 #elif defined(USE_ETHERNET_ENC28J60)
-  enc28j60_config.int_gpio_num = this->interrupt_pin_;
   // ENC28J60 does not support poll_period_ms. CS must stay asserted for the chip's CS hold
   // time (t10, 210 ns) after the last clock or MAC/MII register reads fail ("wrong chip ID")
   enc28j60_config.spi_devcfg->cs_ena_posttrans = enc28j60_cal_spi_cs_hold_time(this->clock_speed_ / 1000000);
+  enc28j60_config.int_gpio_num = this->interrupt_pin_;
 #endif
 
   phy_config.phy_addr = this->phy_addr_spi_;

--- a/esphome/components/ethernet/ethernet_component_esp32.cpp
+++ b/esphome/components/ethernet/ethernet_component_esp32.cpp
@@ -214,9 +214,6 @@ void EthernetComponent::ethernet_lazy_init_() {
 #elif defined(USE_ETHERNET_DM9051)
   eth_dm9051_config_t dm9051_config = ETH_DM9051_DEFAULT_CONFIG(host, &devcfg);
 #elif defined(USE_ETHERNET_ENC28J60)
-  // CS must stay asserted for the chip's CS hold time (t10, 210 ns) after the
-  // last clock or MAC/MII register reads fail ("wrong chip ID" at driver init)
-  devcfg.cs_ena_posttrans = enc28j60_cal_spi_cs_hold_time(this->clock_speed_ / 1000000);
   eth_enc28j60_config_t enc28j60_config = ETH_ENC28J60_DEFAULT_CONFIG(host, &devcfg);
 #endif
 
@@ -236,6 +233,9 @@ void EthernetComponent::ethernet_lazy_init_() {
 #endif
 #elif defined(USE_ETHERNET_ENC28J60)
   enc28j60_config.int_gpio_num = this->interrupt_pin_;
+  // CS must stay asserted for the chip's CS hold time (t10, 210 ns) after the
+  // last clock or MAC/MII register reads fail ("wrong chip ID" at driver init)
+  devcfg.cs_ena_posttrans = enc28j60_cal_spi_cs_hold_time(this->clock_speed_ / 1000000);
   // ENC28J60 does not support poll_period_ms
 #endif
 

--- a/esphome/components/ethernet/ethernet_component_esp32.cpp
+++ b/esphome/components/ethernet/ethernet_component_esp32.cpp
@@ -233,10 +233,10 @@ void EthernetComponent::ethernet_lazy_init_() {
 #endif
 #elif defined(USE_ETHERNET_ENC28J60)
   enc28j60_config.int_gpio_num = this->interrupt_pin_;
+  // ENC28J60 does not support poll_period_ms
   // CS must stay asserted for the chip's CS hold time (t10, 210 ns) after the
   // last clock or MAC/MII register reads fail ("wrong chip ID" at driver init)
   enc28j60_config.spi_devcfg->cs_ena_posttrans = enc28j60_cal_spi_cs_hold_time(this->clock_speed_ / 1000000);
-  // ENC28J60 does not support poll_period_ms
 #endif
 
   phy_config.phy_addr = this->phy_addr_spi_;

--- a/esphome/components/ethernet/ethernet_component_esp32.cpp
+++ b/esphome/components/ethernet/ethernet_component_esp32.cpp
@@ -235,7 +235,7 @@ void EthernetComponent::ethernet_lazy_init_() {
   enc28j60_config.int_gpio_num = this->interrupt_pin_;
   // CS must stay asserted for the chip's CS hold time (t10, 210 ns) after the
   // last clock or MAC/MII register reads fail ("wrong chip ID" at driver init)
-  devcfg.cs_ena_posttrans = enc28j60_cal_spi_cs_hold_time(this->clock_speed_ / 1000000);
+  enc28j60_config.spi_devcfg->cs_ena_posttrans = enc28j60_cal_spi_cs_hold_time(this->clock_speed_ / 1000000);
   // ENC28J60 does not support poll_period_ms
 #endif
 

--- a/esphome/components/ethernet/ethernet_component_esp32.cpp
+++ b/esphome/components/ethernet/ethernet_component_esp32.cpp
@@ -214,6 +214,9 @@ void EthernetComponent::ethernet_lazy_init_() {
 #elif defined(USE_ETHERNET_DM9051)
   eth_dm9051_config_t dm9051_config = ETH_DM9051_DEFAULT_CONFIG(host, &devcfg);
 #elif defined(USE_ETHERNET_ENC28J60)
+  // CS must stay asserted for the chip's CS hold time (t10, 210 ns) after the
+  // last clock or MAC/MII register reads fail ("wrong chip ID" at driver init)
+  devcfg.cs_ena_posttrans = enc28j60_cal_spi_cs_hold_time(this->clock_speed_ / 1000000);
   eth_enc28j60_config_t enc28j60_config = ETH_ENC28J60_DEFAULT_CONFIG(host, &devcfg);
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

The ENC28J60 requires CS to stay asserted for its CS hold time (t10, 210 ns) after the last clock edge or MAC/MII register reads return garbage. The SPI device config hardcoded `cs_ena_posttrans = 0`, which the classic ESP32 SPI peripheral tolerated but the S2/S3/C3 peripheral does not (it deasserts CS immediately after the last clock — same root cause as espressif/esp-idf#7758), making driver init fail with `enc28j60: wrong chip ID` when reading the revision register.

Compute the hold time from the configured clock speed using the driver's own `enc28j60_cal_spi_cs_hold_time()` helper, the same way the ESP-IDF ENC28J60 example does. W5500 and DM9051 are unchanged (no CS hold requirement).

The ENC28J60 also gets its own `clock_speed` schema: default 20MHz and a 8-20MHz range. The chip's SCK maximum is 20MHz, so the shared 26.67MHz SPI default was out of spec for it — and above 20MHz the driver's hold time helper returns zero, which would have silently disabled this fix for any config without an explicit `clock_speed`. Existing configs with `clock_speed` above 20MHz for ENC28J60 now fail validation; lower the value to 20MHz or less (the chip never supported faster clocks, such configs were relying on out-of-spec behaviour).

Hardware-confirmed by the reporter in #17882 on ESP32-C3: previously failing module now initializes, gets a DHCP lease, and connects to Home Assistant (tested via a 2026.7.2-based build of this change as an external component).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17882

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
ethernet:
  type: ENC28J60
  clk_pin: GPIO04
  clock_speed: 8MHz
  mosi_pin: GPIO06
  miso_pin: GPIO05
  cs_pin: GPIO07
  interrupt_pin: GPIO09
  reset_pin: GPIO10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

