### PR TITLE
[ci] Enable the ruff rule requiring explicit encoding on text file I/O

### DIFF
--- a/esphome/components/wifi/wpa2_eap.py
+++ b/esphome/components/wifi/wpa2_eap.py
@@ -58,7 +58,7 @@ def wrapped_load_pem_private_key(value, password):
 
 def read_relative_config_path(value):
     # pylint: disable=unspecified-encoding
-    return Path(CORE.relative_config_path(value)).read_text()
+    return Path(CORE.relative_config_path(value)).read_text(encoding="utf-8")
 
 
 def _validate_load_certificate(value):

--- a/esphome/espidf/extra_script.py
+++ b/esphome/espidf/extra_script.py
@@ -107,7 +107,7 @@ def run_extra_script(
     script shouldn't block the build.
     """
     env = _FakeSConsEnv(board_mcu=idf_target, pio_env=f"esphome_{idf_target}")
-    code = compile(script_path.read_text(), str(script_path), "exec")
+    code = compile(script_path.read_text(encoding="utf-8"), str(script_path), "exec")
     old_cwd = Path.cwd()
     try:
         os.chdir(library_dir)

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -57,7 +57,7 @@ def _find_app_partition_size(partitions_csv: Path) -> int:
     """
     if not partitions_csv.is_file():
         raise ValueError(f"partitions.csv not found at {partitions_csv}")
-    for row in csv.reader(partitions_csv.read_text().splitlines()):
+    for row in csv.reader(partitions_csv.read_text(encoding="utf-8").splitlines()):
         cells = [c.strip() for c in row]
         if not cells or cells[0].startswith("#") or len(cells) < 5:
             continue
@@ -89,7 +89,7 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         _LOGGER.debug("Skipping size summary: %s not found", size_json)
         return
     try:
-        data = json.loads(size_json.read_text())
+        data = json.loads(size_json.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as e:
         _LOGGER.debug("Skipping size summary: %s", e)
         return

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -110,8 +110,12 @@ def prepare(
             CONF_CLIENT_CERTIFICATE_KEY
         ):
             with (
-                tempfile.NamedTemporaryFile(mode="w+", delete=False) as cert_file,
-                tempfile.NamedTemporaryFile(mode="w+", delete=False) as key_file,
+                tempfile.NamedTemporaryFile(
+                    encoding="utf-8", mode="w+", delete=False
+                ) as cert_file,
+                tempfile.NamedTemporaryFile(
+                    encoding="utf-8", mode="w+", delete=False
+                ) as key_file,
             ):
                 try:
                     cert_file.write(config[CONF_MQTT].get(CONF_CLIENT_CERTIFICATE))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,10 @@ target-version = "py312"
 exclude = ['generated']
 
 [tool.ruff.lint]
+# Preview mode is scoped: with explicit-preview-rules only rules named in
+# select run in preview, prefixes like "PL" keep their stable set.
+preview = true
+explicit-preview-rules = true
 select = [
   "B",    # flake8-bugbear
   "BLE",  # flake8-blind-except
@@ -131,6 +135,7 @@ select = [
   "PGH",  # pygrep-hooks
   "PIE",  # flake8-pie
   "PL",   # pylint
+  "PLW1514", # require explicit encoding on text file I/O (Windows defaults to cp1252)
   "PTH",  # flake8-use-pathlib
   "PYI",  # flake8-pyi
   "Q",    # flake8-quotes

--- a/script/check_import_time.py
+++ b/script/check_import_time.py
@@ -194,7 +194,7 @@ def cmd_update(args: argparse.Namespace) -> int:
 
 
 def cmd_har_only(args: argparse.Namespace) -> int:
-    Path(args.har).write_text(run_waterfall(TARGET_MODULE))
+    Path(args.har).write_text(run_waterfall(TARGET_MODULE), encoding="utf-8")
     print(f"Wrote waterfall HAR to {args.har}")
     return 0
 

--- a/script/ci_memory_impact_extract.py
+++ b/script/ci_memory_impact_extract.py
@@ -269,7 +269,7 @@ def main() -> int:
     if args.output_build_dir and build_dir:
         build_dir_path = Path(args.output_build_dir)
         build_dir_path.parent.mkdir(parents=True, exist_ok=True)
-        build_dir_path.write_text(build_dir)
+        build_dir_path.write_text(build_dir, encoding="utf-8")
         print(f"Wrote build directory to {args.output_build_dir}", file=sys.stderr)
 
     # Run detailed analysis if build directory available

--- a/script/setup_codspeed_lib.py
+++ b/script/setup_codspeed_lib.py
@@ -84,7 +84,7 @@ def _read_codspeed_version(cmake_path: Path) -> str:
     """Extract CODSPEED_VERSION from core/CMakeLists.txt."""
     if not cmake_path.exists():
         return "0.0.0"
-    for line in cmake_path.read_text().splitlines():
+    for line in cmake_path.read_text(encoding="utf-8").splitlines():
         if line.startswith("set(CODSPEED_VERSION"):
             return line.split()[1].rstrip(")")
     return "0.0.0"

--- a/script/test_build_components.py
+++ b/script/test_build_components.py
@@ -367,7 +367,7 @@ def run_esphome_test(
     output_file = build_dir / f"{component}.{test_name}.{platform_with_version}.yaml"
 
     # Copy base file and substitute component test file reference
-    base_content = base_file.read_text()
+    base_content = base_file.read_text(encoding="utf-8")
     # Get relative path from build dir to test file
     repo_root = Path(__file__).parent.parent
     component_test_ref = f"../../{test_file.relative_to(repo_root / 'tests')}"
@@ -524,7 +524,7 @@ def run_grouped_test(
 
     # Create test file that includes merged config
     output_file = build_dir / f"test_{group_name}.{platform_with_version}.yaml"
-    base_content = base_file.read_text()
+    base_content = base_file.read_text(encoding="utf-8")
     merged_ref = merged_config_file.name
     output_content = base_content.replace("$component_test_file", merged_ref)
     output_file.write_text(output_content)

--- a/tests/unit_tests/analyze_memory/test_build_artifacts.py
+++ b/tests/unit_tests/analyze_memory/test_build_artifacts.py
@@ -22,7 +22,7 @@ def _make_build_dir(tmp_path: Path, name: str = "mydevice") -> Path:
 
 def _touch(path: Path) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("")
+    path.write_text("", encoding="utf-8")
     return path
 
 

--- a/tests/unit_tests/test_compiled_config.py
+++ b/tests/unit_tests/test_compiled_config.py
@@ -74,13 +74,13 @@ def _write_storage(
         "framework": "arduino",
         "core_platform": core_platform,
     }
-    storage_path.write_text(json.dumps(data))
+    storage_path.write_text(json.dumps(data), encoding="utf-8")
 
 
 def _write_cache(cache_path: Path, body: str = _VALIDATED_CONFIG_YAML) -> Path:
     """Write the cache file and return it."""
     cache_path.parent.mkdir(parents=True, exist_ok=True)
-    cache_path.write_text(body)
+    cache_path.write_text(body, encoding="utf-8")
     return cache_path
 
 


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #17896, which fixed a Windows CI failure caused by reading a UTF-8 file without an explicit encoding. This enables ruff's `PLW1514` (unspecified-encoding) so the whole bug class is caught at lint time; on Windows the platform default is cp1252, so any text file opened without an encoding breaks as soon as the content carries non ASCII bytes. esphome/device-builder#1027 already enabled this rule in that repo after hitting the same class of bug and it has kept it from coming back there; this brings the same guard here, which we forgot at the time.

`PLW1514` is a preview rule, so preview mode is enabled with `explicit-preview-rules`; only rules named explicitly in `select` run in preview, prefixes like `PL` keep their stable set. The 14 existing violations are fixed by adding `encoding="utf-8"`; all of them read or write YAML, JSON, source or PEM text where UTF-8 is correct.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Lint and tooling only; ruff check and ruff format pass over the whole tree, affected unit tests pass.

## Example entry for `config.yaml`:

```yaml
# No config change.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

