### PR TITLE
[core] Skip library entries with an empty source

### DIFF
--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -550,11 +550,9 @@ def _add_library_str(lib: str) -> None:
         else:
             cg.add_library(None, None, lib)
     elif lib.endswith("="):
-        # A "Name=" entry with an empty source. This happens when a package
-        # default like "Name=${var}" is left blank so a later list entry can
-        # override it; there is nothing to add here. Without this the whole
-        # "Name=" string became the library name and the native library
-        # resolver failed to find a package named "Name=".
+        # "Name=" with an empty source: a package default like "Name=${var}"
+        # left blank for a later entry to override. Skip it so the whole
+        # "Name=" string is not treated as the library name.
         return
     else:
         cg.add_library(lib, None)

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -549,6 +549,13 @@ def _add_library_str(lib: str) -> None:
             cg.add_library(name, None, repo)
         else:
             cg.add_library(None, None, lib)
+    elif lib.endswith("="):
+        # A "Name=" entry with an empty source. This happens when a package
+        # default like "Name=${var}" is left blank so a later list entry can
+        # override it; there is nothing to add here. Without this the whole
+        # "Name=" string became the library name and the native library
+        # resolver failed to find a package named "Name=".
+        return
     else:
         cg.add_library(lib, None)
 

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -1332,6 +1332,28 @@ def test_add_library_str_bare_url_requires_name() -> None:
         config._add_library_str("https://github.com/esphome/noise-c.git")
 
 
+def test_add_library_str_empty_source_skipped() -> None:
+    """A "Name=" entry with an empty source is skipped instead of being added as
+    a library literally named "Name=" that no resolver can find.
+
+    This happens when a package default like "Name=${var}" is left blank so a
+    later list entry overrides it; the override still applies.
+    """
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp32",
+        KEY_TARGET_FRAMEWORK: "esp-idf",
+    }
+
+    # Order as a package merge produces it: blank default first, override second.
+    config._add_library_str("TeslaBLE=")
+    config._add_library_str("TeslaBLE=file:///config/esphome/lib_dev")
+
+    libraries = list(CORE.platformio_libraries.values())
+    assert len(libraries) == 1
+    assert libraries[0].name == "TeslaBLE"
+    assert libraries[0].repository == "file:///config/esphome/lib_dev"
+
+
 @pytest.mark.asyncio
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 async def test_to_code_adds_libraries(yaml_file: Callable[[str], Path]) -> None:


### PR DESCRIPTION
# What does this implement/fix?

A `libraries` entry of the form `Name=` (a name with an empty source) was parsed as a library literally named `Name=`, because `_add_library_str` only split on `=` when the string also contained a `://` URL.

This happens in practice when a package sets a default like:

```yaml
substitutions:
  BLE_library: ""
esphome:
  libraries:
    - TeslaBLE=${BLE_library}
```

and the user leaves the substitution blank so a later `libraries` entry (`TeslaBLE=file:///...`) overrides it. Package merging concatenates the two `libraries` lists rather than deduplicating by name, so both `TeslaBLE=` and the real override reach code generation.

The old PlatformIO toolchain tolerated the junk `lib_deps` entry, but the native library resolver looks up a registry package named `TeslaBLE=` and fails with `Could not find the package with 'TeslaBLE=' requirements`. This regressed builds that relied on the blank-default-plus-override pattern on 2026.7.x.

The fix skips a `Name=` entry with an empty source, so the intended override provides the library.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
substitutions:
  BLE_library: ""
esphome:
  libraries:
    - TeslaBLE=${BLE_library}
    - TeslaBLE=file:///config/esphome/lib_dev
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).