### PR TITLE
[ble_client] Do not walk the GATT cache after releasing services

### DIFF
--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -51,7 +51,9 @@ bool BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
   for (auto *node : this->nodes_)
     node->gattc_event_handler(event, esp_gattc_if, param);
 
-  if (!this->services_.empty() && this->all_nodes_established_()) {
+  // The release frees the GATT cache that BLEClientBase's CCCD lookup still needs.
+  // The last REG_FOR_NOTIFY event clears the counter before node dispatch, so the release still runs here.
+  if (!this->services_.empty() && !this->notify_registration_pending() && this->all_nodes_established_()) {
     this->release_services();
     ESP_LOGD(TAG, "All clients established, services released");
   }

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -34,6 +34,11 @@ class BLEClientNode {
   // This should be transitioned to Established once the node no longer needs
   // the services/descriptors/characteristics of the parent client. This will
   // allow some memory to be freed.
+  // The parent frees the peer's GATT cache once every node reports Established.
+  // Never report Established while an operation that reads that cache is outstanding.
+  // - esp_ble_gattc_register_for_notify() completes asynchronously.
+  // - Register from ESP_GATTC_SEARCH_CMPL_EVT, then set this from ESP_GATTC_REG_FOR_NOTIFY_EVT.
+  // - BLEClientBase::register_for_notify() holds the release until the registration completes.
   espbt::ClientState node_state;
 
   BLEClient *parent() { return this->parent_; }

--- a/esphome/components/ble_client/sensor/ble_sensor.cpp
+++ b/esphome/components/ble_client/sensor/ble_sensor.cpp
@@ -77,8 +77,7 @@ void BLESensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
         this->handle = descr->handle;
       }
       if (this->notify_) {
-        auto status = esp_ble_gattc_register_for_notify(this->parent()->get_gattc_if(),
-                                                        this->parent()->get_remote_bda(), chr->handle);
+        auto status = this->parent()->register_for_notify(chr->handle);
         if (status) {
           ESP_LOGW(TAG, "esp_ble_gattc_register_for_notify failed, status=%d", status);
         }

--- a/esphome/components/ble_client/text_sensor/ble_text_sensor.cpp
+++ b/esphome/components/ble_client/text_sensor/ble_text_sensor.cpp
@@ -77,8 +77,7 @@ void BLETextSensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         this->handle = descr->handle;
       }
       if (this->notify_) {
-        auto status = esp_ble_gattc_register_for_notify(this->parent()->get_gattc_if(),
-                                                        this->parent()->get_remote_bda(), chr->handle);
+        auto status = this->parent()->register_for_notify(chr->handle);
         if (status) {
           ESP_LOGW(TAG, "esp_ble_gattc_register_for_notify failed, status=%d", status);
         }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -528,8 +528,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       }
       if (this->services_released_) {
         // The lookup below walks the freed GATT cache, and Bluedroid asserts on it rather than erroring.
-        ESP_LOGW(TAG, "[%d] [%s] REG_FOR_NOTIFY after services released, notifications not enabled",
-                 this->connection_index_, this->address_str_);
+        this->log_warning_("REG_FOR_NOTIFY after services released, notifications not enabled");
         break;
       }
       esp_gattc_descr_elem_t desc_result;

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -125,6 +125,9 @@ void BLEClientBase::connect() {
   }
   ESP_LOGI(TAG, "[%d] [%s] 0x%02x Connecting", this->connection_index_, this->address_str_, this->remote_addr_type_);
   this->paired_ = false;
+  // A registration whose event never arrived must not block this connection's release.
+  this->services_released_ = false;
+  this->pending_notify_regs_ = 0;
   // Enable loop for state processing
   this->enable_loop();
   // Immediately transition to CONNECTING to prevent duplicate connection attempts
@@ -200,8 +203,24 @@ void BLEClientBase::release_services() {
   this->services_.clear();
 #endif
 #ifndef CONFIG_BT_GATTC_CACHE_NVS_FLASH
+  // Only the cache clean makes the stack's database unsafe to walk.
+  this->services_released_ = true;
   esp_ble_gattc_cache_clean(this->remote_bda_);
 #endif
+}
+
+esp_err_t BLEClientBase::register_for_notify(uint16_t char_handle) {
+  esp_err_t err = esp_ble_gattc_register_for_notify(this->gattc_if_, this->remote_bda_, char_handle);
+  if (err != ESP_OK)
+    return err;
+  if (this->pending_notify_regs_ == UINT8_MAX) {
+    // Saturating undercounts, so the release can run before the last registration completes.
+    // Wrapping to zero would undercount by the full range instead, which is worse.
+    this->log_warning_("Too many outstanding notify registrations to track");
+    return err;
+  }
+  this->pending_notify_regs_++;
+  return err;
 }
 
 void BLEClientBase::log_event_(const char *name) {
@@ -498,10 +517,19 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
       this->log_gattc_data_event_("REG_FOR_NOTIFY");
+      // The event carries no conn_id, so this is the only place the request can be retired.
+      if (this->pending_notify_regs_ > 0)
+        this->pending_notify_regs_--;
       if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
           this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
         // Client is responsible for flipping the descriptor value
         // when using the cache
+        break;
+      }
+      if (this->services_released_) {
+        // The lookup below walks the freed GATT cache, and Bluedroid asserts on it rather than erroring.
+        ESP_LOGW(TAG, "[%d] [%s] REG_FOR_NOTIFY after services released, notifications not enabled",
+                 this->connection_index_, this->address_str_);
         break;
       }
       esp_gattc_descr_elem_t desc_result;

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -44,6 +44,12 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void unconditional_disconnect();
   void release_services();
 
+  /// Register for notifications, holding the service release until the registration completes.
+  esp_err_t register_for_notify(uint16_t char_handle);
+
+  /// True while a register_for_notify() request has not completed.
+  bool notify_registration_pending() const { return this->pending_notify_regs_ > 0; }
+
   bool connected() { return this->state() == espbt::ClientState::ESTABLISHED; }
 
   void set_auto_connect(bool auto_connect) { this->auto_connect_ = auto_connect; }
@@ -125,9 +131,13 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   espbt::ConnectionType connection_type_{espbt::ConnectionType::V1};
   uint8_t connection_index_;
   uint8_t service_count_{0};  // ESP32 has max handles < 255, typical devices have < 50 services
+  // Outstanding register_for_notify() requests
+  uint8_t pending_notify_regs_{0};
   bool auto_connect_{false};
   bool paired_{false};
-  // 6 bytes used, 2 bytes padding
+  // Set only when release_services() cleans the stack's GATT cache, which no API may then walk
+  bool services_released_{false};
+  // 8 bytes used, no padding
 
   void log_event_(const char *name);
   void log_gattc_lifecycle_event_(const char *name);

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -132,6 +132,8 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   uint8_t connection_index_;
   uint8_t service_count_{0};  // ESP32 has max handles < 255, typical devices have < 50 services
   // Outstanding register_for_notify() requests
+  // A count, not per-request state, so a raw esp_ble_gattc_register_for_notify() on the same client can retire one
+  // services_released_ is the backstop if that ever lets the release run early
   uint8_t pending_notify_regs_{0};
   bool auto_connect_{false};
   bool paired_{false};


### PR DESCRIPTION
# What does this implement/fix?

`ble_client` releases the peer's GATT database while a notify registration is still in flight, then calls an ESP-IDF API that walks that database.

`esp_ble_gattc_register_for_notify()` completes asynchronously. [`BLEClient::gattc_event_handler`](https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/ble_client/ble_client.cpp#L46-L59) dispatches each event to every node and then [releases the services](https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/ble_client/ble_client.cpp#L54-L57) as soon as all nodes report `ESTABLISHED`, and [`release_services()`](https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/esp32_ble_client/ble_client_base.cpp#L196-L205) calls `esp_ble_gattc_cache_clean()`, which frees Bluedroid's GATT cache rather than only ESPHome's mirror of it.

A node that reports `ESTABLISHED` while its own registration is outstanding therefore makes the release run first. The [`ESP_GATTC_REG_FOR_NOTIFY_EVT` handler](https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/esp32_ble_client/ble_client_base.cpp#L499-L514) then calls [`esp_ble_gattc_get_descr_by_char_handle()`](https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/esp32_ble_client/ble_client_base.cpp#L509-L510) on the freed cache. That event carries no `conn_id`, so unlike every other event in the handler it has no existing guard.

Bluedroid responds one of two ways. Usually it returns `ESP_GATT_NOT_FOUND`, and because the handler breaks out before `esp_ble_gattc_write_char_descr()` the CCCD is never written, so no notification ever arrives while the node believes it is subscribed. Sometimes it asserts on the freed list and panics:

```text
assert failed: list_end list.c:272 (list != NULL)

list_end                                bta/../common/osi/list.c:272
bta_gattc_get_db_with_operation         bta/gatt/bta_gattc_cache.c:1637
BTA_GATTC_GetDescrByCharHandle          bta/gatt/bta_gattc_api.c:432
btc_ble_gattc_get_descr_by_char_handle  btc/profile/std/gatt/btc_gattc.c:516
esp_ble_gattc_get_descr_by_char_handle  api/esp_gattc_api.c:533
BLEClientBase::gattc_event_handler      esp32_ble_client/ble_client_base.cpp:509
BLEClient::gattc_event_handler          ble_client/ble_client.cpp:48
ESP32BLETracker::gattc_event_handler    esp32_ble_tracker/esp32_ble_tracker.cpp:424
```

## The change

Two independent fixes, either of which prevents the panic.

**Hold the release while a registration is outstanding.** A new `BLEClientBase::register_for_notify()` wraps the ESP-IDF call and counts outstanding requests, `ESP_GATTC_REG_FOR_NOTIFY_EVT` retires them, and the release is skipped while the count is non-zero. The release still happens one event later, so the memory optimization is preserved. The bundled `sensor` and `text_sensor` nodes are migrated to the wrapper. The counter saturates rather than wraps, with a warning, since wrapping to zero would permit a premature release.

**Guard the lookup.** `release_services()` sets `services_released_` on the path that actually calls `esp_ble_gattc_cache_clean()`, `connect()` clears it, and the handler returns early with a warning instead of calling into a cache that is gone. This covers external components that call the ESP-IDF API directly and so cannot be seen by the counter. A `CONFIG_BT_GATTC_CACHE_NVS_FLASH` build never cleans the stack cache, so the flag stays false there and the lookup proceeds unchanged.

The `BLEClientNode::node_state` comment is extended to state the ordering requirement. Both new members fit existing struct padding, so `BLEClientBase` does not grow.

`bluetooth_proxy` deliberately keeps calling `esp_ble_gattc_register_for_notify()` directly: its connections are `V3_WITH_CACHE` / `V3_WITHOUT_CACHE`, which break out of the handler before the cache lookup, and it manages its own release lifecycle.

`bedjet` also keeps the raw call, and must not be migrated to the wrapper. Holding the release would let the base handler's lookup succeed again, which restores the double CCCD write described below. The remaining in-tree components that register for notifications (`airthings_wave_base`, `alpha3`, `am43`, `anova`) report `ESTABLISHED` only after the registration completes, and `radon_eye_rd200` never reports it at all, so none of them can trigger the early release or gain anything from the wrapper.

## Why this is reachable

`bedjet` reproduces this with a stock configuration, so the panic is not limited to external components. [`BedJetHub::gattc_event_handler`](https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/bedjet/bedjet_hub.cpp#L245-L246) reports `ESTABLISHED` and then starts the registration, in that order, inside `ESP_GATTC_SEARCH_CMPL_EVT`:

```cpp
this->node_state = espbt::ClientState::ESTABLISHED;
this->set_notify_(true);  // calls esp_ble_gattc_register_for_notify()
```

`BedJetHub` is the only node a `bedjet` configuration registers, so `all_nodes_established_()` goes true on that same event, the release runs, and the base handler walks the freed cache when `ESP_GATTC_REG_FOR_NOTIFY_EVT` arrives. The component has been working around the consequence for years, and [documents it in a comment](https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/bedjet/bedjet_hub.cpp#L317-L322):

> as soon as we set our status to Established, the parent is going to purge all the service/char/descriptor handles, and then `get_config_descriptor()` won't work anymore. There's no way to disable the BLEClient parent behavior, so our only option is to write the handle anyway, and hope a double-write doesn't break anything.

`bedjet` [writes the CCCD itself](https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/bedjet/bedjet_hub.cpp#L423-L440), from a descriptor handle it cached during discovery, so its notifications survive the failed lookup. The guard makes that write the only one, rather than a second write racing a lookup into freed memory.

Beyond that, the ordering contract is undocumented and `node_state` is public. Most bundled node types assign it directly in `ESP_GATTC_SEARCH_CMPL_EVT`; only `sensor` and `text_sensor` with `notify: true` wait for the registration. An external component that subscribes to notifications and copies the common pattern hits the same thing, and the penalty is a panic rather than an error.

The new `register_for_notify()` is public because `BLEClientNode` subclasses live outside the class, but it adds no capability: external components could already call `esp_ble_gattc_register_for_notify()` directly and still can. It is the mechanism of the fix rather than a new developer-facing feature, so only the bugfix box is checked. Happy to reclassify if you disagree.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17921

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Testing

Hardware: ESP32-S3 (Unexpected Maker ProS3D), ESP-IDF 5.5.5, `esp32_ble: max_connections: 2`, one `ble_client` against a Micro-Air EasyStart soft starter, plus a `type: rssi` sensor as a second node. A minimal test node registers for notifications and then reports `ESTABLISHED`. A 60 second forced reconnect drives the cycle, from a `lambda` calling `disconnect()` rather than the `ble_client.disconnect` action, for the reason in the follow-up PR. A temporary `ESP_LOGW` in `BLEClient::gattc_event_handler` printed the gate inputs.

Event 6 is `ESP_GATTC_SEARCH_CMPL_EVT`, event 38 is `ESP_GATTC_REG_FOR_NOTIFY_EVT`.

**Before, 4 of 4 cycles.** The service vector empties between the two events and the lookup fails:

```text
DIAG event=6 services=3 nodes=2 client_state=6 all_established=1
All clients established, services released
[W][esp32_ble_client]: esp_ble_gattc_get_descr_by_char_handle error, status=10
DIAG event=38 services=0 nodes=2 client_state=6 all_established=1
```

**After, node using the raw ESP-IDF call, 3 of 3 cycles.** The guard fires and nothing calls into Bluedroid:

```text
All clients established, services released
[W][esp32_ble_client]: REG_FOR_NOTIFY after services released, notifications not enabled
```

**After, node using `register_for_notify()`, 3 of 3 cycles.** The release is held, the lookup succeeds, and the release still runs:

```text
DIAG event=6  services=3 nodes=2 client_state=6 all_established=1 notify_pending=1
REG_FOR_NOTIFY handle 14, status 0, services held
DIAG event=38 services=3 nodes=2 client_state=6 all_established=1 notify_pending=0
All clients established, services released
```

Separately, an 80 minute capture on a production build recorded five releases, five races, four `status=10` and one panic with the backtrace above.

`script/clang-tidy --all-headers --changed --environment esp32-idf-tidy` is clean, as is `script/ci-custom.py` and `clang-format`.

## Example entry for `config.yaml`:

```yaml
# No configuration change. The reproduction uses an external component that
# registers for notifications and then reports ESTABLISHED in the same event.
esp32_ble:
  max_connections: 2

esp32_ble_tracker:
  scan_parameters:
    active: false

ble_client:
  - id: race_client
    mac_address: XX:XX:XX:XX:XX:XX
    auto_connect: true

sensor:
  - platform: ble_client
    ble_client_id: race_client
    type: rssi
    name: "Signal Strength"
```

## Checklist:

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).

No new test fixtures: the change adds no configuration options, and the existing `tests/components/ble_client` configs cover compilation. The behavior needs a peripheral with a notify characteristic and a node that violates the ordering, which the existing test harness cannot express.
