### PR TITLE
[ble_client] Reject descriptor_uuid combined with notify

### DIFF
--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from esphome import automation
 from esphome.automation import maybe_simple_id
 import esphome.codegen as cg
@@ -9,6 +11,7 @@ from esphome.const import (
     CONF_ID,
     CONF_MAC_ADDRESS,
     CONF_NAME,
+    CONF_NOTIFY,
     CONF_ON_CONNECT,
     CONF_ON_DISCONNECT,
     CONF_SERVICE_UUID,
@@ -16,10 +19,42 @@ from esphome.const import (
     CONF_VALUE,
 )
 from esphome.core import ID
+from esphome.types import ConfigType
 
 AUTO_LOAD = ["esp32_ble_client"]
 CODEOWNERS = ["@buxtronix", "@clydebarrow"]
 DEPENDENCIES = ["esp32_ble_tracker"]
+
+CONF_DESCRIPTOR_UUID = "descriptor_uuid"
+
+
+def check_descriptor_notify(entity: str) -> Callable[[ConfigType], ConfigType]:
+    """Create a validator rejecting descriptor_uuid combined with notify.
+
+    Notifications carry the characteristic value, so an entity configured for both reads
+    the descriptor handle and then never matches the notification it subscribed to.
+
+    Args:
+        entity: The entity noun used in the error message, e.g. "sensor"
+
+    Returns:
+        A validator function that rejects the combination
+    """
+
+    def validate(config: ConfigType) -> ConfigType:
+        # Not cv.has_at_most_one_key: that tests key presence, and CONF_NOTIFY carries a
+        # default, so it is always present. Only a true value conflicts with a descriptor.
+        if config.get(CONF_DESCRIPTOR_UUID) and config.get(CONF_NOTIFY):
+            raise cv.Invalid(
+                f"'{CONF_DESCRIPTOR_UUID}' cannot be combined with '{CONF_NOTIFY}: true'. "
+                "Notifications carry the characteristic value, not a descriptor value, so "
+                f"this {entity} would never publish. Remove '{CONF_DESCRIPTOR_UUID}' to "
+                f"receive notifications, or set '{CONF_NOTIFY}: false' to read the descriptor."
+            )
+        return config
+
+    return validate
+
 
 ble_client_ns = cg.esphome_ns.namespace("ble_client")
 BLEClient = ble_client_ns.class_("BLEClient", esp32_ble_client.BLEClientBase)

--- a/esphome/components/ble_client/sensor/__init__.py
+++ b/esphome/components/ble_client/sensor/__init__.py
@@ -13,6 +13,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_DECIBEL_MILLIWATT,
 )
+from esphome.types import ConfigType
 
 from .. import ble_client_ns
 
@@ -45,6 +46,19 @@ def checkType(value):
             "Looks like you're trying to create a ble characteristic sensor. Please add `type: characteristic` to your sensor config."
         )
     return value
+
+
+def check_descriptor_notify(config: ConfigType) -> ConfigType:
+    # Not cv.has_at_most_one_key: that tests key presence, and CONF_NOTIFY carries a
+    # default, so it is always present. Only a true value conflicts with a descriptor.
+    if config.get(CONF_DESCRIPTOR_UUID) and config.get(CONF_NOTIFY):
+        raise cv.Invalid(
+            f"'{CONF_DESCRIPTOR_UUID}' cannot be combined with '{CONF_NOTIFY}: true'. "
+            "Notifications carry the characteristic value, not a descriptor value, so this "
+            f"sensor would never publish. Remove '{CONF_DESCRIPTOR_UUID}' to receive "
+            f"notifications, or set '{CONF_NOTIFY}: false' to read the descriptor."
+        )
+    return config
 
 
 CONFIG_SCHEMA = cv.All(
@@ -85,6 +99,7 @@ CONFIG_SCHEMA = cv.All(
         },
         lower=True,
     ),
+    check_descriptor_notify,
 )
 
 

--- a/esphome/components/ble_client/sensor/__init__.py
+++ b/esphome/components/ble_client/sensor/__init__.py
@@ -13,13 +13,10 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_DECIBEL_MILLIWATT,
 )
-from esphome.types import ConfigType
 
-from .. import ble_client_ns
+from .. import CONF_DESCRIPTOR_UUID, ble_client_ns, check_descriptor_notify
 
 DEPENDENCIES = ["ble_client"]
