### PR TITLE
[epaper_spi] Default init sequence to empty not None

### DIFF
--- a/esphome/components/epaper_spi/models/__init__.py
+++ b/esphome/components/epaper_spi/models/__init__.py
@@ -15,7 +15,7 @@ class EpaperModel:
         self,
         name: str,
         class_name: str,
-        initsequence=None,
+        initsequence=(),
         **defaults,
     ):
         name = name.upper()

--- a/tests/component_tests/epaper_spi/config/t133a01_no_init_sequence.yaml
+++ b/tests/component_tests/epaper_spi/config/t133a01_no_init_sequence.yaml
@@ -1,0 +1,26 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+spi:
+  clk_pin: GPIO18
+  mosi_pin: GPIO19
+
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: t133a01
+    dc_pin: GPIO21
+    reset_pin: GPIO38
+    cs_pin: GPIO10
+    cs1_pin: GPIO2
+    busy_pin: GPIO13
+    update_interval: never
+    dimensions:
+      width: 200
+      height: 200

--- a/tests/component_tests/epaper_spi/test_init.py
+++ b/tests/component_tests/epaper_spi/test_init.py
@@ -462,3 +462,24 @@ def test_enable_pin_code_generation(
     # Both pin objects must be passed to the display via set_enable_pins() as a
     # std::vector initializer list, in the configured order.
     assert f"set_enable_pins({{{pin_25}, {pin_26}}});" in main_cpp
+
+
+def test_model_with_no_default_init_sequence_generates(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Test that code generation succeeds for a model with no default init sequence.
+
+    The base "t133a01" model (used directly, not via one of its `.extend()`
+    variants) doesn't override `get_init_sequence()` or pass `initsequence` to
+    its constructor, and the user didn't supply `init_sequence:` either.
+    `EpaperModel.get_init_sequence()` used to default to `None` in this case,
+    which made `flatten_sequence()` raise a `TypeError` during code
+    generation. Regression test for that crash.
+    """
+    main_cpp = generate_main(component_config_path("t133a01_no_init_sequence.yaml"))
+
+    # The generated constructor call takes (name, width, height, init_sequence,
+    # init_sequence_length, ...); a length of 0 confirms the empty init
+    # sequence array was generated instead of raising during code generation.
+    assert re.search(r"epaper_spi::EPaperT133A01\([^;]*,\s*\w+,\s*0\);", main_cpp)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The t133a01 display model defines no init sequence leading to build-time crash. Make
the epaper_spi default init sequence an empty sequence instead of None.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #17958 

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
