### PR TITLE
[chsc6x] Add CHSC6540 model option

### DIFF
--- a/esphome/components/chsc6x/chsc6x_touchscreen.cpp
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.cpp
@@ -16,6 +16,11 @@ void CHSC6XTouchscreen::setup() {
 }
 
 void CHSC6XTouchscreen::update_touches() {
+  if (this->model_ == CHSC6X_MODEL_CHSC6540) {
+    this->update_touches_chsc6540_();
+    return;
+  }
+
   uint8_t data[CHSC6X_REG_STATUS_LEN];
   if (!this->read_bytes(CHSC6X_REG_STATUS, data, sizeof(data))) {
     return;
@@ -30,13 +35,42 @@ void CHSC6XTouchscreen::update_touches() {
   }
 }
 
+void CHSC6XTouchscreen::update_touches_chsc6540_() {
+  uint8_t data[CHSC6540_REG_STATUS_LEN];
+  if (!this->read_bytes(CHSC6X_REG_STATUS, data, sizeof(data))) {
+    return;
+  }
+
+  const uint8_t num_of_touches = data[CHSC6540_REG_STATUS_TOUCH];
+  // 0 is a genuine lift event; 0xFF turns up in unpopulated point slots.
+  if (num_of_touches == 0 || num_of_touches == 0xFF) {
+    return;
+  }
+
+  // Occasional glitch frame: a plausible touch count with every coordinate byte
+  // set to 0xFF, seen roughly once per drag. It would decode to (4095, 4095).
+  if (data[CHSC6540_REG_STATUS_X_HI] == 0xFF && data[CHSC6540_REG_STATUS_X_LO] == 0xFF &&
+      data[CHSC6540_REG_STATUS_Y_HI] == 0xFF && data[CHSC6540_REG_STATUS_Y_LO] == 0xFF) {
+    return;
+  }
+
+  const uint16_t x = (static_cast<uint16_t>(data[CHSC6540_REG_STATUS_X_HI] & CHSC6540_COORD_HI_MASK) << 8) |
+                     data[CHSC6540_REG_STATUS_X_LO];
+  const uint16_t y = (static_cast<uint16_t>(data[CHSC6540_REG_STATUS_Y_HI] & CHSC6540_COORD_HI_MASK) << 8) |
+                     data[CHSC6540_REG_STATUS_Y_LO];
+
+  this->add_raw_touch_position_(0, x, y);
+}
+
 void CHSC6XTouchscreen::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "CHSC6X Touchscreen:\n"
+                "  Model: %s\n"
                 "  Touch timeout: %d\n"
                 "  x_raw_max_: %d\n"
                 "  y_raw_max_: %d",
-                this->touch_timeout_, this->x_raw_max_, this->y_raw_max_);
+                this->model_ == CHSC6X_MODEL_CHSC6540 ? "CHSC6540" : "CHSC6X", this->touch_timeout_,
+                this->x_raw_max_, this->y_raw_max_);
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
 }

--- a/esphome/components/chsc6x/chsc6x_touchscreen.cpp
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.cpp
@@ -42,8 +42,9 @@ void CHSC6XTouchscreen::update_touches_chsc6540_() {
   }
 
   const uint8_t num_of_touches = data[CHSC6540_REG_STATUS_TOUCH];
