### PR TITLE
[core] Reject configs that set both keys in cv.rename_key

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -2723,6 +2723,9 @@ def rename_key(
 ):
     """Rename a config key from ``old_key`` to ``new_key``.
 
+    Specifying both keys is an error; otherwise only one of the two would
+    survive the rename and the other would be dropped silently.
+
     When ``removed_in`` is set, a deprecation warning is logged if the old key is
     present. Pass ``component`` (the platform/component name) alongside
     ``removed_in`` so the warning identifies where it originates.
@@ -2731,6 +2734,7 @@ def rename_key(
     def validator(config: dict) -> dict:
         config = config.copy()
         if old_key in config:
+            has_at_most_one_key(old_key, new_key)(config)
             if removed_in is not None:
                 prefix = f"[{component}] " if component else ""
                 _LOGGER.warning(

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -2956,6 +2956,22 @@ def test_rename_key_removed_in_with_component_prefixes_warning(
     )
 
 
+def test_rename_key_both_keys_rejected() -> None:
+    with pytest.raises(Invalid, match="Cannot specify more than one of"):
+        cv.rename_key("old", "new")({"old": 5, "new": 6})
+
+
+def test_rename_key_both_keys_rejected_with_removed_in(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with (
+        caplog.at_level(logging.WARNING, logger="esphome.config_validation"),
+        pytest.raises(Invalid, match="Cannot specify more than one of"),
+    ):
+        cv.rename_key("old", "new", removed_in="2026.8.0")({"old": 5, "new": 6})
+    assert not caplog.records
+
+
 def test_file__existing_relative_path(setup_core: Path) -> None:
     (setup_core / "partitions.csv").write_text("csv\n")
 


### PR DESCRIPTION
# What does this implement/fix?

`cv.rename_key` renames `old_key` to `new_key`, but when a config sets both, only one survives: the old key's value overwrites the new one and the block written under the new key is dropped with no error. With `removed_in` set the user gets a deprecation warning, which points at the wrong thing entirely.

This reuses the existing `has_at_most_one_key` validator to reject that config instead:

```
Cannot specify more than one of 'voc_index', 'voc'. @ data['voc_index']
```

Follow-up to #17740, suggested in review on #17723.

No behavior change for the existing callers. All three `api` call sites already pair `rename_key` with `cv.has_exactly_one_key` or `cv.Exclusive` on both keys, so those configs are rejected today and are rejected identically after this change.

The deprecation case is the one that can't do that, which is what makes this worth having. The old key isn't in the schema at all, so `rename_key` has to run first in the `cv.All` and there's no schema-level place to declare the two keys mutually exclusive. The gas index key renames in #17723, #17724 and #17725 are in that shape: a user who reads the deprecation warning, adds `voc_index:` with their name and id, then forgets to delete the old `voc:` block silently keeps running the old one.

The check runs before the deprecation warning, so a rejected config doesn't also get told its old key is deprecated. It is not gated on `removed_in`, since the two keys collide the same way whether or not the rename is a deprecation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

An external component calling `rename_key` without a paired exclusivity check will now reject a config setting both keys rather than silently dropping one. That's the intent of the change.

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A, no documented option changes.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Python-only config-validation change, no platform-specific behavior.

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: sgp4x
    voc:
      name: Old VOC
    voc_index:
      name: New VOC Index
```

Before, the `voc_index` block is discarded and the config validates. After, it fails with the message above.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
