### PR TITLE
[core] Ship secrets referenced by remote package files in config bundles

### DIFF
--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -166,7 +166,11 @@ def add_secret_scan_dir(path: Path) -> None:
     for YAML the build consumes without bundling it — such as git-fetched
     packages, which the builder re-fetches — so the secrets those files
     reference are still shipped in the filtered secrets file.
+
+    A relative path is taken as relative to the config directory.
     """
+    if not path.is_absolute():
+        path = CORE.relative_config_path(path)
     _get_data().secret_scan_dirs.add(path)
 
 

--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -29,6 +29,7 @@ from esphome.const import (
     CONF_TYPE,
 )
 from esphome.core import CORE, EsphomeError
+from esphome.util import filter_yaml_files
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -128,6 +129,9 @@ class BundleData:
     """Files components asked to include, keyed under DOMAIN in CORE.data."""
 
     extra_files: list[Path] = field(default_factory=list)
+    # Directories whose YAML files are scanned for !secret references but
+    # never bundled, e.g. git package checkouts the builder re-fetches.
+    secret_scan_dirs: set[Path] = field(default_factory=set)
     # Original config dir parsed from an extracted bundle's manifest.json,
     # kept in the path flavor of the machine the bundle was created on.
     # The checked flag makes the manifest lookup happen at most once per run;
@@ -153,6 +157,26 @@ def add_bundle_file(path: Path) -> None:
     config directory are skipped when the bundle is built.
     """
     _get_data().extra_files.append(CORE.relative_config_path(path))
+
+
+def add_secret_scan_dir(path: Path) -> None:
+    """Register a directory to scan for ``!secret`` references when bundling.
+
+    The directory's files are not added to the bundle. Components call this
+    for YAML the build consumes without bundling it — such as git-fetched
+    packages, which the builder re-fetches — so the secrets those files
+    reference are still shipped in the filtered secrets file.
+    """
+    _get_data().secret_scan_dirs.add(path)
+
+
+def _secret_scan_yaml_files() -> list[Path]:
+    """Return the YAML files inside registered secret-scan directories."""
+    return [
+        f
+        for scan_dir in _get_data().secret_scan_dirs
+        for f in filter_yaml_files(list(yaml_util.find_files(scan_dir, "*")))
+    ]
 
 
 # Windows paths start with a drive letter or contain backslashes; POSIX
@@ -310,6 +334,7 @@ class ConfigBundleCreator:
         yaml_sources = [
             bf.source for bf in files if bf.source.suffix in (".yaml", ".yml")
         ]
+        yaml_sources.extend(_secret_scan_yaml_files())
         used_secret_keys = _find_used_secret_keys(yaml_sources)
         filtered_secrets = self._build_filtered_secrets(used_secret_keys)
 
