### PR TITLE
[ble_device_base] Add mac_lsb_first_to_uint64 address-packing helper

### DIFF
--- a/esphome/components/ble_device_base/ble_device.h
+++ b/esphome/components/ble_device_base/ble_device.h
@@ -144,6 +144,20 @@ class ESPBLEiBeacon {
   } beacon_data_;
 };
 
+/// Pack a controller-order (LSB-first) MAC into the uint64 the API speaks.
+///
+/// The result is the printable-order value esp32 has always sent
+/// (esp32_ble::ble_addr_to_uint64), so both proxy paths agree on the wire.
+/// This takes the raw controller order delivered by BLEHub's raw-advertisement
+/// callback; ESPBTDevice::address_uint64() is the equivalent for an already
+/// parsed device, whose address is stored MSB-first.
+inline uint64_t mac_lsb_first_to_uint64(const uint8_t *mac) {
+  uint64_t addr = 0;
+  for (int i = 0; i < 6; i++)
+    addr |= static_cast<uint64_t>(mac[i]) << (i * 8);
+  return addr;
+}
+
 // ---------------------------------------------------------------------------
 // ESPBTDevice — parsed BLE advertisement
 // ---------------------------------------------------------------------------

--- a/tests/components/ble_device_base/test_address.cpp
+++ b/tests/components/ble_device_base/test_address.cpp
@@ -28,4 +28,19 @@ TEST(BleDeviceAddress, AccessorsMatchEsp32Semantics) {
   EXPECT_EQ(device.address_str(), "AA:BB:CC:DD:EE:FF");
 }
 
+// mac_lsb_first_to_uint64() packs the controller-order bytes a raw-advertisement
+// callback delivers into the printable-order uint64 the native API speaks — the
+// value esp32_ble::ble_addr_to_uint64() has always produced for that address.
+TEST(BleDeviceAddress, MacLsbFirstToUint64MatchesWireValue) {
+  EXPECT_EQ(mac_lsb_first_to_uint64(MAC_LSB_FIRST), 0xAABBCCDDEEFFULL);
+}
+
+// The helper and the parsed-device accessor are two routes to the same wire
+// value: byte order must agree no matter which path an advertisement takes.
+TEST(BleDeviceAddress, MacLsbFirstToUint64AgreesWithParsedDevice) {
+  ESPBTDevice device;
+  device.from_scan_result(MAC_LSB_FIRST, -50, BLE_ADDR_TYPE_PUBLIC, nullptr, 0);
+  EXPECT_EQ(mac_lsb_first_to_uint64(MAC_LSB_FIRST), device.address_uint64());
+}
+
 }  // namespace esphome::ble_device_base::testing


### PR DESCRIPTION
# What does this implement/fix?

Adds `ble_device_base::mac_lsb_first_to_uint64()` — a free helper that packs a controller-order (LSB-first) MAC into the uint64 the native API speaks.

For the same address it produces the value `esp32_ble::ble_addr_to_uint64()` has always produced (verified bit-identical for reversed byte order), but it lives in the platform-neutral layer and takes the byte order `BLEHub`'s raw-advertisement callback delivers — `esp32_ble`'s helper is not compiled off-esp32 and expects MSB-first bytes. `ESPBTDevice::address_uint64()` remains the equivalent for an already-parsed device, whose stored address is MSB-first.

First consumer is the platform-neutral `bluetooth_proxy` (#17880), which was asked in review to replace open-coded shifts with a helper; split into its own PR so the change to the merged `ble_device_base` component is reviewed on its own, and #17880 stays scoped to `bluetooth_proxy`.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#164 (BLE architecture page — the new "Address byte order" section documents this helper alongside `address_uint64()`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Checklist:

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (under `tests/` folder): `tests/components/ble_device_base/test_address.cpp` gains two cases — the helper produces the exact wire value for a known address, and it agrees with `ESPBTDevice::address_uint64()` for the same controller-order input.
