### PR TITLE
feature: ability to remap 7219 segments and digits

### DIFF
--- a/esphome/components/max7219/display.py
+++ b/esphome/components/max7219/display.py
@@ -12,6 +12,8 @@ MAX7219Component = max7219_ns.class_(
 MAX7219ComponentRef = MAX7219Component.operator("ref")
 
 CONF_REVERSE_ENABLE = "reverse_enable"
+CONF_BITMAPPING = "bit_mapping"
+CONF_DIGIT_MAPPING = "digit_mapping"
 
 CONFIG_SCHEMA = (
     display.BASIC_DISPLAY_SCHEMA.extend(
@@ -20,6 +22,12 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_NUM_CHIPS, default=1): cv.int_range(min=1, max=255),
             cv.Optional(CONF_INTENSITY, default=15): cv.int_range(min=0, max=15),
             cv.Optional(CONF_REVERSE_ENABLE, default=False): cv.boolean,
+            cv.Optional(CONF_BITMAPPING, default=[0, 1, 2, 3, 4, 5, 6, 7]): cv.All(
+                cv.ensure_list(cv.int_range(min=0, max=7)), cv.Length(min=8, max=8)
+            ),
+            cv.Optional(CONF_DIGIT_MAPPING, default=list(range(256))): cv.All(
+                cv.ensure_list(cv.int_range(min=0, max=255)), cv.Length(min=8, max=256)
+            ),
         }
     )
     .extend(cv.polling_component_schema("1s"))
@@ -34,6 +42,8 @@ async def to_code(config):
 
     cg.add(var.set_intensity(config[CONF_INTENSITY]))
     cg.add(var.set_reverse(config[CONF_REVERSE_ENABLE]))
