### PR TITLE
[esp8266] Move wifi rate tables to DRAM to fix beacon parse crash

### DIFF
--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -299,6 +299,7 @@ async def to_code(config):
         "pre:testing_mode.py",
         "pre:exclude_updater.py",
         "pre:exclude_waveform.py",
+        "pre:relocate_ratetable.py",
     ]
     if not enable_scanf_float:
         extra_scripts.append("pre:remove_float_scanf.py")
@@ -451,6 +452,7 @@ def copy_files() -> None:
         "exclude_updater",
         "exclude_waveform",
         "remove_float_scanf",
+        "relocate_ratetable",
     ):
         copy_file_if_changed(
             dir / f"{script}.py.script",

--- a/esphome/components/esp8266/relocate_ratetable.py.script
+++ b/esphome/components/esp8266/relocate_ratetable.py.script
@@ -1,0 +1,70 @@
+# pylint: disable=E0602
+Import("env")  # noqa
+
+# Move the NONOS SDK wifi rate tables from flash to DRAM
+#
+# libnet80211.a ships its 802.11b/11g rate tables in the .irom.text section
+# of ieee80211_phy.o (440 bytes of pure data, no relocations). The Arduino
+# core linker script places .irom.text in flash, but the SDK reads these
+# tables with byte loads and ets_memcpy from the wifi RX path while parsing
+# beacons. Byte access to flash-mapped memory from that context misbehaves
+# and crashes with StoreProhibited in ROM memcpy (PC 0x4000df64):
+#
+#   scan_parse_beacon -> cnx_update_bss_more -> ieee80211_phy_init
+#     -> ieee80211_setup_ratetable -> ets_memcpy -> crash
+#
+# See https://github.com/espressif/ESP8266_NONOS_SDK/issues/320 (1000+
+# reports). The SDK is abandoned so the fix from
+# https://github.com/espressif/ESP8266_NONOS_SDK/pull/345 was never merged;
+# we apply the same linker rule here: place ieee80211_phy.o's .irom.text
+# inside the DRAM .data output section so the tables are copied to RAM at
+# boot. Costs 440 bytes of DRAM.
+#
+# The rule is inserted into the working linker script that PlatformIO
+# generates in the build directory (local.eagle.app.v6.common.ld). SDK
+# package files are never modified.
+
+import re
+from os.path import join
+
+RULE = "*libnet80211.a:ieee80211_phy.o(.irom.text .irom.text.*)"
+# Match the whole line: "_data_start" is also a substring of the
+# "_dport0_data_start" line in the earlier .dport0.data section
+ANCHOR = re.compile(r"^\s*_data_start = ABSOLUTE\(\.\);", re.MULTILINE)
+
+
+def relocate_ratetable(source, target, env):
+    """Insert the rate table DRAM rule into the generated linker script.
+
+    Runs as a pre-action of the link step; the linker script is a declared
+    dependency of the elf, so it has already been generated at this point.
+    """
+    ld_path = join(env.subst("$BUILD_DIR"), "ld", "local.eagle.app.v6.common.ld")
+    with open(ld_path, encoding="utf-8") as f:
+        contents = f.read()
+
+    if RULE in contents:
+        return  # Already patched (incremental build)
+
+    match = ANCHOR.search(contents)
+    if match is None:
+        raise RuntimeError(
+            f"ESPHome: '_data_start' anchor not found in {ld_path}; "
+            "cannot apply wifi rate table DRAM relocation "
+            "(has the Arduino core linker script changed?)"
+        )
+
+    insert_pos = match.end()
+    patched = (
+        contents[:insert_pos]
+        + "\n    /* ESPHome: wifi rate tables must live in DRAM, see NONOS SDK issue 320 */"
+        + f"\n    {RULE}"
+        + contents[insert_pos:]
+    )
+    with open(ld_path, "w", encoding="utf-8") as f:
+        f.write(patched)
+    print("ESPHome: Relocated wifi rate tables to DRAM (fixes beacon parse crash)")
+
+
+# Register the callback to run before the link step
+env.AddPreAction("$BUILD_DIR/${PROGNAME}.elf", relocate_ratetable)


### PR DESCRIPTION
# What does this implement/fix?

Fixes a wifi crash seen in the field on ESP8266, StoreProhibited in ROM memcpy at PC 0x4000df64 while parsing beacons, backtrace scan_parse_beacon, cnx_update_bss_more, ieee80211_phy_init, ieee80211_setup_ratetable.

The NONOS SDK ships its 802.11b/11g rate tables in the .irom.text section of ieee80211_phy.o inside libnet80211.a, 440 bytes of pure data with no relocations. The Arduino core linker script places .irom.text in flash, but the SDK reads these tables with byte loads and ets_memcpy from the wifi RX path, which crashes; see espressif/ESP8266_NONOS_SDK#320 with over 1000 reports. The SDK is abandoned so the fix in espressif/ESP8266_NONOS_SDK#345 was never merged.

This applies the same linker rule at build time. A new pre link script inserts the rule into the generated local.eagle.app.v6.common.ld in the build directory, placing the tables inside the DRAM .data output section so they are copied to RAM at boot. SDK package files are never touched, the patch is idempotent on incremental builds, and the build fails loudly if the anchor line ever disappears from the Arduino core script. Costs 440 bytes of RAM, the table section is identical across all seven NONOSDK versions shipped with the core.

Verified locally, the 440 byte table blob now lands at the start of .data at 0x3ffe8000 and is gone from irom0.text.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/espressif/ESP8266_NONOS_SDK/issues/320

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp8266:
  board: d1_mini
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder), the existing esp8266 compile test exercises the new script on every build.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
