### PR TITLE
[modbus] Restore function code byte for custom codes in deprecated on_modbus_data

### DIFF
--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -405,7 +405,12 @@ class ESPDEPRECATED("Subclass ModbusClientDevice and override on_response()/on_e
   virtual void on_modbus_error(uint8_t function_code, uint8_t exception_code) {}
 
   void on_response(std::span<const uint8_t> request_pdu, std::span<const uint8_t> response_pdu) override {
-    auto payload = helpers::server_pdu_payload(response_pdu);
+    // Custom (user-defined) function codes historically delivered the payload starting AT the function
+    // code byte (frame data_offset 1). server_pdu_payload() drops that byte, so pass the whole PDU for
+    // them - external components match the first byte against the code they sent (issue #17994).
+    auto payload = !response_pdu.empty() && helpers::is_function_code_custom(response_pdu[0])
+                       ? response_pdu
+                       : helpers::server_pdu_payload(response_pdu);
     this->on_modbus_data(std::vector<uint8_t>(payload.begin(), payload.end()));
   }
   void on_error(std::span<const uint8_t> request_pdu, ExceptionCode exception_code) override {

--- a/tests/components/modbus/modbus_client_device_test.cpp
+++ b/tests/components/modbus/modbus_client_device_test.cpp
@@ -350,7 +350,7 @@ class LegacyDevice : public ModbusDevice {
  public:
   void on_modbus_data(const std::vector<uint8_t> &data) override { this->data_calls.push_back(data); }
   void on_modbus_error(uint8_t function_code, uint8_t exception_code) override {
-    this->error_calls.push_back({function_code, exception_code});
+    this->error_calls.emplace_back(function_code, exception_code);
   }
   std::vector<std::vector<uint8_t>> data_calls;
   std::vector<std::pair<uint8_t, uint8_t>> error_calls;

--- a/tests/components/modbus/modbus_client_device_test.cpp
+++ b/tests/components/modbus/modbus_client_device_test.cpp
@@ -341,4 +341,45 @@ TEST(ModbusTypedDispatch, SingleWriteAckPrefersTheResponseEcho) {
   EXPECT_EQ(device.write_single_register_calls.back().value, 0x002A);  // exception: request copy
 }
 
+// Deprecated on_modbus_data() compatibility shim (pre-2026.8 API). Records the vectors delivered to
+// the old callback so we can pin its payload framing against the pre-2026.7 behavior.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+namespace {
+class LegacyDevice : public ModbusDevice {
+ public:
+  void on_modbus_data(const std::vector<uint8_t> &data) override { this->data_calls.push_back(data); }
+  void on_modbus_error(uint8_t function_code, uint8_t exception_code) override {
+    this->error_calls.push_back({function_code, exception_code});
+  }
+  std::vector<std::vector<uint8_t>> data_calls;
+  std::vector<std::pair<uint8_t, uint8_t>> error_calls;
+};
+}  // namespace
+
+// Custom (user-defined) function codes historically delivered the payload INCLUDING the function code
+// byte (frame data_offset 1). External components such as the Century VS pump match that first byte
+// against the code they sent, so dropping it (issue #17994) makes every response get ignored.
+TEST(ModbusLegacyShim, CustomFunctionCodeKeepsFunctionCodeByte) {
+  LegacyDevice device;
+  const uint8_t request[] = {0x45, 0x01, 0x02};         // custom function 0x45
+  const uint8_t response[] = {0x45, 0xAA, 0xBB, 0xCC};  // echo of the custom code + data
+  device.on_response(request, response);
+
+  ASSERT_EQ(device.data_calls.size(), 1u);
+  EXPECT_EQ(device.data_calls.front(), (std::vector<uint8_t>{0x45, 0xAA, 0xBB, 0xCC}));
+}
+
+// Standard reads still strip the function code and byte-count header, matching the pre-2026.7 shim.
+TEST(ModbusLegacyShim, StandardReadStripsHeader) {
+  LegacyDevice device;
+  const uint8_t request[] = {0x03, 0x01, 0x00, 0x00, 0x02};
+  const uint8_t response[] = {0x03, 0x04, 0x00, 0x2A, 0x01, 0x00};
+  device.on_response(request, response);
+
+  ASSERT_EQ(device.data_calls.size(), 1u);
+  EXPECT_EQ(device.data_calls.front(), (std::vector<uint8_t>{0x00, 0x2A, 0x01, 0x00}));
+}
+#pragma GCC diagnostic pop
+
 }  // namespace esphome::modbus::testing


### PR DESCRIPTION
# What does this implement/fix?

The 2026.7 modbus refactor (#11969) routes the deprecated `on_modbus_data()` callback through `server_pdu_payload()`, which strips the leading function code byte.
For custom (user-defined) function codes the pre-2026.7 API delivered the payload starting *at* the function code byte, and external components (for example Gazoodle's Century VS pump) match that first byte against the code they sent.
With the byte gone, every sensor response was rejected (`Payload data function mismatch (10 != 45), ignoring`).

This restores the old framing: for custom function codes the whole PDU is passed to `on_modbus_data()`, while standard reads and writes keep their existing offsets.
This only touches the deprecated compatibility shim; external components should still migrate to `on_response()`/`on_custom_response()` before the shim is removed in 2027.2.0.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17994

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change. The fix restores the payload delivered to the
# deprecated on_modbus_data() callback for external components that subclass
# ModbusDevice and use a custom (user-defined) Modbus function code.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