+    cg.add(var.set_bitmapping(config[CONF_BITMAPPING]))
+    cg.add(var.set_digitmapping(config[CONF_DIGIT_MAPPING]))
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(

--- a/esphome/components/max7219/max7219.cpp
+++ b/esphome/components/max7219/max7219.cpp
@@ -146,11 +146,8 @@ void MAX7219Component::display() {
   for (uint8_t i = 0; i < 8; i++) {
     this->enable();
     for (uint8_t j = 0; j < this->num_chips_; j++) {
-      if (reverse_) {
-        this->send_byte_(8 - i, buffer_[(num_chips_ - j - 1) * 8 + i]);
-      } else {
-        this->send_byte_(8 - i, buffer_[j * 8 + i]);
-      }
+      this->send_byte_(8 - i, reverse_ ? this->byte_mapping[buffer_[this->digit_mapping[(num_chips_ - j - 1) * 8 + i]]] 
+                                       : this->byte_mapping[buffer_[this->digit_mapping[j * 8 + i]]]);
     }
     this->disable();
   }
@@ -230,6 +227,23 @@ void MAX7219Component::set_intensity(uint8_t intensity) {
     this->intensity_ = intensity;
   }
 }
+void MAX7219Component::set_bitmapping(const std::array<uint8_t, 8> &bitmapping) { 
+  for (uint16_t u = 0 ; u < 256 ; u++) {
+    this->byte_mapping[u] = 0;
+    for (uint8_t i = 0 ; i < 8 ; i++) {
+      if (u & (1 << i)) {
+        this->byte_mapping[u] |= (1 << bitmapping[i]);
+      }
+    }
+  }
+ }
+
+void MAX7219Component::set_digitmapping(const std::vector<uint8_t> &digitmapping) {
+  for (uint16_t u = 0 ; u < digitmapping.size() ; u++) {
+    this->digit_mapping[u] = digitmapping[u];
+  }
+}
+
 
 uint8_t MAX7219Component::strftime(uint8_t pos, const char *format, ESPTime time) {
   char buffer[64];

--- a/esphome/components/max7219/max7219.cpp
+++ b/esphome/components/max7219/max7219.cpp
@@ -146,7 +146,7 @@ void MAX7219Component::display() {
   for (uint8_t i = 0; i < 8; i++) {
     this->enable();
     for (uint8_t j = 0; j < this->num_chips_; j++) {
-      this->send_byte_(8 - i, reverse_ ? this->byte_mapping[buffer_[this->digit_mapping[(num_chips_ - j - 1) * 8 + i]]] 
+      this->send_byte_(8 - i, reverse_ ? this->byte_mapping[buffer_[this->digit_mapping[(num_chips_ - j - 1) * 8 + i]]]
                                        : this->byte_mapping[buffer_[this->digit_mapping[j * 8 + i]]]);
     }
     this->disable();
@@ -227,23 +227,22 @@ void MAX7219Component::set_intensity(uint8_t intensity) {
     this->intensity_ = intensity;
   }
 }
-void MAX7219Component::set_bitmapping(const std::array<uint8_t, 8> &bitmapping) { 
-  for (uint16_t u = 0 ; u < 256 ; u++) {
+void MAX7219Component::set_bitmapping(const std::array<uint8_t, 8> &bitmapping) {
+  for (uint16_t u = 0; u < 256; u++) {
     this->byte_mapping[u] = 0;
-    for (uint8_t i = 0 ; i < 8 ; i++) {
+    for (uint8_t i = 0; i < 8; i++) {
       if (u & (1 << i)) {
         this->byte_mapping[u] |= (1 << bitmapping[i]);
       }
     }
   }
- }
+}
 
 void MAX7219Component::set_digitmapping(const std::vector<uint8_t> &digitmapping) {
-  for (uint16_t u = 0 ; u < digitmapping.size() ; u++) {
+  for (uint16_t u = 0; u < digitmapping.size(); u++) {
     this->digit_mapping[u] = digitmapping[u];
   }
 }
-
 
 uint8_t MAX7219Component::strftime(uint8_t pos, const char *format, ESPTime time) {
   char buffer[64];

--- a/esphome/components/max7219/max7219.h
+++ b/esphome/components/max7219/max7219.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <array>
+#include <vector>
+
 #include "esphome/core/component.h"
 #include "esphome/core/time.h"
 
@@ -31,7 +34,10 @@ class MAX7219Component final : public PollingComponent,
   void display();
 
   void set_intensity(uint8_t intensity);
+  void set_bitmapping(const std::array<uint8_t, 8> &bitmapping);
+  void set_digitmapping(const std::vector<uint8_t> &digitmapping);
   void set_reverse(bool reverse) { this->reverse_ = reverse; };
+
 
   /// Evaluate the printf-format and print the result at the given position.
   uint8_t printf(uint8_t pos, const char *format, ...) __attribute__((format(printf, 3, 4)));
@@ -58,6 +64,9 @@ class MAX7219Component final : public PollingComponent,
   uint8_t num_chips_{1};
   uint8_t *buffer_{nullptr};
   bool reverse_{false};
+
+  uint8_t byte_mapping[256] ;
+  uint8_t digit_mapping[256] ;
   max7219_writer_t writer_{};
 };
 

--- a/esphome/components/max7219/max7219.h
+++ b/esphome/components/max7219/max7219.h
@@ -38,7 +38,6 @@ class MAX7219Component final : public PollingComponent,
   void set_digitmapping(const std::vector<uint8_t> &digitmapping);
   void set_reverse(bool reverse) { this->reverse_ = reverse; };
 
-
   /// Evaluate the printf-format and print the result at the given position.
   uint8_t printf(uint8_t pos, const char *format, ...) __attribute__((format(printf, 3, 4)));
   /// Evaluate the printf-format and print the result at position 0.
@@ -65,8 +64,8 @@ class MAX7219Component final : public PollingComponent,
   uint8_t *buffer_{nullptr};
   bool reverse_{false};
 
-  uint8_t byte_mapping[256] ;
-  uint8_t digit_mapping[256] ;
+  uint8_t byte_mapping[256];
+  uint8_t digit_mapping[256];
   max7219_writer_t writer_{};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

This feature adds the ability to shuffle segments and digits to cope for non-standard connections to the digits.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A
## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: max7219
    data_rate: 5MHz
    cs_pin:
      number: GPIO5
      ignore_strapping_warning: true
    num_chips: 1
    bit_mapping: [2,3,5,6,1,7,4,0]
    digit_mapping: [2,5,1,6,3,4,0,7]
    lambda: |-
      static int cycle ;
      static bool blink=false ;

      it.print("        ");
      switch ((++cycle/10)%4) {
        case 0:
          it.printf(2, "%4.1f C", id(temperature_sensor).state);
          break ;
        case 1:
          it.printf(1, "%3.0f rH", id(humidity_sensor).state);
          break ;
        case 2:
        case 3:
          it.strftime(2, blink?"%H.%M":"%H%M", id(homeassistant_time).now());
          break ;
      }
      blink = !blink ;


```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
