### PR TITLE
[core] Unbind the esp-idf toolchain from the esp32 component package

### DIFF
--- a/esphome/components/esp32/const.py
+++ b/esphome/components/esp32/const.py
@@ -9,6 +9,9 @@ from esphome.const import (  # noqa: F401  # pylint: disable=unused-import
     KEY_IDF_VERSION,
     KEY_VARIANT,
 )
+
+# Back compat for external components only; in-tree callers import it
+# from esphome.espidf directly.
 from esphome.espidf import (  # noqa: F401  # pylint: disable=unused-import
     variant_to_idf_target,
 )

--- a/esphome/components/esp32/const.py
+++ b/esphome/components/esp32/const.py
@@ -1,15 +1,19 @@
 import esphome.codegen as cg
 
-# Re-exported for the many esp32-side users; defined in esphome.const so
-# the upload/logs fast path can read them without importing this package.
+# Re-exported for the many esp32-side users; defined in esphome.const
+# and esphome.espidf so the upload/logs fast path can use them without
+# importing this package.
 from esphome.const import (  # noqa: F401  # pylint: disable=unused-import
     KEY_ESP32,
+    KEY_FLASH_SIZE,
     KEY_IDF_VERSION,
     KEY_VARIANT,
 )
+from esphome.espidf import (  # noqa: F401  # pylint: disable=unused-import
+    variant_to_idf_target,
+)
 
 KEY_BOARD = "board"
-KEY_FLASH_SIZE = "flash_size"
 KEY_SDKCONFIG_OPTIONS = "sdkconfig_options"
 KEY_COMPONENTS = "components"
 KEY_EXCLUDE_COMPONENTS = "exclude_components"
@@ -67,11 +71,6 @@ VARIANT_FRIENDLY = {
     VARIANT_ESP32S3: "ESP32-S3",
     VARIANT_ESP32S31: "ESP32-S31",
 }
-
-
-def variant_to_idf_target(variant: str) -> str:
-    """Map an esp32 variant name (e.g. "ESP32S3") to its ESP-IDF target name."""
-    return variant.lower().replace("-", "")
 
 
 esp32_ns = cg.esphome_ns.namespace("esp32")

--- a/esphome/components/esp8266/boards.py
+++ b/esphome/components/esp8266/boards.py
@@ -1,3 +1,5 @@
+from esphome.const import KEY_FLASH_SIZE
+
 FLASH_SIZE_1_MB = 2**20
 FLASH_SIZE_512_KB = FLASH_SIZE_1_MB // 2
 FLASH_SIZE_2_MB = 2 * FLASH_SIZE_1_MB
