### PR TITLE
[core] Lift the log line processor into esphome/stacktrace.py

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -55,6 +55,7 @@ from esphome.core import CORE, EsphomeError, coroutine
 from esphome.enum import StrEnum
 from esphome.helpers import get_bool_env, indent, is_ip_address
 from esphome.log import AnsiFore, color, setup_log
+from esphome.stacktrace import LogLineProcessor
 from esphome.types import ConfigType
 from esphome.upload_targets import PortType, get_port_type
 from esphome.util import (
@@ -630,11 +631,9 @@ def run_miniterm(config: ConfigType, port: str, args) -> int:
         return 1
     _LOGGER.info("Starting log output from %s with baud rate %s", port, baud_rate)
 
-    # Stacktrace analysis is optional; platform_hooks owns resolution
-    # and the user-facing messages.
-    process_stacktrace = platform_hooks.get_stacktrace_handler(CORE.target_platform)
-
-    backtrace_state = False
+    # Decoder resolution, crash isolation, and disable-after-failure
+    # all live in LogLineProcessor, shared with the API log path.
+    processor = LogLineProcessor(config, CORE.target_platform)
     ser = serial.Serial()
     ser.baudrate = baud_rate
     ser.port = port
@@ -674,11 +673,7 @@ def run_miniterm(config: ConfigType, port: str, args) -> int:
                                 "utf8", "backslashreplace"
                             )
                             safe_print(parser.parse_line(line, time_str))
-
-                            if process_stacktrace is not None:
-                                backtrace_state = process_stacktrace(
-                                    config, line, backtrace_state
-                                )
+                            processor.process_line(line)
                     except serial.SerialException:
                         _LOGGER.error("Serial port closed!")
                         return 0

--- a/esphome/api_client.py
+++ b/esphome/api_client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 from contextlib import suppress
 from datetime import datetime
-import importlib
 import logging
 from typing import TYPE_CHECKING, Any
 import warnings
@@ -18,6 +17,7 @@ with warnings.catch_warnings():
 
 from esphome.const import CONF_ENCRYPTION, CONF_KEY, CONF_PORT, __version__
 from esphome.core import CORE
+from esphome.stacktrace import LogLineProcessor
 from esphome.util import safe_print
 
 if TYPE_CHECKING:
