### PR TITLE
[bthome_mithermometer] Gate log-only MAC helper by log level

### DIFF
--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -25,6 +25,9 @@ static constexpr size_t BTHOME_NONCE_SIZE = 13;
 static constexpr size_t BTHOME_MIC_SIZE = 4;
 static constexpr size_t BTHOME_COUNTER_SIZE = 4;
 
+// Both callers are log macros (LOGCONFIG / LOGVV); below CONFIG level they
+// compile away and an ungated helper trips -Wunused-function.
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_CONFIG
 static const char *format_mac_address(std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buffer, uint64_t address) {
   std::array<uint8_t, MAC_ADDRESS_SIZE> mac{};
   for (size_t i = 0; i < MAC_ADDRESS_SIZE; i++) {
@@ -34,6 +37,7 @@ static const char *format_mac_address(std::span<char, MAC_ADDRESS_PRETTY_BUFFER_
   format_mac_addr_upper(mac.data(), buffer.data());
   return buffer.data();
 }
+#endif  // ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_CONFIG
 
 static bool get_bthome_value_length(uint8_t obj_type, size_t &value_length) {
   switch (obj_type) {


### PR DESCRIPTION
## What does this implement?

`format_mac_address()` in `bthome_ble.cpp` is only called from `ESP_LOGCONFIG` and `ESP_LOGVV` sites. At log levels below CONFIG both call sites compile away and every build emits:

```
warning: 'const char* ... format_mac_address(std::span<char, 18>, uint64_t)' defined but not used [-Wunused-function]
```

The helper now sits behind `#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_CONFIG` — the same gate its callers already have — so helper and call sites vanish together. No behavior change at any log level.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature:** warning observed on every INFO/WARN-level build of this component

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test/verification

Built for ESP32 (2026.7.3 addon, where the warning was observed — gone), and BK72xx + LN882H locally with OTA to test devices — zero warnings, zero runtime errors.

## Checklist:
- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (compile-time-only change; existing component tests cover the file)
