### PR TITLE
[esp32_hosted] Bump esp_hosted to 2.12.12, esp_wifi_remote to 1.6.3

### DIFF
--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -259,7 +259,7 @@ async def to_code(config):
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.5.1")
         esp32.add_idf_component(name="espressif/wifi_remote_over_eppp", ref="0.3.2")
         esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.5")
-        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.9")
+        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.12")
     else:
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="0.13.0")
         esp32.add_idf_component(name="espressif/eppp_link", ref="0.2.0")

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -256,8 +256,8 @@ async def to_code(config):
     idf_ver = esp32.idf_version()
     os.environ["ESP_IDF_VERSION"] = f"{idf_ver.major}.{idf_ver.minor}"
     if idf_ver >= cv.Version(5, 5, 0):
-        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.5.1")
-        esp32.add_idf_component(name="espressif/wifi_remote_over_eppp", ref="0.3.2")
+        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.6.3")
+        esp32.add_idf_component(name="espressif/wifi_remote_over_eppp", ref="0.3.3")
         esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.5")
         esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.12")
     else:

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -26,11 +26,11 @@ dependencies:
   espressif/mdns:
     version: 1.11.3
   espressif/esp_wifi_remote:
-    version: 1.5.1
+    version: 1.6.3
     rules:
       - if: "target in [esp32h2, esp32p4]"
   espressif/wifi_remote_over_eppp:
-    version: 0.3.2
+    version: 0.3.3
     rules:
       - if: "target in [esp32h2, esp32p4]"
   espressif/eppp_link:

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -38,7 +38,7 @@ dependencies:
     rules:
       - if: "target in [esp32h2, esp32p4]"
   espressif/esp_hosted:
-    version: 2.12.9
+    version: 2.12.12
     rules:
       - if: "target in [esp32h2, esp32p4]"
   zorxx/multipart-parser:


### PR DESCRIPTION
# What does this implement/fix?

Bumps the managed components for esp32_hosted (both the `add_idf_component` refs and the `esphome/idf_component.yml` pins):

- `espressif/esp_hosted` 2.12.9 -> 2.12.12
- `espressif/esp_wifi_remote` 1.5.1 -> 1.6.3
- `espressif/wifi_remote_over_eppp` 0.3.2 -> 0.3.3

`eppp_link` 1.1.5 is already the latest release.

Notable esp_hosted fixes since 2.12.9:

- 2.12.12: fixed SDIO incorrect identification of all-ones bus read; removed memory leaks caused by mempool
- 2.12.11: fixed SDIO deinit tearing down the shared SDMMC host (broke a co-existing SD card on the other slot); fixed public headers failing to build under `-Werror=undef`
- 2.12.10: added `esp_wifi_disable_pmf_config()` RPC support; fixed SDIO RX heap corruption on transport deinit and hardened RX buffer allocation

esp_wifi_remote 1.6.x carries the IDF 5.5 API updates (we build with 5.5.5) and adds compatibility checks with the IDF built-in wifi/remote. Its constraints (idf >=5.3, esp_hosted >=2.11,<3.0) match the pins here. wifi_remote_over_eppp 0.3.3 adds a missing mutex header.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32_hosted:
  variant: esp32c6
  active_high: true
  reset_pin: GPIO54
  cmd_pin: GPIO19
  clk_pin: GPIO18
  d0_pin: GPIO14
  d1_pin: GPIO15
  d2_pin: GPIO16
  d3_pin: GPIO17
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).