@@ -27,50 +27,6 @@ if TYPE_CHECKING:
 
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class _LogLineProcessor:
-    """Feeds incoming log lines to the stack-trace decoder.
-
-    Two responsibilities beyond just calling the decoder:
-    1. Catch everything the decoder can raise. aioesphomeapi isolates
-       exceptions raised by log handlers, so an escaping one no longer
-       kills the session, but it does log a full traceback per line. A
-       crash dump carries a PC line plus one per backtrace frame, so the
-       tracebacks bury the dump the user is trying to read. Decoding is a
-       diagnostic nicety; nothing it raises is worth that noise.
-    2. Disable decoding after the first failure. _decode_pc shells out to
-       the toolchain to resolve addr2line, which is expensive; a single
-       crash dump can contain many PC/BT lines and we don't want to retry
-       the failing subprocess for each one. This only works if every
-       failure is caught, which is why 1 is not narrowed to EsphomeError.
-    """
-
-    def __init__(self, config: dict[str, Any], platform_handler: Any | None) -> None:
-        self._config = config
-        self._platform_handler = platform_handler
-        self._decode_enabled = platform_handler is not None
-        self.backtrace_state = False
-
-    def process_line(self, raw_line: str) -> None:
-        if not self._decode_enabled:
-            return
-        try:
-            self.backtrace_state = self._platform_handler(
-                self._config, raw_line, self.backtrace_state
-            )
-        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
-            self._decode_enabled = False
-            self.backtrace_state = False
-            # _run_idedata raises EsphomeError with no message; fall back
-            # to a generic explanation when str(exc) is empty.
-            detail = str(exc) or "build artifacts not found locally"
-            _LOGGER.debug("Stack-trace decoding failed", exc_info=True)
-            _LOGGER.warning(
-                "Crash trace decoding unavailable: %s. "
-                "Run 'esphome compile' for this device to enable PC decoding.",
-                detail,
-            )
 
 
 async def async_run_logs(
@@ -100,21 +56,9 @@ async def async_run_logs(
         provide_time=False,
     )
 
-    # Try platform-specific stacktrace handler first, fall back to generic
-    platform_process_stacktrace = None
-    try:
-        module = importlib.import_module("esphome.components." + CORE.target_platform)
-        platform_process_stacktrace = module.process_stacktrace
-    except (AttributeError, ImportError):
-        # Distinguish "platform has no analyzer" from a genuinely broken
-        # platform package when debugging.
-        _LOGGER.debug("Stacktrace analyzer lookup failed", exc_info=True)
-        _LOGGER.info(
-            'Stacktrace analysis is unavailable: no compatible analyzer found for target platform "%s".',
-            CORE.target_platform,
-        )
-
-    processor = _LogLineProcessor(config, platform_process_stacktrace)
+    # Decoder resolution, crash isolation, and disable-after-failure
+    # all live in LogLineProcessor, shared with the serial log path.
+    processor = LogLineProcessor(config, CORE.target_platform)
 
     def on_log(msg: SubscribeLogsResponse) -> None:
         """Handle a new log message."""

--- a/esphome/platform_hooks.py
+++ b/esphome/platform_hooks.py
@@ -10,10 +10,9 @@ imports each platform package and fails when they drift.
 
 The compile-path ``run_compile`` hook is deliberately not registered:
 compiling imports the platform package regardless, so its probe in
-``__main__.py`` stays eager. The serial log path resolves
-``process_stacktrace`` through get_stacktrace_handler below; the network
-log client's probe in ``esphome/api_client.py`` still uses the old
-importlib pattern and is converted separately.
+``__main__.py`` stays eager. Both log paths resolve
+``process_stacktrace`` through ``esphome.stacktrace.LogLineProcessor``,
+which uses get_stacktrace_handler below.
 """
 
 from __future__ import annotations

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -370,7 +370,9 @@ def _run_idedata(config):
         raise EsphomeError("Could not launch platformio to get idedata")
     match = re.search(r'{\s*".*}', stdout)
     if match is None:
-        _LOGGER.error("Could not match idedata, please report this error")
+        # A run that launches but fails emits its build error instead of
+        # idedata; the logged stdout is the useful part, not a bug report.
+        _LOGGER.error("Could not find idedata in the platformio output")
         _LOGGER.error("Stdout: %s", stdout)
         raise EsphomeError("PlatformIO did not report idedata")
 
@@ -457,8 +459,10 @@ class IDEData:
                 for entry in self._require("extra", "flash_images")
             ]
         except (KeyError, TypeError) as err:
+            # Covers entries missing path/offset and a null or non-list
+            # flash_images value alike.
             raise EsphomeError(
-                "Cached idedata is incomplete (missing extra.flash_images entry fields)"
+                "Cached idedata is incomplete (malformed extra.flash_images)"
             ) from err
 
     @property

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -365,11 +365,9 @@ def _run_idedata(config):
     args = ["-t", "idedata"]
     stdout = run_platformio_cli_run(config, False, *args, capture_stdout=True)
     if not isinstance(stdout, str):
-        # run_external_process returns its exit code when launching
-        # platformio itself failed; that is the environment, not us.
-        raise EsphomeError(
-            f"Running platformio to get idedata failed with exit code {stdout}"
-        )
+        # run_external_process returns 1 instead of captured output when
+        # launching platformio raised; see the error it logged above.
+        raise EsphomeError("Could not launch platformio to get idedata")
     match = re.search(r'{\s*".*}', stdout)
     if match is None:
         _LOGGER.error("Could not match idedata, please report this error")
@@ -433,10 +431,11 @@ class IDEData:
         the key so a platformio schema change stays diagnosable.
         """
         value = self.raw
+        # TypeError covers a key that is null instead of absent.
         try:
             for key in keys:
                 value = value[key]
-        except KeyError as err:
+        except (KeyError, TypeError) as err:
             raise EsphomeError(
                 f"Cached idedata is incomplete (missing {'.'.join(keys)})"
             ) from err
@@ -452,10 +451,15 @@ class IDEData:
 
     @property
     def extra_flash_images(self) -> list[FlashImage]:
-        return [
-            FlashImage(path=Path(entry["path"]), offset=entry["offset"])
-            for entry in self._require("extra", "flash_images")
-        ]
+        try:
+            return [
+                FlashImage(path=Path(entry["path"]), offset=entry["offset"])
+                for entry in self._require("extra", "flash_images")
+            ]
+        except (KeyError, TypeError) as err:
+            raise EsphomeError(
+                "Cached idedata is incomplete (missing extra.flash_images entry fields)"
+            ) from err
 
     @property
     def cc_path(self) -> str:

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -364,18 +364,22 @@ def run_compile(config, verbose):
 def _run_idedata(config):
     args = ["-t", "idedata"]
     stdout = run_platformio_cli_run(config, False, *args, capture_stdout=True)
+    if not isinstance(stdout, str):
+        # run_external_process returns its exit code when launching
+        # platformio itself failed; that is the environment, not us.
+        raise EsphomeError("Running platformio to get idedata failed")
     match = re.search(r'{\s*".*}', stdout)
     if match is None:
         _LOGGER.error("Could not match idedata, please report this error")
         _LOGGER.error("Stdout: %s", stdout)
-        raise EsphomeError
+        raise EsphomeError("PlatformIO did not report idedata")
 
     try:
         return json.loads(match.group())
-    except ValueError:
+    except ValueError as err:
         _LOGGER.exception("Could not parse idedata")
         _LOGGER.error("Stdout: %s", stdout)
-        raise
+        raise EsphomeError("Could not parse idedata from platformio") from err
 
 
 def _load_idedata(config):
@@ -421,7 +425,12 @@ class IDEData:
 
     @property
     def firmware_elf_path(self) -> Path:
-        return Path(self.raw["prog_path"])
+        try:
+            return Path(self.raw["prog_path"])
+        except KeyError as err:
+            # A stale or truncated cached idedata JSON is the user's
+            # build tree, not a bug; recompiling regenerates it.
+            raise EsphomeError("Cached idedata is incomplete") from err
 
     @property
     def firmware_bin_path(self) -> Path:

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -423,14 +423,23 @@ class IDEData:
     def __init__(self, raw):
         self.raw = raw
 
+    def _require(self, *keys: str):
+        """Read a nested key, classifying a miss as an environment error.
+
+        A stale or truncated cached idedata JSON is the user's build
+        tree, not a bug; recompiling regenerates it.
+        """
+        value = self.raw
+        try:
+            for key in keys:
+                value = value[key]
+        except KeyError as err:
+            raise EsphomeError("Cached idedata is incomplete") from err
+        return value
+
     @property
     def firmware_elf_path(self) -> Path:
-        try:
-            return Path(self.raw["prog_path"])
-        except KeyError as err:
-            # A stale or truncated cached idedata JSON is the user's
-            # build tree, not a bug; recompiling regenerates it.
-            raise EsphomeError("Cached idedata is incomplete") from err
+        return Path(self._require("prog_path"))
 
     @property
     def firmware_bin_path(self) -> Path:
@@ -440,13 +449,13 @@ class IDEData:
     def extra_flash_images(self) -> list[FlashImage]:
         return [
             FlashImage(path=Path(entry["path"]), offset=entry["offset"])
-            for entry in self.raw["extra"]["flash_images"]
+            for entry in self._require("extra", "flash_images")
         ]
 
     @property
     def cc_path(self) -> str:
         # For example /Users/<USER>/.platformio/packages/toolchain-xtensa32/bin/xtensa-esp32-elf-gcc
-        return self.raw["cc_path"]
+        return self._require("cc_path")
 
     @property
     def addr2line_path(self) -> str:

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import re
 import shutil
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import platformdirs
 
@@ -367,7 +367,9 @@ def _run_idedata(config):
     if not isinstance(stdout, str):
         # run_external_process returns its exit code when launching
         # platformio itself failed; that is the environment, not us.
-        raise EsphomeError("Running platformio to get idedata failed")
+        raise EsphomeError(
+            f"Running platformio to get idedata failed with exit code {stdout}"
+        )
     match = re.search(r'{\s*".*}', stdout)
     if match is None:
         _LOGGER.error("Could not match idedata, please report this error")
@@ -423,18 +425,21 @@ class IDEData:
     def __init__(self, raw):
         self.raw = raw
 
-    def _require(self, *keys: str):
+    def _require(self, *keys: str) -> Any:
         """Read a nested key, classifying a miss as an environment error.
 
         A stale or truncated cached idedata JSON is the user's build
-        tree, not a bug; recompiling regenerates it.
+        tree, not a bug; recompiling regenerates it. The message names
+        the key so a platformio schema change stays diagnosable.
         """
         value = self.raw
         try:
             for key in keys:
                 value = value[key]
         except KeyError as err:
-            raise EsphomeError("Cached idedata is incomplete") from err
+            raise EsphomeError(
+                f"Cached idedata is incomplete (missing {'.'.join(keys)})"
+            ) from err
         return value
 
     @property

--- a/esphome/stacktrace.py
+++ b/esphome/stacktrace.py
@@ -93,6 +93,9 @@ class LogLineProcessor:
             self.backtrace_state = self._platform_handler(
                 self._config, raw_line, self.backtrace_state
             )
+            # A success ends the failure episode; a later failure with
+            # the same message is a new episode and warns in full again.
+            self._last_failure = None
         except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
             self._decode_enabled = False
             self._disabled_at = time.monotonic()

--- a/esphome/stacktrace.py
+++ b/esphome/stacktrace.py
@@ -1,0 +1,73 @@
+"""Stack-trace decoding for streamed device log lines.
+
+Shared by the serial (run_miniterm) and network (api_client) log paths.
+Deliberately light: importing this module must not pull in aioesphomeapi
+or any platform package.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from esphome import platform_hooks
+from esphome.core import EsphomeError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LogLineProcessor:
+    """Feeds incoming log lines to the stack-trace decoder.
+
+    Two responsibilities beyond just calling the decoder:
+    1. Catch everything the decoder can raise. aioesphomeapi isolates
+       exceptions raised by log handlers, so an escaping one no longer
+       kills the session, but it does log a full traceback per line. A
+       crash dump carries a PC line plus one per backtrace frame, so the
+       tracebacks bury the dump the user is trying to read. Decoding is a
+       diagnostic nicety; nothing it raises is worth that noise.
+    2. Disable decoding after the first failure. _decode_pc shells out to
+       the toolchain to resolve addr2line, which is expensive; a single
+       crash dump can contain many PC/BT lines and we don't want to retry
+       the failing subprocess for each one. This only works if every
+       failure is caught, which is why 1 is not narrowed to EsphomeError.
+    """
+
+    def __init__(self, config: dict[str, Any], platform: str) -> None:
+        self._config = config
+        self._platform = platform
+        self._platform_handler = platform_hooks.get_stacktrace_handler(platform)
+        self._decode_enabled = self._platform_handler is not None
+        self.backtrace_state = False
+
+    def process_line(self, raw_line: str) -> None:
+        if not self._decode_enabled:
+            return
+        self._feed(raw_line)
+
+    def _feed(self, raw_line: str) -> None:
+        try:
+            self.backtrace_state = self._platform_handler(
+                self._config, raw_line, self.backtrace_state
+            )
+        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
+            self._decode_enabled = False
+            self.backtrace_state = False
+            _LOGGER.debug("Stack-trace decoding failed", exc_info=True)
+            if isinstance(exc, EsphomeError):
+                # _run_idedata raises EsphomeError with no message; give
+                # that case its friendly remediation hint.
+                _LOGGER.warning(
+                    "Crash trace decoding unavailable: %s. "
+                    "Run 'esphome compile' for this device to enable PC decoding.",
+                    str(exc) or "build artifacts not found locally",
+                )
+            else:
+                # A decoder bug is ESPHome's problem, not the user's;
+                # don't send them to recompile a healthy build.
+                _LOGGER.warning(
+                    'Crash trace decoding disabled: decoder for "%s" raised %s '
+                    "(this is a bug; run with -v for the traceback)",
+                    self._platform,
+                    str(exc) or type(exc).__name__,
+                )

--- a/esphome/stacktrace.py
+++ b/esphome/stacktrace.py
@@ -8,12 +8,21 @@ or any platform package.
 from __future__ import annotations
 
 import logging
+import time
 
 from esphome import platform_hooks
 from esphome.core import EsphomeError
 from esphome.types import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
+
+# How long a decode failure keeps decoding off. Long enough that a dump
+# with many PC/BT lines fails once instead of retrying a failing
+# addr2line per line, short enough that a transient cause (a concurrent
+# compile rewriting the build tree, a momentary toolchain lock) does not
+# blank out decoding for the rest of a multi-hour session. A permanent
+# cause re-fails and re-warns at most once per cooldown.
+_REARM_COOLDOWN_S = 60.0
 
 
 class LogLineProcessor:
@@ -26,11 +35,13 @@ class LogLineProcessor:
        crash dump carries a PC line plus one per backtrace frame, so the
        tracebacks bury the dump the user is trying to read. Decoding is a
        diagnostic nicety; nothing it raises is worth that noise.
-    2. Disable decoding after the first failure. _decode_pc shells out to
-       the toolchain to resolve addr2line, which is expensive; a single
-       crash dump can contain many PC/BT lines and we don't want to retry
-       the failing subprocess for each one. This only works if every
-       failure is caught, which is why 1 is not narrowed to EsphomeError.
+    2. Disable decoding after a failure, for _REARM_COOLDOWN_S. _decode_pc
+       shells out to the toolchain to resolve addr2line, which is
+       expensive; a single crash dump can contain many PC/BT lines and we
+       don't want to retry the failing subprocess for each one. This only
+       works if every failure is caught, which is why 1 is not narrowed
+       to EsphomeError. A platform without an analyzer stays off for the
+       whole session; there is nothing to retry.
     """
 
     def __init__(self, config: ConfigType, platform: str) -> None:
@@ -38,12 +49,23 @@ class LogLineProcessor:
         self._platform = platform
         self._platform_handler = platform_hooks.get_stacktrace_handler(platform)
         self._decode_enabled = self._platform_handler is not None
+        self._disabled_at: float | None = None
         self.backtrace_state = False
 
     def process_line(self, raw_line: str) -> None:
-        if not self._decode_enabled:
+        if not self._decode_enabled and not self._rearm():
             return
         self._feed(raw_line)
+
+    def _rearm(self) -> bool:
+        """Give decoding another try once the failure cooldown has passed."""
+        if self._disabled_at is None:  # no analyzer; nothing to retry
+            return False
+        if time.monotonic() - self._disabled_at < _REARM_COOLDOWN_S:
+            return False
+        self._decode_enabled = True
+        self._disabled_at = None
+        return True
 
     def _feed(self, raw_line: str) -> None:
         try:
@@ -52,6 +74,7 @@ class LogLineProcessor:
             )
         except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
             self._decode_enabled = False
+            self._disabled_at = time.monotonic()
             self.backtrace_state = False
             _LOGGER.debug("Stack-trace decoding failed", exc_info=True)
             if isinstance(exc, (EsphomeError, OSError)):

--- a/esphome/stacktrace.py
+++ b/esphome/stacktrace.py
@@ -54,9 +54,10 @@ class LogLineProcessor:
             self._decode_enabled = False
             self.backtrace_state = False
             _LOGGER.debug("Stack-trace decoding failed", exc_info=True)
