### PR TITLE
[ci] Order jobs to follow the CI flow and close ci-status gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,225 +68,6 @@ jobs:
           uv pip install -r requirements.txt -r requirements_dev.txt -r requirements_test.txt pre-commit
           uv pip install -e .
 
-  pylint:
-    name: Check pylint
-    runs-on: ubuntu-24.04
-    needs:
-      - common
-      - determine-jobs
-    if: needs.determine-jobs.outputs.python-linters == 'true'
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Run pylint
-        run: |
-          . venv/bin/activate
-          pylint -f parseable --persistent=n esphome
-      - name: Suggested changes
-        run: script/ci-suggest-changes
-        if: always()
-
-  ci-custom:
-    name: Run script/ci-custom
-    runs-on: ubuntu-24.04
-    needs:
-      - common
-      - determine-jobs
-    if: needs.determine-jobs.outputs.core-ci == 'true'
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Register matcher
-        run: echo "::add-matcher::.github/workflows/matchers/ci-custom.json"
-      - name: Run script/ci-custom
-        run: |
-          . venv/bin/activate
-          script/ci-custom.py
-          script/build_codeowners.py --check
-          script/build_language_schema.py --check
-          script/generate-esp32-boards.py --check
-          script/generate-rp2-boards.py --check
-          script/ci_check_duplicate_test_ids.py
-          script/ci_check_test_fixture_list_form.py
-
-  import-time:
-    name: Check import esphome.__main__ time
-    runs-on: ubuntu-24.04
-    needs:
-      - common
-      - determine-jobs
-    if: needs.determine-jobs.outputs.import-time == 'true'
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Check import time against budget and write waterfall HAR
-        run: |
-          . venv/bin/activate
-          script/check_import_time.py --check --har importtime.har
-      - name: Upload waterfall HAR
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: import-time-waterfall
-          path: importtime.har
-          if-no-files-found: ignore
-          retention-days: 14
-
-  device-builder:
-    name: Test downstream esphome/device-builder
-    runs-on: ubuntu-24.04
-    needs:
-      - common
-      - determine-jobs
-    if: needs.determine-jobs.outputs.device-builder == 'true'
-    steps:
-      - name: Check out esphome (this PR)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          path: esphome
-      - name: Check out esphome/device-builder
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: esphome/device-builder
-          ref: main
-          path: device-builder
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.13"
-      - name: Set up uv
-        # Mirrors the install shape device-builder's own CI uses
-        # (esphome/device-builder#192): uv replaces pip for the
-        # install step (order-of-magnitude faster on cold boots,
-        # with its own wheel cache). actions/setup-python still
-        # provides the interpreter.
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          enable-cache: true
-          # Pull request saves land in per-PR scopes nothing else can
-          # reuse; dev pushes seed the shared copy instead.
-          save-cache: ${{ github.event_name != 'pull_request' }}
-          # Pin uv version so the action does not have to fetch the
-          # manifest from raw.githubusercontent.com on every cache
-          # miss; that fetch flakes on Windows runners.
-          version: "0.11.15"
-      - name: Install device-builder + esphome from PR
-        # Install device-builder with its esphome + test extras
-        # first so its pinned versions of pytest/etc. land, then
-        # overlay the PR's esphome so the downstream tests run
-        # against this PR's Python code. ``--system`` installs into
-        # the runner's Python instead of a venv.
-        run: |
-          uv pip install --system -e './device-builder[esphome,test]'
-          uv pip install --system -e ./esphome
-      - name: Run device-builder pytest
-        # ``-n auto`` runs under pytest-xdist (matches device-builder's
-        # own CI). No ``--cov`` here -- this is purely a downstream
-        # smoke check against this PR's esphome code. ``tests/e2e/slow``
-        # is excluded: those are real multi-minute toolchain compiles
-        # (LibreTiny SDK clone, native ESP-IDF install) that device-builder
-        # runs in its own dedicated jobs, not this smoke check.
-        working-directory: device-builder
-        run: pytest -q -n auto --maxfail=5 --durations=30 --no-cov --ignore=tests/benchmarks --ignore=tests/e2e/slow
-
-  pytest:
-    name: Run pytest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - "3.12"
-          - "3.13"
-          - "3.14"
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        exclude:
-          # Minimize CI resource usage
-          # by only running the Python version
-          # version used for docker images on Windows and macOS
-          - python-version: "3.13"
-            os: windows-latest
-          - python-version: "3.13"
-            os: macOS-latest
-    runs-on: ${{ matrix.os }}
-    needs:
-      - common
-      - determine-jobs
-    if: needs.determine-jobs.outputs.core-ci == 'true'
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Restore Python
-        id: restore-python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Register matcher
-        run: echo "::add-matcher::.github/workflows/matchers/pytest.json"
-      - name: Run pytest
-        if: matrix.os == 'windows-latest'
-        run: |
-          . ./venv/Scripts/activate.ps1
-          pytest -vv --cov-report=xml --tb=native --durations=30 -n auto tests --ignore=tests/integration/
-      - name: Run pytest
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
-        run: |
-          . venv/bin/activate
-          pytest -vv --cov-report=xml --tb=native --durations=30 -n auto tests --ignore=tests/integration/
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-      - name: Save Python virtual environment cache
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: venv
-          key: ${{ runner.os }}-${{ steps.restore-python.outputs.python-version }}-venv-${{ needs.common.outputs.cache-key }}
-
-  codecov-empty-upload:
-    name: Report no coverage to Codecov
-    runs-on: ubuntu-24.04
-    needs:
-      - determine-jobs
-    # ``pytest`` is the only job that uploads coverage, and it is skipped when
-    # every changed file is CI-irrelevant (see ``should_run_core_ci`` in
-    # ``script/determine-jobs.py``). With no upload Codecov never reports a
-    # result, so the required ``codecov/patch`` status stays pending forever and
-    # the pull request can never be merged. Tell Codecov up front that this
-    # commit has nothing to cover so it publishes a passing status instead.
-    #
-    # ``force`` skips Codecov's own check that every changed file is ignorable;
-    # ``determine-jobs`` has already decided none of these files can affect
-    # coverage, and Codecov would otherwise fail the status for paths it does
-    # not recognise as non-testable (``docker/**``, ``.yamllint``).
-    if: needs.determine-jobs.outputs.core-ci == 'false'
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Report empty upload to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          run_command: empty-upload
-          force: true
-          fail_ci_if_error: true
-
   determine-jobs:
     name: Determine which jobs to run
     runs-on: ubuntu-24.04
