### PR TITLE
[ci] Read the GitHub event file as UTF-8

### DIFF
--- a/script/helpers.py
+++ b/script/helpers.py
@@ -421,7 +421,10 @@ def _get_github_event_data() -> dict | None:
     """
     github_event_path = os.environ.get("GITHUB_EVENT_PATH")
     if github_event_path and Path(github_event_path).exists():
-        with Path(github_event_path).open() as f:
+        # The event payload is UTF-8 JSON; without an explicit encoding
+        # Windows decodes it as cp1252 and any non ASCII byte (an ellipsis in
+        # a commit title is enough) raises UnicodeDecodeError.
+        with Path(github_event_path).open(encoding="utf-8") as f:
             return json.load(f)
     return None
 

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -79,6 +79,22 @@ def test_get_pr_number_from_github_env_event_file(
     assert result == "5678"
 
 
+def test_get_github_event_data_decodes_utf8_regardless_of_locale(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """The event payload is UTF-8; parsing must not depend on the platform
+    default encoding. On Windows the default is cp1252, which raised
+    UnicodeDecodeError as soon as a commit title carried non ASCII text."""
+    event_file = tmp_path / "event.json"
+    event_data = {"head_commit": {"message": "Answer UNPAIR with Response… é"}}
+    event_file.write_bytes(json.dumps(event_data, ensure_ascii=False).encode("utf-8"))
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+
+    result = helpers._get_github_event_data()
+
+    assert result == event_data
+
+
 def test_get_pr_number_from_github_env_no_pr(
     monkeypatch: MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The `pytest (3.12, windows-latest)` job on dev fails with 36 errors in `tests/script/test_determine_jobs.py` since the merge of #17895. The tests call `main()`, which reads the runner's real `GITHUB_EVENT_PATH` file through `_get_github_event_data()`; that open has no explicit encoding, so Windows decodes the UTF-8 payload as cp1252 and raises `UnicodeDecodeError` as soon as the triggering commit title carries non ASCII text, in this case the ellipsis in the #17895 title.

This opens the event file with `encoding="utf-8"` and adds a regression test whose payload contains non ASCII text, so the parse is exercised on the Windows runner regardless of the platform default encoding.

Failing job: https://github.com/esphome/esphome/actions/runs/30325390938/job/90169690352

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

CI tooling only; no firmware change.

## Example entry for `config.yaml`:

```yaml
# No config change.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
