### PR TITLE
[bk72xx_ble_tracker] Brace single-statement loop flagged by clang-tidy

### DIFF
--- a/esphome/components/bk72xx_ble_tracker/bk72xx_ble_tracker.cpp
+++ b/esphome/components/bk72xx_ble_tracker/bk72xx_ble_tracker.cpp
@@ -171,9 +171,11 @@ void BK72xxBLETracker::on_scan_report(const bk72xx_ble::BLEScanReport &report) {
   ble_device_base::ESPBTDevice device;
   device.from_scan_result(report.mac, report.rssi, report.addr_type, report.data, report.data_len);
   bool found = false;
-  for (auto *listener : this->listeners_)
-    if (listener->parse_device(device))
+  for (auto *listener : this->listeners_) {
+    if (listener->parse_device(device)) {
       found = true;
+    }
+  }
   // Mirror esp32_ble_tracker: log a newly-seen device only when nothing claimed
   // it and the scan is one-shot (continuous scans would spam).
   if (!found && !this->scan_continuous_)


### PR DESCRIPTION
# What does this implement/fix?

Extracted from #16691 per review there. The listener-dispatch loop violates `readability-braces-around-statements`; today's LibreTiny clang-tidy env does not parse this path (`ESPHOME_BLE_DEVICE_BASE_LISTENER_COUNT` is not defined in the LibreTiny block of `defines.h`), so CI does not flag it yet — #16691 adds that coverage and trips over this file. Formatting-only; verified by BK72xx device build + OTA to the test switch (zero errors).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