@@ -375,6 +156,204 @@ jobs:
         with:
           path: .temp/components_graph.json
           key: components-graph-${{ hashFiles('esphome/components/**/*.py') }}
+
+  ci-custom:
+    name: Run script/ci-custom
+    runs-on: ubuntu-24.04
+    needs:
+      - common
+      - determine-jobs
+    if: needs.determine-jobs.outputs.core-ci == 'true'
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Register matcher
+        run: echo "::add-matcher::.github/workflows/matchers/ci-custom.json"
+      - name: Run script/ci-custom
+        run: |
+          . venv/bin/activate
+          script/ci-custom.py
+          script/build_codeowners.py --check
+          script/build_language_schema.py --check
+          script/generate-esp32-boards.py --check
+          script/generate-rp2-boards.py --check
+          script/ci_check_duplicate_test_ids.py
+          script/ci_check_test_fixture_list_form.py
+
+  pylint:
+    name: Check pylint
+    runs-on: ubuntu-24.04
+    needs:
+      - common
+      - determine-jobs
+    if: needs.determine-jobs.outputs.python-linters == 'true'
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Run pylint
+        run: |
+          . venv/bin/activate
+          pylint -f parseable --persistent=n esphome
+      - name: Suggested changes
+        run: script/ci-suggest-changes
+        if: always()
+
+  pre-commit-ci-lite:
+    name: pre-commit.ci lite
+    runs-on: ubuntu-latest
+    needs:
+      - common
+      - determine-jobs
+    if: github.event_name == 'pull_request' && !startsWith(github.base_ref, 'beta') && !startsWith(github.base_ref, 'release') && needs.determine-jobs.outputs.core-ci == 'true'
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      # Inlined from esphome/pre-commit-action with a restore-only cache
+      # step: the pre-commit-seed-cache job owns saving this cache, so
+      # pull request runs never write per-PR copies.
+      - name: Restore pre-commit cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pre-commit
+          # Must match the key pre-commit-seed-cache saves
+          # yamllint disable-line rule:line-length
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit
+        env:
+          SKIP: pylint,ci-custom
+        run: |
+          python -m pip install pre-commit
+          pre-commit run --show-diff-on-failure --color=always --all-files
+      - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
+        if: always()
+
+  pre-commit-seed-cache:
+    name: Seed pre-commit cache
+    runs-on: ubuntu-latest
+    needs:
+      - common
+    # Saves a dev-scoped pre-commit cache that pull request runs can
+    # restore, since pre-commit.ci lite itself never runs on dev pushes.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Cache pre-commit environments
+        id: cache-pre-commit
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pre-commit
+          # Must match the restore key in pre-commit-ci-lite
+          # yamllint disable-line rule:line-length
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install pre-commit hook environments
+        if: steps.cache-pre-commit.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install pre-commit
+          pre-commit install-hooks
+
+  pytest:
+    name: Run pytest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.12"
+          - "3.13"
+          - "3.14"
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        exclude:
+          # Minimize CI resource usage
+          # by only running the Python version
+          # version used for docker images on Windows and macOS
+          - python-version: "3.13"
+            os: windows-latest
+          - python-version: "3.13"
+            os: macOS-latest
+    runs-on: ${{ matrix.os }}
+    needs:
+      - common
+      - determine-jobs
+    if: needs.determine-jobs.outputs.core-ci == 'true'
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Restore Python
+        id: restore-python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Register matcher
+        run: echo "::add-matcher::.github/workflows/matchers/pytest.json"
+      - name: Run pytest
+        if: matrix.os == 'windows-latest'
+        run: |
+          . ./venv/Scripts/activate.ps1
+          pytest -vv --cov-report=xml --tb=native --durations=30 -n auto tests --ignore=tests/integration/
+      - name: Run pytest
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+        run: |
+          . venv/bin/activate
+          pytest -vv --cov-report=xml --tb=native --durations=30 -n auto tests --ignore=tests/integration/
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - name: Save Python virtual environment cache
+        if: github.ref == 'refs/heads/dev'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: venv
+          key: ${{ runner.os }}-${{ steps.restore-python.outputs.python-version }}-venv-${{ needs.common.outputs.cache-key }}
+
+  codecov-empty-upload:
+    name: Report no coverage to Codecov
+    runs-on: ubuntu-24.04
+    needs:
+      - determine-jobs
+    # ``pytest`` is the only job that uploads coverage, and it is skipped when
+    # every changed file is CI-irrelevant (see ``should_run_core_ci`` in
+    # ``script/determine-jobs.py``). With no upload Codecov never reports a
+    # result, so the required ``codecov/patch`` status stays pending forever and
+    # the pull request can never be merged. Tell Codecov up front that this
+    # commit has nothing to cover so it publishes a passing status instead.
+    #
+    # ``force`` skips Codecov's own check that every changed file is ignorable;
+    # ``determine-jobs`` has already decided none of these files can affect
+    # coverage, and Codecov would otherwise fail the status for paths it does
+    # not recognise as non-testable (``docker/**``, ``.yamllint``).
+    if: needs.determine-jobs.outputs.core-ci == 'false'
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Report empty upload to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          run_command: empty-upload
+          force: true
+          fail_ci_if_error: true
 
   integration-tests:
     name: Run integration tests (${{ matrix.bucket.name }})
