### PR TITLE
[espidf] Use forward slashes in generated component CMakeLists

### DIFF
--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -90,12 +90,15 @@ def generate_cmakelists_txt(component: IDFComponent) -> str:
     import shlex
 
     def escape_entry(p: PathType) -> str:
+        # In CMakeLists.txt, backslashes need to be escaped
+        return f'"{str(p)}"'.replace("\\", "\\\\")
+
+    def escape_path(p: PathType) -> str:
         # CMake uses forward slashes for paths on every platform and treats
         # backslashes as escape characters. On Windows os.path.relpath yields
         # backslash paths, which break CMake's list re-parsing (e.g. "\b" in
-        # "src\backend" is an invalid character escape). Normalize to forward
-        # slashes, which Windows accepts too, so the generated CMakeLists is
-        # portable.
+        # "src\backend" is an invalid character escape). Emit forward slashes,
+        # which Windows accepts too, so the generated CMakeLists is portable.
         return f'"{str(p).replace(os.sep, "/")}"'
 
     # Extract the values
@@ -179,10 +182,10 @@ def generate_cmakelists_txt(component: IDFComponent) -> str:
     # Generate the component
     content = "idf_component_register(\n"
     if build_src_files:
-        str_srcs = " ".join([escape_entry(p) for p in sorted(build_src_files)])
+        str_srcs = " ".join([escape_path(p) for p in sorted(build_src_files)])
         content += f"  SRCS {str_srcs}\n"
     if build_include_dirs:
-        str_include_dirs = " ".join([escape_entry(p) for p in build_include_dirs])
+        str_include_dirs = " ".join([escape_path(p) for p in build_include_dirs])
         content += f"  INCLUDE_DIRS {str_include_dirs}\n"
     # Project-managed and built-in component lists are set per-project
     # via idf_build_set_property in the top-level CMakeLists; expanded
@@ -217,7 +220,7 @@ def generate_cmakelists_txt(component: IDFComponent) -> str:
     if link_directories:
         content += "target_link_directories(${COMPONENT_LIB} INTERFACE\n"
         for link_directory in link_directories:
-            str_build_flag = escape_entry(link_directory)
+            str_build_flag = escape_path(link_directory)
             content += f"  {str_build_flag}\n"
         content += ")\n"
 

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -90,8 +90,13 @@ def generate_cmakelists_txt(component: IDFComponent) -> str:
     import shlex
 
     def escape_entry(p: PathType) -> str:
-        # In CMakeLists.txt, backslashes need to be escaped
-        return f'"{str(p)}"'.replace("\\", "\\\\")
+        # CMake uses forward slashes for paths on every platform and treats
+        # backslashes as escape characters. On Windows os.path.relpath yields
+        # backslash paths, which break CMake's list re-parsing (e.g. "\b" in
+        # "src\backend" is an invalid character escape). Normalize to forward
+        # slashes, which Windows accepts too, so the generated CMakeLists is
+        # portable.
+        return f'"{str(p).replace(os.sep, "/")}"'
 
     # Extract the values
     build_src_dir = component.data.get("build", {}).get("srcDir", None)

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -169,28 +169,55 @@ def test_generate_cmakelists_txt_with_flags(tmp_component, tmp_path):
     }
 
     content = generate_cmakelists_txt(tmp_component)
