### PR TITLE
[wifi] Notify connect state listeners after driver initiated roams

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -824,6 +824,15 @@ void WiFiComponent::loop() {
           this->status_clear_warning();
           this->last_connected_ = now;
 
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+          // A driver-initiated roam (e.g. 802.11v BTM) re-associates without the
+          // state machine ever leaving STA_CONNECTED, so the notification the
+          // connected event marked pending would never be flushed by
+          // check_connecting_finished(). Cheap when nothing is pending: the
+          // method returns immediately on a single flag test.
+          this->notify_connect_state_listeners_();
+#endif
+
           // Post-connect roaming: check for better AP
           if (this->post_connect_roaming_) {
             if (this->roaming_state_ == RoamingState::SCANNING) {


### PR DESCRIPTION
# What does this implement/fix?

Connect state listeners are only notified from `check_connecting_finished()`, which runs while the state machine is in the connecting or cooldown states. When the driver roams on its own, for example an 802.11v BTM handoff with `enable_btm: true`, the station disconnects with `WIFI_REASON_ROAMING` and re-associates without the state machine ever leaving `STA_CONNECTED`. The connected event still sets `pending_.connect_state`, but nothing reads it, so listeners never hear about the new AP; the flag then sits stale and would fire with outdated context on the next real reconnect.

The user visible symptom is that the `wifi_info` SSID and BSSID text sensors keep reporting the old access point after such a roam, showing the wrong value until the next full reconnect. The espnow channel tracker misses the roam for the same reason.

Fix: flush the pending notification from the `STA_CONNECTED` branch of `loop()` as well. When nothing is pending this is a single flag test, so the steady state cost is negligible. Found while reviewing #18027, which relies on this listener to notice channel changes after roaming.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
wifi:
  ssid: MySSID
  password: password1
  enable_btm: true

text_sensor:
  - platform: wifi_info
    bssid:
      name: BSSID
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
