### PR TITLE
[waveshare_epaper] Fix partial refreshes on deep-sleeping devices and 1.54inV2

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -115,8 +115,27 @@ void WaveshareEPaperBase::setup() {
   this->setup_pins_();
   this->spi_setup();
   this->reset_();
+  this->restore_update_counter_();
   this->initialize();
 }
+void WaveshareEPaperBase::restore_update_counter_() {
+  // at_update_ decides whether the next refresh uses the full or the partial
+  // waveform. Without persistence it restarts at 0 after every deep sleep, so
+  // a device that sleeps between refreshes takes the full-refresh path every
+  // time and full_update_every never takes effect.
+  // Displays are not entities, so there is no entity preference helper here.
+  // The DC pin summary discriminates between several displays in one
+  // configuration and stays stable across builds as long as the wiring does.
+  char pin_summary[64];
+  this->dc_pin_->dump_summary(pin_summary, sizeof(pin_summary));
+  const uint32_t hash = fnv1_hash(std::string("waveshare_epaper_at_update_") + pin_summary);
+  this->update_counter_pref_ = global_preferences->make_preference<uint32_t>(hash, true);
+  uint32_t at_update = 0;
+  if (this->update_counter_pref_.load(&at_update)) {
+    this->at_update_ = at_update;
+  }
+}
+void WaveshareEPaperBase::save_update_counter_() { this->update_counter_pref_.save(&this->at_update_); }
 void WaveshareEPaperBase::setup_pins_() {
   this->dc_pin_->setup();  // OUTPUT
   this->dc_pin_->digital_write(false);
@@ -169,6 +188,7 @@ bool WaveshareEPaperBase::wait_until_idle_() {
 void WaveshareEPaperBase::update() {
   this->do_update_();
   this->display();
+  this->save_update_counter_();
 }
 void WaveshareEPaper::fill(Color color) {
   // If clipping is active, fall back to base implementation

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -680,7 +680,7 @@ void HOT WaveshareEPaperTypeA::display() {
   }
   this->end_data_();
 
-  if (this->model_ == WAVESHARE_EPAPER_2_13_IN_V2 && full_update) {
+  if ((this->model_ == WAVESHARE_EPAPER_2_13_IN_V2 || this->model_ == WAVESHARE_EPAPER_1_54_IN_V2) && full_update) {
     // Write base image again on full refresh
     this->command(0x26);
     this->start_data_();

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/display/display_buffer.h"
 
@@ -32,6 +33,20 @@ class WaveshareEPaperBase : public display::DisplayBuffer,
 
  protected:
   bool wait_until_idle_();
+
+  /** Partial-refresh cycle counter.
+   *
+   * Models that support partial refreshes compare this against
+   * full_update_every_ to pick the waveform for the next refresh. It is
+   * persisted so the cycle survives deep sleep; see restore_update_counter_().
+   */
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+
+  void restore_update_counter_();
+  void save_update_counter_();
+
+  ESPPreferenceObject update_counter_pref_;
 
   void setup_pins_();
 
@@ -162,8 +177,6 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
 
   int get_width_controller() override;
 
-  uint32_t full_update_every_{30};
-  uint32_t at_update_{0};
   WaveshareEPaperTypeAModel model_;
   uint32_t idle_timeout_() override;
 
@@ -286,8 +299,6 @@ class GDEW029T5 : public WaveshareEPaper {
   int get_height_internal() override;
 
  private:
-  uint32_t full_update_every_{30};
-  uint32_t at_update_{0};
   bool deep_sleep_between_updates_{false};
   bool power_is_on_{false};
   bool is_deep_sleep_{false};
@@ -432,8 +443,6 @@ class WaveshareEPaper2P9InV2R2 : public WaveshareEPaper {
 
   int get_width_controller() override;
 
-  uint32_t full_update_every_{30};
-  uint32_t at_update_{0};
 
  private:
   void reset_();
@@ -456,8 +465,6 @@ class WaveshareEPaper2P9InDKE : public WaveshareEPaper {
   void set_full_update_every(uint32_t full_update_every);
 
  protected:
-  uint32_t full_update_every_{30};
-  uint32_t at_update_{0};
   int get_width_internal() override;
 
   int get_height_internal() override;
@@ -506,8 +513,6 @@ class GDEY042T81 : public WaveshareEPaper {
   void set_full_update_every(uint32_t full_update_every);
 
  protected:
-  uint32_t full_update_every_{30};
-  uint32_t at_update_{0};
 
   int get_width_internal() override;
   int get_height_internal() override;
@@ -712,8 +717,6 @@ class GDEY0583T81 : public WaveshareEPaper {
   void init_partial_();
   void init_display_();
 
-  uint32_t full_update_every_{30};
-  uint32_t at_update_{0};
   bool power_is_on_{false};
   bool is_deep_sleep_{false};
   uint8_t *old_buffer_{nullptr};
@@ -983,8 +986,6 @@ class WaveshareEPaper7P5InV2P : public WaveshareEPaper {
 
   uint32_t idle_timeout_() override;
 
-  uint32_t full_update_every_{30};
-  uint32_t at_update_{0};
 
  private:
   void reset_();
@@ -1036,8 +1037,6 @@ class WaveshareEPaper2P13InDKE : public WaveshareEPaper {
 
   uint32_t idle_timeout_() override;
 
-  uint32_t full_update_every_{30};
-  uint32_t at_update_{0};
 };
 
 class WaveshareEPaper2P13InV3 : public WaveshareEPaper {
@@ -1070,8 +1069,6 @@ class WaveshareEPaper2P13InV3 : public WaveshareEPaper {
   void partial_update_();
   void full_update_();
 
-  uint32_t full_update_every_{30};
-  uint32_t at_update_{0};
   bool is_busy_{false};
   void write_lut_(const uint8_t *lut);
 };

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -443,7 +443,6 @@ class WaveshareEPaper2P9InV2R2 : public WaveshareEPaper {
 
   int get_width_controller() override;
 
-
  private:
   void reset_();
 };
@@ -513,7 +512,6 @@ class GDEY042T81 : public WaveshareEPaper {
   void set_full_update_every(uint32_t full_update_every);
 
  protected:
-
   int get_width_internal() override;
   int get_height_internal() override;
   uint32_t idle_timeout_() override;
@@ -986,7 +984,6 @@ class WaveshareEPaper7P5InV2P : public WaveshareEPaper {
 
   uint32_t idle_timeout_() override;
 
-
  private:
   void reset_();
 
@@ -1036,7 +1033,6 @@ class WaveshareEPaper2P13InDKE : public WaveshareEPaper {
   int get_height_internal() override;
 
   uint32_t idle_timeout_() override;
-
 };
 
 class WaveshareEPaper2P13InV3 : public WaveshareEPaper {


### PR DESCRIPTION
# What does this implement/fix?

Two related fixes for partial refreshes on `waveshare_epaper`, found while running a 1.54inV2 panel on a deep-sleeping battery device.

**1. Persist the partial-refresh counter across deep sleep**

`at_update_` selects between the full and partial refresh waveforms, but it lives in RAM and is reinitialised to 0 on every boot. A device that deep sleeps between refreshes restarts the cycle each time and always takes the full-refresh path, so `full_update_every` never takes effect and every refresh shows the full-waveform flicker.

The counter is now stored in preferences and restored during `setup()`. Displays are not entities, so the key is derived from the DC pin summary to stay stable across builds and distinct between multiple displays in one configuration.

**2. Seed the base image on 1.54inV2 full refreshes**

A partial refresh on these SSD1681 panels differences the new image (RAM bank `0x24`) against the base image (bank `0x26`), so the base has to be seeded by the preceding full refresh. That write was gated to 2.13inV2 only, leaving 1.54inV2 differencing against whatever the controller powered up with: changed regions come out speckled, roughly every other pixel, while untouched regions stay clean.

Waveshare's own driver for this panel writes both banks together in `EPD_DisplayPartBaseImage()` for exactly this reason.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) —
[policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) —
[policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) —
[policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- n/a — no configuration variables are added or changed.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Hardware-tested on an ESP32-S3 (esp-idf) driving a 1.54inV2 panel. The existing component tests were also built for `esp8266-ard` and `rp2040-ard` to confirm the preferences call compiles on those backends, but I have no hardware for either.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: waveshare_epaper
    model: 1.54inv2
    cs_pin: GPIO11
    dc_pin: GPIO10
    reset_pin: GPIO9
    busy_pin: GPIO8
    # Defaults to 30. Before this PR a deep-sleeping device took the full
    # waveform on every refresh regardless, and 1.54inV2 partial refreshes
    # came out speckled.
    full_update_every: 30
    update_interval: never

deep_sleep:
  run_duration: 30s
  sleep_duration: 5min
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).