### PR TITLE
[api] Stop advertising external wake words the device cannot load

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1349,22 +1349,6 @@ bool APIConnection::send_voice_assistant_get_configuration_response_(const Voice
     }
   }
 
-  // Filter external wake words
-  for (auto &wake_word : msg.external_wake_words) {
-    if (wake_word.model_type != "micro") {
-      // microWakeWord only
-      continue;
-    }
-
-    resp.available_wake_words.emplace_back();
-    auto &resp_wake_word = resp.available_wake_words.back();
-    resp_wake_word.id = StringRef(wake_word.id);
-    resp_wake_word.wake_word = StringRef(wake_word.wake_word);
-    for (const auto &lang : wake_word.trained_languages) {
-      resp_wake_word.trained_languages.push_back(lang);
-    }
-  }
-
   resp.active_wake_words = &config.active_wake_words;
   resp.max_active_wake_words = config.max_active_wake_words;
   return this->send_message(resp);

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1329,7 +1329,8 @@ void APIConnection::on_voice_assistant_announce_request(const VoiceAssistantAnno
   }
 }
 
-bool APIConnection::send_voice_assistant_get_configuration_response_(const VoiceAssistantConfigurationRequest &msg) {
+bool APIConnection::send_voice_assistant_get_configuration_response_(
+    const VoiceAssistantConfigurationRequest & /*msg*/) {
   VoiceAssistantConfigurationResponse resp;
   if (!this->check_voice_assistant_api_connection_()) {
     // send_message encodes synchronously, so this stack local outlives the encode


### PR DESCRIPTION
# What does this implement/fix?

The voice assistant configuration response echoed back every external wake word Home Assistant advertised with a model type of `micro`, appending them to `available_wake_words` alongside the compiled-in models.

Nothing on the device can load those models, so the response claimed support for wake words that can never be activated. Home Assistant shows them in the picker, the user selects one, and nothing happens.

This reports only the wake words the device actually has, which for now means the ones compiled into `micro_wake_word`. The echo was added in #10850.

This is the first PR in a stack of three that adds runtime wake word model loading. The later PRs put the external wake words back into the response, sourced from models the device has really downloaded:

1. **This PR** — stop advertising external wake words the device cannot load
2. `[micro_wake_word]` — support adding and removing wake word models at runtime
3. `[voice_assistant]` — download wake word models advertised by Home Assistant

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- not applicable

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- not applicable

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No configuration change. Any existing `voice_assistant` configuration exercises this path.

```yaml
# Example config.yaml
voice_assistant:
  microphone:
    microphone: va_mic_id
  micro_wake_word: mww_id
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
