### PR TITLE
[libretiny] Give each platform its own CONFIG_SCHEMA instance

### DIFF
--- a/esphome/components/bk72xx/__init__.py
+++ b/esphome/components/bk72xx/__init__.py
@@ -51,7 +51,11 @@ def _set_core_data(config):
     return config
 
 
-CONFIG_SCHEMA = libretiny.BASE_SCHEMA
+# extend({}) makes this platform's own schema instance: BASE_SCHEMA is shared
+# by every LibreTiny platform, and prepending this platform's _set_core_data
+# onto the shared object would run it for every platform's validation once two
+# platform modules are imported in one process (device-builder, tests).
+CONFIG_SCHEMA = libretiny.BASE_SCHEMA.extend({})
 
 PIN_SCHEMA = libretiny.gpio.BASE_PIN_SCHEMA
 

--- a/esphome/components/libretiny/generate_components.py
+++ b/esphome/components/libretiny/generate_components.py
@@ -65,6 +65,10 @@ def _set_core_data(config):
     return config
 
 
+# extend({}) makes this platform's own schema instance: BASE_SCHEMA is shared
+# by every LibreTiny platform, and prepending this platform's _set_core_data
+# onto the shared object would run it for every platform's validation once two
+# platform modules are imported in one process (device-builder, tests).
 CONFIG_SCHEMA = {SCHEMA}
 
 PIN_SCHEMA = {PIN_SCHEMA}
@@ -117,7 +121,7 @@ VAR_GPIO_PIN = "validate_pin"
 VAR_GPIO_USAGE = "validate_usage"
 
 # lines for code snippets
-SCHEMA_BASE = "libretiny.BASE_SCHEMA"
+SCHEMA_BASE = "libretiny.BASE_SCHEMA.extend({})"
 SCHEMA_EXTRA = f"libretiny.BASE_SCHEMA.extend({VAR_SCHEMA})"
 PIN_SCHEMA_BASE = "libretiny.gpio.BASE_PIN_SCHEMA"
 PIN_SCHEMA_EXTRA = f"libretiny.BASE_PIN_SCHEMA.extend({VAR_PIN_SCHEMA})"

--- a/esphome/components/ln882x/__init__.py
+++ b/esphome/components/ln882x/__init__.py
@@ -51,7 +51,11 @@ def _set_core_data(config):
     return config
 
 
-CONFIG_SCHEMA = libretiny.BASE_SCHEMA
+# extend({}) makes this platform's own schema instance: BASE_SCHEMA is shared
+# by every LibreTiny platform, and prepending this platform's _set_core_data
+# onto the shared object would run it for every platform's validation once two
+# platform modules are imported in one process (device-builder, tests).
+CONFIG_SCHEMA = libretiny.BASE_SCHEMA.extend({})
 
 PIN_SCHEMA = libretiny.gpio.BASE_PIN_SCHEMA
 

--- a/esphome/components/rtl87xx/__init__.py
+++ b/esphome/components/rtl87xx/__init__.py
@@ -51,7 +51,11 @@ def _set_core_data(config):
     return config
 
 
-CONFIG_SCHEMA = libretiny.BASE_SCHEMA
+# extend({}) makes this platform's own schema instance: BASE_SCHEMA is shared
+# by every LibreTiny platform, and prepending this platform's _set_core_data
+# onto the shared object would run it for every platform's validation once two
+# platform modules are imported in one process (device-builder, tests).
+CONFIG_SCHEMA = libretiny.BASE_SCHEMA.extend({})
 
 PIN_SCHEMA = libretiny.gpio.BASE_PIN_SCHEMA
 

--- a/tests/unit_tests/components/test_libretiny.py
+++ b/tests/unit_tests/components/test_libretiny.py
@@ -77,7 +77,10 @@ def test_each_platform_resolves_its_own_boards() -> None:
     _set_core_data won for every platform, so known boards failed to resolve
     with "This board is unknown"."""
     CORE.data[KEY_CORE] = {}  # written by the schema's _update_core_data extra
-    ln882x.CONFIG_SCHEMA({CONF_BOARD: "generic-ln882h"})
-    assert CORE.data[KEY_LIBRETINY][KEY_COMPONENT_DATA] is ln882x.COMPONENT_DATA
-    bk72xx.CONFIG_SCHEMA({CONF_BOARD: "generic-bk7252"})
-    assert CORE.data[KEY_LIBRETINY][KEY_COMPONENT_DATA] is bk72xx.COMPONENT_DATA
+    for platform, board in (
+        (ln882x, "generic-ln882h"),
+        (bk72xx, "generic-bk7252"),
+        (rtl87xx, "generic-rtl8720cf-2mb-896k"),
+    ):
+        platform.CONFIG_SCHEMA({CONF_BOARD: board})
+        assert CORE.data[KEY_LIBRETINY][KEY_COMPONENT_DATA] is platform.COMPONENT_DATA

--- a/tests/unit_tests/components/test_libretiny.py
+++ b/tests/unit_tests/components/test_libretiny.py
@@ -50,3 +50,23 @@ def test_detect_variant_unknown_board_still_raises(ln882x_core_data: None) -> No
     """Ids outside the rename map keep the family-override error."""
     with pytest.raises(cv.Invalid, match="This board is unknown"):
         _detect_variant({CONF_BOARD: "not-a-real-board"})
+
+
+def test_platform_schemas_are_isolated_instances() -> None:
+    """Each LibreTiny platform must own its CONFIG_SCHEMA instance.
+
+    BASE_SCHEMA is shared; every platform prepends its own _set_core_data
+    extra. On the shared object, importing two platform modules in one process
+    made either platform's validation run both extras, so the wrong platform's
+    component data won and known boards failed to resolve.
+    """
+    from esphome.components import bk72xx, ln882x, rtl87xx
+    from esphome.components.libretiny import BASE_SCHEMA
+
+    schemas = [bk72xx.CONFIG_SCHEMA, ln882x.CONFIG_SCHEMA, rtl87xx.CONFIG_SCHEMA]
+    for schema in schemas:
+        assert schema is not BASE_SCHEMA
+    assert len({id(schema) for schema in schemas}) == len(schemas)
+    # The shared base must not have accumulated any platform's extra.
+    for extra in BASE_SCHEMA._extra_schemas:  # noqa: SLF001
+        assert getattr(extra, "__name__", "") != "_set_core_data"

--- a/tests/unit_tests/components/test_libretiny.py
+++ b/tests/unit_tests/components/test_libretiny.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from esphome.components.libretiny import _detect_variant
+from esphome.components import bk72xx, ln882x, rtl87xx
+from esphome.components.libretiny import BASE_SCHEMA, _detect_variant
 from esphome.components.libretiny.const import (
     FAMILY_LN882H,
     KEY_COMPONENT_DATA,
@@ -60,13 +61,9 @@ def test_platform_schemas_are_isolated_instances() -> None:
     made either platform's validation run both extras, so the wrong platform's
     component data won and known boards failed to resolve.
     """
