### PR TITLE
[ci] Report an empty Codecov upload when pytest is skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,34 @@ jobs:
           path: venv
           key: ${{ runner.os }}-${{ steps.restore-python.outputs.python-version }}-venv-${{ needs.common.outputs.cache-key }}
 
+  codecov-empty-upload:
+    name: Report no coverage to Codecov
+    runs-on: ubuntu-24.04
+    needs:
+      - determine-jobs
+    # ``pytest`` is the only job that uploads coverage, and it is skipped when
+    # every changed file is CI-irrelevant (see ``should_run_core_ci`` in
+    # ``script/determine-jobs.py``). With no upload Codecov never reports a
+    # result, so the required ``codecov/patch`` status stays pending forever and
+    # the pull request can never be merged. Tell Codecov up front that this
+    # commit has nothing to cover so it publishes a passing status instead.
+    #
+    # ``force`` skips Codecov's own check that every changed file is ignorable;
+    # ``determine-jobs`` has already decided none of these files can affect
+    # coverage, and Codecov would otherwise fail the status for paths it does
+    # not recognise as non-testable (``docker/**``, ``.yamllint``).
+    if: needs.determine-jobs.outputs.core-ci == 'false'
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Report empty upload to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: empty-upload
+          force: true
+          fail_ci_if_error: true
+
   determine-jobs:
     name: Determine which jobs to run
     runs-on: ubuntu-24.04
@@ -1436,6 +1464,7 @@ jobs:
       - ci-custom
       - pylint
       - pytest
+      - codecov-empty-upload
       - integration-tests
       - clang-tidy-single
       - clang-tidy-nosplit


### PR DESCRIPTION
# What does this implement/fix?

The `dev` ruleset requires the `codecov/patch` status, pinned to the Codecov GitHub App. Codecov only publishes that status once it receives an upload for the commit, and `pytest` is the only job that uploads coverage. When `determine-jobs` decides every changed file is CI-irrelevant (top-level workflow files other than `ci.yml`, `docker/**`, `.yamllint`, `.github/dependabot.yml`, `.github/actions/build-image/*`) it skips `pytest`, so nothing is ever uploaded, `codecov/patch` stays pending forever, and the pull request cannot be merged. #17974 hit exactly this and had to be force-merged.

This adds a `codecov-empty-upload` job gated on the same `core-ci == 'false'` signal that skips `pytest`. It runs the Codecov CLI's `empty-upload` command, which tells Codecov the commit has nothing to cover so it publishes a passing status rather than staying silent. Because the status still comes from the Codecov app, it satisfies the ruleset; a status posted by Actions under the same name would not, since the rule pins the integration id.

`force` is set so Codecov does not re-derive the decision itself. Without it, Codecov passes only when every changed file matches the `ignore` list in `codecov.yml` or one of its built-in non-testable globs (`*.yml`, `*.md`, `*.png`, and so on). That covers workflow-only changes, but `docker/**` and `.yamllint` are not recognised, and those would get a failing status instead of a pending one. `determine-jobs` is already the single source of truth for whether coverage runs at all, so it should also be the source of truth here.

The job is listed in `ci-status` so that a Codecov outage shows up as a red CI Status rather than a silently pending required check.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).