### PR TITLE
[ci] Switch stale to the shared real-activity workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,9 +6,8 @@ on:
     - cron: "30 0 * * *"
   workflow_dispatch:
 
-permissions:
-  issues: write         # actions/stale labels, comments on, and closes stale issues
-  pull-requests: write  # actions/stale labels, comments on, and closes stale pull requests
+# Deny by default; the stale job opts in to exactly what the reusable workflow needs.
+permissions: {}
 
 concurrency:
   group: lock
@@ -16,51 +15,33 @@ concurrency:
 jobs:
   stale:
     if: github.repository_owner == 'esphome'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Stale
-        uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
-        with:
-          debug-only: ${{ github.ref != 'refs/heads/dev' }} # Dry-run when not run on dev branch
-          remove-stale-when-updated: true
-          operations-per-run: 400
+    permissions:
+      contents: read        # head-commit dates for the PR activity check
+      issues: write         # label, comment on and close stale issues
+      pull-requests: write  # label, comment on and close stale pull requests
+    uses: esphome/workflows/.github/workflows/stale.yml@c87be24a6fd0320ecd32e40b27fe98d25c3af851  # 2026.7.0
+    with:
+      dry-run: true
+      ignored-users: esphbot,codecov-commenter
+      stale-pr-message: >
+        There hasn't been any activity on this pull request recently. This
+        pull request has been automatically marked as stale because of that
+        and will be closed if no further activity occurs within 7 days.
 
-          # The 90 day stale policy for PRs
-          # - PRs
-          # - No PRs marked as "not-stale"
-          # - No Issues (see below)
-          days-before-pr-stale: 90
-          days-before-pr-close: 7
-          stale-pr-label: "stale"
-          exempt-pr-labels: "not-stale"
-          stale-pr-message: >
-            There hasn't been any activity on this pull request recently. This
-            pull request has been automatically marked as stale because of that
-            and will be closed if no further activity occurs within 7 days.
+        If you are the author of this PR, please leave a comment if you want
+        to keep it open. Also, please rebase your PR onto the latest dev
+        branch to ensure that it's up to date with the latest changes.
 
-            If you are the author of this PR, please leave a comment if you want
-            to keep it open. Also, please rebase your PR onto the latest dev
-            branch to ensure that it's up to date with the latest changes.
+        Thank you for your contribution!
+      stale-issue-message: >
+        There hasn't been any activity on this issue recently. Due to the
+        high number of incoming GitHub notifications, we have to clean some
+        of the old issues, as many of them have already been resolved with
+        the latest updates.
 
-            Thank you for your contribution!
+        Please make sure to update to the latest ESPHome version and
+        check if that solves the issue. Let us know if that works for you by
+        adding a comment 👍
 
-          # The 90 day stale policy for Issues
-          # - Issues
-          # - No Issues marked as "not-stale"
-          # - No PRs (see above)
-          days-before-issue-stale: 90
-          days-before-issue-close: 7
-          stale-issue-label: "stale"
-          exempt-issue-labels: "not-stale"
-          stale-issue-message: >
-            There hasn't been any activity on this issue recently. Due to the
-            high number of incoming GitHub notifications, we have to clean some
-            of the old issues, as many of them have already been resolved with
-            the latest updates.
-
-            Please make sure to update to the latest ESPHome version and
-            check if that solves the issue. Let us know if that works for you by
-            adding a comment 👍
-
-            This issue has now been marked as stale and will be closed if no
-            further activity occurs. Thank you for your contributions.
+        This issue has now been marked as stale and will be closed if no
+        further activity occurs. Thank you for your contributions.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: lock
+  group: stale
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,9 +9,6 @@ on:
 # Deny by default; the stale job opts in to exactly what the reusable workflow needs.
 permissions: {}
 
-concurrency:
-  group: stale
-
 jobs:
   stale:
     if: github.repository_owner == 'esphome'
@@ -21,6 +18,12 @@ jobs:
       pull-requests: write  # label, comment on and close stale pull requests
     uses: esphome/workflows/.github/workflows/stale.yml@c87be24a6fd0320ecd32e40b27fe98d25c3af851  # 2026.7.0
     with:
+      # Live only on dev: a workflow_dispatch from any other branch is a dry run
+      dry-run: ${{ github.ref != 'refs/heads/dev' }}
+      days-before-stale: 90
+      days-before-close: 7
+      stale-label: stale
+      exempt-label: not-stale
       ignored-users: esphbot,codecov-commenter
       stale-pr-message: >
         There hasn't been any activity on this pull request recently. This

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,6 @@ jobs:
       pull-requests: write  # label, comment on and close stale pull requests
     uses: esphome/workflows/.github/workflows/stale.yml@c87be24a6fd0320ecd32e40b27fe98d25c3af851  # 2026.7.0
     with:
-      dry-run: true
       ignored-users: esphbot,codecov-commenter
       stale-pr-message: >
         There hasn't been any activity on this pull request recently. This


### PR DESCRIPTION
# What does this implement/fix?

Replaces `actions/stale` with the shared real-activity stale workflow (esphome/workflows#176), called the same way as the shared lock workflow and pinned by SHA.

## Why

`actions/stale` measures staleness from the GitHub `updated_at` timestamp, which also moves on in-place bot comment edits. On this repo, codecov edits its coverage comments on old PRs for months after posting — proven to the second via GraphQL `userContentEdits` on #10182, whose two phantom "updates" (2026-04-08, 2026-06-04) match codecov edit timestamps exactly. This has kept dozens of abandoned PRs from ever being marked stale and repeatedly rescued marked ones during the close window. `actions/stale` has no activity-based mode (actions/stale#1114, open since 2023).

The shared workflow measures real activity directly: comments created by users (bot accounts and the `ignored-users` machine accounts esphbot/codecov-commenter don't count, and comment edits never count), plus commits and human review submissions for PRs. The stale/close policy is unchanged: 90 days to mark, 7 more to close, `not-stale` exempts, and the existing stale messages are carried over verbatim.

<img width="1018" height="492" alt="screenshot-2026-07-30_09-51-55" src="https://github.com/user-attachments/assets/d8d88efe-0025-4b43-a7ec-b4281f240f7f" />

## Validation

Dispatched from this branch as a live dry run: [run 30559690089](https://github.com/esphome/esphome/actions/runs/30559690089). Of 734 open items it would mark 63 (58 PRs whose `updated_at` is phantom-fresh but which have had no real activity for 90+ days, 3 issues, 2 items whose only recent activity was esphbot comments), unmark 0 and close 0 — each decision logged with the item's timestamps. A read-only simulation of the same logic produced a strict subset (61), differing only by the `ignored-users` filter.

**Heads up: the first run after merge will mark those ~63 items and post the stale comment on each in one batch.** The would-mark list is in the linked run log; anything that shouldn't be marked can be given `not-stale` before or after merge (marking is not closing — any real activity within 7 days unmarks).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# CI-only change, no configuration impact
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).