### PR TITLE
[core] Log when a git source update is skipped and when it will next refresh

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -2510,11 +2510,16 @@ def git_ref(value):
     return value
 
 
+# What `refresh: never` validates to; also used to recognize a disabled
+# refresh when logging (see esphome/git.py)
+SOURCE_REFRESH_NEVER = "365250d"
+
+
 def source_refresh(value: str):
     if value.lower() == "always":
         return source_refresh("0s")
     if value.lower() == "never":
-        return source_refresh("365250d")
+        return source_refresh(SOURCE_REFRESH_NEVER)
     return positive_time_period_seconds(value)
 
 

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -12,7 +12,12 @@ import urllib.parse
 
 import esphome.config_validation as cv
 from esphome.core import CORE, EsphomeError, TimePeriodSeconds
-from esphome.helpers import add_git_ceiling_directory, rmtree, write_file
+from esphome.helpers import (
+    add_git_ceiling_directory,
+    format_duration,
+    rmtree,
+    write_file,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -288,17 +293,6 @@ def resolve_symlink_stub(repo_dir: Path, file_path: Path) -> Path | None:
     return target_path
 
 
-def _format_duration(seconds: float) -> str:
-    """Format a duration in seconds as a short string like "1d 2h" or "42s"."""
-    remainder = max(0, int(seconds))
-    parts = []
-    for suffix, length in (("d", 86400), ("h", 3600), ("min", 60), ("s", 1)):
-        value, remainder = divmod(remainder, length)
-        if value:
-            parts.append(f"{value}{suffix}")
-    return " ".join(parts[:2]) if parts else "0s"
-
-
 def clone_or_update(
     *,
     url: str,
@@ -489,8 +483,8 @@ def clone_or_update(
                 "Skipping update for %s, next refresh in %s (refresh: %s); "
                 "use refresh: 0s to update now",
                 safe_key,
-                _format_duration(refresh.total_seconds - age_seconds),
-                _format_duration(refresh.total_seconds),
+                format_duration(refresh.total_seconds - age_seconds),
+                format_duration(refresh.total_seconds),
             )
 
     return repo_dir, None

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -19,6 +19,11 @@ _LOGGER = logging.getLogger(__name__)
 # Special value to indicate never refresh
 NEVER_REFRESH = TimePeriodSeconds(seconds=-1)
 
+# `refresh: never` validates to 365250 days (cv.source_refresh); treat any
+# interval at least that long as refresh disabled instead of logging a
+# countdown of hundreds of years
+_REFRESH_DISABLED_SECONDS = TimePeriodSeconds(days=365250).total_seconds
+
 # Written inside .git only after every clone step (clone, ref fetch, reset,
 # submodule init) has completed. A directory without it is an interrupted
 # clone (e.g. the process was killed mid-clone) and must be re-cloned; without
@@ -283,6 +288,17 @@ def resolve_symlink_stub(repo_dir: Path, file_path: Path) -> Path | None:
     return target_path
 
 
+def _format_duration(seconds: float) -> str:
+    """Format a duration in seconds as a short string like "1d 2h" or "42s"."""
+    remainder = max(0, int(seconds))
+    parts = []
+    for suffix, length in (("d", 86400), ("h", 3600), ("min", 60), ("s", 1)):
+        value, remainder = divmod(remainder, length)
+        if value:
+            parts.append(f"{value}{suffix}")
+    return " ".join(parts[:2]) if parts else "0s"
+
+
 def clone_or_update(
     *,
     url: str,
@@ -465,6 +481,17 @@ def clone_or_update(
                 run_git_command(["git", "reset", "--hard", old_sha], git_dir=repo_dir)
 
             return repo_dir, revert
+        if refresh.total_seconds >= _REFRESH_DISABLED_SECONDS:
+            # refresh: never
+            _LOGGER.debug("Skipping update for %s (refresh disabled)", safe_key)
+        else:
+            _LOGGER.info(
+                "Skipping update for %s, next refresh in %s (refresh: %s); "
+                "use refresh: 0s to update now",
+                safe_key,
+                _format_duration(refresh.total_seconds - age_seconds),
+                _format_duration(refresh.total_seconds),
+            )
 
     return repo_dir, None
 

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -24,10 +24,10 @@ _LOGGER = logging.getLogger(__name__)
 # Special value to indicate never refresh
 NEVER_REFRESH = TimePeriodSeconds(seconds=-1)
 
-# `refresh: never` validates to 365250 days (cv.source_refresh); treat any
-# interval at least that long as refresh disabled instead of logging a
-# countdown of hundreds of years
-_REFRESH_DISABLED_SECONDS = TimePeriodSeconds(days=365250).total_seconds
+# `refresh: never` validates to a huge interval rather than the NEVER_REFRESH
+# sentinel; treat any interval at least that long as refresh disabled instead
+# of logging a countdown of hundreds of years
+_REFRESH_DISABLED_SECONDS = cv.source_refresh(cv.SOURCE_REFRESH_NEVER).total_seconds
 
 # Written inside .git only after every clone step (clone, ref fetch, reset,
 # submodule init) has completed. A directory without it is an interrupted
@@ -480,8 +480,8 @@ def clone_or_update(
             _LOGGER.debug("Skipping update for %s (refresh disabled)", safe_key)
         else:
             _LOGGER.info(
-                "Skipping update for %s, next refresh in %s (refresh: %s); "
-                "use refresh: 0s to update now",
+                "Skipping update for %s, will refresh on the next run after %s "
+                "(refresh: %s); use refresh: always to update now",
                 safe_key,
                 format_duration(refresh.total_seconds - age_seconds),
                 format_duration(refresh.total_seconds),

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -148,6 +148,21 @@ def indent(text, padding="  "):
     return "\n".join(indent_list(text, padding))
 
 
+def format_duration(seconds: float) -> str:
+    """Format a duration in seconds as a short string like "1d 2h" or "42s".
+
+    Uses the two largest non-zero units, with unit suffixes matching the YAML
+    time period shorthand (d, h, min, s).
+    """
+    remainder = max(0, int(seconds))
+    parts = []
+    for suffix, length in (("d", 86400), ("h", 3600), ("min", 60), ("s", 1)):
+        value, remainder = divmod(remainder, length)
+        if value:
+            parts.append(f"{value}{suffix}")
+    return " ".join(parts[:2]) if parts else "0s"
+
+
 # From https://stackoverflow.com/a/14945195/8924614
 def cpp_string_escape(string, encoding="utf-8"):
     def _should_escape(byte: int) -> bool:

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -505,9 +505,16 @@ def test_clone_or_update_with_refresh_skips_fresh_repo(
     # Set modification time to 1 hour ago
     os.utime(fetch_head, (recent_time, recent_time))
 
+    # Freeze the clock at 1 hour (plus a margin larger than any filesystem
+    # mtime rounding) after the mtime so the logged countdown is deterministic
+    frozen_now = fetch_head.stat().st_mtime + 3600.5
+
     # Call with refresh=1d (1 day)
     refresh = TimePeriodSeconds(days=1)
-    with caplog.at_level(logging.INFO, logger="esphome.git"):
+    with (
+        patch("esphome.git.time.time", return_value=frozen_now),
+        caplog.at_level(logging.INFO, logger="esphome.git"),
+    ):
         result_dir, revert = git.clone_or_update(
             url=url,
             ref=ref,

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -479,7 +479,7 @@ def test_clone_or_update_with_refresh_updates_old_repo(
 
 
 def test_clone_or_update_with_refresh_skips_fresh_repo(
-    tmp_path: Path, mock_run_git_command: Mock
+    tmp_path: Path, mock_run_git_command: Mock, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that refresh doesn't update fresh repos."""
     # Set up CORE.config_path so data_dir uses tmp_path
@@ -506,17 +506,23 @@ def test_clone_or_update_with_refresh_skips_fresh_repo(
 
     # Call with refresh=1d (1 day)
     refresh = TimePeriodSeconds(days=1)
-    result_dir, revert = git.clone_or_update(
-        url=url,
-        ref=ref,
-        refresh=refresh,
-        domain=domain,
-    )
+    with caplog.at_level(logging.INFO, logger="esphome.git"):
+        result_dir, revert = git.clone_or_update(
+            url=url,
+            ref=ref,
+            refresh=refresh,
+            domain=domain,
+        )
 
     # Should NOT call git fetch since repo is fresh
     mock_run_git_command.assert_not_called()
     assert result_dir == repo_dir
     assert revert is None
+
+    # Should tell the user the update was skipped and when the next refresh is
+    assert f"Skipping update for {url}@{ref}" in caplog.text
+    assert "next refresh in 22h 59min" in caplog.text
+    assert "(refresh: 1d)" in caplog.text
 
 
 def test_clone_or_update_clones_missing_repo(
@@ -1993,3 +1999,21 @@ def test_resolve_symlink_stub_returns_none_when_read_bytes_raises(
         result = git.resolve_symlink_stub(repo_dir, stub)
 
     assert result is None
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (0, "0s"),
+        (42, "42s"),
+        (60, "1min"),
+        (3661, "1h 1min"),
+        (86400, "1d"),
+        (90000, "1d 1h"),
+        (86700, "1d 5min"),
+        (-5, "0s"),
+    ],
+)
+def test_format_duration(seconds: float, expected: str) -> None:
+    """Test that durations are rendered as short human-readable strings."""
+    assert git._format_duration(seconds) == expected

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from esphome import git
+import esphome.config_validation as cv
 from esphome.core import CORE, EsphomeError, TimePeriodSeconds
 from esphome.git import GitCommandError
 
@@ -523,6 +524,47 @@ def test_clone_or_update_with_refresh_skips_fresh_repo(
     assert f"Skipping update for {url}@{ref}" in caplog.text
     assert "next refresh in 22h 59min" in caplog.text
     assert "(refresh: 1d)" in caplog.text
+
+
+def test_clone_or_update_with_refresh_never_logs_refresh_disabled(
+    tmp_path: Path, mock_run_git_command: Mock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a config-level refresh: never skips without a countdown log."""
+    # Set up CORE.config_path so data_dir uses tmp_path
+    CORE.config_path = tmp_path / "test.yaml"
+
+    url = "https://github.com/test/repo"
+    ref = None
+    domain = "test"
+    repo_dir = _compute_repo_dir(url, ref, domain)
+
+    # Create the git repo directory structure
+    repo_dir.mkdir(parents=True)
+    git_dir = repo_dir / ".git"
+    git_dir.mkdir()
+    _mark_clone_complete(repo_dir)
+
+    # Create FETCH_HEAD file with current timestamp
+    fetch_head = git_dir / "FETCH_HEAD"
+    fetch_head.write_text("test")
+
+    # refresh: never validates to 365250 days, not the NEVER_REFRESH sentinel
+    refresh = cv.source_refresh("never")
+    with caplog.at_level(logging.DEBUG, logger="esphome.git"):
+        result_dir, revert = git.clone_or_update(
+            url=url,
+            ref=ref,
+            refresh=refresh,
+            domain=domain,
+        )
+
+    mock_run_git_command.assert_not_called()
+    assert result_dir == repo_dir
+    assert revert is None
+
+    # Should log refresh disabled at debug level, not a countdown
+    assert f"Skipping update for {url}@{ref} (refresh disabled)" in caplog.text
+    assert "next refresh in" not in caplog.text
 
 
 def test_clone_or_update_clones_missing_repo(

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -529,7 +529,7 @@ def test_clone_or_update_with_refresh_skips_fresh_repo(
 
     # Should tell the user the update was skipped and when the next refresh is
     assert f"Skipping update for {url}@{ref}" in caplog.text
-    assert "next refresh in 22h 59min" in caplog.text
+    assert "will refresh on the next run after 22h 59min" in caplog.text
     assert "(refresh: 1d)" in caplog.text
 
 
@@ -571,7 +571,7 @@ def test_clone_or_update_with_refresh_never_logs_refresh_disabled(
 
     # Should log refresh disabled at debug level, not a countdown
     assert f"Skipping update for {url}@{ref} (refresh disabled)" in caplog.text
-    assert "next refresh in" not in caplog.text
+    assert "will refresh on the next run" not in caplog.text
 
 
 def test_clone_or_update_clones_missing_repo(

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -2048,21 +2048,3 @@ def test_resolve_symlink_stub_returns_none_when_read_bytes_raises(
         result = git.resolve_symlink_stub(repo_dir, stub)
 
     assert result is None
-
-
-@pytest.mark.parametrize(
-    ("seconds", "expected"),
-    [
-        (0, "0s"),
-        (42, "42s"),
-        (60, "1min"),
-        (3661, "1h 1min"),
-        (86400, "1d"),
-        (90000, "1d 1h"),
-        (86700, "1d 5min"),
-        (-5, "0s"),
-    ],
-)
-def test_format_duration(seconds: float, expected: str) -> None:
-    """Test that durations are rendered as short human-readable strings."""
-    assert git._format_duration(seconds) == expected

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -1074,3 +1074,21 @@ def test_progressbar_enabled_on_pipe_with_dashboard(monkeypatch) -> None:
 
     bar = ProgressBar("Uploading", stream=stream)
     assert bar.enabled is True
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (0, "0s"),
+        (42, "42s"),
+        (60, "1min"),
+        (3661, "1h 1min"),
+        (86400, "1d"),
+        (90000, "1d 1h"),
+        (86700, "1d 5min"),
+        (-5, "0s"),
+    ],
+)
+def test_format_duration(seconds: float, expected: str) -> None:
+    """Test that durations are rendered as short human-readable strings."""
+    assert helpers.format_duration(seconds) == expected


### PR DESCRIPTION
# What does this implement/fix?

When a git based external component or package is still inside its refresh window, ESPHome silently skips the fetch; users cannot tell why a change they pushed to the repository is not being picked up. This came up in a Discord report where a user had no `refresh:` set and the default of 1 day applied, so their update was skipped with no indication at all.

This adds an INFO log line when the update is skipped, showing the source, when the next refresh will happen, the configured refresh interval, and how to force an update:

```
INFO Skipping update for https://github.com/user/repo@main, will refresh on the next run after 22h 59min (refresh: 1d); use refresh: always to update now
```

`refresh: never` keeps logging at debug level, matching the existing behavior for disabled refresh.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
external_components:
  - source: github://user/repo
    refresh: 1d
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
