### PR TITLE
[ci] Bind the branch name to env before sanitising it into a docker tag

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -71,11 +71,13 @@ jobs:
 
       - name: Determine tag and whether to push
         id: tag
+        env:
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           # Sanitize the branch name into a valid docker tag: replace invalid
           # characters, ensure the first character is valid (tags must start
           # with [A-Za-z0-9_]), and cap the length at 128 characters.
-          branch="${{ github.head_ref || github.ref_name }}"
+          branch="$HEAD_REF"
           tag="${branch//[^a-zA-Z0-9_.-]/-}"
           case "$tag" in
             [a-zA-Z0-9_]*) ;;


### PR DESCRIPTION
Hi, and thanks for ESPHome.

In `.github/workflows/ci-docker.yml`, the "Determine tag and whether to push" step reads the branch name like this:

```yaml
run: |
  # Sanitize the branch name into a valid docker tag: ...
  branch="${{ github.head_ref || github.ref_name }}"
  tag="${branch//[^a-zA-Z0-9_.-]/-}"
```

The sanitising on the next line is doing the right thing, but it happens one step too late to help with this particular problem. Actions expands `${{ ... }}` into the script text before bash runs, so by the time `${branch//[^a-zA-Z0-9_.-]/-}` executes, the branch name has already been part of the script for one line. Git allows `$`, `(`, `)` and backticks in branch names, and `$(...)` runs inside double quotes — so a PR from a fork on a branch named something like `x$(id)` would execute that before the sanitiser ever sees it.

To be clear about the scope: this workflow is `pull_request`, not `pull_request_target`, so a fork PR gets a read-only token and no secrets. I am raising it as hardening, not as a live path to your credentials.

The change binds the value to an environment variable so the shell receives it as data, and leaves your sanitising exactly as it is:

```yaml
env:
  HEAD_REF: ${{ github.head_ref || github.ref_name }}
run: |
  branch="$HEAD_REF"
  tag="${branch//[^a-zA-Z0-9_.-]/-}"
```

The tag rules — the character replacement, the `[a-zA-Z0-9_]*` first-character check and the `pr-` prefix, the 128-character cap — all behave exactly as before. Two lines added, one changed.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its trigger myself.