@@ -465,32 +444,33 @@ jobs:
           path: ~/.cache/esphome/platformio-ccache
           key: integration-ccache-${{ matrix.bucket.name }}-${{ github.sha }}
 
-  cpp-unit-tests:
-    name: Run C++ unit tests
+  import-time:
+    name: Check import esphome.__main__ time
     runs-on: ubuntu-24.04
     needs:
       - common
       - determine-jobs
-    if: github.event_name == 'pull_request' && (needs.determine-jobs.outputs.cpp-unit-tests-run-all == 'true' || needs.determine-jobs.outputs.cpp-unit-tests-components != '[]')
+    if: needs.determine-jobs.outputs.import-time == 'true'
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
       - name: Restore Python
         uses: ./.github/actions/restore-python
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
-
-      - name: Run cpp_unit_test.py
+      - name: Check import time against budget and write waterfall HAR
         run: |
           . venv/bin/activate
-          if [ "${{ needs.determine-jobs.outputs.cpp-unit-tests-run-all }}" = "true" ]; then
-            script/cpp_unit_test.py --all
-          else
-            ARGS=$(echo '${{ needs.determine-jobs.outputs.cpp-unit-tests-components }}' | jq -r '.[] | @sh' | xargs)
-            script/cpp_unit_test.py $ARGS
-          fi
+          script/check_import_time.py --check --har importtime.har
+      - name: Upload waterfall HAR
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: import-time-waterfall
+          path: importtime.har
+          if-no-files-found: ignore
+          retention-days: 14
 
   benchmarks:
     name: Run CodSpeed benchmarks
