### PR TITLE
[bluetooth_proxy] Scanner-state sync in set_mode; platform-gate tests

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -561,6 +561,10 @@ void BluetoothProxy::bluetooth_scanner_set_mode(bool active) {
     }
   }
   if (this->api_connection_ != nullptr) {
+    // Keep loop()'s change detector in step with the state sent here, so a
+    // failed restart (scan_running_ dropped by the tracker) is not reported
+    // twice — once now and again on the next tick.
+    this->last_scan_running_ = this->hub_->scan_running();
     this->send_bluetooth_scanner_state_();
   }
 }

--- a/tests/component_tests/bluetooth_proxy/test_outer_schema_mirror.py
+++ b/tests/component_tests/bluetooth_proxy/test_outer_schema_mirror.py
@@ -2,9 +2,10 @@
 them without importing the esp32 BLE stack; pin the two declarations together.
 
 The outer schema carries no defaults (the per-platform schema applies them), so
-drift cannot surface in validation output — a key renamed or re-bounded in
+drift cannot surface in validation output — a key renamed or removed in
 _esp32_config_schema() but not here would silently vanish from the dashboard's
-field extractor. This test is what catches that.
+field extractor. This test is what catches that; validator bounds are pinned
+separately only for connection_slots (test_idf_max_connections_mirror).
 """
 
 import voluptuous as vol

--- a/tests/component_tests/bluetooth_proxy/test_platform_gates.py
+++ b/tests/component_tests/bluetooth_proxy/test_platform_gates.py
@@ -1,0 +1,48 @@
+"""The three platform-gate branches: BLE-less platforms are rejected with the
+real reason, hub platforms reject GATT-only options by name, and the
+advertisement-only arm applies its own defaults."""
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components import bluetooth_proxy
+from esphome.const import CONF_ACTIVE, KEY_TARGET_PLATFORM
+from esphome.core import CORE, KEY_CORE
+
+
+def _set_platform(platform: str) -> None:
+    CORE.data.setdefault(KEY_CORE, {})[KEY_TARGET_PLATFORM] = platform
+
+
+def test_ble_less_platform_gets_the_real_reason() -> None:
+    _set_platform("esp8266")
+    with pytest.raises(cv.Invalid, match="not supported on esp8266"):
+        bluetooth_proxy.CONFIG_SCHEMA({})
+
+
+def test_ble_less_platform_connection_keys_fall_through() -> None:
+    # The key-level rejection must not fire here — it would imply an
+    # advertisement-only proxy exists on this platform.
+    _set_platform("esp8266")
+    with pytest.raises(cv.Invalid, match="not supported on esp8266"):
+        bluetooth_proxy.CONFIG_SCHEMA({"connection_slots": 2})
+
+
+def test_hub_platform_rejects_active() -> None:
+    _set_platform("ln882x")
+    with pytest.raises(cv.Invalid, match="Active connections are not supported"):
+        bluetooth_proxy.CONFIG_SCHEMA({"active": True})
+
+
+def test_hub_platform_rejects_connection_keys_by_name() -> None:
+    _set_platform("ln882x")
+    with pytest.raises(cv.Invalid, match="'connection_slots' requires active"):
+        bluetooth_proxy.CONFIG_SCHEMA({"connection_slots": 2})
+    with pytest.raises(cv.Invalid, match="'cache_services' requires active"):
+        bluetooth_proxy.CONFIG_SCHEMA({"cache_services": True})
+
+
+def test_hub_platform_accepts_the_advertisement_only_shape() -> None:
+    _set_platform("ln882x")
+    validated = bluetooth_proxy.CONFIG_SCHEMA({})
+    assert validated[CONF_ACTIVE] is False


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #17880, the three items deferred from its review rounds:

- `bluetooth_scanner_set_mode()` refreshes `last_scan_running_` before sending scanner state, keeping `loop()`'s change detector in step — a failed rp2 restart no longer emits a duplicate IDLE frame on the next tick.
- The three platform-gate branches gain tests (`test_platform_gates.py`): BLE-less platforms get the platform-level rejection (including with connection keys present), hub platforms reject `active:` and the GATT-only keys by name, and the advertisement-only shape validates with `active` defaulting to `false`.
- `test_outer_schema_mirror.py`'s docstring no longer promises validator-bound checking the tests do not perform; the one pinned bound is called out.

## Verification

- LN882H (LibreTiny): full firmware compiled and OTA-flashed to an LN882H test device running the advertisement-only proxy; zero errors
- `pytest tests/component_tests/bluetooth_proxy` (8 tests)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
