### PR TITLE
[runtime_image] Allow decoding into a caller-owned buffer

### DIFF
--- a/esphome/components/runtime_image/runtime_image.cpp
+++ b/esphome/components/runtime_image/runtime_image.cpp
@@ -253,9 +253,9 @@ void RuntimeImage::release_buffer_() {
       ESP_LOGV(TAG, "Letting go of the external %dx%d buffer", this->buffer_width_, this->buffer_height_);
       this->external_buffer_ = false;
     } else {
-      ESP_LOGV(TAG, "Releasing buffer of size %zu", this->get_buffer_size_(this->buffer_width_, this->buffer_height_));
+      ESP_LOGV(TAG, "Releasing buffer of size %zu", this->get_buffer_size(this->buffer_width_, this->buffer_height_));
       RAMAllocator<uint8_t> allocator;
-      allocator.deallocate(this->buffer_, this->get_buffer_size_(this->buffer_width_, this->buffer_height_));
+      allocator.deallocate(this->buffer_, this->get_buffer_size(this->buffer_width_, this->buffer_height_));
     }
     this->buffer_ = nullptr;
     this->data_start_ = nullptr;
@@ -271,6 +271,12 @@ void RuntimeImage::release_buffer_() {
 
 void RuntimeImage::set_external_buffer(uint8_t *buffer, int width, int height) {
   this->release_buffer_();
+  if (buffer == nullptr || this->get_buffer_size(width, height) == 0) {
+    // Keep the released state rather than remembering a buffer that cannot be decoded into: an
+    // external buffer that is never handed back would otherwise block every later allocation.
+    ESP_LOGE(TAG, "Refusing an invalid external buffer for %dx%d", width, height);
+    return;
+  }
   this->buffer_ = buffer;
   this->external_buffer_ = true;
   this->buffer_width_ = width;
@@ -278,7 +284,7 @@ void RuntimeImage::set_external_buffer(uint8_t *buffer, int width, int height) {
 }
 
 size_t RuntimeImage::resize_buffer_(int width, int height) {
-  size_t new_size = this->get_buffer_size_(width, height);
+  size_t new_size = this->get_buffer_size(width, height);
 
   if (new_size == 0) {
     ESP_LOGE(TAG, "Refusing to allocate buffer for invalid image dimensions %dx%d", width, height);
@@ -323,7 +329,7 @@ size_t RuntimeImage::resize_buffer_(int width, int height) {
   return new_size;
 }
 
-size_t RuntimeImage::get_buffer_size_(int width, int height) const {
+size_t RuntimeImage::get_buffer_size(int width, int height) const {
   // Dimensions come from a remote image header; reject absurd values so the size math cannot overflow
   if (width <= 0 || height <= 0 || width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION) {
     return 0;

--- a/esphome/components/runtime_image/runtime_image.cpp
+++ b/esphome/components/runtime_image/runtime_image.cpp
@@ -248,9 +248,15 @@ void RuntimeImage::release() {
 
 void RuntimeImage::release_buffer_() {
   if (this->buffer_) {
-    ESP_LOGV(TAG, "Releasing buffer of size %zu", this->get_buffer_size_(this->buffer_width_, this->buffer_height_));
-    RAMAllocator<uint8_t> allocator;
-    allocator.deallocate(this->buffer_, this->get_buffer_size_(this->buffer_width_, this->buffer_height_));
+    if (this->external_buffer_) {
+      // The caller owns this memory and goes on using it after the image lets go of it.
+      ESP_LOGV(TAG, "Letting go of the external %dx%d buffer", this->buffer_width_, this->buffer_height_);
+      this->external_buffer_ = false;
+    } else {
+      ESP_LOGV(TAG, "Releasing buffer of size %zu", this->get_buffer_size_(this->buffer_width_, this->buffer_height_));
+      RAMAllocator<uint8_t> allocator;
+      allocator.deallocate(this->buffer_, this->get_buffer_size_(this->buffer_width_, this->buffer_height_));
+    }
     this->buffer_ = nullptr;
     this->data_start_ = nullptr;
     this->width_ = 0;
@@ -261,6 +267,14 @@ void RuntimeImage::release_buffer_() {
     memset(&this->dsc_, 0, sizeof(this->dsc_));
 #endif
   }
+}
+
+void RuntimeImage::set_external_buffer(uint8_t *buffer, int width, int height) {
+  this->release_buffer_();
+  this->buffer_ = buffer;
+  this->external_buffer_ = true;
+  this->buffer_width_ = width;
+  this->buffer_height_ = height;
 }
 
 size_t RuntimeImage::resize_buffer_(int width, int height) {
@@ -274,6 +288,15 @@ size_t RuntimeImage::resize_buffer_(int width, int height) {
   if (this->buffer_ && this->buffer_width_ == width && this->buffer_height_ == height) {
     // Buffer already allocated with correct size
     return new_size;
+  }
+
+  if (this->external_buffer_) {
+    ESP_LOGE(TAG, "Image decoded to %dx%d, but the external buffer is %dx%d", width, height, this->buffer_width_,
+             this->buffer_height_);
+    // Let the buffer go rather than free memory that belongs to the caller. Dropping it also stops
+    // a decoder that ignores this failure from publishing a picture it never painted.
+    this->release_buffer_();
+    return 0;
   }
 
   // Release old buffer if dimensions changed

--- a/esphome/components/runtime_image/runtime_image.cpp
+++ b/esphome/components/runtime_image/runtime_image.cpp
@@ -269,28 +269,27 @@ void RuntimeImage::release_buffer_() {
   }
 }
 
-void RuntimeImage::set_external_buffer(uint8_t *buffer, int width, int height) {
+bool RuntimeImage::set_external_buffer(uint8_t *buffer, int width, int height) {
   this->release_buffer_();
   if (buffer == nullptr || this->get_buffer_size(width, height) == 0) {
     // Keep the released state rather than remembering a buffer that cannot be decoded into: an
     // external buffer that is never handed back would otherwise block every later allocation.
     ESP_LOGE(TAG, "Refusing an invalid external buffer for %dx%d", width, height);
-    return;
+    return false;
   }
   this->buffer_ = buffer;
   this->external_buffer_ = true;
   this->buffer_width_ = width;
   this->buffer_height_ = height;
+  return true;
 }
 
 size_t RuntimeImage::resize_buffer_(int width, int height) {
   size_t new_size = this->get_buffer_size(width, height);
 
-  if (new_size == 0) {
-    ESP_LOGE(TAG, "Refusing to allocate buffer for invalid image dimensions %dx%d", width, height);
-    return 0;
-  }
-
+  // A buffer only ever exists with dimensions the image can decode at, so a match here means
+  // new_size is non-zero. Checking it before the invalid dimension case below lets the external
+  // buffer be let go of for every decode it cannot serve, not just for valid other dimensions.
   if (this->buffer_ && this->buffer_width_ == width && this->buffer_height_ == height) {
     // Buffer already allocated with correct size
     return new_size;
@@ -302,6 +301,11 @@ size_t RuntimeImage::resize_buffer_(int width, int height) {
     // Let the buffer go rather than free memory that belongs to the caller. Dropping it also stops
     // a decoder that ignores this failure from publishing a picture it never painted.
     this->release_buffer_();
+    return 0;
+  }
+
+  if (new_size == 0) {
+    ESP_LOGE(TAG, "Refusing to allocate buffer for invalid image dimensions %dx%d", width, height);
     return 0;
   }
 

--- a/esphome/components/runtime_image/runtime_image.h
+++ b/esphome/components/runtime_image/runtime_image.h
@@ -135,14 +135,26 @@ class RuntimeImage : public image::Image {
    * buffer alive for as long as anything can draw the image, and calls release() (or hands over
    * another buffer) before reusing it.
    *
+   * Hand a buffer over before every decode. The image lets go of one whenever a decode fails and
+   * whenever release() is called, and it does not remember that it ever had one: a decode that
+   * starts without a buffer allocates its own, which is the runtime allocation this method exists
+   * to avoid.
+   *
+   * The buffer is decoded into as it is handed over, so the caller owns its initial contents.
+   * Zero it first if anything can draw the image before a decode has painted every pixel.
+   *
+   * Do not hand a buffer over while is_decoding() is true. A running decoder keeps scaling values
+   * for the buffer it started with.
+   *
    * A null buffer or dimensions the image cannot decode at are refused, leaving the image with
    * no buffer at all.
    *
    * @param buffer Memory for a picture of the given size, at least get_buffer_size() bytes.
    * @param width Width of the buffer in pixels.
    * @param height Height of the buffer in pixels.
+   * @return true if the image took the buffer, false if it was refused.
    */
-  void set_external_buffer(uint8_t *buffer, int width, int height);
+  bool set_external_buffer(uint8_t *buffer, int width, int height);
 
   /**
    * @brief Get the buffer size in bytes needed for a picture of the given dimensions.

--- a/esphome/components/runtime_image/runtime_image.h
+++ b/esphome/components/runtime_image/runtime_image.h
@@ -135,11 +135,21 @@ class RuntimeImage : public image::Image {
    * buffer alive for as long as anything can draw the image, and calls release() (or hands over
    * another buffer) before reusing it.
    *
-   * @param buffer Memory for a picture of the given size, at least get_buffer_size_() bytes.
+   * A null buffer or dimensions the image cannot decode at are refused, leaving the image with
+   * no buffer at all.
+   *
+   * @param buffer Memory for a picture of the given size, at least get_buffer_size() bytes.
    * @param width Width of the buffer in pixels.
    * @param height Height of the buffer in pixels.
    */
   void set_external_buffer(uint8_t *buffer, int width, int height);
+
+  /**
+   * @brief Get the buffer size in bytes needed for a picture of the given dimensions.
+   *
+   * Returns 0 for dimensions the image cannot decode at.
+   */
+  size_t get_buffer_size(int width, int height) const;
 
   /**
    * @brief Set whether to allow progressive display during decode.
@@ -165,11 +175,6 @@ class RuntimeImage : public image::Image {
    * This is safe to call from within the decoder (e.g., during resize).
    */
   void release_buffer_();
-
-  /**
-   * @brief Get the buffer size in bytes for given dimensions.
-   */
-  size_t get_buffer_size_(int width, int height) const;
 
   /**
    * @brief Get the position in the buffer for a pixel.

--- a/esphome/components/runtime_image/runtime_image.h
+++ b/esphome/components/runtime_image/runtime_image.h
@@ -183,8 +183,6 @@ class RuntimeImage : public image::Image {
 
   // Memory management
   uint8_t *buffer_{nullptr};
-  /** Whether buffer_ belongs to the caller, so it must not be freed or resized here. */
-  bool external_buffer_{false};
 
   // Decoder management
   std::unique_ptr<ImageDecoder> decoder_{nullptr};
@@ -227,6 +225,8 @@ class RuntimeImage : public image::Image {
    * This is used to determine how to store 16 bit colors in the buffer.
    */
   bool is_big_endian_{false};
+  /** Whether buffer_ belongs to the caller, so it must not be freed or resized here. */
+  bool external_buffer_{false};
 };
 
 }  // namespace esphome::runtime_image

--- a/esphome/components/runtime_image/runtime_image.h
+++ b/esphome/components/runtime_image/runtime_image.h
@@ -121,8 +121,25 @@ class RuntimeImage : public image::Image {
 
   /**
    * @brief Release the image buffer and free memory.
+   *
+   * An external buffer is let go of rather than freed.
    */
   void release();
+
+  /**
+   * @brief Decode into a buffer the caller owns, instead of one allocated here.
+   *
+   * The image never frees an external buffer and never resizes it: a decode that needs other
+   * dimensions fails as if the allocation had failed, and the buffer is let go of so a decoder
+   * that ignores that failure cannot publish a picture it did not paint. The caller keeps the
+   * buffer alive for as long as anything can draw the image, and calls release() (or hands over
+   * another buffer) before reusing it.
+   *
+   * @param buffer Memory for a picture of the given size, at least get_buffer_size_() bytes.
+   * @param width Width of the buffer in pixels.
+   * @param height Height of the buffer in pixels.
+   */
+  void set_external_buffer(uint8_t *buffer, int width, int height);
 
   /**
    * @brief Set whether to allow progressive display during decode.
@@ -166,6 +183,8 @@ class RuntimeImage : public image::Image {
 
   // Memory management
   uint8_t *buffer_{nullptr};
+  /** Whether buffer_ belongs to the caller, so it must not be freed or resized here. */
+  bool external_buffer_{false};
 
   // Decoder management
   std::unique_ptr<ImageDecoder> decoder_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

Adds `RuntimeImage::set_external_buffer()`, so a component can hand the image memory it allocated and owns itself instead of letting the image allocate its own buffer.

An external buffer is never freed and never resized by the image. A decode that needs different dimensions fails the same way a failed allocation does, and the buffer is let go of, so a decoder that ignores the failure cannot publish a picture it never painted.

This lets a component decode into buffers allocated once during setup, so no picture-sized allocation happens at runtime. First user is the Sendspin image platform in #17937, which ping-pongs between two permanent artwork buffers.

The protected helper `get_buffer_size_()` is now the public `get_buffer_size()`, so a component can size the buffer it hands over. This is a rename, not an addition: an external component that subclasses `RuntimeImage` and calls the old name has to be updated.

```cpp
// Before
size_t size = this->get_buffer_size_(width, height);

// After
size_t size = this->get_buffer_size(width, height);
```

Nothing in ESPHome referenced the old name.

## Types of changes

I'm marking this as "Code Quality" for label purposes. I don't think a change like this deserves its own developer docs and since `runtime_image` is just a helper component, it isn't feasible to test this standalone. However, if developer docs really should be added for this type of change, I can create them.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- not applicable

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- not applicable, there is no configuration change

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable. This adds a C++ method for components to call; there is no new configuration.

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

No test is added here because the new method has no configuration surface of its own. It is exercised by the sendspin image platform tests in #17937.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
