### PR TITLE
[mqtt] Require a supported backend platform to gate mqtt_client on

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -1,6 +1,7 @@
 #include "mqtt_client.h"
 
-#ifdef USE_MQTT
+// See mqtt_client.h for why the gate must also require one of the supported backend platforms.
+#if defined(USE_MQTT) && (defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_LIBRETINY))
 
 #include <utility>
 #include "esphome/components/network/util.h"
@@ -791,4 +792,4 @@ float MQTTMessageTrigger::get_setup_priority() const { return setup_priority::AF
 
 }  // namespace esphome::mqtt
 
-#endif  // USE_MQTT
+#endif  // USE_MQTT && (USE_ESP32 || USE_ESP8266 || USE_LIBRETINY)

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -2,7 +2,11 @@
 
 #include "esphome/core/defines.h"
 
-#ifdef USE_MQTT
+// MQTTClientComponent holds a concrete mqtt_backend_ member (ESP32/ESP8266/LibreTiny below), so this
+// header only compiles on those platforms. USE_MQTT alone isn't enough to gate on: real builds never
+// define it elsewhere (mqtt's CONFIG_SCHEMA restricts to these platforms via cv.only_on), but static
+// analysis (esphome/core/defines.h) defines every USE_* flag regardless of platform.
+#if defined(USE_MQTT) && (defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_LIBRETINY))
 
 #include "esphome/components/json/json_util.h"
 #include "esphome/components/network/ip_address.h"
@@ -448,4 +452,4 @@ template<typename... Ts> class MQTTDisableAction final : public Action<Ts...> {
 
 }  // namespace esphome::mqtt
 
-#endif  // USE_MQTT
+#endif  // USE_MQTT && (USE_ESP32 || USE_ESP8266 || USE_LIBRETINY)


### PR DESCRIPTION
# What does this implement/fix?

`MQTTClientComponent` holds a concrete `mqtt_backend_` member selected by `#if defined(USE_ESP32)/elif USE_ESP8266/elif USE_LIBRETINY`, so `mqtt_client.h`/`.cpp` can only actually compile on those three platforms. The file only guarded its content on `#ifdef USE_MQTT`, relying on the fact that `USE_MQTT` is never defined outside those platforms in a real build (`mqtt`'s `CONFIG_SCHEMA` already restricts configuration to them via `cv.only_on`).

That assumption breaks under clang-tidy: `esphome/core/defines.h` unconditionally defines `USE_MQTT` for every platform for static-analysis purposes. On a full/targeted clang-tidy scan that touches `mqtt_client.h` for the RP2 (or Zephyr/nRF52) tidy environment, none of the three backend branches match, so `MQTTBackend`, `MQTTMessage`, etc. get referenced without ever being declared, producing errors like `use of undeclared identifier 'MQTTBackend'`.

This change tightens the guard to `#if defined(USE_MQTT) && (defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_LIBRETINY))`, so the header/source correctly compile to empty content on any platform mqtt doesn't actually support — matching what's already true everywhere else.

**Verification:**

- `script/clang-tidy --environment rp2-tidy --grep USE_RP2 --all-headers --changed` and `script/clang-tidy --environment nrf52-tidy --grep USE_ZEPHYR --grep USE_NRF52 --all-headers --changed` (reproducing the two CI jobs affected by this bug) both exit clean against the changed files, where the RP2 one previously reproduced the exact errors from [this CI run](https://github.com/esphome/esphome/actions/runs/30945815895/job/92119889095?pr=17909).
- `script/test_build_components -c mqtt` — 5/5 real firmware builds pass (esp32-idf, esp8266-ard, bk72xx-ard, ln882x-ard, rtl87xx-ard), i.e. every platform mqtt actually supports.
- Confirmed the guard still resolves true (not washed out) on supported platforms by inspecting the linked firmware: `nm -C firmware.elf | grep MQTTClientComponent` shows 70–107 defined (not just referenced) symbols per platform, covering real method bodies (`on_message`, `publish_json`, `is_connected`, `set_keep_alive`, etc.) across the ESP32, ESP8266, and LibreTiny backend paths.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related: https://github.com/esphomeplatformzephyr/esphome/issues/20 (tracked in a downstream fork's issue tracker; confirmed present upstream via https://github.com/esphome/esphome/actions/runs/30945815895/job/92119889095?pr=17909)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (no user-facing configuration change)

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

I considered making the change in defines.h, but decided this was the simpler approach and I saw precedent in other components.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

For above, ran compile tests and script/clang-tidy, did not run on any devices.


## Example entry for `config.yaml`:

```yaml
# No configuration change; internal preprocessor guard fix only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