-
-CONF_DESCRIPTOR_UUID = "descriptor_uuid"
 
 CONF_ON_NOTIFY = "on_notify"
 TYPE_CHARACTERISTIC = "characteristic"
@@ -46,19 +43,6 @@ def checkType(value):
             "Looks like you're trying to create a ble characteristic sensor. Please add `type: characteristic` to your sensor config."
         )
     return value
-
-
-def check_descriptor_notify(config: ConfigType) -> ConfigType:
-    # Not cv.has_at_most_one_key: that tests key presence, and CONF_NOTIFY carries a
-    # default, so it is always present. Only a true value conflicts with a descriptor.
-    if config.get(CONF_DESCRIPTOR_UUID) and config.get(CONF_NOTIFY):
-        raise cv.Invalid(
-            f"'{CONF_DESCRIPTOR_UUID}' cannot be combined with '{CONF_NOTIFY}: true'. "
-            "Notifications carry the characteristic value, not a descriptor value, so this "
-            f"sensor would never publish. Remove '{CONF_DESCRIPTOR_UUID}' to receive "
-            f"notifications, or set '{CONF_NOTIFY}: false' to read the descriptor."
-        )
-    return config
 
 
 CONFIG_SCHEMA = cv.All(
@@ -99,7 +83,7 @@ CONFIG_SCHEMA = cv.All(
         },
         lower=True,
     ),
-    check_descriptor_notify,
+    check_descriptor_notify("sensor"),
 )
 
 

--- a/esphome/components/ble_client/text_sensor/__init__.py
+++ b/esphome/components/ble_client/text_sensor/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_SERVICE_UUID,
     CONF_TRIGGER_ID,
 )
+from esphome.types import ConfigType
 
 from .. import ble_client_ns
 
@@ -30,6 +31,20 @@ BLETextSensorNotifyTrigger = ble_client_ns.class_(
     "BLETextSensorNotifyTrigger", automation.Trigger.template(cg.std_string)
 )
 
+
+def check_descriptor_notify(config: ConfigType) -> ConfigType:
+    # Not cv.has_at_most_one_key: that tests key presence, and CONF_NOTIFY carries a
+    # default, so it is always present. Only a true value conflicts with a descriptor.
+    if config.get(CONF_DESCRIPTOR_UUID) and config.get(CONF_NOTIFY):
+        raise cv.Invalid(
+            f"'{CONF_DESCRIPTOR_UUID}' cannot be combined with '{CONF_NOTIFY}: true'. "
+            "Notifications carry the characteristic value, not a descriptor value, so this "
+            f"text sensor would never publish. Remove '{CONF_DESCRIPTOR_UUID}' to receive "
+            f"notifications, or set '{CONF_NOTIFY}: false' to read the descriptor."
+        )
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
     text_sensor.text_sensor_schema(BLETextSensor)
     .extend(
@@ -48,7 +63,8 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("60s"))
-    .extend(ble_client.BLE_CLIENT_SCHEMA)
+    .extend(ble_client.BLE_CLIENT_SCHEMA),
+    check_descriptor_notify,
 )
 
 

--- a/esphome/components/ble_client/text_sensor/__init__.py
+++ b/esphome/components/ble_client/text_sensor/__init__.py
@@ -8,13 +8,10 @@ from esphome.const import (
     CONF_SERVICE_UUID,
     CONF_TRIGGER_ID,
 )
-from esphome.types import ConfigType
 
-from .. import ble_client_ns
+from .. import CONF_DESCRIPTOR_UUID, ble_client_ns, check_descriptor_notify
 
 DEPENDENCIES = ["ble_client"]
-
-CONF_DESCRIPTOR_UUID = "descriptor_uuid"
 
 CONF_ON_NOTIFY = "on_notify"
 
