### PR TITLE
[bluetooth_proxy] Answer UNPAIR with BluetoothDeviceUnpairingResponse

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -247,7 +247,7 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
       esp_bd_addr_t address;
       uint64_to_bd_addr(msg.address, address);
       esp_err_t ret = esp_ble_remove_bond_device(address);
-      this->send_device_pairing(msg.address, ret == ESP_OK, ret);
+      this->send_device_unpairing(msg.address, ret == ESP_OK, ret);
       break;
     }
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE: {


### PR DESCRIPTION
# What does this implement/fix?

`bluetooth_proxy` answers a `BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR` request with a **pairing** response instead of an unpairing one.

`api.proto` defines two distinct messages:

| message | id | payload field |
|---|---|---|
| `BluetoothDevicePairingResponse` | 85 | `paired` |
| `BluetoothDeviceUnpairingResponse` | 86 | `success` |

The `UNPAIR` handler calls `send_device_pairing()`, so it emits id 85 where the client is waiting for id 86:

```cpp
case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR: {
  esp_err_t ret = esp_ble_remove_bond_device(address);
  this->send_device_pairing(msg.address, ret == ESP_OK, ret);   // sends id 85
```

`send_device_unpairing()` already exists immediately below `send_device_pairing()` with the matching signature, and has no callers — which is why the mismatch has gone unnoticed. This changes the one call so the request is answered with the message the client expects.

## Why it went unnoticed

Nothing in the tree called `send_device_unpairing()`, so the helper was effectively dead code and the wrong-type reply was never contrasted with a correct one. It surfaced while reviewing #17880, which adds a second code path handling the same request.

**Related issue or feature (if applicable):**

- Surfaced during review of #17880; opened separately at @bdraco's request so the wire fix lands ahead of that PR.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
