### PR TITLE
[ci] Attribute device class sync commits to the esphome[bot] account

### DIFF
--- a/.github/workflows/sync-device-classes.yml
+++ b/.github/workflows/sync-device-classes.yml
@@ -96,8 +96,8 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "Synchronise Device Classes from Home Assistant"
-          committer: esphomebot <esphome@openhomefoundation.org>
-          author: esphomebot <esphome@openhomefoundation.org>
+          committer: esphome[bot] <115708604+esphome[bot]@users.noreply.github.com>
+          author: esphome[bot] <115708604+esphome[bot]@users.noreply.github.com>
           branch: sync/device-classes
           delete-branch: true
           title: "Synchronise Device Classes from Home Assistant"


### PR DESCRIPTION
# What does this implement/fix?

The `sync-device-classes.yml` workflow mints a GitHub App token from `ESPHOME_GITHUB_APP_CLIENT_ID` / `ESPHOME_GITHUB_APP_PRIVATE_KEY` and hands it to `peter-evans/create-pull-request`, but it set the commit identity to `esphomebot <esphome@openhomefoundation.org>`. `esphomebot` is a separate legacy User account, and that org email does not map to the App's bot account, so GitHub never attributed the resulting commits to `esphome[bot]` even though the App token was what created them.

Both `committer:` and `author:` now use the App bot's real identity, `esphome[bot] <115708604+esphome[bot]@users.noreply.github.com>`. The `<id>+<login>@users.noreply.github.com` form is what GitHub requires to link a commit to an account. The values are verified rather than guessed: `gh api users/esphome%5Bbot%5D` returns `{"id":115708604,"login":"esphome[bot]","type":"Bot"}`, and existing merged commits in this repo such as b395a87c carry exactly that name and email and resolve to `author.login == "esphome[bot]"`.

I also swept the rest of `.github/` for other places that set a git commit identity. This is the only one. `peter-evans/create-pull-request` is used nowhere else, no run step sets `git config user.name` or `user.email`, and the composite actions under `.github/actions/` do not create commits. The other workflows that mint an `ESPHOME_GITHUB_APP_*` token (`auto-label-pr`, `codeowner-review-request`, `external-component-bot`, `release`) only make REST API calls with it, so there is no identity for them to get wrong.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).