### PR TITLE
[espnow] Stop polling the Wi-Fi driver every loop and disable loop when idle

### DIFF
--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -13,7 +13,7 @@ from esphome.const import (
     CONF_TRIGGER_ID,
     CONF_WIFI,
 )
-from esphome.core import HexInt
+from esphome.core import CORE, HexInt
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@jesserockz"]
@@ -151,6 +151,10 @@ async def to_code(config):
 
     cg.add_define("USE_ESPNOW")
     cg.add_define("USE_ESPNOW_MAX_PAYLOAD_SIZE", config[CONF_MAX_PAYLOAD_SIZE])
+
+    if CONF_WIFI in CORE.config:
+        # Track the Wi-Fi channel via connect events instead of polling every loop
+        wifi.request_wifi_connect_state_listener()
     if wifi_channel := config.get(CONF_CHANNEL):
         cg.add(var.set_wifi_channel(wifi_channel))
 

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <cinttypes>
 
-#include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -75,6 +74,7 @@ void on_send_report(const uint8_t *mac_addr, esp_now_send_status_t status)
   if (packet == nullptr) {
     // No events available - queue is full or we're out of memory
     global_esp_now->receive_packet_queue_.increment_dropped_count();
+    global_esp_now->enable_loop_soon_any_context();
     return;
   }
 
@@ -90,8 +90,8 @@ void on_send_report(const uint8_t *mac_addr, esp_now_send_status_t status)
   // Push always succeeds: pool is sized to queue capacity (SIZE-1), so if
   // allocate() returned non-null, the queue cannot be full.
 
