### PR TITLE
[zigbee] Resolution attribute for esp32 sensors

### DIFF
--- a/esphome/components/zigbee/zigbee_esp32.py
+++ b/esphome/components/zigbee/zigbee_esp32.py
@@ -13,6 +13,7 @@ from esphome.components.esp32 import (
 )
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_ACCURACY_DECIMALS,
     CONF_AP,
     CONF_DEVICE,
     CONF_DEVICE_CLASS,
@@ -22,7 +23,6 @@ from esphome.const import (
     CONF_NAME,
     CONF_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
-    CONF_ACCURACY_DECIMALS,
     CONF_VALUE,
     CONF_WIFI,
 )
@@ -206,7 +206,7 @@ def validate_sensor_esp32(config: ConfigType) -> ConfigType:
         ep[CONF_CLUSTERS][0][CONF_ATTRIBUTES].append(
             {
                 CONF_ATTRIBUTE_ID: 0x6A,
-                CONF_VALUE: 10 ** -accuracy,
+                CONF_VALUE: 10**-accuracy,
                 CONF_TYPE: "SINGLE",
             },
         )

--- a/esphome/components/zigbee/zigbee_esp32.py
+++ b/esphome/components/zigbee/zigbee_esp32.py
@@ -203,6 +203,7 @@ def validate_sensor_esp32(config: ConfigType) -> ConfigType:
         },
     )
     if accuracy is not None:
+        # Analog Input Resolution (0x006A): smallest reportable change
         ep[CONF_CLUSTERS][0][CONF_ATTRIBUTES].append(
             {
                 CONF_ATTRIBUTE_ID: 0x6A,

--- a/esphome/components/zigbee/zigbee_esp32.py
+++ b/esphome/components/zigbee/zigbee_esp32.py
@@ -22,6 +22,7 @@ from esphome.const import (
     CONF_NAME,
     CONF_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
+    CONF_ACCURACY_DECIMALS,
     CONF_VALUE,
     CONF_WIFI,
 )
@@ -185,6 +186,7 @@ def validate_sensor_esp32(config: ConfigType) -> ConfigType:
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
     apptype = ANALOG_INPUT_APPTYPE.get((dev_class, unit))
     bacunit = BACNET_UNITS.get(unit, BACNET_UNIT_NO_UNITS)
+    accuracy = config.get(CONF_ACCURACY_DECIMALS)
     if apptype is not None:
         ep[CONF_CLUSTERS][0][CONF_ATTRIBUTES].append(
             {
@@ -200,6 +202,14 @@ def validate_sensor_esp32(config: ConfigType) -> ConfigType:
             CONF_TYPE: "ENUM16",
         },
     )
+    if accuracy is not None:
+        ep[CONF_CLUSTERS][0][CONF_ATTRIBUTES].append(
+            {
+                CONF_ATTRIBUTE_ID: 0x6A,
+                CONF_VALUE: 10 ** -accuracy,
+                CONF_TYPE: "SINGLE",
+            },
+        )
     setup_attributes(config, ep[CONF_CLUSTERS])
     add_ep(ep, config.get(CONF_ENDPOINT), config.get(CONF_USE_DEVICE_TYPE))
     return config

--- a/tests/components/zigbee/common.yaml
+++ b/tests/components/zigbee/common.yaml
@@ -13,6 +13,7 @@ sensor:
   - platform: template
     name: "Analog 1"
     lambda: return 10.0;
+    accuracy_decimals: 0
   - platform: template
     name: "Analog 2"
     lambda: return 11.0;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7074

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
