### PR TITLE
[rp2_ble_tracker] Extract stamp-and-start helper; pin capability/switch independence

### DIFF
--- a/esphome/components/rp2_ble_tracker/rp2_ble_tracker.cpp
+++ b/esphome/components/rp2_ble_tracker/rp2_ble_tracker.cpp
@@ -163,11 +163,7 @@ bool RP2BLETracker::request_scan_mode(bool active) {
   // An idle scanner picks the mode up on its next start.
   if (this->scan_running_) {
     this->parent_->scan_stop();
-    // Stamp the attempt so the SCAN_START_RETRY_MS floor covers this start
-    // like every other one.
-    this->last_scan_start_attempt_ = App.get_loop_component_start_time();
-    if (!this->parent_->scan_start(static_cast<uint16_t>(this->scan_interval_),
-                                   static_cast<uint16_t>(this->scan_window_), this->scan_active_)) {
+    if (!this->controller_scan_start_()) {
       // The controller really stopped: behave exactly like loop()'s
       // reconciliation branch - notify listeners and let its retry recover.
       this->scan_running_ = false;
@@ -186,16 +182,19 @@ void RP2BLETracker::stop_scan() {
   this->disable_loop();
 }
 
+// Stamp-and-start for every controller scan attempt: the stamp keeps the
+// SCAN_START_RETRY_MS floor covering all callers, not only loop()'s retry.
+bool RP2BLETracker::controller_scan_start_() {
+  this->last_scan_start_attempt_ = App.get_loop_component_start_time();
+  return this->parent_->scan_start(static_cast<uint16_t>(this->scan_interval_),
+                                   static_cast<uint16_t>(this->scan_window_), this->scan_active_);
+}
+
 void RP2BLETracker::start_scan_() {
   if (this->scan_running_)
     return;
 
-  // Stamp every attempt regardless of caller so the loop's rate limit also
-  // covers a failed start that came through the public start_scan().
-  this->last_scan_start_attempt_ = App.get_loop_component_start_time();
-
-  if (!this->parent_->scan_start(static_cast<uint16_t>(this->scan_interval_), static_cast<uint16_t>(this->scan_window_),
-                                 this->scan_active_))
+  if (!this->controller_scan_start_())
     return;
 
   this->scan_running_ = true;

--- a/esphome/components/rp2_ble_tracker/rp2_ble_tracker.h
+++ b/esphome/components/rp2_ble_tracker/rp2_ble_tracker.h
@@ -80,6 +80,7 @@ class RP2BLETracker : public Component,
 
  protected:
   void start_scan_();
+  bool controller_scan_start_();
   void stop_scan_();
   void fire_scan_end_();
 

--- a/tests/components/ble_device_base/test_scan_mode_request.cpp
+++ b/tests/components/ble_device_base/test_scan_mode_request.cpp
@@ -36,6 +36,13 @@ class SwitchingHub : public DefaultHub {
   }
 };
 
+// The esp32 shape: the controller supports active scanning but the hub keeps
+// the refusing default (mode is driven through its own tracker API).
+class CapableRefusingHub : public DefaultHub {
+ public:
+  HubCapabilities get_capabilities() const override { return {true, false, false}; }
+};
+
 }  // namespace
 
 TEST(BLEHubScanModeRequest, DefaultRefusesAndChangesNothing) {
@@ -54,6 +61,13 @@ TEST(BLEHubScanModeRequest, OverrideHonorsAndApplies) {
   EXPECT_TRUE(hub.scan_active());
   EXPECT_TRUE(hub.request_scan_mode(false));
   EXPECT_FALSE(hub.scan_active());
+}
+
+TEST(BLEHubScanModeRequest, CapabilityAndSwitchAreIndependent) {
+  CapableRefusingHub hub;
+  EXPECT_TRUE(hub.get_capabilities().active_scan);
+  EXPECT_FALSE(hub.request_scan_mode(false));
+  EXPECT_TRUE(hub.scan_active());
 }
 
 }  // namespace esphome::ble_device_base::testing


### PR DESCRIPTION
# What does this implement/fix?

Follow-up promised in the #18061 review threads:

- `controller_scan_start_()` owns the stamp-and-start sequence, replacing the duplicated block in `start_scan_()` and `request_scan_mode()` (@bdraco's DRY note).
- `CapableRefusingHub` pins the esp32 shape in the host gtest — `active_scan` capability true, base `request_scan_mode()` refusing — the one combination the contract doc calls out that the existing fakes did not cover.

No behavior change; rp2 compiles in CI via the tracker's test config, host gtests run in CI's host job.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
