### PR TITLE
[epaper_spi] Add Good Display GDEY0213F51 4-color e-paper support

### DIFF
--- a/esphome/components/epaper_spi/models/jd79660.py
+++ b/esphome/components/epaper_spi/models/jd79660.py
@@ -116,3 +116,39 @@ jd79660.extend(
         (0x04,),
     ),
 )
+
+# Good Display GDEY0213F51
+#
+# Panel: 2.13" BWYR (4-color) e-paper, 122x250, controller JD79661
+# Init derived from Good Display sample
+# <https://www.good-display.com/companyfile/1047.html>
+# Cross-checked against GxEPD2_213c_GDEY0213F51
+# <https://github.com/ZinggJM/GxEPD2/blob/master/src/epd4c/GxEPD2_213c_GDEY0213F51.cpp>
+#
+# Note: busy pin uses LOW=busy, HIGH=idle.
+#
+# fmt: off
+jd79660.extend(
+    "goodisplay-gdey0213f51-2.13",
+    width=128,
+    height=250,
+
+    initsequence=(
+        (0x4D, 0x78,),
+        (0x00, 0x0F, 0x29,),  # PSR
+        (0x01, 0x07, 0x00,),  # PWRR
+        (0x03, 0x10, 0x54, 0x44,),  # POFS
+        (0x06, 0x05, 0x00, 0x3F, 0x0A, 0x25, 0x12, 0x1A,),  # BTST_P
+        (0x50, 0x37,),  # CDI
+        (0x60, 0x02, 0x02,),  # TCON
+        (0x61, 128 // 256, 128 % 256, 250 // 256, 250 % 256,),  # TRES: 128x250 fixed
+        (0xE7, 0x1C,),
+        (0xE3, 0x22,),
+        (0xB4, 0xD0,),
+        (0xB5, 0x03,),
+        (0xE9, 0x01,),
+        (0x30, 0x08,),
+        # Power On (0x04): Must be early part of init seq = Disabled later!
+        (0x04,),
+    ),
+)

--- a/tests/components/epaper_spi/test.esp32-s3-idf.yaml
+++ b/tests/components/epaper_spi/test.esp32-s3-idf.yaml
@@ -191,6 +191,29 @@ display:
       it.circle(it.get_width() / 2, it.get_height() / 2, 20, Color::BLACK);
       it.circle(it.get_width() / 2, it.get_height() / 2, 15, Color(255, 0, 0));
 
+  # Good Display GDEY0213F51 4-color e-paper (128x250, BWYR, JD79661)
+  - platform: epaper_spi
+    spi_id: spi_bus
+    model: goodisplay-gdey0213f51-2.13
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO5
+    dc_pin:
+      allow_other_uses: true
+      number: GPIO17
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO16
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO4
+      inverted: true
+    lambda: |-
+      it.filled_rectangle(0, 0, it.get_width(), it.get_height(), Color::WHITE);
+      it.circle(it.get_width() / 2, it.get_height() / 2, 30, Color::BLACK);
+      it.circle(it.get_width() / 2, it.get_height() / 2, 20, Color(255, 0, 0));
+      it.circle(it.get_width() / 2, it.get_height() / 2, 10, Color(255, 255, 0));
+
   # Soldered Inkplate 2 3-color e-paper (104x212, BWR)
   - platform: epaper_spi
     spi_id: spi_bus


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the Good Display GDEY0213F51 (2.13" BWYR 4-color e-paper, 122x250) as a new model on the existing `jd79660` driver in `epaper_spi`.

Init sequence derived from Good Display example and checked against GxEPD2
Note that this panel is busy=LOW, idle=HIGH

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7085

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
display:
  - platform: epaper_spi
    model: goodisplay-gdey0213f51-2.13
    cs_pin: GPIO5
    dc_pin: GPIO17
    reset_pin: GPIO16
    busy_pin:
      number: GPIO4
      inverted: true
    lambda: |-
      it.filled_rectangle(0, 0, it.get_width(), it.get_height(), Color::WHITE);
      it.circle(it.get_width() / 2, it.get_height() / 2, 30, Color::BLACK);
      it.circle(it.get_width() / 2, it.get_height() / 2, 20, Color(255, 0, 0));
      it.circle(it.get_width() / 2, it.get_height() / 2, 10, Color(255, 255, 0));
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