@@ -528,6 +508,33 @@ jobs:
             ${{ steps.build.outputs.binary }}
             pytest tests/benchmarks/python/ --codspeed --no-cov
           mode: simulation
+
+  cpp-unit-tests:
+    name: Run C++ unit tests
+    runs-on: ubuntu-24.04
+    needs:
+      - common
+      - determine-jobs
+    if: github.event_name == 'pull_request' && (needs.determine-jobs.outputs.cpp-unit-tests-run-all == 'true' || needs.determine-jobs.outputs.cpp-unit-tests-components != '[]')
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+
+      - name: Run cpp_unit_test.py
+        run: |
+          . venv/bin/activate
+          if [ "${{ needs.determine-jobs.outputs.cpp-unit-tests-run-all }}" = "true" ]; then
+            script/cpp_unit_test.py --all
+          else
+            ARGS=$(echo '${{ needs.determine-jobs.outputs.cpp-unit-tests-components }}' | jq -r '.[] | @sh' | xargs)
+            script/cpp_unit_test.py $ARGS
+          fi
 
   clang-tidy-single:
     name: ${{ matrix.name }}
@@ -1093,69 +1100,62 @@ jobs:
           # Arduino framework via PlatformIO (only components with an esp32-ard test are built):
           python3 script/test_build_components.py -e compile -t esp32-ard -c "$TEST_COMPONENTS" -f --toolchain platformio
 
-  pre-commit-seed-cache:
-    name: Seed pre-commit cache
-    runs-on: ubuntu-latest
-    needs:
-      - common
-    # Saves a dev-scoped pre-commit cache that pull request runs can
-    # restore, since pre-commit.ci lite itself never runs on dev pushes.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Cache pre-commit environments
-        id: cache-pre-commit
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/pre-commit
-          # Must match the restore key in pre-commit-ci-lite
-          # yamllint disable-line rule:line-length
-          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Install pre-commit hook environments
-        if: steps.cache-pre-commit.outputs.cache-hit != 'true'
-        run: |
-          python -m pip install pre-commit
-          pre-commit install-hooks
-
-  pre-commit-ci-lite:
-    name: pre-commit.ci lite
-    runs-on: ubuntu-latest
+  device-builder:
+    name: Test downstream esphome/device-builder
+    runs-on: ubuntu-24.04
     needs:
       - common
       - determine-jobs
-    if: github.event_name == 'pull_request' && !startsWith(github.base_ref, 'beta') && !startsWith(github.base_ref, 'release') && needs.determine-jobs.outputs.core-ci == 'true'
+    if: needs.determine-jobs.outputs.device-builder == 'true'
     steps:
-      - name: Check out code from GitHub
+      - name: Check out esphome (this PR)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
         with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      # Inlined from esphome/pre-commit-action with a restore-only cache