@@ -394,6 +419,13 @@ class ConfigBundleCreator:
         """
         discovered = yaml_util.discover_user_yaml_files(self._config_path)
         self._secrets_paths.update(discovered.secrets)
+        # A !secret inside a file this re-parse does not reach (for example
+        # a git-fetched package the builder re-fetches) still resolves
+        # against the config-dir secrets.yaml at build time, so always
+        # consider that file; filtering no-ops when no key matches.
+        default_secrets = self._config_dir / yaml_util.SECRET_YAML
+        if default_secrets.is_file():
+            self._secrets_paths.add(default_secrets.resolve())
         config_resolved = self._config_path.resolve()
         for fpath in discovered.files:
             if fpath == config_resolved:

--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -175,7 +175,7 @@ def _secret_scan_yaml_files() -> list[Path]:
     return [
         f
         for scan_dir in _get_data().secret_scan_dirs
-        for f in filter_yaml_files(list(yaml_util.find_files(scan_dir, "*")))
+        for f in filter_yaml_files(yaml_util.find_files(scan_dir, "*"))
     ]
 
 

--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -176,11 +176,11 @@ def add_secret_scan_dir(path: Path) -> None:
 
 def _secret_scan_yaml_files() -> list[Path]:
     """Return the YAML files inside registered secret-scan directories."""
-    return [
+    return filter_yaml_files(
         f
         for scan_dir in _get_data().secret_scan_dirs
-        for f in filter_yaml_files(yaml_util.find_files(scan_dir, "*"))
-    ]
+        for f in yaml_util.find_files(scan_dir, "*")
+    )
 
 
 # Windows paths start with a drive letter or contain backslashes; POSIX

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -192,10 +192,6 @@ def _process_remote_package(config: dict[str, Any]) -> dict[str, Any]:
         username=config.get(CONF_USERNAME),
         password=config.get(CONF_PASSWORD),
     )
-    # Deferred import: the device builder must not pay for esphome.bundle
-    # at startup, only when a config actually uses a remote package.
-    from esphome.bundle import add_secret_scan_dir
-
     files: list[dict[str, Any]] = []
 
     # ``repo_root`` is the directory containing ``.git`` and must be passed
@@ -205,11 +201,12 @@ def _process_remote_package(config: dict[str, Any]) -> dict[str, Any]:
     if base_path := config.get(CONF_PATH):
         repo_dir = repo_dir / base_path
 
-    # The checkout is not bundled (the builder re-fetches it), but the
-    # bundle's secrets filter must still see its !secret references. Register
-    # only the path-narrowed directory so example configs elsewhere in the
-    # repo do not widen the shipped secrets; an !include that reaches outside
-    # the package path is not scanned.
+    # Deferred import: keeps esphome.bundle off the device builder's
+    # startup path, since packages is loaded on every config parse.
+    from esphome.bundle import add_secret_scan_dir
+
+    # Register the path-narrowed dir, not repo_root, so example configs
+    # elsewhere in the repo do not widen the shipped secrets.
     add_secret_scan_dir(repo_dir)
 
     for file in config[CONF_FILES]:

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -196,9 +196,6 @@ def _process_remote_package(config: dict[str, Any]) -> dict[str, Any]:
     # at startup, only when a config actually uses a remote package.
     from esphome.bundle import add_secret_scan_dir
 
-    # The checkout is not bundled (the builder re-fetches it), but the
-    # bundle's secrets filter must still see its !secret references.
-    add_secret_scan_dir(repo_root)
     files: list[dict[str, Any]] = []
 
     # ``repo_root`` is the directory containing ``.git`` and must be passed
@@ -207,6 +204,13 @@ def _process_remote_package(config: dict[str, Any]) -> dict[str, Any]:
     repo_dir = repo_root
     if base_path := config.get(CONF_PATH):
         repo_dir = repo_dir / base_path
+
+    # The checkout is not bundled (the builder re-fetches it), but the
+    # bundle's secrets filter must still see its !secret references. Register
+    # only the path-narrowed directory so example configs elsewhere in the
+    # repo do not widen the shipped secrets; an !include that reaches outside
+    # the package path is not scanned.
+    add_secret_scan_dir(repo_dir)
 
     for file in config[CONF_FILES]:
         if isinstance(file, str):

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from esphome import git, yaml_util
+from esphome.bundle import add_secret_scan_dir
 from esphome.components.substitutions import (
     ContextVars,
     ErrList,
@@ -192,6 +193,9 @@ def _process_remote_package(config: dict[str, Any]) -> dict[str, Any]:
         username=config.get(CONF_USERNAME),
         password=config.get(CONF_PASSWORD),
     )
+    # The checkout is not bundled (the builder re-fetches it), but the
+    # bundle's secrets filter must still see its !secret references.
+    add_secret_scan_dir(repo_root)
     files: list[dict[str, Any]] = []
 
     # ``repo_root`` is the directory containing ``.git`` and must be passed

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 from esphome import git, yaml_util
-from esphome.bundle import add_secret_scan_dir
 from esphome.components.substitutions import (
     ContextVars,
     ErrList,
@@ -193,6 +192,10 @@ def _process_remote_package(config: dict[str, Any]) -> dict[str, Any]:
         username=config.get(CONF_USERNAME),
         password=config.get(CONF_PASSWORD),
     )
+    # Deferred import: the device builder must not pay for esphome.bundle
+    # at startup, only when a config actually uses a remote package.
+    from esphome.bundle import add_secret_scan_dir
+
     # The checkout is not bundled (the builder re-fetches it), but the
     # bundle's secrets filter must still see its !secret references.
     add_secret_scan_dir(repo_root)

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -1,5 +1,5 @@
 import collections
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 import io
 import logging
@@ -356,7 +356,7 @@ def list_yaml_files(configs: list[str | Path]) -> list[Path]:
     return sorted(files)
 
 
-def filter_yaml_files(files: list[Path]) -> list[Path]:
+def filter_yaml_files(files: Iterable[Path]) -> list[Path]:
     return [
         f
         for f in files

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 import functools
@@ -1015,8 +1015,8 @@ def _is_file_valid(name: str) -> bool:
     return not name.startswith(".")
 
 
-def find_files(directory: Path, pattern):
-    """Recursively load files in a directory."""
+def find_files(directory: Path, pattern: str) -> Iterator[Path]:
+    """Recursively find files in a directory matching *pattern*, skipping hidden entries."""
     for root, dirs, files in os.walk(directory):
         dirs[:] = [d for d in dirs if _is_file_valid(d)]
         for f in files:

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -791,12 +791,12 @@ class ESPHomeLoaderMixin:
 
     @_add_data_ref
     def construct_include_dir_list(self, node: yaml.Node) -> list[dict[str, Any]]:
-        files = filter_yaml_files(_find_files(self._rel_path(node.value), "*.yaml"))
+        files = filter_yaml_files(find_files(self._rel_path(node.value), "*.yaml"))
         return [self.yaml_loader(f) for f in files]
 
     @_add_data_ref
     def construct_include_dir_merge_list(self, node: yaml.Node) -> list[dict[str, Any]]:
-        files = filter_yaml_files(_find_files(self._rel_path(node.value), "*.yaml"))
+        files = filter_yaml_files(find_files(self._rel_path(node.value), "*.yaml"))
         merged_list = []
         for fname in files:
             loaded_yaml = self.yaml_loader(fname)
@@ -808,7 +808,7 @@ class ESPHomeLoaderMixin:
     def construct_include_dir_named(
         self, node: yaml.Node
     ) -> OrderedDict[str, dict[str, Any]]:
-        files = filter_yaml_files(_find_files(self._rel_path(node.value), "*.yaml"))
+        files = filter_yaml_files(find_files(self._rel_path(node.value), "*.yaml"))
         mapping = OrderedDict()
         for fname in files:
             filename = fname.stem
@@ -819,7 +819,7 @@ class ESPHomeLoaderMixin:
     def construct_include_dir_merge_named(
         self, node: yaml.Node
     ) -> OrderedDict[str, dict[str, Any]]:
-        files = filter_yaml_files(_find_files(self._rel_path(node.value), "*.yaml"))
+        files = filter_yaml_files(find_files(self._rel_path(node.value), "*.yaml"))
         mapping = OrderedDict()
         for fname in files:
             loaded_yaml = self.yaml_loader(fname)
@@ -1015,7 +1015,7 @@ def _is_file_valid(name: str) -> bool:
     return not name.startswith(".")
 
 
-def _find_files(directory: Path, pattern):
+def find_files(directory: Path, pattern):
     """Recursively load files in a directory."""
     for root, dirs, files in os.walk(directory):
         dirs[:] = [d for d in dirs if _is_file_valid(d)]

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -1705,20 +1705,24 @@ def test_remote_package_registers_checkout_for_secret_scan(
 
     The bundle's secrets filter must see !secret references inside
     git-fetched package files (issue 18023), so loading a remote package
-    registers its checkout directory with the bundle module.
+    registers its checkout directory with the bundle module. Only the
+    path-narrowed directory is registered, so example configs elsewhere
+    in the repo do not widen the shipped secrets.
     """