-    sep = "\\\\" if os.name == "nt" else "/"
+    # Paths are always emitted with forward slashes so the CMakeLists is
+    # portable; on Windows os.path.relpath would otherwise yield backslashes
+    # that break CMake's list re-parsing.
     assert (
         content
-        == f"""idf_component_register(
-  SRCS "src{sep}main.c"
+        == """idf_component_register(
+  SRCS "src/main.c"
   INCLUDE_DIRS "src"
-  REQUIRES dep ${{ESPHOME_PROJECT_MANAGED_COMPONENTS}} ${{ESPHOME_PROJECT_BUILTIN_COMPONENTS}}
+  REQUIRES dep ${ESPHOME_PROJECT_MANAGED_COMPONENTS} ${ESPHOME_PROJECT_BUILTIN_COMPONENTS}
 )
-target_compile_options(${{COMPONENT_LIB}} PUBLIC
+target_compile_options(${COMPONENT_LIB} PUBLIC
   "-DTEST"
 )
-target_compile_options(${{COMPONENT_LIB}} PRIVATE
+target_compile_options(${COMPONENT_LIB} PRIVATE
   "-Wall"
 )
-target_link_directories(${{COMPONENT_LIB}} INTERFACE
+target_link_directories(${COMPONENT_LIB} INTERFACE
   "lib"
 )
-target_link_libraries(${{COMPONENT_LIB}} INTERFACE
+target_link_libraries(${COMPONENT_LIB} INTERFACE
   "mylib"
 )
 """
     )
+
+
+def test_generate_cmakelists_txt_uses_forward_slashes_on_windows(
+    tmp_component, monkeypatch
+):
+    # os.path.relpath yields backslash paths on Windows, which CMake rejects
+    # when it re-parses the SRCS list (e.g. "\b" in "src\backend" is an invalid
+    # character escape). Simulate that output and confirm the generated
+    # CMakeLists normalizes the separators to forward slashes.
+    src_dir = tmp_component.path / "src" / "backend"
+    src_dir.mkdir(parents=True)
+    (src_dir / "cipher.c").write_text("int f() {}")
+
+    tmp_component.data = {}
+
+    monkeypatch.setattr("esphome.espidf.component.os.sep", "\\")
+    monkeypatch.setattr(
+        "esphome.espidf.component.os.path.relpath",
+        lambda *args, **kwargs: "src\\backend\\cipher.c",
+    )
+
+    content = generate_cmakelists_txt(tmp_component)
+
+    assert 'SRCS "src/backend/cipher.c"' in content
+    assert "\\" not in content
 
 
 def test_generate_cmakelists_txt_multi_token_flag(tmp_component):

--- a/tests/unit_tests/test_espidf_component.py
+++ b/tests/unit_tests/test_espidf_component.py
@@ -196,8 +196,8 @@ target_link_libraries(${COMPONENT_LIB} INTERFACE
 
 
 def test_generate_cmakelists_txt_uses_forward_slashes_on_windows(
-    tmp_component, monkeypatch
-):
+    tmp_component, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # os.path.relpath yields backslash paths on Windows, which CMake rejects
     # when it re-parses the SRCS list (e.g. "\b" in "src\backend" is an invalid
     # character escape). Simulate that output and confirm the generated


### PR DESCRIPTION
# What does this implement/fix?

On Windows, the native ESP-IDF build fails during component discovery with a CMake syntax error for any config that pulls in a converted PlatformIO library with subdirectory sources — most commonly `noise-c`, which is loaded whenever `api:` encryption is configured:

```
Syntax error in cmake code ... when parsing string
  SRCS;src\backend\openssl\cipher-aesgcm.c;src\backend\ref\cipher-aesgcm.c;...
Invalid character escape '\b'.
```

The generated component `CMakeLists.txt` lists source files from `os.path.relpath()`, which returns backslash-separated paths on Windows (`src\backend\cipher.c`). Those get written into the `SRCS` list, and CMake — which treats `\` as an escape character — fails when it re-parses the list (`\b` in `src\backend`, `\r`, `\c`, etc. are invalid character escapes). The existing `escape_entry` helper doubled backslashes, but that only survives the first parse; the value un-escapes back to single backslashes and the downstream `component_get_requirements` re-parse still fails.

The fix normalizes the emitted paths to forward slashes, which CMake uses as its path separator on every platform including Windows. This covers `SRCS`, `INCLUDE_DIRS`, and link directories via the shared `escape_entry` helper.

This is a regression from the PlatformIO -> native ESP-IDF build migration: the old path let PlatformIO manage the library and its paths. It is not platform/board specific — any Windows Device Builder / desktop user with API encryption hits it (reported for Windows 11 ARM64 in the linked issue, but the cause is the path separator, not the architecture).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17963

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any config on the native ESP-IDF toolchain that loads a converted
# library with nested sources, e.g. api encryption (noise-c), built on Windows
api:
  encryption:
    key: !secret api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).