### PR TITLE
[i2s_audio] Remove internal ADC/DAC and stand_max options that final validation always rejects

### DIFF
--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -236,15 +236,15 @@ def _assign_ports() -> None:
     i2s_configs = full_config[CONF_I2S_AUDIO]
 
     # Find i2s_audio instances with microphones that require port 0
-    # (PDM and internal ADC only work on I2S port 0)
+    # (PDM only works on I2S port 0)
     port0_parent_id = None
     for mic_config in full_config.get("microphone", []):
         if CONF_I2S_AUDIO_ID not in mic_config:
             continue
-        if mic_config.get(CONF_PDM) or mic_config.get(CONF_ADC_TYPE) == "internal":
+        if mic_config.get(CONF_PDM):
             if port0_parent_id is not None:
                 raise cv.Invalid(
-                    "Only one PDM/ADC microphone is supported (requires I2S port 0)"
+                    "Only one PDM microphone is supported (requires I2S port 0)"
                 )
             port0_parent_id = str(mic_config[CONF_I2S_AUDIO_ID])
 

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -1,7 +1,6 @@
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import audio, esp32, microphone
-from esphome.components.adc import validate_adc_pin
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BITS_PER_SAMPLE,
@@ -29,14 +28,12 @@ from .. import (
 CODEOWNERS = ["@jesserockz"]
 DEPENDENCIES = ["i2s_audio"]
 
-CONF_ADC_PIN = "adc_pin"
 CONF_CORRECT_DC_OFFSET = "correct_dc_offset"
 
 I2SAudioMicrophone = i2s_audio_ns.class_(
     "I2SAudioMicrophone", I2SAudioIn, microphone.Microphone, cg.Component
 )
 
-INTERNAL_ADC_VARIANTS = [esp32.VARIANT_ESP32]
 PDM_VARIANTS = [esp32.VARIANT_ESP32, esp32.VARIANT_ESP32S3, esp32.VARIANT_ESP32P4]
 
 i2s_pdm_dsr_t = cg.global_ns.enum("i2s_pdm_dsr_t")
@@ -48,21 +45,15 @@ I2S_PDM_DSR = {
 
 def _validate_esp32_variant(config):
     variant = esp32.get_esp32_variant()
-    if config[CONF_ADC_TYPE] == "external":
-        if config[CONF_PDM] and variant not in PDM_VARIANTS:
-            raise cv.Invalid(f"{variant} does not support PDM")
-        if (
-            variant == esp32.VARIANT_ESP32
-            and config.get(CONF_BITS_PER_SAMPLE) == 8
-            and config.get(CONF_CHANNEL) in (CONF_LEFT, CONF_RIGHT)
-        ):
-            raise cv.Invalid("8-bit mono mode is not supported on ESP32")
-        return config
-    if config[CONF_ADC_TYPE] == "internal":
-        if variant not in INTERNAL_ADC_VARIANTS:
-            raise cv.Invalid(f"{variant} does not have an internal ADC")
-        return config
-    raise NotImplementedError
+    if config[CONF_PDM] and variant not in PDM_VARIANTS:
+        raise cv.Invalid(f"{variant} does not support PDM")
+    if (
+        variant == esp32.VARIANT_ESP32
+        and config.get(CONF_BITS_PER_SAMPLE) == 8
+        and config.get(CONF_CHANNEL) in (CONF_LEFT, CONF_RIGHT)
+    ):
+        raise cv.Invalid("8-bit mono mode is not supported on ESP32")
+    return config
 
 
 def _validate_channel(config):
@@ -109,11 +100,6 @@ BASE_SCHEMA = microphone.MICROPHONE_SCHEMA.extend(
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
         {
-            "internal": BASE_SCHEMA.extend(
-                {
-                    cv.Required(CONF_ADC_PIN): validate_adc_pin,
-                }
-            ),
             "external": BASE_SCHEMA.extend(
                 {
                     cv.Required(CONF_I2S_DIN_PIN): pins.internal_gpio_input_pin_number,
@@ -132,16 +118,6 @@ CONFIG_SCHEMA = cv.All(
     _set_stream_limits,
     validate_mclk_divisible_by_3,
 )
-
-
-def _final_validate(config):
-    if config[CONF_ADC_TYPE] == "internal":
-        raise cv.Invalid(
-            "Internal ADC is no longer supported. Use an external I2S microphone instead."
-        )
-
-
-FINAL_VALIDATE_SCHEMA = _final_validate
 
 
 async def to_code(config):

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -7,7 +7,6 @@ from esphome.const import (
     CONF_BUFFER_DURATION,
     CONF_CHANNEL,
     CONF_ID,
-    CONF_MODE,
     CONF_NEVER,
     CONF_NUM_CHANNELS,
     CONF_SAMPLE_RATE,
@@ -54,28 +53,18 @@ I2SCommFmt = i2s_audio_ns.enum("I2SCommFmt", is_class=True)
 
 I2SCommFmt = i2s_audio_ns.enum("I2SCommFmt", is_class=True)
 
-i2s_dac_mode_t = cg.global_ns.enum("i2s_dac_mode_t")
-INTERNAL_DAC_OPTIONS = {
-    CONF_LEFT: i2s_dac_mode_t.I2S_DAC_CHANNEL_LEFT_EN,
-    CONF_RIGHT: i2s_dac_mode_t.I2S_DAC_CHANNEL_RIGHT_EN,
-    CONF_STEREO: i2s_dac_mode_t.I2S_DAC_CHANNEL_BOTH_EN,
-}
-
 i2s_comm_format_t = cg.global_ns.enum("i2s_comm_format_t")
 I2C_COMM_FMT_OPTIONS = {
     "stand_i2s": i2s_comm_format_t.I2S_COMM_FORMAT_STAND_I2S,
     "stand_msb": i2s_comm_format_t.I2S_COMM_FORMAT_STAND_MSB,
     "stand_pcm_short": i2s_comm_format_t.I2S_COMM_FORMAT_STAND_PCM_SHORT,
     "stand_pcm_long": i2s_comm_format_t.I2S_COMM_FORMAT_STAND_PCM_LONG,
-    "stand_max": i2s_comm_format_t.I2S_COMM_FORMAT_STAND_MAX,
     "i2s_msb": i2s_comm_format_t.I2S_COMM_FORMAT_I2S_MSB,
     "i2s_lsb": i2s_comm_format_t.I2S_COMM_FORMAT_I2S_LSB,
     "pcm": i2s_comm_format_t.I2S_COMM_FORMAT_PCM,
     "pcm_short": i2s_comm_format_t.I2S_COMM_FORMAT_PCM_SHORT,
     "pcm_long": i2s_comm_format_t.I2S_COMM_FORMAT_PCM_LONG,
 }
-
-INTERNAL_DAC_VARIANTS = [esp32.VARIANT_ESP32]
 
 
 def _set_num_channels_from_config(config):
@@ -142,10 +131,7 @@ def _select_speaker_class(config):
 
 def _validate_esp32_variant(config):
     variant = esp32.get_esp32_variant()
-    if config[CONF_DAC_TYPE] == "internal":
-        if variant not in INTERNAL_DAC_VARIANTS:
-            raise cv.Invalid(f"{variant} does not have an internal DAC")
-    elif variant == esp32.VARIANT_ESP32 and config[CONF_BITS_PER_SAMPLE] == 8:
+    if variant == esp32.VARIANT_ESP32 and config[CONF_BITS_PER_SAMPLE] == 8:
         # The original ESP32 I2S peripheral packs each sample into a whole number of 16-bit words, so an
         # 8-bit slot does not line up with ESPHome's tightly packed audio (see start_i2s_driver). Reject it
         # at config time rather than emitting corrupted output at runtime.
@@ -180,11 +166,6 @@ BASE_SCHEMA = (
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
         {
-            "internal": BASE_SCHEMA.extend(
-                {
-                    cv.Required(CONF_MODE): cv.enum(INTERNAL_DAC_OPTIONS, lower=True),
-                }
-            ),
             "external": BASE_SCHEMA.extend(
                 {
                     cv.Required(
@@ -208,13 +189,6 @@ CONFIG_SCHEMA = cv.All(
 
 
 def _final_validate(config):
-    if config[CONF_DAC_TYPE] == "internal":
-        raise cv.Invalid(
-            "Internal DAC is no longer supported. Use an external I2S DAC instead."
-        )
-    if config[CONF_I2S_COMM_FMT] == "stand_max":
-        raise cv.Invalid("I2S standard max format is no longer supported.")
-
     if config.get(CONF_SPDIF_MODE, False):
         # SPDIF mode specific validations
         if config[CONF_SAMPLE_RATE] not in [44100, 48000]:

--- a/tests/component_tests/i2s_audio/test_i2s_audio.py
+++ b/tests/component_tests/i2s_audio/test_i2s_audio.py
@@ -1,0 +1,56 @@
+"""Tests for the i2s_audio microphone and speaker schemas."""
+
+import pytest
+
+from esphome.components.esp32 import KEY_BOARD, KEY_VARIANT, VARIANT_ESP32S3
+import esphome.config_validation as cv
+from esphome.const import CONF_ESPHOME, PlatformFramework
+from tests.component_tests.types import SetCoreConfigCallable
+
+
+@pytest.fixture
+def set_esp32_s3(set_core_config: SetCoreConfigCallable) -> None:
+    set_core_config(
+        PlatformFramework.ESP32_IDF,
+        platform_data={KEY_BOARD: "esp32-s3-devkitc-1", KEY_VARIANT: VARIANT_ESP32S3},
+        full_config={CONF_ESPHOME: {}},
+    )
+
+
+def test_microphone_rejects_internal_adc_type(set_esp32_s3: None) -> None:
+    """adc_type: internal was removed with the legacy I2S driver and is no longer in the schema."""
+    from esphome.components.i2s_audio.microphone import CONFIG_SCHEMA
+
+    with pytest.raises(cv.Invalid, match=r"Unknown value 'internal'"):
+        CONFIG_SCHEMA({"adc_type": "internal", "adc_pin": "GPIO32"})
+
+
+def test_speaker_rejects_internal_dac_type(set_esp32_s3: None) -> None:
+    """dac_type: internal was removed with the legacy I2S driver and is no longer in the schema."""
+    from esphome.components.i2s_audio.speaker import CONFIG_SCHEMA
+
+    with pytest.raises(cv.Invalid, match=r"Unknown value 'internal'"):
+        CONFIG_SCHEMA({"dac_type": "internal", "mode": "mono"})
+
+
+def test_speaker_rejects_stand_max_comm_fmt(set_esp32_s3: None) -> None:
+    """i2s_comm_fmt: stand_max was removed with the legacy I2S driver and is no longer in the schema."""
+    from esphome.components.i2s_audio.speaker import CONFIG_SCHEMA
+
+    with pytest.raises(cv.Invalid, match=r"Unknown value 'stand_max'"):
+        CONFIG_SCHEMA(
+            {"dac_type": "external", "i2s_dout_pin": 5, "i2s_comm_fmt": "stand_max"}
+        )
+
+
+def test_external_schemas_still_validate(set_esp32_s3: None) -> None:
+    """The surviving external variants still pass schema validation."""
+    from esphome.components.i2s_audio.microphone import (
+        CONFIG_SCHEMA as MIC_CONFIG_SCHEMA,
+    )
+    from esphome.components.i2s_audio.speaker import (
+        CONFIG_SCHEMA as SPEAKER_CONFIG_SCHEMA,
+    )
+
+    MIC_CONFIG_SCHEMA({"adc_type": "external", "i2s_din_pin": 4, "channel": "left"})
+    SPEAKER_CONFIG_SCHEMA({"dac_type": "external", "i2s_dout_pin": 5})


### PR DESCRIPTION
# What does this implement/fix?

Since 2026.4.0 removed the legacy I2S driver (#14932), `_final_validate` unconditionally rejects `adc_type: internal` (microphone), `dac_type: internal` (speaker), and `i2s_comm_fmt: stand_max` (speaker) on every chip. The typed schemas and the comm-format enum still declared those options, so they kept shipping in the schema bundle that `script/build_language_schema.py` publishes to schema.esphome.io, and every schema consumer keeps offering options that can never validate — the Device Builder component catalog hit this in esphome/device-builder#2451.

This removes the dead branches so the schema matches what actually validates:

- `microphone/__init__.py`: drop the `internal` typed-schema branch (and with it `adc_pin`, `INTERNAL_ADC_VARIANTS`, the `validate_adc_pin` import), flatten `_validate_esp32_variant` to the external-only checks, and delete the now-unreachable `_final_validate`.
- `speaker/__init__.py`: drop the `internal` typed-schema branch (and `INTERNAL_DAC_OPTIONS`, `INTERNAL_DAC_VARIANTS`, the `CONF_MODE` import), drop `stand_max` from `I2C_COMM_FMT_OPTIONS`, and delete the two unconditional rejections from `_final_validate` (the SPDIF checks stay).
- `__init__.py`: `_assign_ports` no longer checks for the now-impossible `adc_type: internal` when picking the port-0 microphone.

Instead of the misleading schema-stage message on newer chips ("ESP32S3 does not have an internal ADC", implying it works elsewhere) followed by the unconditional final-validation rejection, users now get a normal enum error on every chip: `Unknown value 'internal', did you mean 'external'?` / `Unknown value 'stand_max', did you mean 'stand_msb', 'stand_i2s', 'stand_pcm_long'?`.

No functional change: every removed option was already rejected before codegen, and no test config in the repo used any of them. esphome.io already documents only `external` and does not list `stand_max`, so the schema now matches the docs. Once the published schema bundle stops carrying the options, downstream catalogs heal on their own.

Verification (all on Python 3.14):

- New `tests/component_tests/i2s_audio/test_i2s_audio.py`: the three removed options are rejected at schema stage and the surviving `external` schemas still validate.
- `pytest tests/component_tests/` — 932 passed.
- `script/build_language_schema.py` runs clean; in the generated `i2s_audio.json` both typed schemas offer only `external` and `stand_max` is gone from the `i2s_comm_fmt` enum.
- ruff check/format, flake8, and `script/ci-custom.py` pass on the changed files.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17948
- downstream motivation: esphome/device-builder#2451

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A — esphome.io already documents only the `external` variants and does not list `stand_max`; this change brings the schema in line with the docs.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Config-validation-only change; no firmware behavior is affected, so I did not flash hardware. Verified via the component tests and schema bundle build described above.

## Example entry for `config.yaml`:

```yaml
# No new configuration. The removed values were already rejected by final validation, e.g.:
#
# microphone:
#   - platform: i2s_audio
#     adc_type: internal   # previously "Internal ADC is no longer supported...",
#                          # now "Unknown value 'internal', did you mean 'external'?"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
