### PR TITLE
[api] Fix double free when overflow buffer drain is re-entered

### DIFF
--- a/esphome/components/api/api_overflow_buffer.cpp
+++ b/esphome/components/api/api_overflow_buffer.cpp
@@ -12,6 +12,16 @@ APIOverflowBuffer::~APIOverflowBuffer() {
 }
 
 ssize_t APIOverflowBuffer::try_drain(socket::Socket *socket) {
+  // socket->write() can re-enter this function: a log message emitted from an
+  // lwip callback during the write goes out over the API and lands back in the
+  // frame helper's write/drain path. If a nested drain ran here it would send
+  // and free the entry the outer drain is still holding, causing a double free.
+  // Report "no progress" instead; the outer drain keeps draining, and the
+  // nested send is enqueued behind the existing backlog.
+  if (this->draining_)
+    return 0;
+  this->draining_ = true;
+
   while (this->count_ > 0) {
     Entry *front = this->queue_[this->head_];
 
@@ -20,22 +30,26 @@ ssize_t APIOverflowBuffer::try_drain(socket::Socket *socket) {
     if (sent <= 0) {
       // -1 = error (caller checks errno for EWOULDBLOCK vs hard error)
       // 0 = nothing sent (treat as no progress)
+      this->draining_ = false;
       return sent;
     }
 
     if (static_cast<uint16_t>(sent) < front->remaining()) {
       // Partially sent, update offset and stop
       front->offset += static_cast<uint16_t>(sent);
+      this->draining_ = false;
       return sent;
     }
 
-    // Entry fully sent — free it and advance
-    Entry::destroy(front);
+    // Entry fully sent — unlink it before freeing so a freed pointer is never
+    // reachable from the queue
     this->queue_[this->head_] = nullptr;
     this->head_ = (this->head_ + 1) % API_MAX_SEND_QUEUE;
     this->count_--;
+    Entry::destroy(front);
   }
 
+  this->draining_ = false;
   return 0;  // All drained
 }
 

--- a/esphome/components/api/api_overflow_buffer.cpp
+++ b/esphome/components/api/api_overflow_buffer.cpp
@@ -20,7 +20,13 @@ ssize_t APIOverflowBuffer::try_drain(socket::Socket *socket) {
   // nested send is enqueued behind the existing backlog.
   if (this->draining_)
     return 0;
-  this->draining_ = true;
+
+  // RAII so the flag is cleared on every return path
+  struct DrainGuard {
+    explicit DrainGuard(bool &flag) : flag_(flag) { flag_ = true; }
+    ~DrainGuard() { this->flag_ = false; }
+    bool &flag_;
+  } guard(this->draining_);
 
   while (this->count_ > 0) {
     Entry *front = this->queue_[this->head_];
@@ -30,14 +36,12 @@ ssize_t APIOverflowBuffer::try_drain(socket::Socket *socket) {
     if (sent <= 0) {
       // -1 = error (caller checks errno for EWOULDBLOCK vs hard error)
       // 0 = nothing sent (treat as no progress)
-      this->draining_ = false;
       return sent;
     }
 
     if (static_cast<uint16_t>(sent) < front->remaining()) {
       // Partially sent, update offset and stop
       front->offset += static_cast<uint16_t>(sent);
-      this->draining_ = false;
       return sent;
     }
 
@@ -49,7 +53,6 @@ ssize_t APIOverflowBuffer::try_drain(socket::Socket *socket) {
     Entry::destroy(front);
   }
 
-  this->draining_ = false;
   return 0;  // All drained
 }
 

--- a/esphome/components/api/api_overflow_buffer.h
+++ b/esphome/components/api/api_overflow_buffer.h
@@ -69,6 +69,10 @@ class APIOverflowBuffer {
   uint8_t head_{0};
   uint8_t tail_{0};
   uint8_t count_{0};
+  // Guards against re-entrant drains: socket->write() can re-enter the API
+  // send path (e.g. a log message emitted from an lwip callback), and a nested
+  // drain would free the entry the outer drain is still holding.
+  bool draining_{false};
 };
 
 }  // namespace esphome::api


### PR DESCRIPTION
# What does this implement/fix?

Fixes a StoreProhibit crash on ESP8266, seen on a Sonoff S31 running 2026.7.3; the crash is inside `free()` called from `APIOverflowBuffer::try_drain()`.

`try_drain()` frees the front entry before unlinking it from the queue, and the socket write inside the loop can reenter the API send path; a log line emitted from an lwip callback during the write goes out over the native API and lands back in the frame helper write and drain path. The nested drain sends and frees the same entry the outer drain is still holding, so the entry is freed twice and the second free corrupts the allocator free list, which matches the observed crash exactly.

This adds a reentrancy guard so a nested drain reports no progress and the nested message is queued behind the existing backlog instead; ordering on the wire is preserved because the fast write path already defers to the queue whenever it is not empty. The entry is now also unlinked from the queue before it is freed, so a freed pointer is never reachable from the queue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
