### PR TITLE
[tests] Unignore component-test config fixture directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,8 @@ CTestTestfile.cmake
 .gcc-flags.json
 
 config/
+# Test fixture config/ directories are tracked (the rule above is the dashboard dir)
+!tests/component_tests/**/config/
 tests/build/
 tests/.esphome/
 /.temp-clang-tidy.cpp


### PR DESCRIPTION
## What does this implement/fix?

The bare `config/` rule in `.gitignore` (the dashboard directory) matches at any depth, so test fixtures under `tests/component_tests/*/config/` are silently ignored and need `git add -f`. A fixture moved into such a directory was dropped from a commit twice on #17776/#17778 — pytest passed locally off the untracked file and failed every CI matrix. The existing `tests/component_tests/ble_device_base/config/` fixtures are force-added for the same reason.

Adds a negation so fixture directories track normally:

```
!tests/component_tests/**/config/
```

Suggested during review of #17776.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

## Checklist:

- [x] The code change is tested and works locally (`git check-ignore` no longer matches the fixture paths; the dashboard `config/` at repo root stays ignored).