-    from esphome.components import bk72xx, ln882x, rtl87xx
-    from esphome.components.libretiny import BASE_SCHEMA
-
-    schemas = [bk72xx.CONFIG_SCHEMA, ln882x.CONFIG_SCHEMA, rtl87xx.CONFIG_SCHEMA]
-    for schema in schemas:
-        assert schema is not BASE_SCHEMA
-    assert len({id(schema) for schema in schemas}) == len(schemas)
+    platforms = (bk72xx, ln882x, rtl87xx)
+    schemas = [platform.CONFIG_SCHEMA for platform in platforms]
+    assert len({id(schema) for schema in (BASE_SCHEMA, *schemas)}) == 4
     # The shared base must not have accumulated any platform's extra.
-    for extra in BASE_SCHEMA._extra_schemas:  # noqa: SLF001
-        assert getattr(extra, "__name__", "") != "_set_core_data"
+    for platform in platforms:
+        assert platform._set_core_data not in BASE_SCHEMA._extra_schemas  # noqa: SLF001

--- a/tests/unit_tests/components/test_libretiny.py
+++ b/tests/unit_tests/components/test_libretiny.py
@@ -12,7 +12,7 @@ from esphome.components.libretiny.const import (
 from esphome.components.ln882x import COMPONENT_DATA
 import esphome.config_validation as cv
 from esphome.const import CONF_BOARD, CONF_FAMILY
-from esphome.core import CORE
+from esphome.core import CORE, KEY_CORE
 
 
 @pytest.fixture
@@ -65,5 +65,19 @@ def test_platform_schemas_are_isolated_instances() -> None:
     schemas = [platform.CONFIG_SCHEMA for platform in platforms]
     assert len({id(schema) for schema in (BASE_SCHEMA, *schemas)}) == 4
     # The shared base must not have accumulated any platform's extra.
+    # prepend_extra wraps validators in _Schema, so unwrap before comparing.
+    base_extras = [extra.schema for extra in BASE_SCHEMA._extra_schemas]
     for platform in platforms:
-        assert platform._set_core_data not in BASE_SCHEMA._extra_schemas  # noqa: SLF001
+        assert platform._set_core_data not in base_extras
+
+
+def test_each_platform_resolves_its_own_boards() -> None:
+    """Validating one platform's config must leave that platform's component
+    data in CORE.data. On the shared schema, the last-imported platform's
+    _set_core_data won for every platform, so known boards failed to resolve
+    with "This board is unknown"."""
+    CORE.data[KEY_CORE] = {}  # written by the schema's _update_core_data extra
+    ln882x.CONFIG_SCHEMA({CONF_BOARD: "generic-ln882h"})
+    assert CORE.data[KEY_LIBRETINY][KEY_COMPONENT_DATA] is ln882x.COMPONENT_DATA
+    bk72xx.CONFIG_SCHEMA({CONF_BOARD: "generic-bk7252"})
+    assert CORE.data[KEY_LIBRETINY][KEY_COMPONENT_DATA] is bk72xx.COMPONENT_DATA


### PR DESCRIPTION
# What does this implement/fix?

The three LibreTiny platforms (bk72xx, ln882x, rtl87xx) assign CONFIG_SCHEMA to the shared libretiny BASE_SCHEMA object and then prepend their own _set_core_data validator onto it. Because the object is shared, importing two platform modules in the same process leaves both validators on one schema, so validating either platform also runs the other platform's _set_core_data; the wrong platform's component data wins and known boards fail to resolve. Any long lived process that touches configs for two LibreTiny families hits this, for example the device builder, the dashboard, or a pytest session.

Each platform now extends BASE_SCHEMA into its own instance before prepending; extend copies the extras list, so the platform validator stays on the platform's schema. A regression test pins that the three schemas are distinct objects and that the shared base carries no platform validator.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
fixes https://github.com/esphome/device-builder/issues/2541

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

bk72xx:
  board: generic-bk7252
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