-            if isinstance(exc, EsphomeError):
-                # _run_idedata raises EsphomeError with no message; give
-                # that case its friendly remediation hint.
+            if isinstance(exc, (EsphomeError, OSError)):
+                # _run_idedata raises EsphomeError with no message, and a
+                # missing build tree surfaces as an OSError; both are the
+                # user's environment, so give the remediation hint.
                 _LOGGER.warning(
                     "Crash trace decoding unavailable: %s. "
                     "Run 'esphome compile' for this device to enable PC decoding.",
@@ -64,10 +65,15 @@ class LogLineProcessor:
                 )
             else:
                 # A decoder bug is ESPHome's problem, not the user's;
-                # don't send them to recompile a healthy build.
+                # don't send them to recompile a healthy build. Always
+                # name the type: a bare KeyError message reads like a
+                # raised string in the paste a bug report needs.
+                detail = type(exc).__name__
+                if msg := str(exc):
+                    detail = f"{detail}: {msg}"
                 _LOGGER.warning(
                     'Crash trace decoding disabled: decoder for "%s" raised %s '
                     "(this is a bug; run with -v for the traceback)",
                     self._platform,
-                    str(exc) or type(exc).__name__,
+                    detail,
                 )

--- a/esphome/stacktrace.py
+++ b/esphome/stacktrace.py
@@ -47,8 +47,10 @@ class LogLineProcessor:
        expensive; a single crash dump can contain many PC/BT lines and we
        don't want to retry the failing subprocess for each one. This only
        works if every failure is caught, which is why 1 is not narrowed
-       to EsphomeError. A platform without an analyzer stays off for the
-       whole session; there is nothing to retry.
+       to EsphomeError. A platform without an analyzer, or one whose
+       package failed to load, stays off for the whole session; an
+       import that just failed will not heal mid-stream, so there is
+       nothing worth retrying.
     """
 
     def __init__(self, config: ConfigType, platform: str) -> None:

--- a/esphome/stacktrace.py
+++ b/esphome/stacktrace.py
@@ -27,9 +27,13 @@ _LOGGER = logging.getLogger(__name__)
 # with many PC/BT lines fails once instead of retrying a failing
 # addr2line per line, short enough that a transient cause (a concurrent
 # compile rewriting the build tree, a momentary toolchain lock) does not
-# blank out decoding for the rest of a multi-hour session. A permanent
-# cause re-fails and re-warns at most once per cooldown.
+# blank out decoding for the rest of a multi-hour session. Each retry
+# re-runs the failing toolchain subprocess, which hitches the stream,
+# so identical re-failures double the cooldown up to the ceiling; a fix
+# is still picked up within minutes while a permanently broken
+# environment ends up retrying a few times an hour, not once a minute.
 _REARM_COOLDOWN_S = 60.0
+_REARM_COOLDOWN_MAX_S = 900.0
 
 
 class LogLineProcessor:
@@ -73,6 +77,7 @@ class LogLineProcessor:
         self._decode_enabled = self._platform_handler is not None
         self._disabled_at: float | None = None
         self._last_failure: str | None = None
+        self._cooldown = _REARM_COOLDOWN_S
         self.backtrace_state = False
 
     def process_line(self, raw_line: str) -> None:
@@ -84,7 +89,7 @@ class LogLineProcessor:
         """Give decoding another try once the failure cooldown has passed."""
         if self._disabled_at is None:  # no analyzer; nothing to retry
             return False
-        if time.monotonic() - self._disabled_at < _REARM_COOLDOWN_S:
+        if time.monotonic() - self._disabled_at < self._cooldown:
             return False
         self._decode_enabled = True
         self._disabled_at = None
@@ -96,8 +101,10 @@ class LogLineProcessor:
                 self._config, raw_line, self.backtrace_state
             )
             # A success ends the failure episode; a later failure with
-            # the same message is a new episode and warns in full again.
+            # the same message is a new episode, warns in full again and
+            # starts back at the short cooldown.
             self._last_failure = None
+            self._cooldown = _REARM_COOLDOWN_S
         except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
             self._decode_enabled = False
             self._disabled_at = time.monotonic()
@@ -106,16 +113,19 @@ class LogLineProcessor:
             failure = f"{type(exc).__name__}: {exc}"
             if failure == self._last_failure:
                 # A permanent cause re-fails on every re-arm; one full
-                # warning is enough. Repeats go to debug so an hours-long
-                # crash loop does not bury the dump in reminders, while a
-                # changed failure still warns.
+                # warning is enough. Repeats go to debug and back off so
+                # an hours-long crash loop neither buries the dump in
+                # reminders nor hitches the stream once a minute.
+                self._cooldown = min(self._cooldown * 2, _REARM_COOLDOWN_MAX_S)
                 _LOGGER.debug("Stack-trace decoding still failing: %s", failure)
                 return
             self._last_failure = failure
+            self._cooldown = _REARM_COOLDOWN_S
             if isinstance(exc, (EsphomeError, OSError)):
-                # _run_idedata raises EsphomeError with no message, and a
-                # missing build tree surfaces as an OSError; both are the
-                # user's environment, so give the remediation hint.
+                # The environment branch: idedata and build tree failures
+                # get the remediation hint. The fallback string is
+                # defensive; the in-tree raise sites all carry a message
+                # now, but a bare EsphomeError must not render as parens.
                 _LOGGER.warning(
                     "Crash trace decoding unavailable: %s. "
                     "Run 'esphome compile' for this device to enable PC decoding.",

--- a/esphome/stacktrace.py
+++ b/esphome/stacktrace.py
@@ -8,7 +8,6 @@ or any platform package.
 from __future__ import annotations
 
 import logging
-from time import monotonic
 from typing import TYPE_CHECKING
 
 from esphome import platform_hooks
@@ -23,18 +22,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# How long a decode failure keeps decoding off. Long enough that a dump
-# with many PC/BT lines fails once instead of retrying a failing
-# addr2line per line, short enough that a transient cause (a concurrent
-# compile rewriting the build tree, a momentary toolchain lock) does not
-# blank out decoding for the rest of a multi-hour session. Each retry
-# re-runs the failing toolchain subprocess, which hitches the stream,
-# so identical re-failures double the cooldown up to the ceiling; a fix
-# is still picked up within minutes while a permanently broken
-# environment ends up retrying a few times an hour, not once a minute.
-_REARM_COOLDOWN_S = 60.0
-_REARM_COOLDOWN_MAX_S = 900.0
-
 
 class LogLineProcessor:
     """Feeds incoming log lines to the stack-trace decoder.
@@ -46,15 +33,16 @@ class LogLineProcessor:
        crash dump carries a PC line plus one per backtrace frame, so the
        tracebacks bury the dump the user is trying to read. Decoding is a
        diagnostic nicety; nothing it raises is worth that noise.
-    2. Disable decoding after a failure, for _REARM_COOLDOWN_S. _decode_pc
-       shells out to the toolchain to resolve addr2line, which is
-       expensive; a single crash dump can contain many PC/BT lines and we
-       don't want to retry the failing subprocess for each one. This only
-       works if every failure is caught, which is why 1 is not narrowed
-       to EsphomeError. A platform without an analyzer, or one whose
-       package failed to load, stays off for the whole session; an
-       import that just failed will not heal mid-stream, so there is
-       nothing worth retrying.
+    2. Disable decoding for the rest of the session after a failure.
+       _decode_pc shells out to the toolchain to resolve addr2line,
+       which is expensive; a single crash dump can contain many PC/BT
+       lines and we don't want to retry the failing subprocess for each
+       one. This only works if every failure is caught, which is why 1
+       is not narrowed to EsphomeError. The latch is deliberately one
+       way: nothing a decode failure depends on heals by itself within
+       a session, the warning names the fix, and a fresh ``esphome
+       logs`` run picks it up; retrying mid-session would block the
+       stream with a failing subprocess instead.
     """
 
     def __init__(self, config: ConfigType, platform: str) -> None:
@@ -75,25 +63,12 @@ class LogLineProcessor:
             )
             self._platform_handler = None
         self._decode_enabled = self._platform_handler is not None
-        self._disabled_at: float | None = None
-        self._last_failure: str | None = None
-        self._cooldown = _REARM_COOLDOWN_S
         self.backtrace_state = False
 
     def process_line(self, raw_line: str) -> None:
-        if not self._decode_enabled and not self._rearm():
+        if not self._decode_enabled:
             return
         self._feed(raw_line)
-
-    def _rearm(self) -> bool:
-        """Give decoding another try once the failure cooldown has passed."""
-        if self._disabled_at is None:  # no analyzer; nothing to retry
-            return False
-        if monotonic() - self._disabled_at < self._cooldown:
-            return False
-        self._decode_enabled = True
-        self._disabled_at = None
-        return True
 
     def _feed(self, raw_line: str) -> None:
         try:
@@ -102,23 +77,8 @@ class LogLineProcessor:
             )
         except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
             self._decode_enabled = False
-            self._disabled_at = monotonic()
             self.backtrace_state = False
             _LOGGER.debug("Stack-trace decoding failed", exc_info=True)
-            failure = f"{type(exc).__name__}: {exc}"
-            if failure == self._last_failure:
-                # A permanent cause re-fails on every re-arm; one full
-                # warning is enough. Repeats go to debug and back off so
-                # an hours-long crash loop neither buries the dump in
-                # reminders nor hitches the stream once a minute. The
-                # episode deliberately survives non-raising returns: an
-                # ordinary line proves nothing about the environment,
-                # and a healed one simply stops failing.
-                self._cooldown = min(self._cooldown * 2, _REARM_COOLDOWN_MAX_S)
-                _LOGGER.debug("Stack-trace decoding still failing: %s", failure)
-                return
-            self._last_failure = failure
-            self._cooldown = _REARM_COOLDOWN_S
             if isinstance(exc, (EsphomeError, OSError)):
                 # The environment branch: idedata and build tree failures
                 # get the remediation hint. The fallback string is

--- a/esphome/stacktrace.py
+++ b/esphome/stacktrace.py
@@ -47,9 +47,20 @@ class LogLineProcessor:
     def __init__(self, config: ConfigType, platform: str) -> None:
         self._config = config
         self._platform = platform
-        self._platform_handler = platform_hooks.get_stacktrace_handler(platform)
+        try:
+            self._platform_handler = platform_hooks.get_stacktrace_handler(platform)
+        except Exception:  # noqa: BLE001  # pylint: disable=broad-except
+            # Total containment includes resolution: a platform package
+            # broken in an unanticipated way must not kill the session.
+            _LOGGER.debug("Stacktrace analyzer resolution failed", exc_info=True)
+            _LOGGER.warning(
+                'Stacktrace analysis is unavailable: analyzer for target platform "%s" could not be loaded.',
+                platform,
+            )
+            self._platform_handler = None
         self._decode_enabled = self._platform_handler is not None
         self._disabled_at: float | None = None
+        self._last_failure: str | None = None
         self.backtrace_state = False
 
     def process_line(self, raw_line: str) -> None:
@@ -77,6 +88,15 @@ class LogLineProcessor:
             self._disabled_at = time.monotonic()
             self.backtrace_state = False
             _LOGGER.debug("Stack-trace decoding failed", exc_info=True)
+            failure = f"{type(exc).__name__}: {exc}"
+            if failure == self._last_failure:
+                # A permanent cause re-fails on every re-arm; one full
+                # warning is enough. Repeats go to debug so an hours-long
+                # crash loop does not bury the dump in reminders, while a
+                # changed failure still warns.
+                _LOGGER.debug("Stack-trace decoding still failing: %s", failure)
+                return
+            self._last_failure = failure
             if isinstance(exc, (EsphomeError, OSError)):
                 # _run_idedata raises EsphomeError with no message, and a
                 # missing build tree surfaces as an OSError; both are the

--- a/esphome/stacktrace.py
+++ b/esphome/stacktrace.py
@@ -8,10 +8,10 @@ or any platform package.
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from esphome import platform_hooks
 from esphome.core import EsphomeError
+from esphome.types import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class LogLineProcessor:
        failure is caught, which is why 1 is not narrowed to EsphomeError.
     """
 
