### PR TITLE
[esp32][rp2] Fix serial crash logging

### DIFF
--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -145,6 +145,8 @@ struct RawCrashData {
 static RawCrashData __attribute__((section(".noinit")))
 s_raw_crash_data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+// Whether crash data has been read this boot.
+static bool s_crash_data_read = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 // Whether crash data was found and validated this boot.
 static bool s_crash_data_valid = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
@@ -152,7 +154,10 @@ namespace esphome::esp32 {
 
 static const char *const TAG = "esp32.crash";
 
-void crash_handler_read_and_clear() {
+static void crash_handler_read_and_clear() {
+  if (s_crash_data_read)
+    return;
+  s_crash_data_read = true;
   if (s_raw_crash_data.magic == CRASH_MAGIC && s_raw_crash_data.version == CRASH_DATA_VERSION) {
     s_crash_data_valid = true;
     // Clamp counts to prevent out-of-bounds reads from corrupt .noinit data
@@ -177,7 +182,10 @@ void crash_handler_read_and_clear() {
   // Magic is cleared by crash_handler_clear() after an API client receives the data.
 }
 
-bool crash_handler_has_data() { return s_crash_data_valid; }
+bool crash_handler_has_data() {
+  crash_handler_read_and_clear();
+  return s_crash_data_valid;
+}
 
 void crash_handler_clear() {
   // Only clear the magic so data doesn't survive the next reboot.
@@ -337,7 +345,7 @@ static int append_addrs_to_hint(char *buf, int size, int pos, const uint32_t *ad
 // crashes again during boot, and allowing the CLI's process_stacktrace to match
 // and decode each address individually.
 void crash_handler_log() {
-  if (!s_crash_data_valid)
+  if (!crash_handler_has_data())
     return;
 
   ESP_LOGE(TAG, "*** CRASH DETECTED ON PREVIOUS BOOT ***");

--- a/esphome/components/esp32/crash_handler.h
+++ b/esphome/components/esp32/crash_handler.h
@@ -4,19 +4,16 @@
 
 namespace esphome::esp32 {
 
-/// Read and validate crash data from NOINIT memory.
-/// Does not clear the magic marker — call crash_handler_clear() after
-/// the data has been delivered to an API client so it survives OTA rollback reboots.
-void crash_handler_read_and_clear();
-
-/// Log crash data if a crash was detected on previous boot.
+/// Log crash data if a crash was detected on the previous boot.
+/// Retained data is read and validated on the first call per boot.
 void crash_handler_log();
 
-/// Clear the magic marker and mark crash data as consumed.
-/// Call after the data has been delivered to an API client.
+/// Clear the retained magic marker after the data has been delivered to an API client.
+/// The validated in-memory data remains available for other clients during this boot.
 void crash_handler_clear();
 
-/// Returns true if crash data was found this boot.
+/// Return whether crash data was found and validated this boot.
+/// Retained data is read and validated on the first call per boot.
 bool crash_handler_has_data();
 
 }  // namespace esphome::esp32

--- a/esphome/components/esp32/hal.cpp
+++ b/esphome/components/esp32/hal.cpp
@@ -1,9 +1,6 @@
 #ifdef USE_ESP32
 
-// defines.h must come before crash_handler.h so USE_ESP32_CRASH_HANDLER is set
-// before crash_handler.h's #ifdef-guarded namespace block is parsed.
 #include "esphome/core/defines.h"
-#include "crash_handler.h"
 #include "esphome/core/hal.h"
 
 #include <esp_clk_tree.h>
@@ -45,11 +42,6 @@ void arch_restart() {
 }
 
 void arch_init() {
-#ifdef USE_ESP32_CRASH_HANDLER
-  // Read crash data from previous boot before anything else
-  esp32::crash_handler_read_and_clear();
-#endif
-
   // Enable the task watchdog only on the loop task (from which we're currently running)
   esp_task_wdt_add(nullptr);
 

--- a/esphome/components/rp2/crash_handler.cpp
+++ b/esphome/components/rp2/crash_handler.cpp
@@ -55,8 +55,6 @@ namespace esphome::rp2 {
 
 static const char *const TAG = "rp2.crash";
 
-// Placed in .noinit so BSS zero-init cannot race with crash_handler_read_and_clear().
-// The valid field is explicitly cleared in crash_handler_read_and_clear() instead.
 static struct CrashData {
   bool valid;
   uint32_t pc;
@@ -64,11 +62,14 @@ static struct CrashData {
   uint32_t sp;
   uint32_t backtrace[MAX_BACKTRACE];
   uint8_t backtrace_count;
-} s_crash_data __attribute__((section(".noinit")));  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+} s_crash_data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-bool crash_handler_has_data() { return s_crash_data.valid; }
+static bool s_crash_data_read = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 void crash_handler_read_and_clear() {
+  if (s_crash_data_read)
+    return;
+  s_crash_data_read = true;
   s_crash_data.valid = false;
   uint32_t magic = watchdog_hw->scratch[0];
   if ((magic & 0xFFFF0000) == CRASH_MAGIC_SENTINEL && (magic & 0xFFFF) == CRASH_DATA_VERSION) {
@@ -91,13 +92,18 @@ void crash_handler_read_and_clear() {
   }
 }
 
+bool crash_handler_has_data() {
+  crash_handler_read_and_clear();
+  return s_crash_data.valid;
+}
+
 // Intentionally uses separate ESP_LOGE calls per line instead of combining into
 // one multi-line log message. This ensures each address appears as its own line
 // on the serial console (miniterm), making it possible to see partial output if
 // the device crashes again during boot, and allowing the CLI's process_stacktrace
 // to match and decode each address individually.
 void crash_handler_log() {
-  if (!s_crash_data.valid)
+  if (!crash_handler_has_data())
     return;
 
   ESP_LOGE(TAG, "*** CRASH DETECTED ON PREVIOUS BOOT ***");

--- a/esphome/components/rp2/crash_handler.h
+++ b/esphome/components/rp2/crash_handler.h
@@ -8,13 +8,15 @@
 
 namespace esphome::rp2 {
 
-/// Read crash data from watchdog scratch registers and clear them.
+/// Read crash data from watchdog scratch registers and clear them once per boot.
 void crash_handler_read_and_clear();
 
-/// Log crash data if a crash was detected on previous boot.
+/// Log crash data if a crash was detected on the previous boot.
+/// Watchdog scratch registers are read and cleared on the first call per boot.
 void crash_handler_log();
 
-/// Returns true if crash data was found this boot.
+/// Return whether crash data was found this boot.
+/// Watchdog scratch registers are read and cleared on the first call per boot.
 bool crash_handler_has_data();
 
 }  // namespace esphome::rp2

--- a/esphome/components/rp2/hal.cpp
+++ b/esphome/components/rp2/hal.cpp
@@ -2,10 +2,10 @@
 
 #include "core.h"
 #include "esphome/core/defines.h"
-#include "esphome/core/hal.h"
 #ifdef USE_RP2_CRASH_HANDLER
 #include "crash_handler.h"
 #endif
+#include "esphome/core/hal.h"
 
 #include "hardware/watchdog.h"
 
@@ -26,6 +26,7 @@ void arch_restart() {
 
 void arch_init() {
 #ifdef USE_RP2_CRASH_HANDLER
+  // Read retained data before watchdog_enable() overwrites the scratch registers.
   rp2::crash_handler_read_and_clear();
 #endif
 #if USE_RP2_WATCHDOG_TIMEOUT > 0

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -67,7 +67,6 @@ static constexpr uint32_t TEARDOWN_TIMEOUT_REBOOT_MS = 1000;  // 1 second for qu
 class Application {
  public:
 #ifdef ESPHOME_NAME_ADD_MAC_SUFFIX
-  // Called before Logger::pre_setup() — must not log (global_logger is not yet set).
   /// Pre-setup with MAC suffix: overwrites placeholder in mutable static buffers with actual MAC.
   void pre_setup(char *name, size_t name_len, char *friendly_name, size_t friendly_name_len) {
     arch_init();
@@ -87,7 +86,6 @@ class Application {
     this->friendly_name_ = StringRef(friendly_name, friendly_name_len);
   }
 #else
-  // Called before Logger::pre_setup() — must not log (global_logger is not yet set).
   /// Pre-setup without MAC suffix: StringRef points directly at const string literals in flash.
   void pre_setup(const char *name, size_t name_len, const char *friendly_name, size_t friendly_name_len) {
     arch_init();


### PR DESCRIPTION
# What does this implement/fix?

This fixes a bug where the stack trace of a previous crash wasn't printed on the serial console.

`crash_handler_log()` is called from Logger::pre_setup() early during bootup. At that point `App.pre_setup() -> arch_init() -> crash_handler_read_and_clear()` hasn't run and thus the decoded crash data isn't available.

I made `crash_handler_read_and_clear()` idempotent and now always call it from `crash_handler_log()` and `crash_handler_has_data()`.

I also considered:
- Calling `crash_handler_read_and_clear()` only in `Logger::pre_setup()` and rely on `arch_init()` to call it for API clients, but I found that inconsistent.
- Calling `crash_handler_read_and_clear()` before `crash_handler_log()` everywhere, but I found that noisy.

I also considered renaming `crash_handler_read_and_clear()` to `crash_handler_read()` because on ESP32 it doesn't clear (because of two-partition OTA fallback), but I left it be because on RP2 it does clear.

I didn't test the RP2 implementation because I don't have the hardware. I had AI perform a review of that.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Here's a config that simulates a crash:

```yaml
esphome:
  name: crash-test
  friendly_name: "Crash Test"

esp32:
  variant: esp32s3
  framework:
    type: esp-idf

logger:
  hardware_uart: UART0
  baud_rate: 115200

ota:
  - platform: esphome
    password: !secret ota_password

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

web_server:
  port: 80

button:
  - platform: template
    id: abort_test
    name: "Trigger abort()"
    entity_category: diagnostic
    on_press:
      then:
        - lambda: |-
            ESP_LOGW("abort_test", "Calling abort() - expect an immediate crash");
            abort();

  - platform: template
    id: wdt_test
    name: "Trigger watchdog"
    entity_category: diagnostic
    on_press:
      then:
        - lambda: |-
            ESP_LOGW("wdt_test", "Blocking loop to trigger WDT - expect crash in ~5s");
            uint32_t start = millis();
            while (millis() - start < 15000) {}
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