-      # step: the pre-commit-seed-cache job owns saving this cache, so
-      # pull request runs never write per-PR copies.
-      - name: Restore pre-commit cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+          path: esphome
+      - name: Check out esphome/device-builder
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          path: ~/.cache/pre-commit
-          # Must match the key pre-commit-seed-cache saves
-          # yamllint disable-line rule:line-length
-          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Run pre-commit
-        env:
-          SKIP: pylint,ci-custom
+          repository: esphome/device-builder
+          ref: main
+          path: device-builder
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+      - name: Set up uv
+        # Mirrors the install shape device-builder's own CI uses
+        # (esphome/device-builder#192): uv replaces pip for the
+        # install step (order-of-magnitude faster on cold boots,
+        # with its own wheel cache). actions/setup-python still
+        # provides the interpreter.
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          # Pull request saves land in per-PR scopes nothing else can
+          # reuse; dev pushes seed the shared copy instead.
+          save-cache: ${{ github.event_name != 'pull_request' }}
+          # Pin uv version so the action does not have to fetch the
+          # manifest from raw.githubusercontent.com on every cache
+          # miss; that fetch flakes on Windows runners.
+          version: "0.11.15"
+      - name: Install device-builder + esphome from PR
+        # Install device-builder with its esphome + test extras
+        # first so its pinned versions of pytest/etc. land, then
+        # overlay the PR's esphome so the downstream tests run
+        # against this PR's Python code. ``--system`` installs into
+        # the runner's Python instead of a venv.
         run: |
-          python -m pip install pre-commit
-          pre-commit run --show-diff-on-failure --color=always --all-files
-      - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
-        if: always()
+          uv pip install --system -e './device-builder[esphome,test]'
+          uv pip install --system -e ./esphome
+      - name: Run device-builder pytest
+        # ``-n auto`` runs under pytest-xdist (matches device-builder's
+        # own CI). No ``--cov`` here -- this is purely a downstream
+        # smoke check against this PR's esphome code. ``tests/e2e/slow``
+        # is excluded: those are real multi-minute toolchain compiles
+        # (LibreTiny SDK clone, native ESP-IDF install) that device-builder
+        # runs in its own dedicated jobs, not this smoke check.
+        working-directory: device-builder
+        run: pytest -q -n auto --maxfail=5 --durations=30 --no-cov --ignore=tests/benchmarks --ignore=tests/e2e/slow
 
   memory-impact-target-branch:
     name: Build target branch for memory impact
@@ -1456,22 +1456,28 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-24.04
+    # Listed in the same order the jobs are defined above. Two jobs are
+    # deliberately left out: "benchmarks" reports through CodSpeed rather than
+    # this check, and "pre-commit-seed-cache" only populates a cache on pushes
+    # to dev.
     needs:
       - common
+      - determine-jobs
       - ci-custom
       - pylint
+      - pre-commit-ci-lite
       - pytest
       - codecov-empty-upload
       - integration-tests
+      - import-time
+      - cpp-unit-tests
       - clang-tidy-single
       - clang-tidy-nosplit
       - clang-tidy-split
       - clang-tidy-esp32-variants
-      - determine-jobs
-      - device-builder
       - test-build-components-split
       - test-esp32-platformio
-      - pre-commit-ci-lite
+      - device-builder
       - memory-impact-target-branch
       - memory-impact-pr-branch
       - memory-impact-comment


### PR DESCRIPTION
# What does this implement/fix?

Job order in a workflow file is cosmetic to GitHub Actions, but it is how a reader follows the pipeline. `ci.yml` had grown to the point where the order no longer matched the flow. The clearest example is `determine-jobs`: it gates nearly every other job, yet it was defined part-way down the file, after five jobs that already referenced its outputs. Reading from the top you met `if: needs.determine-jobs.outputs.python-linters == 'true'` roughly two hundred lines before the job that produces that output. A few other jobs sat away from their natural neighbours too - the downstream `device-builder` test split the core lint block, `benchmarks` sat between the C++ unit tests and the clang-tidy group, and the two pre-commit jobs lived after every build job.

This moves the jobs so the file reads in dependency and pipeline order: setup and gating, Python lint, Python tests, C++ analysis and unit tests, component and downstream builds, the memory impact chain, and finally the aggregate status check. Every `needs` reference now points at a job defined above it. No job body is edited - the blocks are moved verbatim, and I verified that all 22 unchanged jobs are byte-identical before and after, including the blank lines between them.

The one job that does change is `ci-status`, which was missing `cpp-unit-tests` and `import-time` from its dependency list. Both run on pull requests, so until now either could fail without turning the overall check red. Its list is also reordered to match the new job order, with a comment recording why `benchmarks` and `pre-commit-seed-cache` are deliberately left out: the first reports through CodSpeed, and the second only populates a cache on pushes to `dev`.

Stacked on #17977.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