-  // Wake main loop immediately to process ESP-NOW send event
-  App.wake_loop_threadsafe();
+  // Re-enable and wake the main loop to process the ESP-NOW send event
+  global_esp_now->enable_loop_soon_any_context();
 }
 
 void on_data_received(const esp_now_recv_info_t *info, const uint8_t *data, int size) {
@@ -101,6 +101,7 @@ void on_data_received(const esp_now_recv_info_t *info, const uint8_t *data, int 
   // larger frame would overflow packet_.receive.data.
   if (size < 0 || size > ESPNOW_MAX_DATA_LEN) {
     global_esp_now->receive_packet_queue_.increment_dropped_count();
+    global_esp_now->enable_loop_soon_any_context();
     return;
   }
 
@@ -109,6 +110,7 @@ void on_data_received(const esp_now_recv_info_t *info, const uint8_t *data, int 
   if (packet == nullptr) {
     // No events available - queue is full or we're out of memory
     global_esp_now->receive_packet_queue_.increment_dropped_count();
+    global_esp_now->enable_loop_soon_any_context();
     return;
   }
 
@@ -120,8 +122,8 @@ void on_data_received(const esp_now_recv_info_t *info, const uint8_t *data, int 
   // Push always succeeds: pool is sized to queue capacity (SIZE-1), so if
   // allocate() returned non-null, the queue cannot be full.
 
-  // Wake main loop immediately to process ESP-NOW receive event
-  App.wake_loop_threadsafe();
+  // Re-enable and wake the main loop to process the ESP-NOW receive event
+  global_esp_now->enable_loop_soon_any_context();
 }
 
 ESPNowComponent::ESPNowComponent() { global_esp_now = this; }
@@ -156,12 +158,30 @@ bool ESPNowComponent::is_wifi_enabled() {
 }
 
 void ESPNowComponent::setup() {
+#if defined(USE_WIFI) && defined(USE_WIFI_CONNECT_STATE_LISTENERS)
+  if (wifi::global_wifi_component != nullptr) {
+    wifi::global_wifi_component->add_connect_state_listener(this);
+  }
+#endif
   if (this->enable_on_boot_) {
     this->enable_();
   } else {
     this->state_ = ESPNOW_STATE_DISABLED;
   }
 }
+
+#if defined(USE_WIFI) && defined(USE_WIFI_CONNECT_STATE_LISTENERS)
+void ESPNowComponent::on_wifi_connect_state(StringRef ssid, std::span<const uint8_t, 6> bssid) {
+  if (ssid.empty()) {
+    return;  // Disconnected; the channel is only meaningful while associated
+  }
+  uint8_t old_channel = this->wifi_channel_;
+  this->get_wifi_channel();
+  if (this->wifi_channel_ != old_channel) {
+    ESP_LOGI(TAG, "Wifi Channel is changed from %d to %d.", old_channel, this->wifi_channel_);
+  }
+}
+#endif
 
 void ESPNowComponent::enable() {
   if (this->state_ == ESPNOW_STATE_ENABLED)
@@ -254,15 +274,6 @@ void ESPNowComponent::apply_wifi_channel() {
 }
 
 void ESPNowComponent::loop() {
-#ifdef USE_WIFI
-  if (wifi::global_wifi_component != nullptr && wifi::global_wifi_component->is_connected()) {
-    int32_t new_channel = wifi::global_wifi_component->get_wifi_channel();
-    if (new_channel != this->wifi_channel_) {
-      ESP_LOGI(TAG, "Wifi Channel is changed from %d to %" PRId32 ".", this->wifi_channel_, new_channel);
-      this->wifi_channel_ = new_channel;
-    }
-  }
-#endif
   // Process received packets
   ESPNowPacket *packet = this->receive_packet_queue_.pop();
   while (packet != nullptr) {
@@ -348,6 +359,13 @@ void ESPNowComponent::loop() {
   if (send_dropped > 0) {
     ESP_LOGW(TAG, "Dropped %u send packets (queue full)", send_dropped);
   }
+
+  // Nothing left to do; sleep until a callback or send() re-enables the loop.
+  // A packet in flight (current_send_packet_) needs no loop time: the send
+  // callback re-enables the loop when the result arrives.
+  if (this->receive_packet_queue_.empty() && this->send_packet_queue_.empty()) {
+    this->disable_loop();
+  }
 }
 
 uint8_t ESPNowComponent::get_wifi_channel() {
@@ -390,6 +408,9 @@ esp_err_t ESPNowComponent::send(const uint8_t *peer_address, const uint8_t *payl
   packet->load_data(peer_address, payload, size, callback);
   // Push the packet to the send queue
   this->send_packet_queue_.push(packet);
+  // Loop may be disabled while idle; re-enable it to send the packet
+  // (any-context variant so callers off the main loop are safe too)
+  this->enable_loop_soon_any_context();
   return ESP_OK;
 }
 

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -178,7 +178,7 @@ void ESPNowComponent::on_wifi_connect_state(StringRef ssid, std::span<const uint
   uint8_t old_channel = this->wifi_channel_;
   this->get_wifi_channel();
   if (this->wifi_channel_ != old_channel) {
-    ESP_LOGI(TAG, "Wifi Channel is changed from %d to %d.", old_channel, this->wifi_channel_);
+    ESP_LOGI(TAG, "WiFi channel changed from %d to %d", old_channel, this->wifi_channel_);
   }
 }
 #endif

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -361,9 +361,11 @@ void ESPNowComponent::loop() {
   }
 
   // Nothing left to do; sleep until a callback or send() re-enables the loop.
-  // A packet in flight (current_send_packet_) needs no loop time: the send
-  // callback re-enables the loop when the result arrives.
-  if (this->receive_packet_queue_.empty() && this->send_packet_queue_.empty()) {
+  // A packet in flight (current_send_packet_) needs no loop time even when more
+  // packets are queued behind it: the send callback re-enables the loop when
+  // the result arrives, and the SENT event handler above starts the next send.
+  if (this->receive_packet_queue_.empty() &&
+      (this->current_send_packet_ != nullptr || this->send_packet_queue_.empty())) {
     this->disable_loop();
   }
 }

--- a/esphome/components/espnow/espnow_component.h
+++ b/esphome/components/espnow/espnow_component.h
@@ -2,12 +2,17 @@
 
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
+#include "esphome/core/defines.h"
 
 #ifdef USE_ESP32
 
 #include "esphome/core/event_pool.h"
 #include "esphome/core/lock_free_queue.h"
 #include "espnow_packet.h"
+
+#if defined(USE_WIFI) && defined(USE_WIFI_CONNECT_STATE_LISTENERS)
+#include "esphome/components/wifi/wifi_component.h"
+#endif
 
 #include <esp_idf_version.h>
 
@@ -88,7 +93,11 @@ class ESPNowBroadcastHandler {
   virtual bool on_broadcast(const ESPNowRecvInfo &info, const uint8_t *data, uint16_t size) = 0;
 };
 
+#if defined(USE_WIFI) && defined(USE_WIFI_CONNECT_STATE_LISTENERS)
+class ESPNowComponent final : public Component, public wifi::WiFiConnectStateListener {
+#else
 class ESPNowComponent final : public Component {
+#endif
  public:
   ESPNowComponent();
   void setup() override;
@@ -113,6 +122,11 @@ class ESPNowComponent final : public Component {
   uint8_t get_wifi_channel();
 
   void set_auto_add_peer(bool value) { this->auto_add_peer_ = value; }
+
+#if defined(USE_WIFI) && defined(USE_WIFI_CONNECT_STATE_LISTENERS)
+  // WiFiConnectStateListener interface: refresh the cached channel after each (re)connect
+  void on_wifi_connect_state(StringRef ssid, std::span<const uint8_t, 6> bssid) override;
+#endif
 
   void enable();
   void disable();

--- a/tests/components/espnow/common-wifi.yaml
+++ b/tests/components/espnow/common-wifi.yaml
@@ -1,0 +1,9 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+espnow:
+  id: espnow_component
+  auto_add_peer: true
+  peers:
+    - 11:22:33:44:55:66

--- a/tests/components/espnow/test-wifi.esp32-idf.yaml
+++ b/tests/components/espnow/test-wifi.esp32-idf.yaml
@@ -1,0 +1,2 @@
+packages:
+  espnow: !include common-wifi.yaml


### PR DESCRIPTION
# What does this implement/fix?

Runtime stats showed espnow as one of the most expensive components while idle, averaging 0.056ms per loop iteration. The cause is that `loop()` called `get_wifi_channel()` on every iteration while Wi-Fi is connected; on ESP-IDF that is `esp_wifi_get_channel()`, a real driver call that takes the Wi-Fi API lock, not a cached read.

The channel can only change when Wi-Fi connects or roams, so espnow now registers a `WiFiConnectStateListener` and refreshes its cached channel once per connect instead of polling. While Wi-Fi manages the radio the cached value only feeds diagnostics, but the "channel changed" log is kept on purpose; a channel mismatch after roaming is the classic reason ESP-NOW peers stop hearing each other, and this log line is the breadcrumb that explains it.
The loop also disables itself when there is nothing left to do, meaning the receive queue is empty and the send side is either empty or waiting on an in-flight packet whose completion callback re-arms the loop. The ESP-NOW receive and send callbacks re-enable it via `enable_loop_soon_any_context()`, which also wakes the main loop, so `App.wake_loop_threadsafe()` is no longer needed. Idle cost drops to zero since `loop()` is not called at all.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
wifi:
  ssid: MySSID
  password: password1

espnow:
  auto_add_peer: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
