### PR TITLE
[openthread_info] Added more sensors

### DIFF
--- a/esphome/components/openthread_info/openthread_info_sensor.cpp
+++ b/esphome/components/openthread_info/openthread_info_sensor.cpp
@@ -11,6 +11,7 @@ void ParentLastRssiOpenThreadInfo::dump_config() { LOG_SENSOR("", "Parent Last R
 void ParentLinkQualityInOpenThreadInfo::dump_config() { LOG_SENSOR("", "Parent Link Quality In", this); }
 void ParentLinkQualityOutOpenThreadInfo::dump_config() { LOG_SENSOR("", "Parent Link Quality Out", this); }
 void ParentPathCostOpenThreadInfo::dump_config() { LOG_SENSOR("", "Parent Path Cost", this); }
+void RssiOpenThreadInfo::dump_config() { LOG_SENSOR("", "Last RSSI", this); }
 void TxTotalOpenThreadInfo::dump_config() { LOG_SENSOR("", "TX Total", this); }
 void TxRetriesOpenThreadInfo::dump_config() { LOG_SENSOR("", "TX Retries", this); }
 void TxErrCcaOpenThreadInfo::dump_config() { LOG_SENSOR("", "TX CCA Errors", this); }

--- a/esphome/components/openthread_info/openthread_info_sensor.cpp
+++ b/esphome/components/openthread_info/openthread_info_sensor.cpp
@@ -10,6 +10,7 @@ void ParentAverageRssiOpenThreadInfo::dump_config() { LOG_SENSOR("", "Parent Ave
 void ParentLastRssiOpenThreadInfo::dump_config() { LOG_SENSOR("", "Parent Last RSSI", this); }
 void ParentLinkQualityInOpenThreadInfo::dump_config() { LOG_SENSOR("", "Parent Link Quality In", this); }
 void ParentLinkQualityOutOpenThreadInfo::dump_config() { LOG_SENSOR("", "Parent Link Quality Out", this); }
+void ParentPathCostOpenThreadInfo::dump_config() { LOG_SENSOR("", "Parent Path Cost", this); }
 void TxTotalOpenThreadInfo::dump_config() { LOG_SENSOR("", "TX Total", this); }
 void TxRetriesOpenThreadInfo::dump_config() { LOG_SENSOR("", "TX Retries", this); }
 void TxErrCcaOpenThreadInfo::dump_config() { LOG_SENSOR("", "TX CCA Errors", this); }

--- a/esphome/components/openthread_info/openthread_info_sensor.h
+++ b/esphome/components/openthread_info/openthread_info_sensor.h
@@ -79,6 +79,18 @@ class ParentPathCostOpenThreadInfo final : public ParentOpenThreadSensor, public
   void dump_config() override;
 };
 
+// Radio Last RSSI
+class RssiOpenThreadInfo : public OpenThreadInstancePollingComponent, public sensor::Sensor {
+ public:
+  void update_instance(otInstance *instance) override {
+    int8_t rssi = otPlatRadioGetRssi(instance);
+    if (rssi != OT_RADIO_RSSI_INVALID) {
+      this->publish_state(rssi);
+    }
+  }
+  void dump_config() override;
+};
+
 // --- MAC counters (otLinkGetCounters) — cumulative since boot ---
 
 class TxTotalOpenThreadInfo final : public OpenThreadInstancePollingComponent, public sensor::Sensor {

--- a/esphome/components/openthread_info/openthread_info_sensor.h
+++ b/esphome/components/openthread_info/openthread_info_sensor.h
@@ -63,6 +63,19 @@ class ParentLinkQualityOutOpenThreadInfo final : public OpenThreadInstancePollin
   void dump_config() override;
 };
 
+// Network path cost to parent. Only valid when device is a child.
+class ParentPathCostOpenThreadInfo final : public OpenThreadInstancePollingComponent, public sensor::Sensor {
+ public:
+  void update_instance(otInstance *instance) override {
+    otRouterInfo parent_info;
+    if (otThreadGetParentInfo(instance, &parent_info) != OT_ERROR_NONE) {
+      return;
+    }
+    this->publish_state(parent_info.mPathCost);
+  }
+  void dump_config() override;
+};
+
 // --- MAC counters (otLinkGetCounters) — cumulative since boot ---
 
 class TxTotalOpenThreadInfo final : public OpenThreadInstancePollingComponent, public sensor::Sensor {

--- a/esphome/components/openthread_info/openthread_info_sensor.h
+++ b/esphome/components/openthread_info/openthread_info_sensor.h
@@ -55,27 +55,21 @@ class ParentLastRssiOpenThreadInfo final : public OpenThreadInstancePollingCompo
 // Incoming link quality from parent (0-3). Only valid when device is a child.
 class ParentLinkQualityInOpenThreadInfo final : public ParentOpenThreadSensor, public sensor::Sensor {
  public:
-  void update_parent_info(otRouterInfo *parent_info) override {
-    this->publish_state(parent_info->mLinkQualityIn);
-  }
+  void update_parent_info(otRouterInfo *parent_info) override { this->publish_state(parent_info->mLinkQualityIn); }
   void dump_config() override;
 };
 
 // Outgoing link quality to parent (0-3). Only valid when device is a child.
 class ParentLinkQualityOutOpenThreadInfo final : public ParentOpenThreadSensor, public sensor::Sensor {
  public:
-  void update_parent_info(otRouterInfo *parent_info) override {
-    this->publish_state(parent_info->mLinkQualityOut);
-  }
+  void update_parent_info(otRouterInfo *parent_info) override { this->publish_state(parent_info->mLinkQualityOut); }
   void dump_config() override;
 };
 
 // Network path cost to parent. Only valid when device is a child.
 class ParentPathCostOpenThreadInfo final : public ParentOpenThreadSensor, public sensor::Sensor {
  public:
-  void update_parent_info(otRouterInfo *parent_info) override {
-    this->publish_state(parent_info->mPathCost);
-  }
+  void update_parent_info(otRouterInfo *parent_info) override { this->publish_state(parent_info->mPathCost); }
   void dump_config() override;
 };
 

--- a/esphome/components/openthread_info/openthread_info_sensor.h
+++ b/esphome/components/openthread_info/openthread_info_sensor.h
@@ -11,6 +11,21 @@
 
 namespace esphome::openthread_info {
 
+class ParentOpenThreadSensor : public OpenThreadInstancePollingComponent {
+ public:
+  void update_instance(otInstance *instance) override {
+    otRouterInfo parent_info;
+    if (otThreadGetParentInfo(instance, &parent_info) != OT_ERROR_NONE) {
+      return;
+    }
+
+    this->update_parent_info(&parent_info);
+  }
+
+ protected:
+  virtual void update_parent_info(otRouterInfo *parent_info) = 0;
+};
+
 // Parent RSSI (average) in dBm. Only valid when device is a child; skips publish otherwise.
 class ParentAverageRssiOpenThreadInfo final : public OpenThreadInstancePollingComponent, public sensor::Sensor {
  public:
@@ -38,40 +53,28 @@ class ParentLastRssiOpenThreadInfo final : public OpenThreadInstancePollingCompo
 };
 
 // Incoming link quality from parent (0-3). Only valid when device is a child.
-class ParentLinkQualityInOpenThreadInfo final : public OpenThreadInstancePollingComponent, public sensor::Sensor {
+class ParentLinkQualityInOpenThreadInfo final : public ParentOpenThreadSensor, public sensor::Sensor {
  public:
-  void update_instance(otInstance *instance) override {
-    otRouterInfo parent_info;
-    if (otThreadGetParentInfo(instance, &parent_info) != OT_ERROR_NONE) {
-      return;
-    }
-    this->publish_state(parent_info.mLinkQualityIn);
+  void update_parent_info(otRouterInfo *parent_info) override {
+    this->publish_state(parent_info->mLinkQualityIn);
   }
   void dump_config() override;
 };
 
 // Outgoing link quality to parent (0-3). Only valid when device is a child.
-class ParentLinkQualityOutOpenThreadInfo final : public OpenThreadInstancePollingComponent, public sensor::Sensor {
+class ParentLinkQualityOutOpenThreadInfo final : public ParentOpenThreadSensor, public sensor::Sensor {
  public:
-  void update_instance(otInstance *instance) override {
-    otRouterInfo parent_info;
-    if (otThreadGetParentInfo(instance, &parent_info) != OT_ERROR_NONE) {
-      return;
-    }
-    this->publish_state(parent_info.mLinkQualityOut);
+  void update_parent_info(otRouterInfo *parent_info) override {
+    this->publish_state(parent_info->mLinkQualityOut);
   }
   void dump_config() override;
 };
 
 // Network path cost to parent. Only valid when device is a child.
-class ParentPathCostOpenThreadInfo final : public OpenThreadInstancePollingComponent, public sensor::Sensor {
+class ParentPathCostOpenThreadInfo final : public ParentOpenThreadSensor, public sensor::Sensor {
  public:
-  void update_instance(otInstance *instance) override {
-    otRouterInfo parent_info;
-    if (otThreadGetParentInfo(instance, &parent_info) != OT_ERROR_NONE) {
-      return;
-    }
-    this->publish_state(parent_info.mPathCost);
+  void update_parent_info(otRouterInfo *parent_info) override {
+    this->publish_state(parent_info->mPathCost);
   }
   void dump_config() override;
 };

--- a/esphome/components/openthread_info/sensor.py
+++ b/esphome/components/openthread_info/sensor.py
@@ -14,6 +14,7 @@ CONF_PARENT_AVERAGE_RSSI = "parent_average_rssi"
 CONF_PARENT_LAST_RSSI = "parent_last_rssi"
 CONF_PARENT_LINK_QUALITY_IN = "parent_link_quality_in"
 CONF_PARENT_LINK_QUALITY_OUT = "parent_link_quality_out"
+CONF_PARENT_PATH_COST = "parent_path_cost"
 CONF_TX_TOTAL = "tx_total"
 CONF_TX_RETRIES = "tx_retries"
 CONF_TX_ERR_CCA = "tx_err_cca"
@@ -38,6 +39,9 @@ ParentLinkQualityInOpenThreadInfo = openthread_info_ns.class_(
 )
 ParentLinkQualityOutOpenThreadInfo = openthread_info_ns.class_(
     "ParentLinkQualityOutOpenThreadInfo", sensor.Sensor, cg.PollingComponent
+)
+ParentPathCostOpenThreadInfo = openthread_info_ns.class_(
+    "ParentPathCostOpenThreadInfo", sensor.Sensor, cg.PollingComponent
 )
 TxTotalOpenThreadInfo = openthread_info_ns.class_(
     "TxTotalOpenThreadInfo", sensor.Sensor, cg.PollingComponent
@@ -94,6 +98,13 @@ CONFIG_SCHEMA = cv.Schema(
         ).extend(cv.polling_component_schema("5s")),
         cv.Optional(CONF_PARENT_LINK_QUALITY_OUT): sensor.sensor_schema(
             ParentLinkQualityOutOpenThreadInfo,
+            unit_of_measurement=UNIT_EMPTY,
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ).extend(cv.polling_component_schema("5s")),
+        cv.Optional(CONF_PARENT_PATH_COST): sensor.sensor_schema(
+            ParentPathCostOpenThreadInfo,
             unit_of_measurement=UNIT_EMPTY,
             accuracy_decimals=0,
             state_class=STATE_CLASS_MEASUREMENT,
@@ -177,6 +188,7 @@ async def to_code(config):
     await setup_conf(config, CONF_PARENT_LAST_RSSI)
     await setup_conf(config, CONF_PARENT_LINK_QUALITY_IN)
     await setup_conf(config, CONF_PARENT_LINK_QUALITY_OUT)
+    await setup_conf(config, CONF_PARENT_PATH_COST)
     await setup_conf(config, CONF_TX_TOTAL)
     await setup_conf(config, CONF_TX_RETRIES)
     await setup_conf(config, CONF_TX_ERR_CCA)

--- a/esphome/components/openthread_info/sensor.py
+++ b/esphome/components/openthread_info/sensor.py
@@ -15,6 +15,7 @@ CONF_PARENT_LAST_RSSI = "parent_last_rssi"
 CONF_PARENT_LINK_QUALITY_IN = "parent_link_quality_in"
 CONF_PARENT_LINK_QUALITY_OUT = "parent_link_quality_out"
 CONF_PARENT_PATH_COST = "parent_path_cost"
+CONF_RSSI = "rssi"
 CONF_TX_TOTAL = "tx_total"
 CONF_TX_RETRIES = "tx_retries"
 CONF_TX_ERR_CCA = "tx_err_cca"
@@ -42,6 +43,9 @@ ParentLinkQualityOutOpenThreadInfo = openthread_info_ns.class_(
 )
 ParentPathCostOpenThreadInfo = openthread_info_ns.class_(
     "ParentPathCostOpenThreadInfo", sensor.Sensor, cg.PollingComponent
+)
+RssiOpenThreadInfo = openthread_info_ns.class_(
+    "RssiOpenThreadInfo", sensor.Sensor, cg.PollingComponent
 )
 TxTotalOpenThreadInfo = openthread_info_ns.class_(
     "TxTotalOpenThreadInfo", sensor.Sensor, cg.PollingComponent
@@ -107,6 +111,14 @@ CONFIG_SCHEMA = cv.Schema(
             ParentPathCostOpenThreadInfo,
             unit_of_measurement=UNIT_EMPTY,
             accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ).extend(cv.polling_component_schema("5s")),
+        cv.Optional(CONF_RSSI): sensor.sensor_schema(
+            RssiOpenThreadInfo,
+            unit_of_measurement=UNIT_DECIBEL_MILLIWATT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
             state_class=STATE_CLASS_MEASUREMENT,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ).extend(cv.polling_component_schema("5s")),
@@ -189,6 +201,7 @@ async def to_code(config):
     await setup_conf(config, CONF_PARENT_LINK_QUALITY_IN)
     await setup_conf(config, CONF_PARENT_LINK_QUALITY_OUT)
     await setup_conf(config, CONF_PARENT_PATH_COST)
+    await setup_conf(config, CONF_RSSI)
     await setup_conf(config, CONF_TX_TOTAL)
     await setup_conf(config, CONF_TX_RETRIES)
     await setup_conf(config, CONF_TX_ERR_CCA)

--- a/tests/components/openthread_info/test.esp32-c6-idf.yaml
+++ b/tests/components/openthread_info/test.esp32-c6-idf.yaml
@@ -39,6 +39,8 @@ sensor:
       name: "Parent Link Quality In"
     parent_link_quality_out:
       name: "Parent Link Quality Out"
+    parent_path_cost:
+      name: "Parent Path Cost"
     tx_total:
       name: "TX Total"
     tx_retries:

--- a/tests/components/openthread_info/test.esp32-c6-idf.yaml
+++ b/tests/components/openthread_info/test.esp32-c6-idf.yaml
@@ -41,6 +41,8 @@ sensor:
       name: "Parent Link Quality Out"
     parent_path_cost:
       name: "Parent Path Cost"
+    rssi:
+      name: "RSSI"
     tx_total:
       name: "TX Total"
     tx_retries:


### PR DESCRIPTION
# What does this implement/fix?

* Added remaining sensors from my misfortunate PR #18013
* Refactored parent sensors to derive from a common class

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7094

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: openthread_info
    rssi:
      name: "Radio Last RSSI"
    parent_path_cost:
      name: "Parent Path Cost"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).