@@ -185,178 +187,178 @@ done | sort
 BOARDS = {
     "agruminolemon": {
         "name": "Lifely Agrumino Lemon v4",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "d1_mini_lite": {
         "name": "WeMos D1 mini Lite",
-        "flash_size": FLASH_SIZE_1_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
     },
     "d1_mini": {
         "name": "WeMos D1 R2 and mini",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "d1_mini_pro": {
         "name": "WeMos D1 mini Pro",
-        "flash_size": FLASH_SIZE_16_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_16_MB,
     },
     "d1": {
         "name": "WEMOS D1 R1",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "eduinowifi": {
         "name": "Schirmilabs Eduino WiFi",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "esp01_1m": {
         "name": "Espressif Generic ESP8266 ESP-01 1M",
-        "flash_size": FLASH_SIZE_1_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
     },
     "esp01": {
         "name": "Espressif Generic ESP8266 ESP-01 512k",
-        "flash_size": FLASH_SIZE_512_KB,
+        KEY_FLASH_SIZE: FLASH_SIZE_512_KB,
     },
     "esp07": {
         "name": "Espressif Generic ESP8266 ESP-07 1MB",
-        "flash_size": FLASH_SIZE_1_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
     },
     "esp07s": {
         "name": "Espressif Generic ESP8266 ESP-07S",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "esp12e": {
         "name": "Espressif ESP8266 ESP-12E",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "esp210": {
         "name": "SweetPea ESP-210",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "esp8285": {
         "name": "Generic ESP8285 Module",
-        "flash_size": FLASH_SIZE_1_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
     },
     "espduino": {
         "name": "ESPDuino (ESP-13 Module)",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "espectro": {
         "name": "ESPectro Core",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "espino": {
         "name": "ESPino",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "espinotee": {
         "name": "ThaiEasyElec ESPino",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "espmxdevkit": {
         "name": "ESP-Mx DevKit (ESP8285)",
-        "flash_size": FLASH_SIZE_1_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
     },
     "espresso_lite_v1": {
         "name": "ESPresso Lite 1.0",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "espresso_lite_v2": {
         "name": "ESPresso Lite 2.0",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "esp_wroom_02": {
         "name": "ESP-WROOM-02",
-        "flash_size": FLASH_SIZE_2_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_2_MB,
     },
     "gen4iod": {
         "name": "4D Systems gen4 IoD Range",
-        "flash_size": FLASH_SIZE_512_KB,
+        KEY_FLASH_SIZE: FLASH_SIZE_512_KB,
     },
     "heltec_wifi_kit_8": {
         "name": "Heltec Wifi kit 8",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "huzzah": {
         "name": "Adafruit HUZZAH ESP8266",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "inventone": {
         "name": "Invent One",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "modwifi": {
         "name": "Olimex MOD-WIFI-ESP8266(-DEV)",
-        "flash_size": FLASH_SIZE_2_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_2_MB,
     },
     "nodemcu": {
         "name": "NodeMCU 0.9 (ESP-12 Module)",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "nodemcuv2": {
         "name": "NodeMCU 1.0 (ESP-12E Module)",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "oak": {
         "name": "DigiStump Oak",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "phoenix_v1": {
         "name": "Phoenix 1.0",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "phoenix_v2": {
         "name": "Phoenix 2.0",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "sonoff_basic": {
         "name": "Sonoff Basic",
-        "flash_size": FLASH_SIZE_1_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
     },
     "sonoff_s20": {
         "name": "Sonoff S20",
-        "flash_size": FLASH_SIZE_1_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
     },
     "sonoff_sv": {
         "name": "Sonoff SV",
-        "flash_size": FLASH_SIZE_1_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
     },
     "sonoff_th": {
         "name": "Sonoff TH",
-        "flash_size": FLASH_SIZE_1_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
     },
     "sparkfunBlynk": {
         "name": "SparkFun Blynk Board",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "thingdev": {
         "name": "SparkFun ESP8266 Thing Dev",
-        "flash_size": FLASH_SIZE_512_KB,
+        KEY_FLASH_SIZE: FLASH_SIZE_512_KB,
     },
     "thing": {
         "name": "SparkFun ESP8266 Thing",
-        "flash_size": FLASH_SIZE_512_KB,
+        KEY_FLASH_SIZE: FLASH_SIZE_512_KB,
     },
     "wifiduino": {
         "name": "WiFiduino",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "wifinfo": {
         "name": "WifInfo",
-        "flash_size": FLASH_SIZE_1_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
     },
     "wifi_slot": {
         "name": "WiFi Slot",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "wio_link": {
         "name": "Wio Link",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "wio_node": {
         "name": "Wio Node",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
     "xinabox_cw01": {
         "name": "XinaBox CW01",
-        "flash_size": FLASH_SIZE_4_MB,
+        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
     },
 }

--- a/esphome/components/esp8266/boards.py
+++ b/esphome/components/esp8266/boards.py
@@ -1,5 +1,3 @@
-from esphome.const import KEY_FLASH_SIZE
-
 FLASH_SIZE_1_MB = 2**20
 FLASH_SIZE_512_KB = FLASH_SIZE_1_MB // 2
 FLASH_SIZE_2_MB = 2 * FLASH_SIZE_1_MB
@@ -187,178 +185,178 @@ done | sort
 BOARDS = {
     "agruminolemon": {
         "name": "Lifely Agrumino Lemon v4",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "d1_mini_lite": {
         "name": "WeMos D1 mini Lite",
-        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
+        "flash_size": FLASH_SIZE_1_MB,
     },
     "d1_mini": {
         "name": "WeMos D1 R2 and mini",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "d1_mini_pro": {
         "name": "WeMos D1 mini Pro",
-        KEY_FLASH_SIZE: FLASH_SIZE_16_MB,
+        "flash_size": FLASH_SIZE_16_MB,
     },
     "d1": {
         "name": "WEMOS D1 R1",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "eduinowifi": {
         "name": "Schirmilabs Eduino WiFi",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "esp01_1m": {
         "name": "Espressif Generic ESP8266 ESP-01 1M",
-        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
+        "flash_size": FLASH_SIZE_1_MB,
     },
     "esp01": {
         "name": "Espressif Generic ESP8266 ESP-01 512k",
-        KEY_FLASH_SIZE: FLASH_SIZE_512_KB,
+        "flash_size": FLASH_SIZE_512_KB,
     },
     "esp07": {
         "name": "Espressif Generic ESP8266 ESP-07 1MB",
-        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
+        "flash_size": FLASH_SIZE_1_MB,
     },
     "esp07s": {
         "name": "Espressif Generic ESP8266 ESP-07S",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "esp12e": {
         "name": "Espressif ESP8266 ESP-12E",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "esp210": {
         "name": "SweetPea ESP-210",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "esp8285": {
         "name": "Generic ESP8285 Module",
-        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
+        "flash_size": FLASH_SIZE_1_MB,
     },
     "espduino": {
         "name": "ESPDuino (ESP-13 Module)",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "espectro": {
         "name": "ESPectro Core",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "espino": {
         "name": "ESPino",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "espinotee": {
         "name": "ThaiEasyElec ESPino",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "espmxdevkit": {
         "name": "ESP-Mx DevKit (ESP8285)",
-        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
+        "flash_size": FLASH_SIZE_1_MB,
     },
     "espresso_lite_v1": {
         "name": "ESPresso Lite 1.0",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "espresso_lite_v2": {
         "name": "ESPresso Lite 2.0",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "esp_wroom_02": {
         "name": "ESP-WROOM-02",
-        KEY_FLASH_SIZE: FLASH_SIZE_2_MB,
+        "flash_size": FLASH_SIZE_2_MB,
     },
     "gen4iod": {
         "name": "4D Systems gen4 IoD Range",
-        KEY_FLASH_SIZE: FLASH_SIZE_512_KB,
+        "flash_size": FLASH_SIZE_512_KB,
     },
     "heltec_wifi_kit_8": {
         "name": "Heltec Wifi kit 8",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "huzzah": {
         "name": "Adafruit HUZZAH ESP8266",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "inventone": {
         "name": "Invent One",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "modwifi": {
         "name": "Olimex MOD-WIFI-ESP8266(-DEV)",
-        KEY_FLASH_SIZE: FLASH_SIZE_2_MB,
+        "flash_size": FLASH_SIZE_2_MB,
     },
     "nodemcu": {
         "name": "NodeMCU 0.9 (ESP-12 Module)",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "nodemcuv2": {
         "name": "NodeMCU 1.0 (ESP-12E Module)",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "oak": {
         "name": "DigiStump Oak",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "phoenix_v1": {
         "name": "Phoenix 1.0",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "phoenix_v2": {
         "name": "Phoenix 2.0",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "sonoff_basic": {
         "name": "Sonoff Basic",
-        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
+        "flash_size": FLASH_SIZE_1_MB,
     },
     "sonoff_s20": {
         "name": "Sonoff S20",
-        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
+        "flash_size": FLASH_SIZE_1_MB,
     },
     "sonoff_sv": {
         "name": "Sonoff SV",
-        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
+        "flash_size": FLASH_SIZE_1_MB,
     },
     "sonoff_th": {
         "name": "Sonoff TH",
-        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
+        "flash_size": FLASH_SIZE_1_MB,
     },
     "sparkfunBlynk": {
         "name": "SparkFun Blynk Board",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "thingdev": {
         "name": "SparkFun ESP8266 Thing Dev",
-        KEY_FLASH_SIZE: FLASH_SIZE_512_KB,
+        "flash_size": FLASH_SIZE_512_KB,
     },
     "thing": {
         "name": "SparkFun ESP8266 Thing",
-        KEY_FLASH_SIZE: FLASH_SIZE_512_KB,
+        "flash_size": FLASH_SIZE_512_KB,
     },
     "wifiduino": {
         "name": "WiFiduino",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "wifinfo": {
         "name": "WifInfo",
-        KEY_FLASH_SIZE: FLASH_SIZE_1_MB,
+        "flash_size": FLASH_SIZE_1_MB,
     },
     "wifi_slot": {
         "name": "WiFi Slot",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "wio_link": {
         "name": "Wio Link",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "wio_node": {
         "name": "Wio Node",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
     "xinabox_cw01": {
         "name": "XinaBox CW01",
-        KEY_FLASH_SIZE: FLASH_SIZE_4_MB,
+        "flash_size": FLASH_SIZE_4_MB,
     },
 }

--- a/esphome/components/esp8266/const.py
+++ b/esphome/components/esp8266/const.py
@@ -1,4 +1,5 @@
 import esphome.codegen as cg
+from esphome.const import KEY_FLASH_SIZE  # noqa: F401  # pylint: disable=unused-import
 from esphome.core import CORE
 
 KEY_ESP8266 = "esp8266"
@@ -8,7 +9,6 @@ CONF_RESTORE_FROM_FLASH = "restore_from_flash"
 CONF_EARLY_PIN_INIT = "early_pin_init"
 CONF_ENABLE_SERIAL = "enable_serial"
 CONF_ENABLE_SERIAL1 = "enable_serial1"
-KEY_FLASH_SIZE = "flash_size"
 KEY_WAVEFORM_REQUIRED = "waveform_required"
 KEY_SERIAL_REQUIRED = "serial_required"
 KEY_SERIAL1_REQUIRED = "serial1_required"

--- a/esphome/components/esp8266/const.py
+++ b/esphome/components/esp8266/const.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 
-# Re-exported; defined in esphome.const so this package and the espidf
-# toolchain share one source without the toolchain importing components.
+# Re-exported from the shared definition; here it indexes the BOARDS
+# metadata dicts, whose entries in boards.py spell the literal.
 from esphome.const import KEY_FLASH_SIZE  # noqa: F401  # pylint: disable=unused-import
 from esphome.core import CORE
 

--- a/esphome/components/esp8266/const.py
+++ b/esphome/components/esp8266/const.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 
-# Re-exported; defined in esphome.const so boards.py and the espidf
-# toolchain share one source without importing this package.
+# Re-exported; defined in esphome.const so this package and the espidf
+# toolchain share one source without the toolchain importing components.
 from esphome.const import KEY_FLASH_SIZE  # noqa: F401  # pylint: disable=unused-import
 from esphome.core import CORE
 

--- a/esphome/components/esp8266/const.py
+++ b/esphome/components/esp8266/const.py
@@ -1,4 +1,8 @@
 import esphome.codegen as cg
+
+# Re-exported; defined in esphome.const so boards.py and the espidf
+# toolchain share one source without importing this package.
+from esphome.const import KEY_FLASH_SIZE  # noqa: F401  # pylint: disable=unused-import
 from esphome.core import CORE
 
 KEY_ESP8266 = "esp8266"
@@ -8,9 +12,6 @@ CONF_RESTORE_FROM_FLASH = "restore_from_flash"
 CONF_EARLY_PIN_INIT = "early_pin_init"
 CONF_ENABLE_SERIAL = "enable_serial"
 CONF_ENABLE_SERIAL1 = "enable_serial1"
-# Deliberately not the shared esphome.const KEY_FLASH_SIZE: this one keys
-# the BOARDS metadata dicts, whose entries in boards.py spell the literal.
-KEY_FLASH_SIZE = "flash_size"
 KEY_WAVEFORM_REQUIRED = "waveform_required"
 KEY_SERIAL_REQUIRED = "serial_required"
 KEY_SERIAL1_REQUIRED = "serial1_required"

--- a/esphome/components/esp8266/const.py
+++ b/esphome/components/esp8266/const.py
@@ -1,5 +1,4 @@
 import esphome.codegen as cg
-from esphome.const import KEY_FLASH_SIZE  # noqa: F401  # pylint: disable=unused-import
 from esphome.core import CORE
 
 KEY_ESP8266 = "esp8266"
@@ -9,6 +8,9 @@ CONF_RESTORE_FROM_FLASH = "restore_from_flash"
 CONF_EARLY_PIN_INIT = "early_pin_init"
 CONF_ENABLE_SERIAL = "enable_serial"
 CONF_ENABLE_SERIAL1 = "enable_serial1"
+# Deliberately not the shared esphome.const KEY_FLASH_SIZE: this one keys
+# the BOARDS metadata dicts, whose entries in boards.py spell the literal.
+KEY_FLASH_SIZE = "flash_size"
 KEY_WAVEFORM_REQUIRED = "waveform_required"
 KEY_SERIAL_REQUIRED = "serial_required"
 KEY_SERIAL1_REQUIRED = "serial1_required"

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1426,6 +1426,8 @@ KEY_PAST_SAFE_MODE = "past_safe_mode"
 # (storage_json.apply_to_core, espidf.toolchain) can use them without
 # importing the esp32 component package.
 KEY_ESP32 = "esp32"
+# Also used by esp8266 to index its BOARDS metadata dicts, whose
+# entries in boards.py spell the literal; do not change the value.
 KEY_FLASH_SIZE = "flash_size"
 KEY_IDF_VERSION = "idf_version"
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1423,9 +1423,10 @@ KEY_NAME = "name"
 KEY_VARIANT = "variant"
 KEY_PAST_SAFE_MODE = "past_safe_mode"
 # esp32 storage keys; defined here so the upload/logs fast path
-# (storage_json.apply_to_core) can use them without importing the
-# esp32 component package.
+# (storage_json.apply_to_core, espidf.toolchain) can use them without
+# importing the esp32 component package.
 KEY_ESP32 = "esp32"
+KEY_FLASH_SIZE = "flash_size"
 KEY_IDF_VERSION = "idf_version"
 
 # Entity categories

--- a/esphome/espidf/__init__.py
+++ b/esphome/espidf/__init__.py
@@ -1,0 +1,11 @@
+"""ESP-IDF direct build support.
+
+Deliberately light: the upload fast path imports submodules of this
+package without the esp32 component package, so nothing here may pull
+in codegen or validation.
+"""
+
+
+def variant_to_idf_target(variant: str) -> str:
+    """Map an esp32 variant name (e.g. "ESP32S3") to its ESP-IDF target name."""
+    return variant.lower().replace("-", "")

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -54,7 +54,7 @@ def _apply_extra_script(component: IDFComponent) -> None:
     if not script_path.is_relative_to(library_root) or not script_path.is_file():
         return
     from esphome.components.esp32 import get_esp32_variant
-    from esphome.components.esp32.const import variant_to_idf_target
+    from esphome.espidf import variant_to_idf_target
     from esphome.espidf.extra_script import captured_as_build_flags, run_extra_script
 
     idf_target = variant_to_idf_target(get_esp32_variant())

--- a/esphome/espidf/component.py
+++ b/esphome/espidf/component.py
@@ -12,6 +12,7 @@ import os
 from pathlib import Path
 
 from esphome.core import CORE, Library
+from esphome.espidf import variant_to_idf_target
 from esphome.helpers import write_file_if_changed
 from esphome.platformio.library import (
     DEFAULT_BUILD_FLAGS,
@@ -54,7 +55,6 @@ def _apply_extra_script(component: IDFComponent) -> None:
     if not script_path.is_relative_to(library_root) or not script_path.is_file():
         return
     from esphome.components.esp32 import get_esp32_variant
-    from esphome.espidf import variant_to_idf_target
     from esphome.espidf.extra_script import captured_as_build_flags, run_extra_script
 
     idf_target = variant_to_idf_target(get_esp32_variant())

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -9,20 +9,18 @@ import re
 import shutil
 import subprocess
 
-from esphome.components.esp32.const import (
-    KEY_ESP32,
-    KEY_FLASH_SIZE,
-    KEY_IDF_VERSION,
-    KEY_VARIANT,
-    variant_to_idf_target,
-)
 from esphome.const import (
     CONF_COMPILE_PROCESS_LIMIT,
     CONF_ESPHOME,
     CONF_FRAMEWORK,
     CONF_SOURCE,
+    KEY_ESP32,
+    KEY_FLASH_SIZE,
+    KEY_IDF_VERSION,
+    KEY_VARIANT,
 )
 from esphome.core import CORE, EsphomeError
+from esphome.espidf import variant_to_idf_target
 from esphome.espidf.framework import check_esp_idf_install, get_framework_env
 from esphome.espidf.size_summary import print_summary
 from esphome.helpers import add_git_ceiling_directory

--- a/tests/unit_tests/test_lazy_imports.py
+++ b/tests/unit_tests/test_lazy_imports.py
@@ -121,3 +121,18 @@ def test_api_client_does_not_import_heavy_modules() -> None:
         "The logs fast path skips validation; importing the validation "
         "stack anyway defeats the validated-config cache."
     )
+
+
+def test_espidf_toolchain_does_not_import_heavy_modules() -> None:
+    """The esp-idf upload path must not pull the esp32 package back in.
+
+    upload_using_esptool reaches espidf.toolchain for esp-idf builds;
+    its keys and the variant mapping live in esphome.const and
+    esphome.espidf precisely so this import stays light.
+    """
+    leaked = _leaked_heavy_modules("esphome.espidf.toolchain")
+    assert not leaked, (
+        f"esphome.espidf.toolchain imports heavy modules: {leaked}. "
+        "The upload fast path skips validation; importing the validation "
+        "stack anyway defeats the validated-config cache."
+    )


### PR DESCRIPTION
# What does this implement/fix?

Part of the series reducing the dependency chains of `esphome upload` and `esphome logs`: users report these commands being slow on small hosts like the Home Assistant Green, and the device builder keeps ESPHome resident in memory, so every module the CLI imports costs startup time on every invocation and resident memory in the builder.

`esphome/espidf/toolchain.py` imported `esphome.components.esp32.const` for its storage keys and the variant to IDF target mapping, and importing any submodule of the esp32 package executes its 3000 line `__init__`, pulling codegen and the validation stack into every esp-idf serial upload. `KEY_FLASH_SIZE` moves to `esphome/const.py` next to the keys #18045 moved, with esp32 and esp8266 both re exporting it from that single source, the boards table stays on plain literal keys since it is a pure data table and the compile tests pin the value; `variant_to_idf_target` moves to the previously empty `esphome/espidf/__init__.py`, which is arguably its real domain, with a re export left in `esp32/const.py` for external importers. `espidf/component.py` switches to the same imports. A lazy import test pins `esphome.espidf.toolchain` staying free of codegen, validation and component packages; esp-idf and esp8266 compiles of real configs pass through the refactored paths.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No configuration changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).





