### PR TITLE
[esp32] Add platformio toolchain deprecation warning

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1237,6 +1237,13 @@ def final_validate(config):
 
     from .gpio import final_validate_pins
 
+    # Remove before 2027.2.0
+    if CORE.using_toolchain_platformio:
+        _LOGGER.warning(
+            "The 'platformio' toolchain for ESP32 is deprecated and will be removed "
+            "in ESPHome 2027.2.0. Please use 'toolchain: esp-idf' instead."
+        )
+
     errs = []
     conf_fw = config[CONF_FRAMEWORK]
     advanced = conf_fw[CONF_ADVANCED]


### PR DESCRIPTION
# What does this implement/fix?

Adds a deprecation warning when the `platformio` toolchain is selected for ESP32, targeting removal in 2027.2.0.

This mirrors the nRF52 deprecation (#17705) with the same removal target, so both platformio toolchains can be removed together. The `esp-idf` toolchain has been the default since it was introduced, and both the ESP-IDF and Arduino frameworks build on it, so only configurations that explicitly select `toolchain: platformio` see the warning, and migration is simply removing that line.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7069

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Deprecated, warns at validation:
esp32:
  board: esp32dev
  toolchain: platformio

# Migration - remove the toolchain line (esp-idf is the default):
esp32:
  board: esp32dev
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).