### PR TITLE
[ci] Authenticate the stale workflow as esphome[bot]

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,17 +6,19 @@ on:
     - cron: "30 0 * * *"
   workflow_dispatch:
 
-# Deny by default; the stale job opts in to exactly what the reusable workflow needs.
+# The reusable workflow authenticates as the ESPHome GitHub App, so GITHUB_TOKEN
+# needs no permissions at all.
 permissions: {}
 
 jobs:
   stale:
     if: github.repository_owner == 'esphome'
-    permissions:
-      contents: read        # head-commit dates for the PR activity check
-      issues: write         # label, comment on and close stale issues
-      pull-requests: write  # label, comment on and close stale pull requests
-    uses: esphome/workflows/.github/workflows/stale.yml@c87be24a6fd0320ecd32e40b27fe98d25c3af851  # 2026.7.0
+    # No GITHUB_TOKEN permissions: the reusable workflow mints an ESPHome
+    # GitHub App token so the labels, comments and closures come from
+    # esphome[bot] instead of github-actions[bot].
+    uses: esphome/workflows/.github/workflows/stale.yml@203cea60ebfd18e2b966e57750750e0417a9feec  # 2026.7.0
+    secrets:
+      ESPHOME_GITHUB_APP_PRIVATE_KEY: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
     with:
       # Live only on dev: a workflow_dispatch from any other branch is a dry run
       dry-run: ${{ github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
     # No GITHUB_TOKEN permissions: the reusable workflow mints an ESPHome
     # GitHub App token so the labels, comments and closures come from
     # esphome[bot] instead of github-actions[bot].
-    uses: esphome/workflows/.github/workflows/stale.yml@203cea60ebfd18e2b966e57750750e0417a9feec  # 2026.7.0
+    uses: esphome/workflows/.github/workflows/stale.yml@203cea60ebfd18e2b966e57750750e0417a9feec  # main
     secrets:
       ESPHOME_GITHUB_APP_PRIVATE_KEY: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
     with:


### PR DESCRIPTION
# What does this implement/fix?

The shared stale workflow now mints an ESPHome GitHub App token (esphome/workflows#177), so the labels, comments and closures it produces are attributed to esphome[bot] rather than github-actions[bot]. This pins the caller to that revision, passes the App private key through as a secret, and drops the job's `GITHUB_TOKEN` permissions since every API call now uses the minted token instead.

The token has to be minted inside the reusable workflow: a caller job that `uses:` a reusable workflow cannot have steps, and a token handed between jobs through job outputs is redacted by Actions.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- follows up #17960

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).