-    def __init__(self, config: dict[str, Any], platform: str) -> None:
+    def __init__(self, config: ConfigType, platform: str) -> None:
         self._config = config
         self._platform = platform
         self._platform_handler = platform_hooks.get_stacktrace_handler(platform)

--- a/esphome/stacktrace.py
+++ b/esphome/stacktrace.py
@@ -8,7 +8,7 @@ or any platform package.
 from __future__ import annotations
 
 import logging
-import time
+from time import monotonic
 from typing import TYPE_CHECKING
 
 from esphome import platform_hooks
@@ -89,7 +89,7 @@ class LogLineProcessor:
         """Give decoding another try once the failure cooldown has passed."""
         if self._disabled_at is None:  # no analyzer; nothing to retry
             return False
-        if time.monotonic() - self._disabled_at < self._cooldown:
+        if monotonic() - self._disabled_at < self._cooldown:
             return False
         self._decode_enabled = True
         self._disabled_at = None
@@ -100,14 +100,9 @@ class LogLineProcessor:
             self.backtrace_state = self._platform_handler(
                 self._config, raw_line, self.backtrace_state
             )
-            # A success ends the failure episode; a later failure with
-            # the same message is a new episode, warns in full again and
-            # starts back at the short cooldown.
-            self._last_failure = None
-            self._cooldown = _REARM_COOLDOWN_S
         except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
             self._decode_enabled = False
-            self._disabled_at = time.monotonic()
+            self._disabled_at = monotonic()
             self.backtrace_state = False
             _LOGGER.debug("Stack-trace decoding failed", exc_info=True)
             failure = f"{type(exc).__name__}: {exc}"
@@ -115,7 +110,10 @@ class LogLineProcessor:
                 # A permanent cause re-fails on every re-arm; one full
                 # warning is enough. Repeats go to debug and back off so
                 # an hours-long crash loop neither buries the dump in
-                # reminders nor hitches the stream once a minute.
+                # reminders nor hitches the stream once a minute. The
+                # episode deliberately survives non-raising returns: an
+                # ordinary line proves nothing about the environment,
+                # and a healed one simply stops failing.
                 self._cooldown = min(self._cooldown * 2, _REARM_COOLDOWN_MAX_S)
                 _LOGGER.debug("Stack-trace decoding still failing: %s", failure)
                 return

--- a/esphome/stacktrace.py
+++ b/esphome/stacktrace.py
@@ -9,10 +9,17 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import TYPE_CHECKING
 
 from esphome import platform_hooks
 from esphome.core import EsphomeError
 from esphome.types import ConfigType
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    # The contract every platform's process_stacktrace implements.
+    StacktraceHandler = Callable[[ConfigType, str, bool], bool]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,15 +54,18 @@ class LogLineProcessor:
     def __init__(self, config: ConfigType, platform: str) -> None:
         self._config = config
         self._platform = platform
+        self._platform_handler: StacktraceHandler | None
         try:
             self._platform_handler = platform_hooks.get_stacktrace_handler(platform)
-        except Exception:  # noqa: BLE001  # pylint: disable=broad-except
+        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
             # Total containment includes resolution: a platform package
             # broken in an unanticipated way must not kill the session.
+            # Name the cause; the full traceback only exists at debug.
             _LOGGER.debug("Stacktrace analyzer resolution failed", exc_info=True)
             _LOGGER.warning(
-                'Stacktrace analysis is unavailable: analyzer for target platform "%s" could not be loaded.',
+                'Stacktrace analysis is unavailable: analyzer for target platform "%s" could not be loaded: %s',
                 platform,
+                f"{type(exc).__name__}: {exc}",
             )
             self._platform_handler = None
         self._decode_enabled = self._platform_handler is not None

