### PR TITLE
[mqtt] Print crash info over MQTT

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -13,6 +13,15 @@
 #ifdef USE_LOGGER
 #include "esphome/components/logger/logger.h"
 #endif
+#ifdef USE_ESP32_CRASH_HANDLER
+#include "esphome/components/esp32/crash_handler.h"
+#endif
+#ifdef USE_ESP8266_CRASH_HANDLER
+#include "esphome/components/esp8266/crash_handler.h"
+#endif
+#ifdef USE_RP2_CRASH_HANDLER
+#include "esphome/components/rp2/crash_handler.h"
+#endif
 #include "lwip/dns.h"
 #include "lwip/err.h"
 #include "mqtt_component.h"
@@ -74,6 +83,24 @@ void MQTTClientComponent::setup() {
         this, [](void *self, uint8_t level, const char *tag, const char *message, size_t message_len) {
           static_cast<MQTTClientComponent *>(self)->on_log(level, tag, message, message_len);
         });
+#if defined(USE_ESP32_CRASH_HANDLER) || defined(USE_ESP8266_CRASH_HANDLER) || defined(USE_RP2_CRASH_HANDLER)
+    // "esphome/logs/" (13) + name (ESPHOME_DEVICE_NAME_MAX_LEN) + null (1)
+    constexpr size_t logs_topic_buffer_size = 13 + ESPHOME_DEVICE_NAME_MAX_LEN + 1;
+    char logs_topic[logs_topic_buffer_size];
+    buf_append_printf(logs_topic, sizeof(logs_topic), 0, "esphome/logs/%s", App.get_name().c_str());
+    this->subscribe(logs_topic, [](const std::string &, const std::string &) {
+#ifdef USE_ESP32_CRASH_HANDLER
+      esp32::crash_handler_log();
+      esp32::crash_handler_clear();
+#endif
+#ifdef USE_ESP8266_CRASH_HANDLER
+      esp8266::crash_handler_log();
+#endif
+#ifdef USE_RP2_CRASH_HANDLER
+      rp2::crash_handler_log();
+#endif
+    });
+#endif
   }
 #endif
 

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -258,7 +258,14 @@ def show_logs(config, topic=None, username=None, password=None, client_id=None):
         message = time_ + payload
         safe_print(message)
 
-    return initialize(config, [topic], on_message, None, username, password, client_id)
+    def on_connect(client, userdata, flags, return_code):
+        logs_topic = f"esphome/logs/{config[CONF_ESPHOME][CONF_NAME]}"
+        _LOGGER.info("Logs client connected, informing device via topic: %s", logs_topic)
+        client.publish(logs_topic, None, retain=False)
+
+    return initialize(
+        config, [topic], on_message, on_connect, username, password, client_id
+    )
 
 
 def clear_topic(config, topic, username=None, password=None, client_id=None):

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -260,7 +260,9 @@ def show_logs(config, topic=None, username=None, password=None, client_id=None):
 
     def on_connect(client, userdata, flags, return_code):
         logs_topic = f"esphome/logs/{config[CONF_ESPHOME][CONF_NAME]}"
-        _LOGGER.info("Logs client connected, informing device via topic: %s", logs_topic)
+        _LOGGER.info(
+            "Logs client connected, informing device via topic: %s", logs_topic
+        )
         client.publish(logs_topic, None, retain=False)
 
     return initialize(

--- a/tests/unit_tests/test_mqtt.py
+++ b/tests/unit_tests/test_mqtt.py
@@ -2,11 +2,43 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock, patch
+
 import pytest
 
-from esphome.const import CONF_BROKER, CONF_ESPHOME, CONF_MQTT, CONF_NAME
+from esphome.const import (
+    CONF_BROKER,
+    CONF_ESPHOME,
+    CONF_MQTT,
+    CONF_NAME,
+    CONF_TOPIC_PREFIX,
+)
 from esphome.core import EsphomeError
-from esphome.mqtt import get_esphome_device_ip
+from esphome.mqtt import get_esphome_device_ip, show_logs
+
+
+@patch("esphome.mqtt.initialize")
+def test_show_logs_informs_device(mock_initialize: Mock) -> None:
+    """Test that a logs client informs the device."""
+    config = {
+        CONF_MQTT: {
+            CONF_BROKER: "mqtt.local",
+            CONF_TOPIC_PREFIX: "custom-prefix",
+        },
+        CONF_ESPHOME: {
+            CONF_NAME: "test-device",
+        },
+    }
+
+    show_logs(config)
+
+    assert mock_initialize.call_args.args[1] == ["custom-prefix/debug"]
+    on_connect = mock_initialize.call_args.args[3]
+    client = Mock()
+    on_connect(client, None, None, 0)
+    client.publish.assert_called_once_with(
+        "esphome/logs/test-device", None, retain=False
+    )
 
 
 def test_get_esphome_device_ip_empty_broker() -> None:


### PR DESCRIPTION
# What does this implement/fix?

When a native API client connects, info about a previous crash is already printed. This implements the same for MQTT.

To trigger the crash info, the CLI publishes to `esphome/logs/<device name>` when it connects for `esphome logs`.

The device then logs the crash info the same way it would over serial or native API.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Here is a config that simulates a crash:

```yaml
esphome:
  name: crash-test
  friendly_name: "Crash Test"

esp32:
  variant: esp32s3
  framework:
    type: esp-idf

logger:
  hardware_uart: UART0
  baud_rate: 115200

ota:
  - platform: esphome
    password: !secret ota_password

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

web_server:
  port: 80

button:
  - platform: template
    id: abort_test
    name: "Trigger abort()"
    entity_category: diagnostic
    on_press:
      then:
        - lambda: |-
            ESP_LOGW("abort_test", "Calling abort() - expect an immediate crash");
            abort();

  - platform: template
    id: wdt_test
    name: "Trigger watchdog"
    entity_category: diagnostic
    on_press:
      then:
        - lambda: |-
            ESP_LOGW("wdt_test", "Blocking loop to trigger WDT - expect crash in ~5s");
            uint32_t start = millis();
            while (millis() - start < 15000) {}
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

The docs already claim that crash info is printed in the logs, making no distinction between native API and MQTT clients, so the docs need no change.
