### PR TITLE
[m5_unit_bldc] Add M5Stack M5Unit-BLDC platform support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -306,6 +306,7 @@ esphome/components/ltr390/* @latonita @sjtrny
 esphome/components/ltr501/* @latonita
 esphome/components/ltr_als_ps/* @latonita
 esphome/components/lvgl/* @clydebarrow
+esphome/components/m5_unit_bldc/* @lboue
 esphome/components/m5stack_8angle/* @rnauber
 esphome/components/mapping/* @clydebarrow
 esphome/components/matrix_keypad/* @ssieb

--- a/esphome/components/m5_unit_bldc/__init__.py
+++ b/esphome/components/m5_unit_bldc/__init__.py
@@ -1,0 +1,84 @@
+import esphome.codegen as cg
+from esphome.components import i2c
+import esphome.config_validation as cv
+from esphome.const import CONF_DIRECTION, CONF_ID, CONF_MODE, CONF_MODEL
+
+CODEOWNERS = ["@lboue"]
+DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
+
+CONF_M5_UNIT_BLDC_ID = "m5_unit_bldc_id"
+CONF_POLE_PAIRS = "pole_pairs"
+CONF_PID = "pid"
+CONF_P = "p"
+CONF_I = "i"
+CONF_D = "d"
+CONF_SAVE_TO_FLASH = "save_to_flash"
+
+UNIT_RPM = "rpm"
+
+m5_unit_bldc_ns = cg.esphome_ns.namespace("m5_unit_bldc")
+M5UnitBldc = m5_unit_bldc_ns.class_("M5UnitBldc", i2c.I2CDevice, cg.PollingComponent)
+
+ControlMode = m5_unit_bldc_ns.enum("ControlMode", is_class=True)
+CONTROL_MODES = {
+    "open_loop": ControlMode.OPEN_LOOP,
+    "closed_loop": ControlMode.CLOSED_LOOP,
+}
+
+Direction = m5_unit_bldc_ns.enum("Direction", is_class=True)
+DIRECTIONS = {
+    "forward": Direction.FORWARD,
+    "backward": Direction.BACKWARD,
+}
+
+MotorModel = m5_unit_bldc_ns.enum("MotorModel", is_class=True)
+MOTOR_MODELS = {
+    "low_speed": MotorModel.LOW_SPEED,
+    "high_speed": MotorModel.HIGH_SPEED,
+}
+
+PID_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_P): cv.float_,
+        cv.Required(CONF_I): cv.float_,
+        cv.Required(CONF_D): cv.float_,
+    }
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(M5UnitBldc),
+            cv.Optional(CONF_MODE, default="open_loop"): cv.enum(
+                CONTROL_MODES, lower=True
+            ),
+            cv.Optional(CONF_DIRECTION, default="forward"): cv.enum(
+                DIRECTIONS, lower=True
+            ),
+            cv.Optional(CONF_MODEL, default="low_speed"): cv.enum(
+                MOTOR_MODELS, lower=True
+            ),
+            cv.Required(CONF_POLE_PAIRS): cv.int_range(min=1, max=255),
+            cv.Optional(CONF_PID): PID_SCHEMA,
+            cv.Optional(CONF_SAVE_TO_FLASH, default=False): cv.boolean,
+        }
+    )
+    .extend(cv.polling_component_schema("1s"))
+    .extend(i2c.i2c_device_schema(0x65))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    cg.add(var.set_control_mode(config[CONF_MODE]))
+    cg.add(var.set_initial_direction(config[CONF_DIRECTION]))
+    cg.add(var.set_motor_model(config[CONF_MODEL]))
+    cg.add(var.set_pole_pairs(config[CONF_POLE_PAIRS]))
+    cg.add(var.set_save_to_flash(config[CONF_SAVE_TO_FLASH]))
+
+    if pid := config.get(CONF_PID):
+        cg.add(var.set_pid(pid[CONF_P], pid[CONF_I], pid[CONF_D]))

--- a/esphome/components/m5_unit_bldc/m5_unit_bldc.cpp
+++ b/esphome/components/m5_unit_bldc/m5_unit_bldc.cpp
@@ -100,17 +100,43 @@ void M5UnitBldc::dump_config() {
   }
 }
 
-void M5UnitBldc::write_pwm(uint16_t duty) {
+void M5UnitBldc::write_pwm_raw_(uint16_t duty) {
   uint8_t buf[2];
   std::memcpy(buf, &duty, 2);
   this->write_register(REG_PWM, buf, 2);
 }
 
-void M5UnitBldc::write_target_rpm(float rpm) { this->write_float_(REG_SET_RPM, rpm); }
+void M5UnitBldc::write_pwm(uint16_t duty) {
+  this->last_pwm_ = duty;
+  this->write_pwm_raw_(duty);
+}
+
+void M5UnitBldc::write_target_rpm(float rpm) {
+  this->last_target_rpm_ = rpm;
+  this->write_float_(REG_SET_RPM, rpm);
+}
 
 void M5UnitBldc::write_direction(Direction direction) {
   uint8_t value = static_cast<uint8_t>(direction);
   this->write_register(REG_DIRECTION, &value, 1);
+
+  // The device only latches a new direction once the motor has actually spun down to a stop --
+  // zeroing and immediately restoring the PWM/RPM register isn't enough, it needs real time to
+  // decelerate first (datasheet note "[1] Change direction": setup direction, zero, then
+  // non-zero once stopped). 800ms comfortably covers spin-down for the small motors this driver
+  // targets; restoring is deferred via a named timeout so repeated direction changes replace any
+  // still-pending restore instead of stacking.
+  if (this->control_mode_ == ControlMode::CLOSED_LOOP) {
+    this->write_float_(REG_SET_RPM, 0.0f);
+    if (this->last_target_rpm_ != 0.0f) {
+      this->set_timeout("direction_change", 800, [this]() { this->write_float_(REG_SET_RPM, this->last_target_rpm_); });
+    }
+  } else {
+    this->write_pwm_raw_(0);
+    if (this->last_pwm_ != 0) {
+      this->set_timeout("direction_change", 800, [this]() { this->write_pwm_raw_(this->last_pwm_); });
+    }
+  }
 }
 
 }  // namespace esphome::m5_unit_bldc

--- a/esphome/components/m5_unit_bldc/m5_unit_bldc.cpp
+++ b/esphome/components/m5_unit_bldc/m5_unit_bldc.cpp
@@ -1,0 +1,116 @@
+#include "m5_unit_bldc.h"
+
+#include <cstring>
+
+#include "esphome/core/log.h"
+
+namespace esphome::m5_unit_bldc {
+
+static const char *const TAG = "m5_unit_bldc";
+
+bool M5UnitBldc::write_float_(uint8_t reg, float value) {
+  uint8_t buf[4];
+  std::memcpy(buf, &value, 4);
+  return this->write_register(reg, buf, 4) == i2c::ERROR_OK;
+}
+
+bool M5UnitBldc::read_float_(uint8_t reg, float *value) {
+  uint8_t buf[4];
+  if (this->read_register(reg, buf, 4) != i2c::ERROR_OK)
+    return false;
+  std::memcpy(value, buf, 4);
+  return true;
+}
+
+void M5UnitBldc::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up M5Unit-BLDC...");
+
+  uint8_t mode = static_cast<uint8_t>(this->control_mode_);
+  if (this->write_register(REG_MODE, &mode, 1) != i2c::ERROR_OK) {
+    this->mark_failed();
+    return;
+  }
+
+  uint8_t direction = static_cast<uint8_t>(this->initial_direction_);
+  this->write_register(REG_DIRECTION, &direction, 1);
+
+  uint8_t motor_config[2] = {static_cast<uint8_t>(this->motor_model_), this->pole_pairs_};
+  this->write_register(REG_MOTOR_CONFIG, motor_config, 2);
+
+  if (this->has_pid_) {
+    uint8_t pid[12];
+    int32_t p_int = static_cast<int32_t>(this->p_ * 100);
+    int32_t i_int = static_cast<int32_t>(this->i_ * 100);
+    int32_t d_int = static_cast<int32_t>(this->d_ * 100);
+    std::memcpy(pid, &p_int, 4);
+    std::memcpy(pid + 4, &i_int, 4);
+    std::memcpy(pid + 8, &d_int, 4);
+    this->write_register(REG_PID, pid, 12);
+  }
+
+  if (this->save_to_flash_) {
+    uint8_t save = 1;
+    this->write_register(REG_SAVE_TO_FLASH, &save, 1);
+  }
+}
+
+void M5UnitBldc::update() {
+  if (this->rpm_sensor_ != nullptr) {
+    float rpm;
+    if (this->read_float_(REG_READBACK_RPM, &rpm))
+      this->rpm_sensor_->publish_state(rpm);
+  }
+
+  if (this->frequency_sensor_ != nullptr) {
+    float freq;
+    if (this->read_float_(REG_READBACK_FREQ, &freq))
+      this->frequency_sensor_->publish_state(freq);
+  }
+
+  if (this->status_text_sensor_ != nullptr) {
+    uint8_t status;
+    if (this->read_register(REG_MOTOR_STATUS, &status, 1) == i2c::ERROR_OK) {
+      const char *status_str = "Unknown";
+      switch (static_cast<MotorStatus>(status)) {
+        case MotorStatus::STANDBY:
+          status_str = "Standby";
+          break;
+        case MotorStatus::RUNNING:
+          status_str = "Running";
+          break;
+        case MotorStatus::ERROR:
+          status_str = "Error";
+          break;
+      }
+      this->status_text_sensor_->publish_state(status_str);
+    }
+  }
+}
+
+void M5UnitBldc::dump_config() {
+  ESP_LOGCONFIG(TAG, "M5Unit-BLDC:");
+  LOG_I2C_DEVICE(this);
+  ESP_LOGCONFIG(TAG, "  Control mode: %s",
+                this->control_mode_ == ControlMode::CLOSED_LOOP ? "closed loop" : "open loop");
+  ESP_LOGCONFIG(TAG, "  Direction: %s", this->initial_direction_ == Direction::BACKWARD ? "backward" : "forward");
+  ESP_LOGCONFIG(TAG, "  Motor model: %s", this->motor_model_ == MotorModel::HIGH_SPEED ? "high speed" : "low speed");
+  ESP_LOGCONFIG(TAG, "  Pole pairs: %u", this->pole_pairs_);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with M5Unit-BLDC failed");
+  }
+}
+
+void M5UnitBldc::write_pwm(uint16_t duty) {
+  uint8_t buf[2];
+  std::memcpy(buf, &duty, 2);
+  this->write_register(REG_PWM, buf, 2);
+}
+
+void M5UnitBldc::write_target_rpm(float rpm) { this->write_float_(REG_SET_RPM, rpm); }
+
+void M5UnitBldc::write_direction(Direction direction) {
+  uint8_t value = static_cast<uint8_t>(direction);
+  this->write_register(REG_DIRECTION, &value, 1);
+}
+
+}  // namespace esphome::m5_unit_bldc

--- a/esphome/components/m5_unit_bldc/m5_unit_bldc.cpp
+++ b/esphome/components/m5_unit_bldc/m5_unit_bldc.cpp
@@ -70,7 +70,7 @@ void M5UnitBldc::update() {
   if (this->status_text_sensor_ != nullptr) {
     uint8_t status;
     if (this->read_register(REG_MOTOR_STATUS, &status, 1) == i2c::ERROR_OK) {
-      const char *status_str = "Unknown";
+      const char *status_str;
       switch (static_cast<MotorStatus>(status)) {
         case MotorStatus::STANDBY:
           status_str = "Standby";
@@ -80,6 +80,9 @@ void M5UnitBldc::update() {
           break;
         case MotorStatus::ERROR:
           status_str = "Error";
+          break;
+        default:
+          status_str = "Unknown";
           break;
       }
       this->status_text_sensor_->publish_state(status_str);

--- a/esphome/components/m5_unit_bldc/m5_unit_bldc.h
+++ b/esphome/components/m5_unit_bldc/m5_unit_bldc.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+
+namespace esphome::m5_unit_bldc {
+
+// I2C register map, from M5Stack's "Unit BLDC I2C Protocol" datasheet and the official
+// M5UnitBLDC Arduino library (https://github.com/m5stack/M5Unit-BLDC).
+enum : uint8_t {
+  REG_MODE = 0x00,           // 1B, W/R -- 0: open loop, 1: closed loop
+  REG_PWM = 0x10,            // 2B, W/R -- little-endian uint16_t, 0-2047
+  REG_READBACK_RPM = 0x20,   // 4B, R   -- float
+  REG_READBACK_FREQ = 0x30,  // 4B, R   -- float, Hz
+  REG_SET_RPM = 0x40,        // 4B, W/R -- float, only honoured in closed loop
+  REG_PID = 0x50,            // 12B, W/R -- 3x int32_t, each value * 100 (P, I, D)
+  REG_DIRECTION = 0x60,      // 1B, W/R -- 0: forward, 1: backward
+  REG_MOTOR_CONFIG = 0x70,   // 2B, W/R -- byte0: motor model, byte1: pole pairs
+  REG_MOTOR_STATUS = 0x80,   // 1B, R   -- 0: standby, 1: running, 2: error
+  REG_SAVE_TO_FLASH = 0xF0,  // 1B, W   -- write 1 to persist model/pole pairs/PID
+  REG_FIRMWARE_VERSION = 0xFE,
+};
+
+enum class ControlMode : uint8_t { OPEN_LOOP = 0, CLOSED_LOOP = 1 };
+enum class Direction : uint8_t { FORWARD = 0, BACKWARD = 1 };
+enum class MotorModel : uint8_t { LOW_SPEED = 0, HIGH_SPEED = 1 };
+enum class MotorStatus : uint8_t { STANDBY = 0, RUNNING = 1, ERROR = 2 };
+
+/// Hub component for a single M5Stack M5Unit-BLDC brushless DC motor driver. Add `number`/`select`
+/// sub-platforms to drive it, and `sensor`/`text_sensor` sub-platforms to read it back.
+class M5UnitBldc : public i2c::I2CDevice, public PollingComponent {
+ public:
+  void setup() override;
+  void update() override;
+  void dump_config() override;
+
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void set_control_mode(ControlMode mode) { this->control_mode_ = mode; }
+  void set_initial_direction(Direction direction) { this->initial_direction_ = direction; }
+  void set_motor_model(MotorModel model) { this->motor_model_ = model; }
+  void set_pole_pairs(uint8_t pole_pairs) { this->pole_pairs_ = pole_pairs; }
+  void set_pid(float p, float i, float d) {
+    this->has_pid_ = true;
+    this->p_ = p;
+    this->i_ = i;
+    this->d_ = d;
+  }
+  void set_save_to_flash(bool save_to_flash) { this->save_to_flash_ = save_to_flash; }
+
+  void set_rpm_sensor(sensor::Sensor *rpm_sensor) { this->rpm_sensor_ = rpm_sensor; }
+  void set_frequency_sensor(sensor::Sensor *frequency_sensor) { this->frequency_sensor_ = frequency_sensor; }
+  void set_status_text_sensor(text_sensor::TextSensor *status_text_sensor) {
+    this->status_text_sensor_ = status_text_sensor;
+  }
+
+  // Called by the `number`/`select` sub-platforms to drive the motor.
+  void write_pwm(uint16_t duty);
+  void write_target_rpm(float rpm);
+  void write_direction(Direction direction);
+
+ protected:
+  bool write_float_(uint8_t reg, float value);
+  bool read_float_(uint8_t reg, float *value);
+
+  ControlMode control_mode_{ControlMode::OPEN_LOOP};
+  Direction initial_direction_{Direction::FORWARD};
+  MotorModel motor_model_{MotorModel::LOW_SPEED};
+  uint8_t pole_pairs_{1};
+  bool has_pid_{false};
+  float p_{0}, i_{0}, d_{0};
+  bool save_to_flash_{false};
+
+  sensor::Sensor *rpm_sensor_{nullptr};
+  sensor::Sensor *frequency_sensor_{nullptr};
+  text_sensor::TextSensor *status_text_sensor_{nullptr};
+};
+
+}  // namespace esphome::m5_unit_bldc

--- a/esphome/components/m5_unit_bldc/m5_unit_bldc.h
+++ b/esphome/components/m5_unit_bldc/m5_unit_bldc.h
@@ -64,6 +64,7 @@ class M5UnitBldc : public i2c::I2CDevice, public PollingComponent {
  protected:
   bool write_float_(uint8_t reg, float value);
   bool read_float_(uint8_t reg, float *value);
+  void write_pwm_raw_(uint16_t duty);
 
   ControlMode control_mode_{ControlMode::OPEN_LOOP};
   Direction initial_direction_{Direction::FORWARD};
@@ -72,6 +73,12 @@ class M5UnitBldc : public i2c::I2CDevice, public PollingComponent {
   bool has_pid_{false};
   float p_{0}, i_{0}, d_{0};
   bool save_to_flash_{false};
+
+  // Last commanded PWM/target RPM, so `write_direction()` can restore them after the
+  // zero-then-nonzero cycle the device needs to actually latch a new direction (see datasheet
+  // note "[1] Change direction").
+  uint16_t last_pwm_{0};
+  float last_target_rpm_{0};
 
   sensor::Sensor *rpm_sensor_{nullptr};
   sensor::Sensor *frequency_sensor_{nullptr};

--- a/esphome/components/m5_unit_bldc/number/__init__.py
+++ b/esphome/components/m5_unit_bldc/number/__init__.py
@@ -1,0 +1,49 @@
+import esphome.codegen as cg
+from esphome.components import number
+import esphome.config_validation as cv
+from esphome.const import ICON_ROTATE_RIGHT
+
+from .. import CONF_M5_UNIT_BLDC_ID, UNIT_RPM, M5UnitBldc, m5_unit_bldc_ns
+
+CONF_PWM = "pwm"
+CONF_TARGET_RPM = "target_rpm"
+
+M5UnitBldcNumber = m5_unit_bldc_ns.class_(
+    "M5UnitBldcNumber", number.Number, cg.Parented.template(M5UnitBldc)
+)
+NumberType = m5_unit_bldc_ns.enum("NumberType", is_class=True)
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_M5_UNIT_BLDC_ID): cv.use_id(M5UnitBldc),
+    # Open-loop control -- raw PWM duty cycle. Only takes effect while the hub's `mode` is `open_loop`.
+    cv.Optional(CONF_PWM): number.number_schema(
+        M5UnitBldcNumber,
+        icon=ICON_ROTATE_RIGHT,
+    ),
+    # Closed-loop control -- target RPM. Only takes effect while the hub's `mode` is `closed_loop`.
+    cv.Optional(CONF_TARGET_RPM): number.number_schema(
+        M5UnitBldcNumber,
+        icon=ICON_ROTATE_RIGHT,
+        unit_of_measurement=UNIT_RPM,
+    ),
+}
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_M5_UNIT_BLDC_ID])
+
+    if pwm_config := config.get(CONF_PWM):
+        num = await number.new_number(
+            pwm_config, NumberType.PWM, min_value=0, max_value=2047, step=1
+        )
+        await cg.register_parented(num, parent)
+
+    if target_rpm_config := config.get(CONF_TARGET_RPM):
+        num = await number.new_number(
+            target_rpm_config,
+            NumberType.TARGET_RPM,
+            min_value=0,
+            max_value=20000,
+            step=1,
+        )
+        await cg.register_parented(num, parent)

--- a/esphome/components/m5_unit_bldc/number/m5_unit_bldc_number.cpp
+++ b/esphome/components/m5_unit_bldc/number/m5_unit_bldc_number.cpp
@@ -1,0 +1,17 @@
+#include "m5_unit_bldc_number.h"
+
+namespace esphome::m5_unit_bldc {
+
+void M5UnitBldcNumber::control(float value) {
+  this->publish_state(value);
+  switch (this->type_) {
+    case NumberType::PWM:
+      this->parent_->write_pwm(static_cast<uint16_t>(value));
+      break;
+    case NumberType::TARGET_RPM:
+      this->parent_->write_target_rpm(value);
+      break;
+  }
+}
+
+}  // namespace esphome::m5_unit_bldc

--- a/esphome/components/m5_unit_bldc/number/m5_unit_bldc_number.h
+++ b/esphome/components/m5_unit_bldc/number/m5_unit_bldc_number.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/number/number.h"
+#include "esphome/components/m5_unit_bldc/m5_unit_bldc.h"
+
+namespace esphome::m5_unit_bldc {
+
+enum class NumberType : uint8_t { PWM, TARGET_RPM };
+
+/// A `number` entity driving either the open-loop PWM duty or the closed-loop target RPM of an
+/// M5Unit-BLDC. Which register it writes to is fixed at construction time by `type`.
+class M5UnitBldcNumber : public number::Number, public Parented<M5UnitBldc> {
+ public:
+  explicit M5UnitBldcNumber(NumberType type) : type_(type) {}
+
+ protected:
+  void control(float value) override;
+
+  NumberType type_;
+};
+
+}  // namespace esphome::m5_unit_bldc

--- a/esphome/components/m5_unit_bldc/select/__init__.py
+++ b/esphome/components/m5_unit_bldc/select/__init__.py
@@ -1,0 +1,28 @@
+import esphome.codegen as cg
+from esphome.components import select
+import esphome.config_validation as cv
+from esphome.const import CONF_DIRECTION, ICON_ROTATE_RIGHT
+
+from .. import CONF_M5_UNIT_BLDC_ID, M5UnitBldc, m5_unit_bldc_ns
+
+M5UnitBldcDirectionSelect = m5_unit_bldc_ns.class_(
+    "M5UnitBldcDirectionSelect", select.Select, cg.Parented.template(M5UnitBldc)
+)
+
+DIRECTION_OPTIONS = ["Forward", "Backward"]
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_M5_UNIT_BLDC_ID): cv.use_id(M5UnitBldc),
+    cv.Optional(CONF_DIRECTION): select.select_schema(
+        M5UnitBldcDirectionSelect,
+        icon=ICON_ROTATE_RIGHT,
+    ),
+}
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_M5_UNIT_BLDC_ID])
+
+    if direction_config := config.get(CONF_DIRECTION):
+        sel = await select.new_select(direction_config, options=DIRECTION_OPTIONS)
+        await cg.register_parented(sel, parent)

--- a/esphome/components/m5_unit_bldc/select/m5_unit_bldc_select.cpp
+++ b/esphome/components/m5_unit_bldc/select/m5_unit_bldc_select.cpp
@@ -1,0 +1,10 @@
+#include "m5_unit_bldc_select.h"
+
+namespace esphome::m5_unit_bldc {
+
+void M5UnitBldcDirectionSelect::control(const std::string &value) {
+  this->publish_state(value);
+  this->parent_->write_direction(value == "Backward" ? Direction::BACKWARD : Direction::FORWARD);
+}
+
+}  // namespace esphome::m5_unit_bldc

--- a/esphome/components/m5_unit_bldc/select/m5_unit_bldc_select.h
+++ b/esphome/components/m5_unit_bldc/select/m5_unit_bldc_select.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/select/select.h"
+#include "esphome/components/m5_unit_bldc/m5_unit_bldc.h"
+
+namespace esphome::m5_unit_bldc {
+
+/// A `select` entity for the motor's rotation direction ("Forward"/"Backward").
+class M5UnitBldcDirectionSelect : public select::Select, public Parented<M5UnitBldc> {
+ protected:
+  void control(const std::string &value) override;
+};
+
+}  // namespace esphome::m5_unit_bldc

--- a/esphome/components/m5_unit_bldc/sensor/__init__.py
+++ b/esphome/components/m5_unit_bldc/sensor/__init__.py
@@ -1,0 +1,42 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_FREQUENCY,
+    DEVICE_CLASS_FREQUENCY,
+    ICON_ROTATE_RIGHT,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_HERTZ,
+)
+
+from .. import CONF_M5_UNIT_BLDC_ID, UNIT_RPM, M5UnitBldc
+
+CONF_RPM = "rpm"
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_M5_UNIT_BLDC_ID): cv.use_id(M5UnitBldc),
+    cv.Optional(CONF_RPM): sensor.sensor_schema(
+        unit_of_measurement=UNIT_RPM,
+        icon=ICON_ROTATE_RIGHT,
+        accuracy_decimals=1,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    cv.Optional(CONF_FREQUENCY): sensor.sensor_schema(
+        unit_of_measurement=UNIT_HERTZ,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_FREQUENCY,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+}
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_M5_UNIT_BLDC_ID])
+
+    if rpm_config := config.get(CONF_RPM):
+        sens = await sensor.new_sensor(rpm_config)
+        cg.add(parent.set_rpm_sensor(sens))
+
+    if frequency_config := config.get(CONF_FREQUENCY):
+        sens = await sensor.new_sensor(frequency_config)
+        cg.add(parent.set_frequency_sensor(sens))

--- a/esphome/components/m5_unit_bldc/text_sensor/__init__.py
+++ b/esphome/components/m5_unit_bldc/text_sensor/__init__.py
@@ -1,0 +1,19 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_STATUS
+
+from .. import CONF_M5_UNIT_BLDC_ID, M5UnitBldc
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_M5_UNIT_BLDC_ID): cv.use_id(M5UnitBldc),
+    cv.Optional(CONF_STATUS): text_sensor.text_sensor_schema(),
+}
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_M5_UNIT_BLDC_ID])
+
+    if status_config := config.get(CONF_STATUS):
+        sens = await text_sensor.new_text_sensor(status_config)
+        cg.add(parent.set_status_text_sensor(sens))

--- a/tests/components/m5_unit_bldc/common.yaml
+++ b/tests/components/m5_unit_bldc/common.yaml
@@ -1,0 +1,40 @@
+m5_unit_bldc:
+  i2c_id: i2c_bus
+  id: bldc_hub
+  address: 0x65
+  mode: open_loop
+  direction: forward
+  model: low_speed
+  pole_pairs: 7
+  pid:
+    p: 1.0
+    i: 0.0
+    d: 0.0
+
+number:
+  - platform: m5_unit_bldc
+    m5_unit_bldc_id: bldc_hub
+    pwm:
+      name: Motor PWM
+    target_rpm:
+      name: Motor Target RPM
+
+select:
+  - platform: m5_unit_bldc
+    m5_unit_bldc_id: bldc_hub
+    direction:
+      name: Motor Direction
+
+sensor:
+  - platform: m5_unit_bldc
+    m5_unit_bldc_id: bldc_hub
+    rpm:
+      name: Motor RPM
+    frequency:
+      name: Motor Frequency
+
+text_sensor:
+  - platform: m5_unit_bldc
+    m5_unit_bldc_id: bldc_hub
+    status:
+      name: Motor Status

--- a/tests/components/m5_unit_bldc/test.esp32-idf.yaml
+++ b/tests/components/m5_unit_bldc/test.esp32-idf.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+  m5_unit_bldc: !include common.yaml

--- a/tests/components/m5_unit_bldc/test.esp8266-ard.yaml
+++ b/tests/components/m5_unit_bldc/test.esp8266-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
+  m5_unit_bldc: !include common.yaml

--- a/tests/components/m5_unit_bldc/test.rp2040-ard.yaml
+++ b/tests/components/m5_unit_bldc/test.rp2040-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
+  m5_unit_bldc: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a new `m5_unit_bldc` component for the [M5Stack M5Unit-BLDC](https://github.com/m5stack/M5Unit-BLDC) brushless DC motor driver unit (STM32-based, I2C, default address `0x65`).

- Hub component (`m5_unit_bldc`): configures control mode (open loop / closed loop), initial rotation direction, motor model, pole pairs, and optional PID, matching the vendor's documented I2C register map ([Unit_BLDC_I2C_Protocol.pdf](https://m5stack-doc.oss-cn-shenzhen.aliyuncs.com/772/Unit_BLDC_I2C_Protocol.pdf)).
- `number`: PWM duty cycle (open loop) and target RPM (closed loop).
- `select`: rotation direction (Forward/Backward). Changing direction while the motor is spinning automatically zeroes and restores the active control register after a short delay, since the device only latches a new direction once the motor has actually spun down (documented in the datasheet's "Change direction" note).
- `sensor`: readback RPM and frequency.
- `text_sensor`: motor status (Standby/Running/Error).

Verified against a real M5Unit-BLDC wired to an M5Stack AtomS3 (Port A, GPIO1/GPIO2): the device is found on the I2C bus scan at `0x65`, open-loop PWM control spins the motor, closed-loop RPM control converges to the target via the device's own PID loop, direction reversal works on a running motor, and RPM/frequency readback match the datasheet's `RPM = frequency * 60 / pole_pairs` relationship.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7115

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

ESP8266 and RP2040 were only verified to compile (`script/test_build_components.py`), not tested against real hardware — only the ESP32-S3 (AtomS3, ESP-IDF) path was hardware-verified.

## Example entry for `config.yaml`:

```yaml
i2c:
  sda: GPIO2
  scl: GPIO1

m5_unit_bldc:
  id: bldc1
  mode: closed_loop
  direction: forward
  model: low_speed
  pole_pairs: 7

number:
  - platform: m5_unit_bldc
    m5_unit_bldc_id: bldc1
    pwm:
      name: "BLDC PWM"
    target_rpm:
      name: "BLDC Target RPM"

select:
  - platform: m5_unit_bldc
    m5_unit_bldc_id: bldc1
    direction:
      name: "BLDC Direction"

sensor:
  - platform: m5_unit_bldc
    m5_unit_bldc_id: bldc1
    rpm:
      name: "BLDC RPM"
    frequency:
      name: "BLDC Frequency"

text_sensor:
  - platform: m5_unit_bldc
    m5_unit_bldc_id: bldc1
    status:
      name: "BLDC Status"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