--- a/tests/unit_tests/analyze_memory/test_build_artifacts.py
+++ b/tests/unit_tests/analyze_memory/test_build_artifacts.py
@@ -143,8 +143,8 @@ def test_cc_path_from_cxx(cxx_path: str, expected: str) -> None:
 def test_native_idedata_resolves_toolchain_tools() -> None:
     """The binutils paths are derived from the native ESP-IDF cc_path.
 
-    Without cc_path, IDEData.objdump_path raises KeyError and the memory
-    analysis silently degrades to no component or symbol detail.
+    Without cc_path, IDEData.objdump_path raises EsphomeError and the
+    memory analysis silently degrades to no component or symbol detail.
     """
     idedata = IDEData(
         {

--- a/tests/unit_tests/test_api_client.py
+++ b/tests/unit_tests/test_api_client.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from esphome import api_client
-from esphome.components import esp32
 from esphome.const import (
     CONF_ENCRYPTION,
     CONF_KEY,
@@ -16,7 +15,7 @@ from esphome.const import (
     KEY_CORE,
     KEY_TARGET_PLATFORM,
 )
-from esphome.core import CORE, EsphomeError
+from esphome.core import CORE
 
 
 def test_component_shim_reexports_runtime_client() -> None:
@@ -27,135 +26,6 @@ def test_component_shim_reexports_runtime_client() -> None:
     assert shim.run_logs is api_client.run_logs
     assert shim.async_run_logs is api_client.async_run_logs
     assert api.CONF_ENCRYPTION is CONF_ENCRYPTION
-
-
-def test_decoder_swallows_esphome_error() -> None:
-    """A failing stack-trace decode must not propagate.
-
-    aioesphomeapi isolates exceptions raised by log handlers, so an
-    escaping one logs a full traceback for every line it fires on rather
-    than being reported once as an unavailable decoder.
-    """
-    config = {"esphome": {"name": "test"}}
-
-    with patch.object(
-        esp32, "process_stacktrace", side_effect=EsphomeError("no idedata")
-    ) as mock_process:
-        processor = api_client._LogLineProcessor(config, esp32.process_stacktrace)
-        processor.process_line("PC: 0x4010496e")
-
-    assert mock_process.called
-    assert processor.backtrace_state is False
-
-
-def test_decoder_swallows_platform_handler_error() -> None:
-    """The same protection must apply to the platform-specific handler."""
-    config = {"esphome": {"name": "test"}}
-
-    def platform_handler(_config, _line, _state):
-        raise EsphomeError("no idedata")
-
-    processor = api_client._LogLineProcessor(config, platform_handler)
-    processor.process_line("PC: 0x4010496e")
-
-    assert processor.backtrace_state is False
-
-
-def test_decoder_swallows_non_esphome_error() -> None:
-    """Decoding failures that aren't EsphomeError must be contained too.
-
-    A missing build directory surfaces as FileNotFoundError from the toolchain
-    subprocess. aioesphomeapi isolates it, so the session survives, but it logs
-    a traceback for every PC/BT line and decoding is never disabled, which
-    buries the crash dump the user is trying to read.
-    """
-    config = {"esphome": {"name": "test"}}
-
-    with patch.object(
-        esp32,
-        "process_stacktrace",
-        side_effect=FileNotFoundError(
-            2, "No such file or directory", "/build/ol/build"
-        ),
-    ) as mock_process:
-        processor = api_client._LogLineProcessor(config, esp32.process_stacktrace)
-        processor.process_line("PC: 0x4010496e")
-        processor.process_line("BT0: 0x4010496e")
-
-    # Disabled after the first failure rather than retried per backtrace line.
-    assert mock_process.call_count == 1
-    assert processor.backtrace_state is False
-
-
-def test_decoder_warning_uses_fallback_for_empty_error(caplog) -> None:
-    """_run_idedata raises EsphomeError with no message; the warning
-    must show a useful explanation rather than empty parens.
-    """
-    config = {"esphome": {"name": "test"}}
-
-    with patch.object(esp32, "process_stacktrace", side_effect=EsphomeError()):
-        processor = api_client._LogLineProcessor(config, esp32.process_stacktrace)
-        processor.process_line("PC: 0x4010496e")
-
-    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
-    assert any("build artifacts not found locally" in m for m in warnings)
-    assert not any("()" in m for m in warnings)
-
-
-def test_decoder_short_circuits_after_failure() -> None:
-    """After one failure, subsequent lines must not retry the decoder.
-
-    _decode_pc shells out to the toolchain; a crash dump can contain many
-    PC/BT lines and retrying the failing subprocess for each one would
-    stall log streaming.
-    """
-    config = {"esphome": {"name": "test"}}
-
-    with patch.object(
-        esp32, "process_stacktrace", side_effect=EsphomeError("no idedata")
-    ) as mock_process:
-        processor = api_client._LogLineProcessor(config, esp32.process_stacktrace)
-        processor.process_line("PC: 0x4010496e")
-        processor.process_line("BT0: 0x4010496e")
-        processor.process_line("BT1: 0x401049aa")
-
-    assert mock_process.call_count == 1
-
-
-def test_decoder_threads_backtrace_state() -> None:
-    """When decoding succeeds, backtrace_state is threaded across calls."""
-    config = {"esphome": {"name": "test"}}
-
-    with patch.object(
-        esp32, "process_stacktrace", side_effect=[True, False]
-    ) as mock_process:
-        processor = api_client._LogLineProcessor(config, esp32.process_stacktrace)
-        processor.process_line(">>>stack>>>")
-        assert processor.backtrace_state is True
-        processor.process_line("<<<stack<<<")
-        assert processor.backtrace_state is False
-
-    assert not mock_process.call_args_list[0].args[-1]
-    assert mock_process.call_args_list[1].args[-1]
-
-
-def test_decoder_uses_platform_handler_when_provided() -> None:
-    """The platform handler is preferred over the generic one."""
-    config = {"esphome": {"name": "test"}}
-    calls: list[tuple[object, str, bool]] = []
-
-    def platform_handler(cfg, line, state):
-        calls.append((cfg, line, state))
-        return True
-
-    processor = api_client._LogLineProcessor(config, platform_handler)
-
-    with patch.object(esp32, "process_stacktrace") as mock_generic:
-        processor.process_line("BT0: 0x4010496e")
-
-    assert calls == [(config, "BT0: 0x4010496e", False)]
-    assert mock_generic.called is False
-    assert processor.backtrace_state is True
 
 
 @pytest.mark.asyncio
@@ -194,6 +64,7 @@ async def test_async_run_logs_full_flow(caplog) -> None:
     stop() cleanup in the finally block.
     """
     caplog.set_level("INFO", logger="esphome.api_client")
+    caplog.set_level("INFO", logger="esphome.platform_hooks")
     CORE.data[KEY_CORE] = {KEY_TARGET_PLATFORM: "host"}
     config = {
         "esphome": {"name": "test"},
@@ -233,7 +104,7 @@ async def test_async_run_logs_full_flow(caplog) -> None:
     assert mock_client.call_args.kwargs["noise_psk"] == "psk123"
     assert mock_client.call_args.kwargs["addresses"] == ["1.2.3.4", "5.6.7.8"]
     assert "1.2.3.4 or 5.6.7.8" in caplog.text
-    # host has no stacktrace analyzer; the fallback message is logged.
+    # host has no stacktrace analyzer; the notice fires at session start.
     assert "Stacktrace analysis is unavailable" in caplog.text
     # The log message was printed with a timestamp prefix.
     assert any("hello world" in line for line in printed)

--- a/tests/unit_tests/test_lazy_imports.py
+++ b/tests/unit_tests/test_lazy_imports.py
@@ -37,6 +37,10 @@ HEAVY_MODULES = (
 # existence guard and the leak check must watch the same list.
 FAST_PATH_HEAVY_MODULES = HEAVY_MODULES + ("esphome.components.esp32",)
 
+# Heavy only for modules that must not know about the API transport;
+# in the existence guard so a rename can't silently no-op its check.
+API_HEAVY_MODULES = ("aioesphomeapi",)
+
 
 def _leaked_heavy_modules(module: str, extra: tuple[str, ...] = ()) -> str:
     """Import ``module`` in a subprocess and report the heavy modules it pulled.
@@ -73,7 +77,7 @@ def test_main_module_does_not_import_heavy_modules() -> None:
 
 def test_watched_heavy_modules_exist() -> None:
     """A renamed heavy module would silently disable the leak checks."""
-    for module in FAST_PATH_HEAVY_MODULES:
+    for module in FAST_PATH_HEAVY_MODULES + API_HEAVY_MODULES:
         assert importlib.util.find_spec(module) is not None, (
             f"{module} no longer resolves; update the heavy-module lists"
         )
@@ -131,7 +135,7 @@ def test_stacktrace_does_not_import_heavy_modules() -> None:
     starts; importing the module must not pull in aioesphomeapi or
     any platform package.
     """
-    leaked = _leaked_heavy_modules("esphome.stacktrace", extra=("aioesphomeapi",))
+    leaked = _leaked_heavy_modules("esphome.stacktrace", extra=API_HEAVY_MODULES)
     assert not leaked, (
         f"esphome.stacktrace imports heavy modules at top level: {leaked}. "
         "The logs fast path skips validation; importing the validation "

--- a/tests/unit_tests/test_lazy_imports.py
+++ b/tests/unit_tests/test_lazy_imports.py
@@ -38,15 +38,16 @@ HEAVY_MODULES = (
 FAST_PATH_HEAVY_MODULES = HEAVY_MODULES + ("esphome.components.esp32",)
 
 
-def _leaked_heavy_modules(module: str) -> str:
+def _leaked_heavy_modules(module: str, extra: tuple[str, ...] = ()) -> str:
     """Import ``module`` in a subprocess and report the heavy modules it pulled.
 
     Any ``esphome.components.*`` package counts as heavy: executing a
     component package drags in codegen/validation machinery by design.
+    ``extra`` adds modules that are heavy for this caller specifically.
     """
     check = (
         f"import sys; import {module}; "
-        f"leaked = [m for m in {HEAVY_MODULES!r} if m in sys.modules]; "
+        f"leaked = [m for m in {HEAVY_MODULES + extra!r} if m in sys.modules]; "
         "leaked += [m for m in sys.modules if m.startswith('esphome.components.')]; "
         "print(','.join(leaked))"
     )
@@ -118,6 +119,21 @@ def test_api_client_does_not_import_heavy_modules() -> None:
     leaked = _leaked_heavy_modules("esphome.api_client")
     assert not leaked, (
         f"esphome.api_client imports heavy modules at top level: {leaked}. "
+        "The logs fast path skips validation; importing the validation "
+        "stack anyway defeats the validated-config cache."
+    )
+
+
+def test_stacktrace_does_not_import_heavy_modules() -> None:
+    """``esphome.stacktrace`` guards its own docstring's contract.
+
+    Both log paths construct a LogLineProcessor before streaming
+    starts; importing the module must not pull in aioesphomeapi or
+    any platform package.
+    """
+    leaked = _leaked_heavy_modules("esphome.stacktrace", extra=("aioesphomeapi",))
+    assert not leaked, (
+        f"esphome.stacktrace imports heavy modules at top level: {leaked}. "
         "The logs fast path skips validation; importing the validation "
         "stack anyway defeats the validated-config cache."
     )

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -5904,6 +5904,38 @@ def test_run_miniterm_backtrace_state_maintained() -> None:
     assert backtrace_states[3][1] is True
 
 
+def test_run_miniterm_decoder_failure_keeps_streaming(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A decoder exception must not kill serial streaming.
+
+    This is the serial path's gain from sharing LogLineProcessor: before
+    the lift a decoder exception propagated out of the read loop.
+    """
+    chunk = b"PC: 0x4010496e\r\nBT0: 0x4010496e\r\nstill streaming\r\n"
+    mock_serial = MockSerial([chunk, MOCK_SERIAL_END])
+
+    CORE.data[KEY_CORE] = {KEY_TARGET_PLATFORM: PLATFORM_ESP32}
+    config = {
+        CONF_LOGGER: {
+            CONF_BAUD_RATE: 115200,
+            "deassert_rts_dtr": False,
+        }
+    }
+    args = MockArgs()
+
+    decoder = Mock(side_effect=EsphomeError("no idedata"))
+    with (
+        patch("serial.Serial", return_value=mock_serial),
+        patch.object(esp32, "process_stacktrace", decoder),
+    ):
+        run_miniterm(config, "/dev/ttyUSB0", args)
+
+    # The failure is contained and latched; streaming continued to EOF.
+    assert decoder.call_count == 1
+    assert "Crash trace decoding unavailable" in caplog.text
+
+
 def test_run_miniterm_handles_empty_reads(
     capfd: CaptureFixture[str],
 ) -> None:

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -309,6 +309,25 @@ def test_idedata_missing_prog_path_raises_esphome_error(setup_core: Path) -> Non
         _ = toolchain.IDEData({}).firmware_elf_path
 
 
+def test_idedata_missing_flash_image_field_raises_esphome_error(
+    setup_core: Path,
+) -> None:
+    """A cached idedata whose flash image entries lost a field must
+    classify as an environment error too, not a raw KeyError.
+    """
+    idedata = toolchain.IDEData({"extra": {"flash_images": [{"offset": "0x1000"}]}})
+    with pytest.raises(EsphomeError):
+        _ = idedata.extra_flash_images
+
+
+def test_idedata_null_section_raises_esphome_error(setup_core: Path) -> None:
+    """A section that is null instead of absent must classify the same
+    as a missing key instead of escaping as TypeError.
+    """
+    with pytest.raises(EsphomeError):
+        _ = toolchain.IDEData({"extra": None}).extra_flash_images
+
+
 def test_run_platformio_cli_sets_environment_variables(
     setup_core: Path, mock_run_external_process: Mock
 ) -> None:

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -278,13 +278,35 @@ def test_run_idedata_raises_on_no_json(
 def test_run_idedata_raises_on_invalid_json(
     setup_core: Path, mock_run_platformio_cli_run: Mock
 ) -> None:
-    """Test _run_idedata raises on malformed JSON."""
+    """Malformed JSON is the environment (garbage stdout), so it must
+    surface as EsphomeError and get the recompile hint downstream.
+    """
     config = {"name": "test"}
     mock_run_platformio_cli_run.return_value = '{"invalid": json"}'
 
-    # The ValueError from json.loads is re-raised
-    with pytest.raises(ValueError):
+    with pytest.raises(EsphomeError):
         toolchain._run_idedata(config)
+
+
+def test_run_idedata_raises_on_launch_failure(
+    setup_core: Path, mock_run_platformio_cli_run: Mock
+) -> None:
+    """A failed platformio launch returns its exit code as an int; that
+    must surface as EsphomeError, not a TypeError from re.search.
+    """
+    config = {"name": "test"}
+    mock_run_platformio_cli_run.return_value = 1
+
+    with pytest.raises(EsphomeError):
+        toolchain._run_idedata(config)
+
+
+def test_idedata_missing_prog_path_raises_esphome_error(setup_core: Path) -> None:
+    """A stale cached idedata JSON without prog_path is the build tree's
+    fault; it must surface as EsphomeError, not a KeyError.
+    """
+    with pytest.raises(EsphomeError):
+        _ = toolchain.IDEData({}).firmware_elf_path
 
 
 def test_run_platformio_cli_sets_environment_variables(

--- a/tests/unit_tests/test_stacktrace.py
+++ b/tests/unit_tests/test_stacktrace.py
@@ -50,12 +50,12 @@ def test_decoder_contains_failures_and_short_circuits() -> None:
     assert processor.backtrace_state is False
 
 
-def test_decoder_swallows_non_esphome_error() -> None:
+def test_decoder_swallows_os_error_with_remediation_hint(caplog) -> None:
     """Decoding failures that aren't EsphomeError must be contained too.
 
-    A missing build directory surfaces as FileNotFoundError from the
-    toolchain subprocess; it must disable decoding exactly like an
-    EsphomeError does.
+    A missing build directory surfaces as an OSError; that is the
+    user's environment, not a decoder bug, so it disables decoding
+    like an EsphomeError does and keeps the recompile hint.
     """
     handler = Mock(
         side_effect=FileNotFoundError(2, "No such file or directory", "/build")
@@ -64,6 +64,9 @@ def test_decoder_swallows_non_esphome_error() -> None:
 
     assert handler.call_count == 1
     assert processor.backtrace_state is False
+    warnings = _warnings(caplog)
+    assert any("esphome compile" in m for m in warnings)
+    assert not any("this is a bug" in m for m in warnings)
 
 
 def test_decoder_warning_uses_fallback_for_empty_error(caplog) -> None:
@@ -89,6 +92,16 @@ def test_decoder_bug_with_empty_message_names_the_type(caplog) -> None:
     warnings = _warnings(caplog)
     assert any("IndexError" in m and "this is a bug" in m for m in warnings)
     assert not any("esphome compile" in m for m in warnings)
+
+
+def test_decoder_bug_warning_keeps_the_type_with_a_message(caplog) -> None:
+    """The type must survive a non-empty message; a bare KeyError message
+    like 'prog_path' reads as a raised string in a bug report paste.
+    """
+    _run(Mock(side_effect=KeyError("prog_path")))
+
+    warnings = _warnings(caplog)
+    assert any("KeyError: 'prog_path'" in m for m in warnings)
 
 
 def test_state_threads_between_lines() -> None:

--- a/tests/unit_tests/test_stacktrace.py
+++ b/tests/unit_tests/test_stacktrace.py
@@ -1,0 +1,119 @@
+"""Tests for esphome.stacktrace."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from esphome import stacktrace
+from esphome.core import EsphomeError
+
+CONFIG = {"esphome": {"name": "test"}}
+
+
+def _run(
+    handler,
+    platform: str = "esp32",
+    lines: tuple[str, ...] = ("PC: 0x4010496e",),
+) -> stacktrace.LogLineProcessor:
+    """Processor with the resolver stubbed, fed the given lines."""
+    with patch.object(
+        stacktrace.platform_hooks, "get_stacktrace_handler", return_value=handler
+    ):
+        processor = stacktrace.LogLineProcessor(CONFIG, platform)
+    for line in lines:
+        processor.process_line(line)
+    return processor
+
+
+def _fed(handler) -> list[str]:
+    return [call.args[1] for call in handler.call_args_list]
+
+
+def _warnings(caplog) -> list[str]:
+    return [r.message for r in caplog.records if r.levelname == "WARNING"]
+
+
+def test_decoder_contains_failures_and_short_circuits() -> None:
+    """One decode failure is contained and never retried.
+
+    aioesphomeapi isolates exceptions raised by log handlers, so an
+    escaping one logs a full traceback for every line it fires on; and
+    _decode_pc shells out to the toolchain, so retrying it per backtrace
+    line would stall streaming.
+    """
+    handler = Mock(side_effect=EsphomeError("no idedata"))
+    processor = _run(
+        handler, lines=("PC: 0x4010496e", "BT0: 0x4010496e", "BT1: 0x401049aa")
+    )
+
+    assert handler.call_count == 1
+    assert processor.backtrace_state is False
+
+
+def test_decoder_swallows_non_esphome_error() -> None:
+    """Decoding failures that aren't EsphomeError must be contained too.
+
+    A missing build directory surfaces as FileNotFoundError from the
+    toolchain subprocess; it must disable decoding exactly like an
+    EsphomeError does.
+    """
+    handler = Mock(
+        side_effect=FileNotFoundError(2, "No such file or directory", "/build")
+    )
+    processor = _run(handler, lines=("PC: 0x4010496e", "BT0: 0x4010496e"))
+
+    assert handler.call_count == 1
+    assert processor.backtrace_state is False
+
+
+def test_decoder_warning_uses_fallback_for_empty_error(caplog) -> None:
+    """_run_idedata raises EsphomeError with no message; the warning
+    must show a useful explanation rather than empty parens.
+    """
+    _run(Mock(side_effect=EsphomeError()))
+
+    warnings = _warnings(caplog)
+    assert any("build artifacts not found locally" in m for m in warnings)
+    assert not any("()" in m for m in warnings)
+
+
+def test_decoder_bug_with_empty_message_names_the_type(caplog) -> None:
+    """A zero-message decoder bug must not masquerade as missing artifacts.
+
+    The recompile hint is only right for EsphomeError from _run_idedata;
+    anything else is ESPHome's own bug and says so instead of sending
+    the user down a dead-end remediation path.
+    """
+    _run(Mock(side_effect=IndexError()))
+
+    warnings = _warnings(caplog)
+    assert any("IndexError" in m and "this is a bug" in m for m in warnings)
+    assert not any("esphome compile" in m for m in warnings)
+
+
+def test_state_threads_between_lines() -> None:
+    """backtrace_state carries from one decoded line to the next."""
+    handler = Mock(side_effect=[True, True])
+    processor = _run(
+        handler,
+        platform="esp8266",
+        lines=(">>>stack>>>", "3ffffe10: 40201234 3ffe8410 00000000 40201000"),
+    )
+
+    assert _fed(handler) == [
+        ">>>stack>>>",
+        "3ffffe10: 40201234 3ffe8410 00000000 40201000",
+    ]
+    assert handler.call_args_list[0].args[2] is False
+    assert handler.call_args_list[1].args[2] is True
+    assert processor.backtrace_state is True
+
+
+def test_no_analyzer_disables_decoding(caplog) -> None:
+    """Platforms without an analyzer report at session start and stay quiet."""
+    caplog.set_level("INFO", logger="esphome.platform_hooks")
+    processor = stacktrace.LogLineProcessor(CONFIG, "bk72xx")
+    processor.process_line("PC: 0x40104960")
+
+    assert "Stacktrace analysis is unavailable" in caplog.text
+    assert processor.backtrace_state is False

--- a/tests/unit_tests/test_stacktrace.py
+++ b/tests/unit_tests/test_stacktrace.py
@@ -55,10 +55,10 @@ def test_latch_rearms_after_cooldown(caplog) -> None:
     """A transient failure must not kill decoding for the whole session.
 
     Within the cooldown lines are skipped; once it passes the next line
-    gets a fresh decode attempt, and a still-failing decoder warns again
-    instead of degrading silently.
+    gets a fresh decode attempt, and a failure with a new cause warns
+    again instead of degrading silently.
     """
-    handler = Mock(side_effect=EsphomeError("no idedata"))
+    handler = Mock(side_effect=[EsphomeError("no idedata"), EsphomeError("port busy")])
     with patch.object(
         stacktrace.time, "monotonic", side_effect=[0.0, 30.0, 61.0, 61.0]
     ):
@@ -69,6 +69,36 @@ def test_latch_rearms_after_cooldown(caplog) -> None:
     assert handler.call_count == 2
     assert processor.backtrace_state is False
     assert len([m for m in _warnings(caplog) if "esphome compile" in m]) == 2
+
+
+def test_identical_refailure_downgrades_to_debug(caplog) -> None:
+    """A permanent cause must not warn once per cooldown for hours.
+
+    The first failure warns in full; an identical re-failure after the
+    cooldown logs at debug only.
+    """
+    handler = Mock(side_effect=EsphomeError("no idedata"))
+    with patch.object(stacktrace.time, "monotonic", side_effect=[0.0, 61.0, 61.0]):
+        _run(handler, lines=("PC: 0x4010496e", "BT0: 0x4010496e"))
+
+    assert handler.call_count == 2
+    assert len([m for m in _warnings(caplog) if "esphome compile" in m]) == 1
+
+
+def test_resolution_failure_is_contained(caplog) -> None:
+    """A platform package broken in an unanticipated way must not kill
+    the session; decoding degrades with a warning like any other failure.
+    """
+    with patch.object(
+        stacktrace.platform_hooks,
+        "get_stacktrace_handler",
+        side_effect=RuntimeError("boom"),
+    ):
+        processor = stacktrace.LogLineProcessor(CONFIG, PLATFORM_ESP32)
+    processor.process_line("PC: 0x4010496e")
+
+    assert processor.backtrace_state is False
+    assert any("could not be loaded" in m for m in _warnings(caplog))
 
 
 def test_no_analyzer_never_rearms(caplog) -> None:

--- a/tests/unit_tests/test_stacktrace.py
+++ b/tests/unit_tests/test_stacktrace.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from itertools import chain, repeat
 from unittest.mock import Mock, patch
 
 from esphome import stacktrace
@@ -35,16 +34,8 @@ def _warnings(caplog) -> list[str]:
     return [r.message for r in caplog.records if r.levelname == "WARNING"]
 
 
-def _clock(*times: float):
-    """Stub the module's monotonic, repeating the last value so an
-    extra call cannot fail with StopIteration."""
-    return patch.object(
-        stacktrace, "monotonic", side_effect=chain(times, repeat(times[-1]))
-    )
-
-
 def test_decoder_contains_failures_and_short_circuits() -> None:
-    """One decode failure is contained and not retried within the cooldown.
+    """One decode failure is contained and never retried.
 
     aioesphomeapi isolates exceptions raised by log handlers, so an
     escaping one logs a full traceback for every line it fires on; and
@@ -58,79 +49,6 @@ def test_decoder_contains_failures_and_short_circuits() -> None:
 
     assert handler.call_count == 1
     assert processor.backtrace_state is False
-
-
-def test_latch_rearms_after_cooldown(caplog) -> None:
-    """A transient failure must not kill decoding for the whole session.
-
-    Within the cooldown lines are skipped; once it passes the next line
-    gets a fresh decode attempt, and a failure with a new cause warns
-    again instead of degrading silently.
-    """
-    handler = Mock(side_effect=[EsphomeError("no idedata"), EsphomeError("port busy")])
-    with _clock(0.0, 30.0, 61.0):
-        processor = _run(
-            handler, lines=("PC: 0x4010496e", "BT0: 0x4010496e", "BT1: 0x401049aa")
-        )
-
-    assert handler.call_count == 2
-    assert processor.backtrace_state is False
-    assert len([m for m in _warnings(caplog) if "esphome compile" in m]) == 2
-
-
-def test_identical_refailure_downgrades_to_debug(caplog) -> None:
-    """A permanent cause must not warn once per cooldown for hours.
-
-    The first failure warns in full; an identical re-failure after the
-    cooldown logs at debug only.
-    """
-    handler = Mock(side_effect=EsphomeError("no idedata"))
-    with _clock(0.0, 61.0):
-        _run(handler, lines=("PC: 0x4010496e", "BT0: 0x4010496e"))
-
-    assert handler.call_count == 2
-    assert len([m for m in _warnings(caplog) if "esphome compile" in m]) == 1
-
-
-def test_backoff_doubles_after_identical_refailure() -> None:
-    """Identical re-failures back off exponentially.
-
-    Every retry re-runs the failing toolchain subprocess, so a
-    permanently broken environment must retry less and less often
-    instead of hitching the stream once a minute for the session.
-    """
-    handler = Mock(side_effect=EsphomeError("no idedata"))
-    with _clock(0.0, 61.0, 61.0, 100.0, 200.0, 200.0):
-        _run(
-            handler,
-            lines=(
-                "PC: 0x4010496e",  # fails; cooldown 60
-                "BT0: 0x4010496e",  # t=61: re-arms, fails again; cooldown 120
-                "BT1: 0x401049aa",  # t=100: 39s into the 120s cooldown, skipped
-                "BT2: 0x401049aa",  # t=200: 139s elapsed, re-arms, fails
-            ),
-        )
-
-    assert handler.call_count == 3
-
-
-def test_ordinary_lines_do_not_end_the_failure_episode(caplog) -> None:
-    """A non-raising return proves nothing about the environment.
-
-    The handler is fed every log line and returns without decoding on
-    ordinary ones, so treating that as recovery would reset the episode
-    on the first chatty line and the backoff would never engage; a
-    crash-looping device would warn and launch platformio once a minute
-    for the whole session.
-    """
-    handler = Mock(
-        side_effect=[EsphomeError("no idedata"), False, EsphomeError("no idedata")]
-    )
-    with _clock(0.0, 61.0, 61.0):
-        _run(handler, lines=("PC: 0x4010496e", "BT0: 0x4010496e", "BT1: 0x401049aa"))
-
-    assert handler.call_count == 3
-    assert len([m for m in _warnings(caplog) if "esphome compile" in m]) == 1
 
 
 def test_resolution_failure_is_contained(caplog) -> None:
@@ -147,17 +65,6 @@ def test_resolution_failure_is_contained(caplog) -> None:
 
     assert processor.backtrace_state is False
     assert any("could not be loaded" in m for m in _warnings(caplog))
-
-
-def test_no_analyzer_never_rearms(caplog) -> None:
-    """A platform without an analyzer stays off; there is nothing to retry."""
-    processor = _run(None, platform=PLATFORM_BK72XX, lines=())
-    with _clock(1e9):
-        processor.process_line("PC: 0x4010496e")
-
-    assert processor.backtrace_state is False
-    # A re-arm here would feed the missing handler and warn; it must not.
-    assert not _warnings(caplog)
 
 
 def test_decoder_swallows_os_error_with_remediation_hint(caplog) -> None:

--- a/tests/unit_tests/test_stacktrace.py
+++ b/tests/unit_tests/test_stacktrace.py
@@ -92,6 +92,28 @@ def test_identical_refailure_downgrades_to_debug(caplog) -> None:
     assert len([m for m in _warnings(caplog) if "esphome compile" in m]) == 1
 
 
+def test_backoff_doubles_after_identical_refailure() -> None:
+    """Identical re-failures back off exponentially.
+
+    Every retry re-runs the failing toolchain subprocess, so a
+    permanently broken environment must retry less and less often
+    instead of hitching the stream once a minute for the session.
+    """
+    handler = Mock(side_effect=EsphomeError("no idedata"))
+    with _clock(0.0, 61.0, 61.0, 100.0, 200.0, 200.0):
+        _run(
+            handler,
+            lines=(
+                "PC: 0x4010496e",  # fails; cooldown 60
+                "BT0: 0x4010496e",  # t=61: re-arms, fails again; cooldown 120
+                "BT1: 0x401049aa",  # t=100: 39s into the 120s cooldown, skipped
+                "BT2: 0x401049aa",  # t=200: 139s elapsed, re-arms, fails
+            ),
+        )
+
+    assert handler.call_count == 3
+
+
 def test_new_episode_after_success_warns_in_full(caplog) -> None:
     """A success ends the failure episode.
 
@@ -155,8 +177,10 @@ def test_decoder_swallows_os_error_with_remediation_hint(caplog) -> None:
 
 
 def test_decoder_warning_uses_fallback_for_empty_error(caplog) -> None:
-    """_run_idedata raises EsphomeError with no message; the warning
-    must show a useful explanation rather than empty parens.
+    """A message-less EsphomeError must show a useful explanation.
+
+    Defensive: the in-tree idedata raise sites all carry a message now,
+    but a bare EsphomeError from elsewhere must not render as parens.
     """
     _run(Mock(side_effect=EsphomeError()))
 

--- a/tests/unit_tests/test_stacktrace.py
+++ b/tests/unit_tests/test_stacktrace.py
@@ -34,7 +34,7 @@ def _warnings(caplog) -> list[str]:
 
 
 def test_decoder_contains_failures_and_short_circuits() -> None:
-    """One decode failure is contained and never retried.
+    """One decode failure is contained and not retried within the cooldown.
 
     aioesphomeapi isolates exceptions raised by log handlers, so an
     escaping one logs a full traceback for every line it fires on; and
@@ -48,6 +48,37 @@ def test_decoder_contains_failures_and_short_circuits() -> None:
 
     assert handler.call_count == 1
     assert processor.backtrace_state is False
+
+
+def test_latch_rearms_after_cooldown(caplog) -> None:
+    """A transient failure must not kill decoding for the whole session.
+
+    Within the cooldown lines are skipped; once it passes the next line
+    gets a fresh decode attempt, and a still-failing decoder warns again
+    instead of degrading silently.
+    """
+    handler = Mock(side_effect=EsphomeError("no idedata"))
+    with patch.object(
+        stacktrace.time, "monotonic", side_effect=[0.0, 30.0, 61.0, 61.0]
+    ):
+        processor = _run(
+            handler, lines=("PC: 0x4010496e", "BT0: 0x4010496e", "BT1: 0x401049aa")
+        )
+
+    assert handler.call_count == 2
+    assert processor.backtrace_state is False
+    assert len([m for m in _warnings(caplog) if "esphome compile" in m]) == 2
+
+
+def test_no_analyzer_never_rearms(caplog) -> None:
+    """A platform without an analyzer stays off; there is nothing to retry."""
+    processor = _run(None, lines=())
+    with patch.object(stacktrace.time, "monotonic", return_value=1e9):
+        processor.process_line("PC: 0x4010496e")
+
+    assert processor.backtrace_state is False
+    # A re-arm here would feed the missing handler and warn; it must not.
+    assert not _warnings(caplog)
 
 
 def test_decoder_swallows_os_error_with_remediation_hint(caplog) -> None:

--- a/tests/unit_tests/test_stacktrace.py
+++ b/tests/unit_tests/test_stacktrace.py
@@ -72,7 +72,7 @@ def test_latch_rearms_after_cooldown(caplog) -> None:
 
 def test_no_analyzer_never_rearms(caplog) -> None:
     """A platform without an analyzer stays off; there is nothing to retry."""
-    processor = _run(None, lines=())
+    processor = _run(None, platform="bk72xx", lines=())
     with patch.object(stacktrace.time, "monotonic", return_value=1e9):
         processor.process_line("PC: 0x4010496e")
 

--- a/tests/unit_tests/test_stacktrace.py
+++ b/tests/unit_tests/test_stacktrace.py
@@ -36,10 +36,10 @@ def _warnings(caplog) -> list[str]:
 
 
 def _clock(*times: float):
-    """Stub monotonic to repeat its last value; the patch is process
-    wide, so an extra call must not fail with StopIteration."""
+    """Stub the module's monotonic, repeating the last value so an
+    extra call cannot fail with StopIteration."""
     return patch.object(
-        stacktrace.time, "monotonic", side_effect=chain(times, repeat(times[-1]))
+        stacktrace, "monotonic", side_effect=chain(times, repeat(times[-1]))
     )
 
 
@@ -114,20 +114,23 @@ def test_backoff_doubles_after_identical_refailure() -> None:
     assert handler.call_count == 3
 
 
-def test_new_episode_after_success_warns_in_full(caplog) -> None:
-    """A success ends the failure episode.
+def test_ordinary_lines_do_not_end_the_failure_episode(caplog) -> None:
+    """A non-raising return proves nothing about the environment.
 
-    A later failure with the same message is a fresh problem, not spam
-    from the same one, so it must warn in full again.
+    The handler is fed every log line and returns without decoding on
+    ordinary ones, so treating that as recovery would reset the episode
+    on the first chatty line and the backoff would never engage; a
+    crash-looping device would warn and launch platformio once a minute
+    for the whole session.
     """
     handler = Mock(
         side_effect=[EsphomeError("no idedata"), False, EsphomeError("no idedata")]
     )
-    with _clock(0.0, 61.0):
+    with _clock(0.0, 61.0, 61.0):
         _run(handler, lines=("PC: 0x4010496e", "BT0: 0x4010496e", "BT1: 0x401049aa"))
 
     assert handler.call_count == 3
-    assert len([m for m in _warnings(caplog) if "esphome compile" in m]) == 2
+    assert len([m for m in _warnings(caplog) if "esphome compile" in m]) == 1
 
 
 def test_resolution_failure_is_contained(caplog) -> None:

--- a/tests/unit_tests/test_stacktrace.py
+++ b/tests/unit_tests/test_stacktrace.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import Mock, patch
 
 from esphome import stacktrace
+from esphome.const import PLATFORM_BK72XX, PLATFORM_ESP32, PLATFORM_ESP8266
 from esphome.core import EsphomeError
 
 CONFIG = {"esphome": {"name": "test"}}
@@ -12,7 +13,7 @@ CONFIG = {"esphome": {"name": "test"}}
 
 def _run(
     handler,
-    platform: str = "esp32",
+    platform: str = PLATFORM_ESP32,
     lines: tuple[str, ...] = ("PC: 0x4010496e",),
 ) -> stacktrace.LogLineProcessor:
     """Processor with the resolver stubbed, fed the given lines."""
@@ -72,7 +73,7 @@ def test_latch_rearms_after_cooldown(caplog) -> None:
 
 def test_no_analyzer_never_rearms(caplog) -> None:
     """A platform without an analyzer stays off; there is nothing to retry."""
-    processor = _run(None, platform="bk72xx", lines=())
+    processor = _run(None, platform=PLATFORM_BK72XX, lines=())
     with patch.object(stacktrace.time, "monotonic", return_value=1e9):
         processor.process_line("PC: 0x4010496e")
 
@@ -140,7 +141,7 @@ def test_state_threads_between_lines() -> None:
     handler = Mock(side_effect=[True, True])
     processor = _run(
         handler,
-        platform="esp8266",
+        platform=PLATFORM_ESP8266,
         lines=(">>>stack>>>", "3ffffe10: 40201234 3ffe8410 00000000 40201000"),
     )
 
@@ -156,7 +157,7 @@ def test_state_threads_between_lines() -> None:
 def test_no_analyzer_disables_decoding(caplog) -> None:
     """Platforms without an analyzer report at session start and stay quiet."""
     caplog.set_level("INFO", logger="esphome.platform_hooks")
-    processor = stacktrace.LogLineProcessor(CONFIG, "bk72xx")
+    processor = stacktrace.LogLineProcessor(CONFIG, PLATFORM_BK72XX)
     processor.process_line("PC: 0x40104960")
 
     assert "Stacktrace analysis is unavailable" in caplog.text

--- a/tests/unit_tests/test_stacktrace.py
+++ b/tests/unit_tests/test_stacktrace.py
@@ -95,7 +95,7 @@ def test_resolution_failure_is_contained(caplog) -> None:
         side_effect=RuntimeError("boom"),
     ):
         processor = stacktrace.LogLineProcessor(CONFIG, PLATFORM_ESP32)
-    processor.process_line("PC: 0x4010496e")
+        processor.process_line("PC: 0x4010496e")
 
     assert processor.backtrace_state is False
     assert any("could not be loaded" in m for m in _warnings(caplog))

--- a/tests/unit_tests/test_stacktrace.py
+++ b/tests/unit_tests/test_stacktrace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from itertools import chain, repeat
 from unittest.mock import Mock, patch
 
 from esphome import stacktrace
@@ -34,6 +35,14 @@ def _warnings(caplog) -> list[str]:
     return [r.message for r in caplog.records if r.levelname == "WARNING"]
 
 
+def _clock(*times: float):
+    """Stub monotonic to repeat its last value; the patch is process
+    wide, so an extra call must not fail with StopIteration."""
+    return patch.object(
+        stacktrace.time, "monotonic", side_effect=chain(times, repeat(times[-1]))
+    )
+
+
 def test_decoder_contains_failures_and_short_circuits() -> None:
     """One decode failure is contained and not retried within the cooldown.
 
@@ -59,9 +68,7 @@ def test_latch_rearms_after_cooldown(caplog) -> None:
     again instead of degrading silently.
     """
     handler = Mock(side_effect=[EsphomeError("no idedata"), EsphomeError("port busy")])
-    with patch.object(
-        stacktrace.time, "monotonic", side_effect=[0.0, 30.0, 61.0, 61.0]
-    ):
+    with _clock(0.0, 30.0, 61.0):
         processor = _run(
             handler, lines=("PC: 0x4010496e", "BT0: 0x4010496e", "BT1: 0x401049aa")
         )
@@ -78,11 +85,27 @@ def test_identical_refailure_downgrades_to_debug(caplog) -> None:
     cooldown logs at debug only.
     """
     handler = Mock(side_effect=EsphomeError("no idedata"))
-    with patch.object(stacktrace.time, "monotonic", side_effect=[0.0, 61.0, 61.0]):
+    with _clock(0.0, 61.0):
         _run(handler, lines=("PC: 0x4010496e", "BT0: 0x4010496e"))
 
     assert handler.call_count == 2
     assert len([m for m in _warnings(caplog) if "esphome compile" in m]) == 1
+
+
+def test_new_episode_after_success_warns_in_full(caplog) -> None:
+    """A success ends the failure episode.
+
+    A later failure with the same message is a fresh problem, not spam
+    from the same one, so it must warn in full again.
+    """
+    handler = Mock(
+        side_effect=[EsphomeError("no idedata"), False, EsphomeError("no idedata")]
+    )
+    with _clock(0.0, 61.0):
+        _run(handler, lines=("PC: 0x4010496e", "BT0: 0x4010496e", "BT1: 0x401049aa"))
+
+    assert handler.call_count == 3
+    assert len([m for m in _warnings(caplog) if "esphome compile" in m]) == 2
 
 
 def test_resolution_failure_is_contained(caplog) -> None:
@@ -104,7 +127,7 @@ def test_resolution_failure_is_contained(caplog) -> None:
 def test_no_analyzer_never_rearms(caplog) -> None:
     """A platform without an analyzer stays off; there is nothing to retry."""
     processor = _run(None, platform=PLATFORM_BK72XX, lines=())
-    with patch.object(stacktrace.time, "monotonic", return_value=1e9):
+    with _clock(1e9):
         processor.process_line("PC: 0x4010496e")
 
     assert processor.backtrace_state is False


### PR DESCRIPTION
# What does this implement/fix?

Split out of #18048 to keep each piece reviewable; the first piece, #18075, is merged, so this now sits directly on dev.

The API log path carried a private `_LogLineProcessor` with the crash isolation and disable after first failure behavior, while the serial path called the decoder bare, so a decoder exception could kill serial streaming and a broken build retried addr2line per backtrace line. This lifts the class into a new light module, `esphome/stacktrace.py`, resolves the decoder through the #18075 helper, and points both paths at it; the serial path gains the containment for free. Environment failures (EsphomeError or OSError, like a missing build tree) keep the recompile hint; anything else reports itself as a bug with the exception type named instead of telling the user to recompile a healthy build. The platformio idedata path now classifies its own environment failures at the source, raising EsphomeError for a failed platformio launch, unparseable idedata and any key missing from a stale cached idedata, so they get the recompile hint too. Resolution failures are contained like decode failures instead of aborting the session, with the cause named in the warning, and the handler is typed to the decoder signature. A lazy import test pins the module's light import contract. The disable latch stays session wide and deliberately one way: nothing a decode failure depends on heals by itself within a session, the warning names the fix, and a fresh esphome logs run picks it up, so a failure warns exactly once and never blocks the stream again with a retrying subprocess. A run_miniterm level test pins the serial path's new containment. Resolution stays eager exactly as today; the follow up makes it lazy behind an address gate. The moved containment tests live in the new `tests/unit_tests/test_stacktrace.py`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No configuration changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).