-    repo_dir = tmp_path / "repo"
-    repo_dir.mkdir()
-    (repo_dir / "base.yml").write_text(
+    repo_root = tmp_path / "repo"
+    package_dir = repo_root / "packages"
+    package_dir.mkdir(parents=True)
+    (package_dir / "base.yml").write_text(
         f"sensor:\n  - platform: {TEST_SENSOR_PLATFORM_1}\n    name: {TEST_SENSOR_NAME_1}\n"
     )
-    mock_clone_or_update.return_value = (repo_dir, None)
+    mock_clone_or_update.return_value = (repo_root, None)
 
     config = {
         CONF_PACKAGES: {
             "package1": {
                 CONF_URL: "https://github.com/esphome/non-existant-repo",
                 CONF_REF: "main",
+                CONF_PATH: "packages",
                 CONF_FILES: ["base.yml"],
                 CONF_REFRESH: "1d",
             }
@@ -1726,4 +1730,5 @@ def test_remote_package_registers_checkout_for_secret_scan(
     }
     packages_pass(config)
 
-    assert repo_dir in bundle._get_data().secret_scan_dirs
+    assert package_dir in bundle._get_data().secret_scan_dirs
+    assert repo_root not in bundle._get_data().secret_scan_dirs

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -1701,14 +1701,8 @@ def test_resolve_packages_does_not_apply_extend_remove() -> None:
 def test_remote_package_registers_checkout_for_secret_scan(
     mock_clone_or_update, tmp_path: Path
 ) -> None:
-    """Remote package checkouts are registered as bundle secret-scan dirs.
-
-    The bundle's secrets filter must see !secret references inside
-    git-fetched package files (issue 18023), so loading a remote package
-    registers its checkout directory with the bundle module. Only the
-    path-narrowed directory is registered, so example configs elsewhere
-    in the repo do not widen the shipped secrets.
-    """
+    """Loading a remote package registers its path-narrowed checkout dir
+    as a bundle secret-scan dir (issue 18023)."""
     repo_root = tmp_path / "repo"
     package_dir = repo_root / "packages"
     package_dir.mkdir(parents=True)

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from esphome import bundle
 from esphome.components.packages import (
     CONFIG_SCHEMA,
     _substitute_package_definition,
@@ -1694,3 +1695,35 @@ def test_resolve_packages_does_not_apply_extend_remove() -> None:
     # over the package value during merge), and the marker is not
     # resolved by this wrapper.
     assert isinstance(result[CONF_WIFI], Remove)
+
+
+@patch("esphome.git.clone_or_update")
+def test_remote_package_registers_checkout_for_secret_scan(
+    mock_clone_or_update, tmp_path: Path
+) -> None:
+    """Remote package checkouts are registered as bundle secret-scan dirs.
+
+    The bundle's secrets filter must see !secret references inside
+    git-fetched package files (issue 18023), so loading a remote package
+    registers its checkout directory with the bundle module.
+    """
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    (repo_dir / "base.yml").write_text(
+        f"sensor:\n  - platform: {TEST_SENSOR_PLATFORM_1}\n    name: {TEST_SENSOR_NAME_1}\n"
+    )
+    mock_clone_or_update.return_value = (repo_dir, None)
+
+    config = {
+        CONF_PACKAGES: {
+            "package1": {
+                CONF_URL: "https://github.com/esphome/non-existant-repo",
+                CONF_REF: "main",
+                CONF_FILES: ["base.yml"],
+                CONF_REFRESH: "1d",
+            }
+        }
+    }
+    packages_pass(config)
+
+    assert repo_dir in bundle._get_data().secret_scan_dirs

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -1653,13 +1653,8 @@ def test_create_bundle_filters_secrets_quoted(tmp_path: Path) -> None:
 
 
 def test_create_bundle_scans_remote_package_files_for_secrets(tmp_path: Path) -> None:
-    """Secrets referenced only by git-fetched package files must be shipped.
-
-    Regression test for issue 18023: remote package files are not bundled
-    (the builder re-fetches them), so their !secret references were never
-    scanned and the keys were stripped from the filtered secrets.yaml,
-    breaking the build on the remote builder.
-    """
+    """Secrets referenced only by git-fetched package files must be shipped
+    in the filtered secrets.yaml (regression test for issue 18023)."""
     config_dir = _setup_config_dir(tmp_path)
 
     secrets = config_dir / "secrets.yaml"

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -23,6 +23,7 @@ from esphome.bundle import (
     _default_target_dir,
     _find_used_secret_keys,
     add_bundle_file,
+    add_secret_scan_dir,
     extract_bundle,
     is_bundle_path,
     prepare_bundle_for_compile,
@@ -1649,6 +1650,49 @@ def test_create_bundle_filters_secrets_quoted(tmp_path: Path) -> None:
     assert "ota_password" in secrets_data
     assert "hunter2" in secrets_data
     assert "unused" not in secrets_data
+
+
+def test_create_bundle_scans_remote_package_files_for_secrets(tmp_path: Path) -> None:
+    """Secrets referenced only by git-fetched package files must be shipped.
+
+    Regression test for issue 18023: remote package files are not bundled
+    (the builder re-fetches them), so their !secret references were never
+    scanned and the keys were stripped from the filtered secrets.yaml,
+    breaking the build on the remote builder.
+    """
+    config_dir = _setup_config_dir(tmp_path)
+
+    secrets = config_dir / "secrets.yaml"
+    secrets.write_text("ota_password: hunter2\nunused: should_not_appear\n")
+
+    # Simulate a git-fetched package checkout referencing a secret
+    repo_dir = config_dir / ".esphome" / "packages" / "6bcd6aa8"
+    package_dir = repo_dir / "packages"
+    package_dir.mkdir(parents=True)
+    (package_dir / "base.yml").write_text(
+        "ota:\n  - platform: esphome\n    password: !secret ota_password\n"
+    )
+    # References inside hidden directories such as .git must not be scanned
+    hidden_dir = repo_dir / ".git"
+    hidden_dir.mkdir()
+    (hidden_dir / "leak.yaml").write_text("password: !secret unused\n")
+    add_secret_scan_dir(repo_dir)
+
+    creator = ConfigBundleCreator({})
+    result = creator.create_bundle()
+
+    assert result.manifest[ManifestKey.HAS_SECRETS] is True
+
+    buf = io.BytesIO(result.data)
+    with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+        secrets_data = tar.extractfile("secrets.yaml").read().decode()
+        names = tar.getnames()
+
+    assert "ota_password" in secrets_data
+    assert "hunter2" in secrets_data
+    assert "unused" not in secrets_data
+    # The package checkout itself must not be bundled
+    assert not any("base.yml" in name for name in names)
 
 
 def test_create_bundle_no_secrets(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -283,7 +283,7 @@ test: !include_dir_named test_dir
 
 
 def test_include_dir_list(tmp_path: Path) -> None:
-    """!include_dir_list loads every YAML file in the directory as a list."""
+    """!include_dir_list loads every .yaml file in the directory as a list."""
     test_dir = tmp_path / "test_dir"
     test_dir.mkdir()
     (test_dir / "a.yaml").write_text("key: value_a")
@@ -299,7 +299,7 @@ def test_include_dir_list(tmp_path: Path) -> None:
 
 
 def test_include_dir_merge_list(tmp_path: Path) -> None:
-    """!include_dir_merge_list concatenates the lists from every YAML file."""
+    """!include_dir_merge_list concatenates the lists from every .yaml file."""
     test_dir = tmp_path / "test_dir"
     test_dir.mkdir()
     (test_dir / "a.yaml").write_text("- item_a1\n- item_a2\n")
@@ -314,7 +314,7 @@ def test_include_dir_merge_list(tmp_path: Path) -> None:
 
 
 def test_include_dir_merge_named(tmp_path: Path) -> None:
-    """!include_dir_merge_named merges the mappings from every YAML file."""
+    """!include_dir_merge_named merges the mappings from every .yaml file."""
     test_dir = tmp_path / "test_dir"
     test_dir.mkdir()
     (test_dir / "a.yaml").write_text("key_a: value_a")

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -282,8 +282,54 @@ test: !include_dir_named test_dir
     assert ".hidden_dir" not in actual["test"]
 
 
+def test_include_dir_list(tmp_path: Path) -> None:
+    """!include_dir_list loads every YAML file in the directory as a list."""
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+    (test_dir / "a.yaml").write_text("key: value_a")
+    (test_dir / "b.yaml").write_text("key: value_b")
+
+    test_yaml = tmp_path / "test.yaml"
+    test_yaml.write_text("test: !include_dir_list test_dir\n")
+
+    actual = yaml_util.load_yaml(test_yaml)
+
+    assert len(actual["test"]) == 2
+    assert {entry["key"] for entry in actual["test"]} == {"value_a", "value_b"}
+
+
+def test_include_dir_merge_list(tmp_path: Path) -> None:
+    """!include_dir_merge_list concatenates the lists from every YAML file."""
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+    (test_dir / "a.yaml").write_text("- item_a1\n- item_a2\n")
+    (test_dir / "b.yaml").write_text("- item_b1\n")
+
+    test_yaml = tmp_path / "test.yaml"
+    test_yaml.write_text("test: !include_dir_merge_list test_dir\n")
+
+    actual = yaml_util.load_yaml(test_yaml)
+
+    assert sorted(actual["test"]) == ["item_a1", "item_a2", "item_b1"]
+
+
+def test_include_dir_merge_named(tmp_path: Path) -> None:
+    """!include_dir_merge_named merges the mappings from every YAML file."""
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+    (test_dir / "a.yaml").write_text("key_a: value_a")
+    (test_dir / "b.yaml").write_text("key_b: value_b")
+
+    test_yaml = tmp_path / "test.yaml"
+    test_yaml.write_text("test: !include_dir_merge_named test_dir\n")
+
+    actual = yaml_util.load_yaml(test_yaml)
+
+    assert actual["test"] == {"key_a": "value_a", "key_b": "value_b"}
+
+
 def test_find_files_recursive(fixture_path: Path, tmp_path: Path) -> None:
-    """Test that _find_files works recursively through include_dir_named."""
+    """Test that find_files works recursively through include_dir_named."""
     # Copy fixture directory to temporary location
     src_dir = fixture_path / "yaml_util"
     dst_dir = tmp_path / "yaml_util"


### PR DESCRIPTION
# What does this implement/fix?

When a config pulls packages from git, the bundle only scanned the YAML files it ships for `!secret` references. Package files fetched from git are not shipped, the builder fetches them again at build time, so a secret referenced only inside a package file was stripped from the filtered secrets.yaml and the remote build failed with `Secret 'ota_password' not defined`.

Loading a remote package now registers its checkout directory with the bundle module through a new `add_secret_scan_dir()` hook, mirroring the existing `add_bundle_file()`. Bundle creation scans YAML files in registered directories for `!secret` references without adding them to the bundle. The config directory secrets.yaml is also always considered for filtering; before, it was only picked up when a bundled file itself loaded a secret. `yaml_util._find_files` is now public `find_files` so the bundle can reuse its walk, which skips hidden directories such as `.git`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18023

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
packages:
  remote_package_files:
    url: https://github.com/PedroKTFC/esphome-tesla-ble/
    path: packages
    files:
      - base.yml
    ref: dev
    refresh: 60s
# base.yml contains "password: !secret ota_password", the key is now
# shipped in the bundle's filtered secrets.yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
