### PR TITLE
[core] Read the esp32 variant for esptool without importing the esp32 package

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -48,6 +48,8 @@ from esphome.const import (
     CONF_WEB_SERVER,
     CONF_WIFI,
     ENV_NOGITIGNORE,
+    KEY_ESP32,
+    KEY_VARIANT,
     SECRETS_FILES,
     Toolchain,
 )
@@ -930,9 +932,10 @@ def upload_using_esptool(
 
     mcu = "esp8266"
     if CORE.is_esp32:
-        from esphome.components.esp32 import get_esp32_variant
-
-        mcu = get_esp32_variant().lower()
+        # Same lookup as esp32.get_esp32_variant(), read directly so the
+        # serial upload path does not import the esp32 package; both the
+        # validator and the warm-cache apply_to_core populate this key.
+        mcu = CORE.data[KEY_ESP32][KEY_VARIANT].lower()
 
     line_callbacks: list[Callable[[str], str | None]] = []
     if (

--- a/esphome/storage_json.py
+++ b/esphome/storage_json.py
@@ -329,9 +329,9 @@ class StorageJSON:
         }
         # The compile pipeline populates CORE.data[KEY_ESP32] when esp32's
         # validator runs; on the cache fast path that validator is skipped,
-        # so populate the variant upload_using_esptool reads via
-        # esp32.get_esp32_variant(). target_platform on disk is the variant
-        # (e.g. "ESP32S3"); core_platform is the family (e.g. "esp32").
+        # so populate the variant upload_using_esptool reads from
+        # CORE.data[KEY_ESP32][KEY_VARIANT]. target_platform on disk is the
+        # variant (e.g. "ESP32S3"); core_platform is the family (e.g. "esp32").
         if target_platform == const.PLATFORM_ESP32:
             esp32_data = {KEY_VARIANT: self.target_platform}
             if self.framework_version:

--- a/tests/unit_tests/fixtures/lazy_imports/_leak_report.py
+++ b/tests/unit_tests/fixtures/lazy_imports/_leak_report.py
@@ -1,0 +1,19 @@
+"""Shared tail for the lazy-import fixture scripts."""
+
+import sys
+
+
+def print_leaked_modules() -> None:
+    """Report argv-listed heavy modules (plus any component package) loaded.
+
+    Any component package counts as a leak, not just the ones on the
+    watch list: executing one drags in codegen/validation machinery by
+    design.
+    """
+    leaked = [module for module in sys.argv[1:] if module in sys.modules]
+    leaked += [
+        module
+        for module in sys.modules
+        if module.startswith("esphome.components.") and module not in leaked
+    ]
+    print(",".join(leaked))

--- a/tests/unit_tests/fixtures/lazy_imports/esptool_upload_fast_path.py
+++ b/tests/unit_tests/fixtures/lazy_imports/esptool_upload_fast_path.py
@@ -6,6 +6,7 @@ The variant reaches the esptool command line from CORE.data directly; if
 someone re-adds the esp32 package import for it, this reports the leak.
 """
 
+import os
 import sys
 from unittest.mock import patch
 
@@ -20,6 +21,10 @@ from esphome.const import (
     KEY_VARIANT,
 )
 from esphome.core import CORE
+
+# An ambient ESPHOME_USE_SUBPROCESS would route past the patched
+# run_external_command into run_external_process and confuse the checks.
+os.environ.pop("ESPHOME_USE_SUBPROCESS", None)
 
 CORE.data[KEY_CORE] = {KEY_TARGET_PLATFORM: "esp32"}
 CORE.data[KEY_ESP32] = {KEY_VARIANT: "ESP32S3"}

--- a/tests/unit_tests/fixtures/lazy_imports/esptool_upload_fast_path.py
+++ b/tests/unit_tests/fixtures/lazy_imports/esptool_upload_fast_path.py
@@ -1,0 +1,58 @@
+"""Run the esptool serial-upload path and report which heavy modules loaded.
+
+Executed as a subprocess by test_lazy_imports.py: heavy module names come
+in on argv, the ones found in sys.modules afterwards go out on stdout.
+The variant reaches the esptool command line from CORE.data directly; if
+someone re-adds the esp32 package import for it, this reports the leak.
+"""
+
+from pathlib import Path
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from esphome.__main__ import upload_using_esptool
+from esphome.const import (
+    CONF_ESPHOME,
+    KEY_CORE,
+    KEY_ESP32,
+    KEY_TARGET_PLATFORM,
+    KEY_VARIANT,
+)
+from esphome.core import CORE
+
+tmp = Path(tempfile.mkdtemp())
+CORE.config_path = tmp / "test.yaml"
+CORE.name = "test"
+CORE.build_path = tmp
+CORE.data[KEY_CORE] = {KEY_TARGET_PLATFORM: "esp32"}
+CORE.data[KEY_ESP32] = {KEY_VARIANT: "ESP32S3"}
+(tmp / "firmware.bin").touch()
+
+idedata = MagicMock()
+idedata.firmware_bin_path = tmp / "firmware.bin"
+idedata.extra_flash_images = []
+
+with (
+    patch("esphome.platformio.toolchain.get_idedata", return_value=idedata),
+    patch("esphome.__main__.run_external_command", return_value=0) as mock_run,
+):
+    rc = upload_using_esptool(
+        {CONF_ESPHOME: {"platformio_options": {}}}, "/dev/ttyUSB0", None, None
+    )
+
+# Fail loudly if the upload path stopped doing its work; otherwise an
+# empty leak list could just mean nothing ran.
+if rc != 0:
+    sys.exit(f"upload_using_esptool returned {rc}")
+cmd = list(mock_run.call_args[0][1:])
+if cmd[cmd.index("--chip") + 1] != "esp32s3":
+    sys.exit(f"variant did not reach the esptool command line: {cmd}")
+
+leaked = [module for module in sys.argv[1:] if module in sys.modules]
+leaked += [
+    module
+    for module in sys.modules
+    if module.startswith("esphome.components.") and module not in leaked
+]
+print(",".join(leaked))

--- a/tests/unit_tests/fixtures/lazy_imports/esptool_upload_fast_path.py
+++ b/tests/unit_tests/fixtures/lazy_imports/esptool_upload_fast_path.py
@@ -6,10 +6,10 @@ The variant reaches the esptool command line from CORE.data directly; if
 someone re-adds the esp32 package import for it, this reports the leak.
 """
 
-from pathlib import Path
 import sys
-import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
+
+from _leak_report import print_leaked_modules
 
 from esphome.__main__ import upload_using_esptool
 from esphome.const import (
@@ -21,24 +21,12 @@ from esphome.const import (
 )
 from esphome.core import CORE
 
-tmp = Path(tempfile.mkdtemp())
-CORE.config_path = tmp / "test.yaml"
-CORE.name = "test"
-CORE.build_path = tmp
 CORE.data[KEY_CORE] = {KEY_TARGET_PLATFORM: "esp32"}
 CORE.data[KEY_ESP32] = {KEY_VARIANT: "ESP32S3"}
-(tmp / "firmware.bin").touch()
 
-idedata = MagicMock()
-idedata.firmware_bin_path = tmp / "firmware.bin"
-idedata.extra_flash_images = []
-
-with (
-    patch("esphome.platformio.toolchain.get_idedata", return_value=idedata),
-    patch("esphome.__main__.run_external_command", return_value=0) as mock_run,
-):
+with patch("esphome.__main__.run_external_command", return_value=0) as mock_run:
     rc = upload_using_esptool(
-        {CONF_ESPHOME: {"platformio_options": {}}}, "/dev/ttyUSB0", None, None
+        {CONF_ESPHOME: {"platformio_options": {}}}, "/dev/ttyUSB0", "firmware.bin", None
     )
 
 # Fail loudly if the upload path stopped doing its work; otherwise an
@@ -49,10 +37,4 @@ cmd = list(mock_run.call_args[0][1:])
 if cmd[cmd.index("--chip") + 1] != "esp32s3":
     sys.exit(f"variant did not reach the esptool command line: {cmd}")
 
-leaked = [module for module in sys.argv[1:] if module in sys.modules]
-leaked += [
-    module
-    for module in sys.modules
-    if module.startswith("esphome.components.") and module not in leaked
-]
-print(",".join(leaked))
+print_leaked_modules()

--- a/tests/unit_tests/fixtures/lazy_imports/storage_json_fast_path.py
+++ b/tests/unit_tests/fixtures/lazy_imports/storage_json_fast_path.py
@@ -6,6 +6,8 @@ in on argv, the ones found in sys.modules afterwards go out on stdout.
 
 import sys
 
+from _leak_report import print_leaked_modules
+
 from esphome.const import KEY_ESP32, KEY_IDF_VERSION, KEY_VARIANT
 from esphome.core import CORE, Version
 from esphome.storage_json import StorageJSON
@@ -41,12 +43,4 @@ if esp32_data.get(KEY_VARIANT) != "ESP32S3":
 if esp32_data.get(KEY_IDF_VERSION) != Version(5, 3, 1):
     sys.exit(f"apply_to_core did not parse the framework version: {esp32_data!r}")
 
-# Any component package counts as a leak, not just the ones on the watch
-# list: executing one drags in codegen/validation machinery by design.
-leaked = [module for module in sys.argv[1:] if module in sys.modules]
-leaked += [
-    module
-    for module in sys.modules
-    if module.startswith("esphome.components.") and module not in leaked
-]
-print(",".join(leaked))
+print_leaked_modules()

--- a/tests/unit_tests/test_lazy_imports.py
+++ b/tests/unit_tests/test_lazy_imports.py
@@ -121,3 +121,33 @@ def test_api_client_does_not_import_heavy_modules() -> None:
         "The logs fast path skips validation; importing the validation "
         "stack anyway defeats the validated-config cache."
     )
+
+
+def test_esptool_upload_fast_path_does_not_import_heavy_modules(
+    fixture_path: Path,
+) -> None:
+    """The esptool serial upload reads the esp32 variant from CORE.data;
+    resolving it must not drag in the esp32 component package or the
+    validation stack.
+    """
+    script = fixture_path / "lazy_imports" / "esptool_upload_fast_path.py"
+    # Running a script file drops the cwd from sys.path, so prepend the
+    # repo root for the child; check=False keeps its stderr visible.
+    python_path = str(Path(__file__).parents[2])
+    if ambient := os.environ.get("PYTHONPATH"):
+        python_path = os.pathsep.join((python_path, ambient))
+    env = os.environ | {"PYTHONPATH": python_path}
+    result = subprocess.run(
+        [sys.executable, str(script), *FAST_PATH_HEAVY_MODULES],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    leaked = result.stdout.strip()
+    assert not leaked, (
+        f"upload_using_esptool pulls in heavy modules: {leaked}. "
+        "The upload fast path skips validation; importing the validation "
+        "stack anyway defeats the validated-config cache."
+    )

--- a/tests/unit_tests/test_lazy_imports.py
+++ b/tests/unit_tests/test_lazy_imports.py
@@ -78,16 +78,13 @@ def test_watched_heavy_modules_exist() -> None:
         )
 
 
-def test_storage_json_fast_path_does_not_import_heavy_modules(
-    fixture_path: Path,
-) -> None:
-    """``apply_to_core`` runs on the upload/logs fast path for every
-    platform; parsing the stored framework version must not drag in the
-    validation stack or the esp32 component package.
+def _leaked_from_fixture(fixture_path: Path, script_name: str) -> str:
+    """Run a fixture script with the watched modules on argv.
+
+    Running a script file drops the cwd from sys.path, so prepend the
+    repo root for the child; a non-zero exit surfaces the child's stderr.
     """
-    script = fixture_path / "lazy_imports" / "storage_json_fast_path.py"
-    # Running a script file drops the cwd from sys.path, so prepend the
-    # repo root for the child; check=False keeps its stderr visible.
+    script = fixture_path / "lazy_imports" / script_name
     python_path = str(Path(__file__).parents[2])
     if ambient := os.environ.get("PYTHONPATH"):
         python_path = os.pathsep.join((python_path, ambient))
@@ -100,11 +97,36 @@ def test_storage_json_fast_path_does_not_import_heavy_modules(
         check=False,
     )
     assert result.returncode == 0, result.stderr
-    leaked = result.stdout.strip()
+    return result.stdout.strip()
+
+
+def test_storage_json_fast_path_does_not_import_heavy_modules(
+    fixture_path: Path,
+) -> None:
+    """``apply_to_core`` runs on the upload/logs fast path for every
+    platform; parsing the stored framework version must not drag in the
+    validation stack or the esp32 component package.
+    """
+    leaked = _leaked_from_fixture(fixture_path, "storage_json_fast_path.py")
     assert not leaked, (
         f"storage_json.apply_to_core pulls in heavy modules: {leaked}. "
         "The upload/logs fast path skips validation; importing the "
         "validation stack anyway defeats the validated-config cache."
+    )
+
+
+def test_esptool_upload_fast_path_does_not_import_heavy_modules(
+    fixture_path: Path,
+) -> None:
+    """The esptool serial upload reads the esp32 variant from CORE.data;
+    resolving it must not drag in the esp32 component package or the
+    validation stack.
+    """
+    leaked = _leaked_from_fixture(fixture_path, "esptool_upload_fast_path.py")
+    assert not leaked, (
+        f"upload_using_esptool pulls in heavy modules: {leaked}. "
+        "The upload fast path skips validation; importing the validation "
+        "stack anyway defeats the validated-config cache."
     )
 
 
@@ -119,35 +141,5 @@ def test_api_client_does_not_import_heavy_modules() -> None:
     assert not leaked, (
         f"esphome.api_client imports heavy modules at top level: {leaked}. "
         "The logs fast path skips validation; importing the validation "
-        "stack anyway defeats the validated-config cache."
-    )
-
-
-def test_esptool_upload_fast_path_does_not_import_heavy_modules(
-    fixture_path: Path,
-) -> None:
-    """The esptool serial upload reads the esp32 variant from CORE.data;
-    resolving it must not drag in the esp32 component package or the
-    validation stack.
-    """
-    script = fixture_path / "lazy_imports" / "esptool_upload_fast_path.py"
-    # Running a script file drops the cwd from sys.path, so prepend the
-    # repo root for the child; check=False keeps its stderr visible.
-    python_path = str(Path(__file__).parents[2])
-    if ambient := os.environ.get("PYTHONPATH"):
-        python_path = os.pathsep.join((python_path, ambient))
-    env = os.environ | {"PYTHONPATH": python_path}
-    result = subprocess.run(
-        [sys.executable, str(script), *FAST_PATH_HEAVY_MODULES],
-        capture_output=True,
-        text=True,
-        env=env,
-        check=False,
-    )
-    assert result.returncode == 0, result.stderr
-    leaked = result.stdout.strip()
-    assert not leaked, (
-        f"upload_using_esptool pulls in heavy modules: {leaked}. "
-        "The upload fast path skips validation; importing the validation "
         "stack anyway defeats the validated-config cache."
     )

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -1622,6 +1622,39 @@ def test_upload_using_esptool_path_conversion(
     assert partitions_path.endswith("partitions.bin")
 
 
+def test_upload_using_esptool_chip_matches_esp32_helper(
+    tmp_path: Path,
+    mock_run_external_command_main: Mock,
+    mock_get_idedata: Mock,
+) -> None:
+    """The direct variant read must stay in step with get_esp32_variant.
+
+    upload_using_esptool reads CORE.data[KEY_ESP32][KEY_VARIANT] without
+    importing the esp32 package; if get_esp32_variant ever resolves the
+    variant from somewhere else, the esptool --chip argument would drift.
+    This pins both to the same source and asserts the value reaches the
+    esptool command line.
+    """
+    from esphome.components.esp32 import get_esp32_variant
+
+    setup_core(platform=PLATFORM_ESP32, tmp_path=tmp_path, name="test")
+    CORE.data[KEY_ESP32] = {KEY_VARIANT: VARIANT_ESP32}
+
+    mock_idedata = MagicMock(spec=toolchain.IDEData)
+    mock_idedata.firmware_bin_path = tmp_path / "firmware.bin"
+    mock_idedata.extra_flash_images = []
+    mock_get_idedata.return_value = mock_idedata
+    (tmp_path / "firmware.bin").touch()
+
+    config = {CONF_ESPHOME: {"platformio_options": {}}}
+    assert upload_using_esptool(config, "/dev/ttyUSB0", None, None) == 0
+
+    cmd_list = list(mock_run_external_command_main.call_args[0][1:])
+    chip = cmd_list[cmd_list.index("--chip") + 1]
+    assert chip == get_esp32_variant().lower()
+    assert chip == CORE.data[KEY_ESP32][KEY_VARIANT].lower()
+
+
 def test_upload_using_esptool_skips_missing_extra_flash_images(
     tmp_path: Path,
     mock_run_external_command_main: Mock,

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -64,7 +64,12 @@ from esphome.__main__ import (
 from esphome.address_cache import AddressCache
 from esphome.bundle import BUNDLE_EXTENSION, BundleFile, BundleResult
 from esphome.components import esp32
-from esphome.components.esp32 import KEY_ESP32, KEY_VARIANT, VARIANT_ESP32
+from esphome.components.esp32 import (
+    KEY_ESP32,
+    KEY_VARIANT,
+    VARIANT_ESP32,
+    get_esp32_variant,
+)
 from esphome.const import (
     CONF_API,
     CONF_AUTH,
@@ -1621,38 +1626,11 @@ def test_upload_using_esptool_path_conversion(
     assert isinstance(partitions_path, str)
     assert partitions_path.endswith("partitions.bin")
 
-
-def test_upload_using_esptool_chip_matches_esp32_helper(
-    tmp_path: Path,
-    mock_run_external_command_main: Mock,
-    mock_get_idedata: Mock,
-) -> None:
-    """The direct variant read must stay in step with get_esp32_variant.
-
-    upload_using_esptool reads CORE.data[KEY_ESP32][KEY_VARIANT] without
-    importing the esp32 package; if get_esp32_variant ever resolves the
-    variant from somewhere else, the esptool --chip argument would drift.
-    This pins both to the same source and asserts the value reaches the
-    esptool command line.
-    """
-    from esphome.components.esp32 import get_esp32_variant
-
-    setup_core(platform=PLATFORM_ESP32, tmp_path=tmp_path, name="test")
-    CORE.data[KEY_ESP32] = {KEY_VARIANT: VARIANT_ESP32}
-
-    mock_idedata = MagicMock(spec=toolchain.IDEData)
-    mock_idedata.firmware_bin_path = tmp_path / "firmware.bin"
-    mock_idedata.extra_flash_images = []
-    mock_get_idedata.return_value = mock_idedata
-    (tmp_path / "firmware.bin").touch()
-
-    config = {CONF_ESPHOME: {"platformio_options": {}}}
-    assert upload_using_esptool(config, "/dev/ttyUSB0", None, None) == 0
-
-    cmd_list = list(mock_run_external_command_main.call_args[0][1:])
+    # The chip argument must track get_esp32_variant: upload_using_esptool
+    # reads CORE.data directly to avoid the esp32 package import, and the
+    # two resolutions must not drift.
     chip = cmd_list[cmd_list.index("--chip") + 1]
     assert chip == get_esp32_variant().lower()
-    assert chip == CORE.data[KEY_ESP32][KEY_VARIANT].lower()
 
 
 def test_upload_using_esptool_skips_missing_extra_flash_images(


### PR DESCRIPTION
# What does this implement/fix?

Part of the series reducing the dependency chains of `esphome upload` and `esphome logs`: users report these commands being slow on small hosts like the Home Assistant Green, and the device builder keeps ESPHome resident in memory, so every module the CLI imports costs startup time on every invocation and resident memory in the builder. `upload_using_esptool` imported the esp32 package just to call `get_esp32_variant`, which only reads `CORE.data[KEY_ESP32][KEY_VARIANT]`; with those keys in `esphome/const.py` after #18045 the serial upload path can read the dict directly and skip the package import, which pulls the validation stack. Both the esp32 validator and the warm cache `apply_to_core` populate the key, and the existing esptool unit tests exercise the branch through the real function.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No configuration changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