@@ -30,19 +27,6 @@ BLETextSensor = ble_client_ns.class_(
 BLETextSensorNotifyTrigger = ble_client_ns.class_(
     "BLETextSensorNotifyTrigger", automation.Trigger.template(cg.std_string)
 )
-
-
-def check_descriptor_notify(config: ConfigType) -> ConfigType:
-    # Not cv.has_at_most_one_key: that tests key presence, and CONF_NOTIFY carries a
-    # default, so it is always present. Only a true value conflicts with a descriptor.
-    if config.get(CONF_DESCRIPTOR_UUID) and config.get(CONF_NOTIFY):
-        raise cv.Invalid(
-            f"'{CONF_DESCRIPTOR_UUID}' cannot be combined with '{CONF_NOTIFY}: true'. "
-            "Notifications carry the characteristic value, not a descriptor value, so this "
-            f"text sensor would never publish. Remove '{CONF_DESCRIPTOR_UUID}' to receive "
-            f"notifications, or set '{CONF_NOTIFY}: false' to read the descriptor."
-        )
-    return config
 
 
 CONFIG_SCHEMA = cv.All(
@@ -64,7 +48,7 @@ CONFIG_SCHEMA = cv.All(
     )
     .extend(cv.polling_component_schema("60s"))
     .extend(ble_client.BLE_CLIENT_SCHEMA),
-    check_descriptor_notify,
+    check_descriptor_notify("text sensor"),
 )
 
 

--- a/tests/component_tests/ble_client/test_descriptor_notify_validation.py
+++ b/tests/component_tests/ble_client/test_descriptor_notify_validation.py
@@ -1,0 +1,119 @@
+"""Tests for ble_client descriptor_uuid and notify validation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components.ble_client.sensor import CONFIG_SCHEMA as SENSOR_SCHEMA
+from esphome.components.ble_client.text_sensor import (
+    CONFIG_SCHEMA as TEXT_SENSOR_SCHEMA,
+)
+
+SERVICE_UUID = "abcd1234-abcd-1234-abcd-abcd12345678"
+CHARACTERISTIC_UUID = "abcd1236-abcd-1234-abcd-abcd12345678"
+DESCRIPTOR_UUID = "abcd1237-abcd-1234-abcd-abcd12345678"
+
+REJECTED = "cannot be combined with"
+
+
+def _sensor(name: str, **kwargs: Any) -> dict:
+    """Run a characteristic sensor config through the full platform schema."""
+    return SENSOR_SCHEMA(
+        {
+            "type": "characteristic",
+            "name": name,
+            "ble_client_id": "test_blec",
+            "service_uuid": SERVICE_UUID,
+            "characteristic_uuid": CHARACTERISTIC_UUID,
+            **kwargs,
+        }
+    )
+
+
+def _text_sensor(name: str, **kwargs: Any) -> dict:
+    """Run a text sensor config through the full platform schema."""
+    return TEXT_SENSOR_SCHEMA(
+        {
+            "name": name,
+            "ble_client_id": "test_blec",
+            "service_uuid": SERVICE_UUID,
+            "characteristic_uuid": CHARACTERISTIC_UUID,
+            **kwargs,
+        }
+    )
+
+
+# --- accepted configurations ---
+
+
+def test_sensor_descriptor_without_notify_accepted() -> None:
+    """Reading a descriptor is what descriptor_uuid is for.
+
+    The schema normalizes a UUID to upper case, hence folding the validated value.
+    """
+    config = _sensor("descriptor read", descriptor_uuid=DESCRIPTOR_UUID)
+    assert config["descriptor_uuid"].lower() == DESCRIPTOR_UUID
+    assert config["notify"] is False
+
+
+def test_sensor_notify_without_descriptor_accepted() -> None:
+    """Subscribing to the characteristic is unaffected by this check."""
+    config = _sensor("notifications", notify=True)
+    assert config["notify"] is True
+    assert "descriptor_uuid" not in config
+
+
+def test_sensor_descriptor_with_explicit_notify_false_accepted() -> None:
+    """An explicit false must not trip the check, only a true one."""
+    config = _sensor("explicit false", descriptor_uuid=DESCRIPTOR_UUID, notify=False)
+    assert config["descriptor_uuid"].lower() == DESCRIPTOR_UUID
+
+
+def test_sensor_with_neither_key_given_accepted() -> None:
+    """A plain characteristic sensor gives neither key, and defaults notify to false."""
+    config = _sensor("plain")
+    assert "descriptor_uuid" not in config
+    assert config["notify"] is False
+
+
+def test_rssi_sensor_accepted() -> None:
+    """The rssi type carries neither key, so the check must pass it through."""
+    config = SENSOR_SCHEMA(
+        {"type": "rssi", "name": "rssi", "ble_client_id": "test_blec"}
+    )
+    assert config["type"] == "rssi"
+
+
+def test_text_sensor_descriptor_without_notify_accepted() -> None:
+    config = _text_sensor("descriptor read", descriptor_uuid=DESCRIPTOR_UUID)
+    assert config["descriptor_uuid"].lower() == DESCRIPTOR_UUID
+    assert config["notify"] is False
+
+
+def test_text_sensor_notify_without_descriptor_accepted() -> None:
+    config = _text_sensor("notifications", notify=True)
+    assert config["notify"] is True
+
+
+# --- rejected configurations ---
+
+
+def test_sensor_descriptor_with_notify_rejected() -> None:
+    """Regression: this pair validated and produced a sensor that never published.
+
+    descriptor_uuid repoints BLESensor::handle at the descriptor while the
+    registration is still issued on the characteristic handle. ESP_GATTC_REG_FOR_NOTIFY_EVT
+    then never matches, so node_state never reaches ESTABLISHED, update() refuses to
+    poll, and ESP_GATTC_NOTIFY_EVT does not match either.
+    """
+    with pytest.raises(cv.Invalid, match=REJECTED):
+        _sensor("both", descriptor_uuid=DESCRIPTOR_UUID, notify=True)
+
+
+def test_text_sensor_descriptor_with_notify_rejected() -> None:
+    """The text sensor shares the handle overload, and the same fate."""
+    with pytest.raises(cv.Invalid, match=REJECTED):
+        _text_sensor("both", descriptor_uuid=DESCRIPTOR_UUID, notify=True)

--- a/tests/component_tests/ble_client/test_descriptor_notify_validation.py
+++ b/tests/component_tests/ble_client/test_descriptor_notify_validation.py
@@ -17,6 +17,9 @@ CHARACTERISTIC_UUID = "abcd1236-abcd-1234-abcd-abcd12345678"
 DESCRIPTOR_UUID = "abcd1237-abcd-1234-abcd-abcd12345678"
 
 REJECTED = "cannot be combined with"
+# The shared factory takes the entity noun, so each platform must name itself.
+REJECTED_SENSOR = "so this sensor would never publish"
+REJECTED_TEXT_SENSOR = "so this text sensor would never publish"
 
 
 def _sensor(name: str, **kwargs: Any) -> dict:
@@ -109,11 +112,13 @@ def test_sensor_descriptor_with_notify_rejected() -> None:
     then never matches, so node_state never reaches ESTABLISHED, update() refuses to
     poll, and ESP_GATTC_NOTIFY_EVT does not match either.
     """
-    with pytest.raises(cv.Invalid, match=REJECTED):
+    with pytest.raises(cv.Invalid, match=REJECTED) as excinfo:
         _sensor("both", descriptor_uuid=DESCRIPTOR_UUID, notify=True)
+    assert REJECTED_SENSOR in str(excinfo.value)
 
 
 def test_text_sensor_descriptor_with_notify_rejected() -> None:
     """The text sensor shares the handle overload, and the same fate."""
-    with pytest.raises(cv.Invalid, match=REJECTED):
+    with pytest.raises(cv.Invalid, match=REJECTED) as excinfo:
         _text_sensor("both", descriptor_uuid=DESCRIPTOR_UUID, notify=True)
+    assert REJECTED_TEXT_SENSOR in str(excinfo.value)

--- a/tests/components/ble_client/common.yaml
+++ b/tests/components/ble_client/common.yaml
@@ -52,6 +52,38 @@ sensor:
     name: "BLE Sensor without Lambda"
     service_uuid: "abcd1234-abcd-1234-abcd-abcd12345678"
     characteristic_uuid: "abcd1237-abcd-1234-abcd-abcd12345678"
+  - platform: ble_client
+    ble_client_id: test_blec
+    type: characteristic
+    id: test_sensor_descriptor
+    name: "BLE Sensor reading a descriptor"
+    service_uuid: "abcd1234-abcd-1234-abcd-abcd12345678"
+    characteristic_uuid: "abcd1238-abcd-1234-abcd-abcd12345678"
+    descriptor_uuid: "abcd1239-abcd-1234-abcd-abcd12345678"
+  - platform: ble_client
+    ble_client_id: test_blec
+    type: characteristic
+    id: test_sensor_notify
+    name: "BLE Sensor with notifications"
+    service_uuid: "abcd1234-abcd-1234-abcd-abcd12345678"
+    characteristic_uuid: "abcd123a-abcd-1234-abcd-abcd12345678"
+    notify: true
+
+text_sensor:
+  - platform: ble_client
+    ble_client_id: test_blec
+    id: test_text_sensor_descriptor
+    name: "BLE Text Sensor reading a descriptor"
+    service_uuid: "abcd1234-abcd-1234-abcd-abcd12345678"
+    characteristic_uuid: "abcd123b-abcd-1234-abcd-abcd12345678"
+    descriptor_uuid: "abcd123c-abcd-1234-abcd-abcd12345678"
+  - platform: ble_client
+    ble_client_id: test_blec
+    id: test_text_sensor_notify
+    name: "BLE Text Sensor with notifications"
+    service_uuid: "abcd1234-abcd-1234-abcd-abcd12345678"
+    characteristic_uuid: "abcd123d-abcd-1234-abcd-abcd12345678"
+    notify: true
 
 number:
   - platform: template


### PR DESCRIPTION
# What does this implement/fix?

`descriptor_uuid` combined with `notify: true` produces a `ble_client` sensor that never publishes anything, and says nothing about it beyond a repeating poll warning. This rejects the combination at config time.

`BLESensor::handle` is two things at once: the handle `update()` reads, and the identity every notification path compares against. Setting `descriptor_uuid` repoints it at the descriptor, while the registration is still issued on the characteristic handle:

```cpp
this->handle = chr->handle;
if (this->descr_uuid_.get_uuid().len > 0) {
  ...
  this->handle = descr->handle;          // read target moves
}
if (this->notify_) {
  esp_ble_gattc_register_for_notify(..., chr->handle);   // identity does not
}
```

Every downstream comparison then fails, and they fail in a way that closes both paths to publishing:

- `ESP_GATTC_REG_FOR_NOTIFY_EVT` compares `param->reg_for_notify.handle` against the descriptor handle and does not match, so `node_state` never becomes `ESTABLISHED`.
- `BLESensor` is a `PollingComponent`, and `update()` returns early unless `node_state == ESTABLISHED`, so it never issues a read and logs `Cannot poll, not connected` once per `update_interval`, 60s by default.
- `ESP_GATTC_NOTIFY_EVT` compares `param->notify.handle`, which carries the characteristic handle, against the descriptor handle, so notifications are dropped too.

`BLESensorNotifyTrigger` reads the same `sensor_->handle`, so an `on_notify` automation never fires either. `ble_client` `text_sensor` has the identical shape.

The combination cannot be made to work as written, because a descriptor is not a notifiable attribute. A Handle Value Notification only ever carries a characteristic value handle, so there is no such thing as being notified of a descriptor's value.

## Why this has not been reported

In `sensor` the overload dates to BLE client support landing in #1177. In `text_sensor` it only became reachable on 2026-04-02, when #15374 fixed `descriptor_uuid` being silently ignored there; before that the descriptor UUID never reached C++, so the handle was never repointed. No fixture under `tests/` exercised `descriptor_uuid` at all, in either platform.

## The change

`ble_client/__init__.py` gains a `check_descriptor_notify(entity)` factory, following the shape of
`entity_duplicate_validator(platform)` in `esphome/core/entity_helpers.py`. `sensor` and `text_sensor`
each compose the validator it returns into their `cv.All` chain, passing their own entity noun, and
share the `CONF_DESCRIPTOR_UUID` constant from the same module rather than defining it twice. The
rejection reads:

```text
'descriptor_uuid' cannot be combined with 'notify: true'. Notifications carry the
characteristic value, not a descriptor value, so this sensor would never publish.
Remove 'descriptor_uuid' to receive notifications, or set 'notify: false' to read
the descriptor.
```

`tests/component_tests/ble_client/test_descriptor_notify_validation.py` asserts the rejection through the full platform `CONFIG_SCHEMA` for both platforms, rather than against the validator function, so unwiring the check from the `cv.All` chain fails the suite. It also pins the accepted cases: descriptor alone, notify alone, an explicit `notify: false` alongside a descriptor, neither key, and the `rssi` sensor type that carries neither.

The build fixture gains the combinations that must keep compiling: a descriptor-reading sensor, a notifying sensor, and the same pair for `text_sensor`. `descriptor_uuid` had no fixture at all before this, in either platform, which is part of why #15374 went unnoticed for as long as it did.

## Two options were evaluated, and this is the simpler one

**Option A, implemented here: refuse the combination.** Two schema files, no C++, no RAM cost, and it turns a silent dead sensor into a config error that names the fix.

**Option B, not implemented: separate the notify identity from the read target.** Add a `char_handle_` member to both platforms, register on it, and compare `REG_FOR_NOTIFY` and `NOTIFY` against it while `handle` stays the read target. That is about twenty lines across four files and two bytes of RAM per sensor.

Option B was rejected on semantics rather than cost. It would leave one entity fed by two unrelated sources: notifications publishing the characteristic value, polls publishing the descriptor value. That is not a behaviour I can find a justification for, and inventing it to rescue a configuration that never worked seemed worse than refusing the configuration.

**The systemic issue is the overload itself**, not this pair. `handle` meaning both "what to read" and "what to match notifications against" is what makes `descriptor_uuid` able to break notifications at a distance. This PR takes the narrow option deliberately, so that the defect is exposed and documented rather than papered over. If codeowners would rather fix the overload than avoid it, Option B is the shape that does it, and I am happy to build it instead.

## Note on classification

This is checked as a breaking change because a configuration that compiles today will now fail validation. Nothing functional breaks: any config hitting this error has a sensor that publishes nothing and warns every 60s. If breaking a build on update is judged too aggressive for that, the softer form is a codegen-time `_LOGGER.warning` rather than `cv.Invalid`, and I will switch it on request.

## Relationship to the other open `ble_client` PRs

This is **independent of #17919 and #17920 and needs no particular merge order**. It touches only `sensor/__init__.py`, `text_sensor/__init__.py` and the test fixture, with no file overlap with either. #17919 does modify `ble_sensor.cpp` and `ble_text_sensor.cpp`, but not the handle logic this concerns.

For context, the defect was surfaced during review of #17919 and confirmed against the tree there, which is why it is filed separately rather than folded into that PR.

- #17919, `[ble_client]` do not walk the GATT cache after releasing services
- #17920, `[ble_client]` report Established from nodes that never read services

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not opened yet. The `ble_client` sensor and text sensor pages document `descriptor_uuid` and `notify` independently, with nothing saying they are mutually exclusive. Happy to open one saying so if this lands in this form.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Testing

Both platforms were checked against the relevant configurations, and the rejection was confirmed end to end through `esphome config` rather than only against the validator function. The new component test was also mutation-checked: removing `check_descriptor_notify` from the two `cv.All` chains fails exactly the two rejection tests and nothing else, so the coverage is real rather than incidental.

`script/ci-custom.py`, `ruff format --check`, `ruff check`, `script/build_codeowners.py --check`, `script/build_language_schema.py --check`, `script/ci_check_duplicate_test_ids.py` and `script/ci_check_test_fixture_list_form.py` are clean, `pytest tests/component_tests/ble_client/` passes, and `script/test_build_components.py -c ble_client -t esp32-idf` compiles the extended fixture.

## Example entry for `config.yaml`:

```yaml
# Rejected: the sensor would never publish.
sensor:
  - platform: ble_client
    ble_client_id: test_blec
    type: characteristic
    name: "Descriptor with notify"
    service_uuid: "abcd1234-abcd-1234-abcd-abcd12345678"
    characteristic_uuid: "abcd1236-abcd-1234-abcd-abcd12345678"
    descriptor_uuid: "abcd1237-abcd-1234-abcd-abcd12345678"
    notify: true

# Both still accepted, separately.
sensor:
  - platform: ble_client
    ble_client_id: test_blec
    type: characteristic
    name: "Descriptor read"
    service_uuid: "abcd1234-abcd-1234-abcd-abcd12345678"
    characteristic_uuid: "abcd1236-abcd-1234-abcd-abcd12345678"
    descriptor_uuid: "abcd1237-abcd-1234-abcd-abcd12345678"
  - platform: ble_client
    ble_client_id: test_blec
    type: characteristic
    name: "Notifications"
    service_uuid: "abcd1234-abcd-1234-abcd-abcd12345678"
    characteristic_uuid: "abcd1238-abcd-1234-abcd-abcd12345678"
    notify: true
```

## Checklist:

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (under `tests/` folder).