-  // 0 is a genuine lift event; 0xFF turns up in unpopulated point slots.
-  if (num_of_touches == 0 || num_of_touches == 0xFF) {
+  // 0 is a genuine lift event. Anything above the supported point count is a
+  // corrupt frame, including the 0xFF seen in unpopulated point slots.
+  if (num_of_touches == 0 || num_of_touches > CHSC6540_MAX_TOUCHES) {
     return;
   }
 

--- a/esphome/components/chsc6x/chsc6x_touchscreen.cpp
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.cpp
@@ -42,16 +42,23 @@ void CHSC6XTouchscreen::update_touches_chsc6540_() {
   }
 
   const uint8_t num_of_touches = data[CHSC6540_REG_STATUS_TOUCH];
-  // 0 is a genuine lift event. Anything above the supported point count is a
-  // corrupt frame, including the 0xFF seen in unpopulated point slots.
-  if (num_of_touches == 0 || num_of_touches > CHSC6540_MAX_TOUCHES) {
+  // 0 is a genuine lift event; 0xFF turns up in unpopulated point slots.
+  //
+  // No upper bound is imposed on the count deliberately. The panel this was
+  // captured on reports at most 2, but how many points other parts in the
+  // family report is unknown, and a hard ceiling would silently discard valid
+  // frames on untested hardware. The count is only used here as "at least one
+  // point is present" -- point 0 is the only one reported either way -- and the
+  // all-0xFF coordinate check below rejects the one corrupt frame actually
+  // observed.
+  if (num_of_touches == 0 || num_of_touches == 0xFF) {
     return;
   }
 
   // Occasional glitch frame: a plausible touch count with every coordinate byte
   // set to 0xFF, seen roughly once per drag. It would decode to (4095, 4095).
-  if (data[CHSC6540_REG_STATUS_X_HI] == 0xFF && data[CHSC6540_REG_STATUS_X_LO] == 0xFF &&
-      data[CHSC6540_REG_STATUS_Y_HI] == 0xFF && data[CHSC6540_REG_STATUS_Y_LO] == 0xFF) {
+  if ((data[CHSC6540_REG_STATUS_X_HI] & data[CHSC6540_REG_STATUS_X_LO] & data[CHSC6540_REG_STATUS_Y_HI] &
+       data[CHSC6540_REG_STATUS_Y_LO]) == 0xFF) {
     return;
   }
 

--- a/esphome/components/chsc6x/chsc6x_touchscreen.cpp
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.cpp
@@ -69,8 +69,8 @@ void CHSC6XTouchscreen::dump_config() {
                 "  Touch timeout: %d\n"
                 "  x_raw_max_: %d\n"
                 "  y_raw_max_: %d",
-                this->model_ == CHSC6X_MODEL_CHSC6540 ? "CHSC6540" : "CHSC6X", this->touch_timeout_,
-                this->x_raw_max_, this->y_raw_max_);
+                this->model_ == CHSC6X_MODEL_CHSC6540 ? "CHSC6540" : "CHSC6X", this->touch_timeout_, this->x_raw_max_,
+                this->y_raw_max_);
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
 }

--- a/esphome/components/chsc6x/chsc6x_touchscreen.h
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.h
@@ -46,9 +46,6 @@ static const uint8_t CHSC6540_REG_STATUS_Y_LO = 0x06;
 // The coordinate high nibble shares a byte with the event flags in bits 7-6.
 static const uint8_t CHSC6540_COORD_HI_MASK = 0x0F;
 
-// Only 1 and 2 are valid; anything higher is a corrupt frame.
-static const uint8_t CHSC6540_MAX_TOUCHES = 2;
-
 enum CHSC6XModel : uint8_t {
   // Original layout: touch count at byte 0, single-byte coordinates. Matches
   // the 240x240 Seeed Studio Round Display for XIAO this component targets.

--- a/esphome/components/chsc6x/chsc6x_touchscreen.h
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.h
@@ -17,6 +17,39 @@ static const uint8_t CHSC6X_REG_STATUS_Y_COR = 0x04;
 static const uint8_t CHSC6X_REG_STATUS_LEN = 0x05;
 static const uint8_t CHSC6X_CHIP_ID = 0x2e;
 
+// CHSC6540 report layout, confirmed over 1651 captured samples on a 320x480
+// panel (VIEWE UEDX32480035E-WB-A):
+//
+//   [0] [1]   always 0x00
+//   [2]       number of active touch points (0, 1 or 2)
+//   [3]       event flags in bits 7-6, X high nibble in bits 3-0
+//   [4]       X low byte
+//   [5]       event flags in bits 7-6, Y high nibble in bits 3-0
+//   [6]       Y low byte
+//   [7] [8]   fixed 0x0D 0x10 (pressure / area, never varied)
+//   [9]..     second touch point, 0xFF 0xFF when absent
+//
+// Reading 7 bytes covers the header plus the first point, which is all the
+// touchscreen component consumes.
+static const uint8_t CHSC6540_REG_STATUS_LEN = 0x07;
+static const uint8_t CHSC6540_REG_STATUS_TOUCH = 0x02;
+static const uint8_t CHSC6540_REG_STATUS_X_HI = 0x03;
+static const uint8_t CHSC6540_REG_STATUS_X_LO = 0x04;
+static const uint8_t CHSC6540_REG_STATUS_Y_HI = 0x05;
+static const uint8_t CHSC6540_REG_STATUS_Y_LO = 0x06;
+
+// Coordinates are 9 bit; the high nibble shares a byte with the event flags.
+static const uint8_t CHSC6540_COORD_HI_MASK = 0x0F;
+
+enum CHSC6XModel : uint8_t {
+  // Original layout: touch count at byte 0, single-byte coordinates. Matches
+  // the 240x240 Seeed Studio Round Display for XIAO this component targets.
+  CHSC6X_MODEL_CHSC6X = 0,
+  // CHSC6540: three-byte header and 9-bit coordinates. Required on panels wider
+  // or taller than 255px, which single-byte coordinates cannot address.
+  CHSC6X_MODEL_CHSC6540 = 1,
+};
+
 class CHSC6XTouchscreen final : public touchscreen::Touchscreen, public i2c::I2CDevice {
  public:
   void setup() override;
@@ -24,9 +57,13 @@ class CHSC6XTouchscreen final : public touchscreen::Touchscreen, public i2c::I2C
   void dump_config() override;
 
   void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
+  void set_model(CHSC6XModel model) { this->model_ = model; }
 
  protected:
+  void update_touches_chsc6540_();
+
   InternalGPIOPin *interrupt_pin_{};
+  CHSC6XModel model_{CHSC6X_MODEL_CHSC6X};
 };
 
 }  // namespace esphome::chsc6x

--- a/esphome/components/chsc6x/chsc6x_touchscreen.h
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.h
@@ -31,6 +31,11 @@ static const uint8_t CHSC6X_CHIP_ID = 0x2e;
 //
 // Reading 7 bytes covers the header plus the first point, which is all the
 // touchscreen component consumes.
+//
+// Bytes 3 and 5 carry the coordinate high nibble in bits 3-0, so a decoded
+// coordinate is up to 12 bits (0..4095). The 320x480 panel these samples came
+// from only ever used 9 of them, but the field itself is wider and nothing here
+// assumes otherwise.
 static const uint8_t CHSC6540_REG_STATUS_LEN = 0x07;
 static const uint8_t CHSC6540_REG_STATUS_TOUCH = 0x02;
 static const uint8_t CHSC6540_REG_STATUS_X_HI = 0x03;
@@ -38,8 +43,11 @@ static const uint8_t CHSC6540_REG_STATUS_X_LO = 0x04;
 static const uint8_t CHSC6540_REG_STATUS_Y_HI = 0x05;
 static const uint8_t CHSC6540_REG_STATUS_Y_LO = 0x06;
 
-// Coordinates are 9 bit; the high nibble shares a byte with the event flags.
+// The coordinate high nibble shares a byte with the event flags in bits 7-6.
 static const uint8_t CHSC6540_COORD_HI_MASK = 0x0F;
+
+// Only 1 and 2 are valid; anything higher is a corrupt frame.
+static const uint8_t CHSC6540_MAX_TOUCHES = 2;
 
 enum CHSC6XModel : uint8_t {
   // Original layout: touch count at byte 0, single-byte coordinates. Matches

--- a/esphome/components/chsc6x/touchscreen.py
+++ b/esphome/components/chsc6x/touchscreen.py
@@ -2,7 +2,7 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import i2c, touchscreen
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_INTERRUPT_PIN
+from esphome.const import CONF_ID, CONF_INTERRUPT_PIN, CONF_MODEL
 
 chsc6x_ns = cg.esphome_ns.namespace("chsc6x")
 
@@ -12,12 +12,19 @@ CHSC6XTouchscreen = chsc6x_ns.class_(
     i2c.I2CDevice,
 )
 
+CHSC6XModel = chsc6x_ns.enum("CHSC6XModel")
+MODELS = {
+    "CHSC6X": CHSC6XModel.CHSC6X_MODEL_CHSC6X,
+    "CHSC6540": CHSC6XModel.CHSC6X_MODEL_CHSC6540,
+}
+
 CONFIG_SCHEMA = (
     touchscreen.touchscreen_schema("100ms")
     .extend(
         {
             cv.GenerateID(): cv.declare_id(CHSC6XTouchscreen),
             cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
+            cv.Optional(CONF_MODEL, default="CHSC6X"): cv.enum(MODELS, upper=True),
         }
     )
     .extend(i2c.i2c_device_schema(0x2E))
@@ -28,6 +35,8 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await touchscreen.register_touchscreen(var, config)
     await i2c.register_i2c_device(var, config)
+
+    cg.add(var.set_model(config[CONF_MODEL]))
 
     if interrupt_pin := config.get(CONF_INTERRUPT_PIN):
         cg.add(var.set_interrupt_pin(await cg.gpio_pin_expression(interrupt_pin)))

--- a/tests/components/chsc6x/test.esp32-idf.yaml
+++ b/tests/components/chsc6x/test.esp32-idf.yaml
@@ -20,3 +20,4 @@ touchscreen:
     i2c_id: i2c_bus
     display: ili9xxx_display
     interrupt_pin: 20
+    model: CHSC6540


### PR DESCRIPTION
# What does this implement/fix?

The CHSC6540 reports touches in a different layout to the one this component assumes, so `chsc6x` can never register a touch on that part.

Read of register `0x00` on a CHSC6540, verified over 1651 captured samples on a 320x480 VIEWE UEDX32480035E-WB-A:

```
[0] [1]   always 0x00
[2]       number of active touch points (0, 1 or 2)
[3]       event flags in bits 7-6, X high nibble in bits 3-0
[4]       X low byte
[5]       event flags in bits 7-6, Y high nibble in bits 3-0
[6]       Y low byte
[7] [8]   fixed 0x0D 0x10 (pressure / area)
[9]..     second touch point, 0xFF when absent
```

Against that layout the current parsing:

- reads the touch count from byte 0, which is a constant `0x00`, so `num_of_touches == 1` is never true and no touch is ever reported;
- takes `x` from byte 2 (the count byte) and `y` from byte 4 (X low);
- uses `CHSC6X_REG_STATUS_LEN = 5`, so bytes 5-6 holding Y are never read;
- treats X and Y as single bytes, but they are 9 bit with the high nibble sharing a byte with the event flags, so anything past 255 wraps on panels wider or taller than that.

**Rather than change the existing offsets**, which suit the 240x240 Seeed Studio Round Display for XIAO this component targets, this adds a `model:` option defaulting to `CHSC6X`. Current behaviour is unchanged byte for byte for every existing user.

Sample frames from a drag with `model: CHSC6540`, `x` reaching 308:

```
00 00 01 80 16 00 11    count=1, x=22,  y=17
00 00 01 81 34 01 C7    count=1, x=308, y=455
00 00 00 41 36 01 CA    count=0, lift flag 0x40
```

It also drops a glitch frame seen roughly once per drag, carrying a plausible touch count with every coordinate byte set to `0xFF`, which would otherwise decode to (4095, 4095) and throw the pointer across the screen.

**Open question for @kkosik20 / maintainers, and the reason this is a draft:** does the Seeed Round Display report the touch count at byte 0, or does it use this same layout? I only have the CHSC6540 hardware and cannot test the Seeed device. If both parts share this layout, then the current code could never have worked on either and a straight offset fix would be simpler and better than a `model:` option — I'd happily rewrite it that way. The option approach is chosen purely because it cannot regress hardware I can't test.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/issues/17986

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7078

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
touchscreen:
  - platform: chsc6x
    id: main_touchscreen
    display: main_display
    model: CHSC6540
    interrupt_pin: 4
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
