### PR TITLE
[logger] Stub out ROM ets_putc on ESP8266 when serial logging is disabled

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -410,18 +410,18 @@ async def _late_logger_init(config: ConfigType) -> None:
         from esphome.components.esp8266.const import enable_serial, enable_serial1
 
         hw_uart = config.get(CONF_HARDWARE_UART, UART0)
-        if has_serial_logging and hw_uart in (UART0, UART0_SWAP):
-            cg.add_define("USE_ESP8266_LOGGER_SERIAL")
-            enable_serial()
-        elif has_serial_logging and hw_uart == UART1:
-            cg.add_define("USE_ESP8266_LOGGER_SERIAL1")
-            enable_serial1()
-        else:
+        if not has_serial_logging:
             # No serial logging: stub out ROM ets_putc so stray output (newlib
             # stdout, lwIP diagnostics) cannot block on a slow or shared UART0.
             # ets_putc always writes to the physical UART and cannot be disabled
             # through uart_set_debug(); see __wrap_ets_putc in logger_esp8266.cpp.
             cg.add_build_flag("-Wl,--wrap=ets_putc")
+        elif hw_uart in (UART0, UART0_SWAP):
+            cg.add_define("USE_ESP8266_LOGGER_SERIAL")
+            enable_serial()
+        elif hw_uart == UART1:
+            cg.add_define("USE_ESP8266_LOGGER_SERIAL1")
+            enable_serial1()
 
     if (CORE.is_esp8266 or CORE.is_rp2) and has_serial_logging and is_at_least_verbose:
         debug_serial_port = HARDWARE_UART_TO_SERIAL[CORE.target_platform][

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -416,6 +416,12 @@ async def _late_logger_init(config: ConfigType) -> None:
         elif has_serial_logging and hw_uart == UART1:
             cg.add_define("USE_ESP8266_LOGGER_SERIAL1")
             enable_serial1()
+        else:
+            # No serial logging: stub out ROM ets_putc so stray output (newlib
+            # stdout, lwIP diagnostics) cannot block on a slow or shared UART0.
+            # ets_putc always writes to the physical UART and cannot be disabled
+            # through uart_set_debug(); see __wrap_ets_putc in logger_esp8266.cpp.
+            cg.add_build_flag("-Wl,--wrap=ets_putc")
 
     if (CORE.is_esp8266 or CORE.is_rp2) and has_serial_logging and is_at_least_verbose:
         debug_serial_port = HARDWARE_UART_TO_SERIAL[CORE.target_platform][

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -49,4 +49,15 @@ const LogString *Logger::get_uart_selection_() {
 }
 
 }  // namespace esphome::logger
+
+#if !defined(USE_ESP8266_LOGGER_SERIAL) && !defined(USE_ESP8266_LOGGER_SERIAL1)
+// With serial logging disabled, ROM ets_putc still writes to the physical UART0
+// at whatever baud rate a uart bus configured there; uart_set_debug(UART_NO)
+// only silences the installable putc1 hook, not ets_putc itself. Blocking
+// writes at a low baud rate (for example 4800 for a power monitoring chip) can
+// starve the soft watchdog. All linked callers (newlib stdout, lwIP
+// diagnostics, postmortem dumps) are redirected here by -Wl,--wrap=ets_putc.
+extern "C" void __wrap_ets_putc(char) {}
+#endif
+
 #endif

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -57,7 +57,9 @@ const LogString *Logger::get_uart_selection_() {
 // writes at a low baud rate (for example 4800 for a power monitoring chip) can
 // starve the soft watchdog. All linked callers (newlib stdout, lwIP
 // diagnostics, postmortem dumps) are redirected here by -Wl,--wrap=ets_putc.
-extern "C" void __wrap_ets_putc(char) {}
+// IRAM_ATTR because the ROM original is callable with the flash cache
+// disabled (for example from newlib's _write_r, which is placed in IRAM).
+extern "C" void IRAM_ATTR __wrap_ets_putc(char) {}
 #endif
 
 #endif

--- a/tests/components/logger/test-uart0_no_logging.esp8266-ard.yaml
+++ b/tests/components/logger/test-uart0_no_logging.esp8266-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common-uart0_no_logging.yaml


### PR DESCRIPTION
# What does this implement/fix?

On ESP8266 the ROM `ets_putc` function always writes to the physical UART0; `uart_set_debug(UART_NO)` only silences the installable putc1 hook and cannot turn off `ets_putc` itself. When serial logging is disabled, a uart bus may reconfigure UART0 to a low baud rate, for example 4800 for the CSE7766 in a Sonoff S31. Any stray output that reaches `ets_putc` (newlib stdout, lwIP diagnostics, postmortem dumps) then busy waits on the TX FIFO at roughly 2.3 ms per character, which can starve the soft watchdog. Seen in the field as a Soft WDT reset with the PC inside ROM `uart_tx_one_char` while the main loop was idle in `esp_delay`:

```
Reason: Soft WDT - Level1Int (exccause=4)
PC: 0x40003B53  (uart_tx_one_char)
BT0: esp_try_delay
BT2: loop
```

With `baud_rate: 0` the logger now links with `-Wl,--wrap=ets_putc` and provides a stub that does nothing, so every linked caller of `ets_putc` is silenced; that output is not observable in this configuration anyway.

Behavior note: crash dumps are not affected. The postmortem dump body prints through ROM `ets_uart_putc1`, a separate ROM routine that this wrap does not touch; only the decorative dash lines around the CUT HERE marker go through `ets_putc`. Verified on real hardware with `baud_rate: 0` and a uart bus at 4800: a deliberate crash still printed the complete decoder ready exception dump on serial, stray `printf`/`puts` output produced nothing and caused no watchdog reset, and the crash handler reported the correct reason (StoreProhibit, PC and backtrace) over the native API on the next boot.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
logger:
  baud_rate: 0

uart:
  rx_pin: RX
  baud_rate: 4800
  parity: EVEN

sensor:
  - platform: cse7766
    power:
      name: Power
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
