### PR TITLE
[rp2] Bump arduino-pico framework to 6.0.0

### DIFF
--- a/esphome/components/rp2/__init__.py
+++ b/esphome/components/rp2/__init__.py
@@ -173,14 +173,9 @@ def get_download_types(storage_json):
 
 
 def _format_framework_arduino_version(ver: cv.Version) -> str:
-    # The most recent releases have not been uploaded to platformio so grabbing them directly from
-    # the GitHub release is one path forward for now.
+    # The framework-arduinopico package is no longer published to the PlatformIO
+    # registry, so install the framework straight from the GitHub release
     return f"https://github.com/earlephilhower/arduino-pico/releases/download/{ver}/rp2040-{ver}.zip"
-
-    # format the given arduino (https://github.com/earlephilhower/arduino-pico/releases) version to
-    # a PIO earlephilhower/framework-arduinopico value
-    # List of package versions: https://api.registry.platformio.org/v3/packages/earlephilhower/tool/framework-arduinopico
-    # return f"~1.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
 
 
 def _parse_platform_version(value):
@@ -198,7 +193,6 @@ def _parse_platform_version(value):
 
 # The default/recommended arduino framework version
 #  - https://github.com/earlephilhower/arduino-pico/releases
-#  - https://api.registry.platformio.org/v3/packages/earlephilhower/tool/framework-arduinopico
 RECOMMENDED_ARDUINO_FRAMEWORK_VERSION = cv.Version(6, 0, 0)
 
 # The raspberrypi platform version to use for arduino frameworks

--- a/esphome/components/rp2/__init__.py
+++ b/esphome/components/rp2/__init__.py
@@ -199,18 +199,20 @@ def _parse_platform_version(value):
 # The default/recommended arduino framework version
 #  - https://github.com/earlephilhower/arduino-pico/releases
 #  - https://api.registry.platformio.org/v3/packages/earlephilhower/tool/framework-arduinopico
-RECOMMENDED_ARDUINO_FRAMEWORK_VERSION = cv.Version(5, 6, 1)
+RECOMMENDED_ARDUINO_FRAMEWORK_VERSION = cv.Version(6, 0, 0)
 
 # The raspberrypi platform version to use for arduino frameworks
 #  - https://github.com/maxgerhardt/platform-raspberrypi/tags
-RECOMMENDED_ARDUINO_PLATFORM_VERSION = "v1.4.0-gcc14-arduinopico460"
+# develop-branch commit carrying the arduino-pico 6.0.0 / pico-quick-toolchain
+# 5.0.0 (GCC 16.1) update; replace with a release tag when one is cut
+RECOMMENDED_ARDUINO_PLATFORM_VERSION = "9c167c6b8aac4f4cfa6d55a0c4e5b848795150c0"
 
 
 def _arduino_check_versions(value):
     value = value.copy()
     lookups = {
-        "dev": (cv.Version(5, 6, 1), "https://github.com/earlephilhower/arduino-pico"),
-        "latest": (cv.Version(5, 6, 1), None),
+        "dev": (cv.Version(6, 0, 0), "https://github.com/earlephilhower/arduino-pico"),
+        "latest": (cv.Version(6, 0, 0), None),
         "recommended": (RECOMMENDED_ARDUINO_FRAMEWORK_VERSION, None),
     }
 

--- a/esphome/components/rp2/boards.py
+++ b/esphome/components/rp2/boards.py
@@ -708,6 +708,19 @@ RP2_BOARD_PINS = {
         "SS": 17,
         "TX": 0,
     },
+    "ilabs_cpico_2350": {
+        "LED": 25,
+        "MISO": 16,
+        "MOSI": 19,
+        "RX": 1,
+        "SCK": 18,
+        "SCL": 5,
+        "SCL1": 27,
+        "SDA": 4,
+        "SDA1": 26,
+        "SS": 17,
+        "TX": 0,
+    },
     "ilabs_rpico32": {
         "MISO": 24,
         "MOSI": 23,
@@ -1513,6 +1526,19 @@ RP2_BOARD_PINS = {
         "SS": 17,
         "TX": 0,
     },
+    "weact_rp2350b": {
+        "LED": 25,
+        "MISO": 16,
+        "MOSI": 19,
+        "RX": 1,
+        "SCK": 18,
+        "SCL": 5,
+        "SCL1": 27,
+        "SDA": 4,
+        "SDA1": 26,
+        "SS": 17,
+        "TX": 0,
+    },
     "wiznet_55rp20_evb_pico": {
         "LED": 19,
         "MISO": 2,
@@ -1877,6 +1903,11 @@ BOARDS = {
         "mcu": "rp2040",
         "max_pin": 29,
     },
+    "ilabs_cpico_2350": {
+        "name": "iLabs CPico 2350",
+        "mcu": "rp2350",
+        "max_pin": 47,
+    },
     "ilabs_rpico32": {
         "name": "iLabs RPICO32",
         "mcu": "rp2040",
@@ -1948,12 +1979,12 @@ BOARDS = {
         "max_pin": 29,
     },
     "pcbcupid_glyph_2040": {
-        "name": "PCBCupid Glyph 2040",
+        "name": "Pcbcupid GLYPH 2040",
         "mcu": "rp2040",
         "max_pin": 29,
     },
     "pcbcupid_glyph_mini_2040": {
-        "name": "PCBCupid Glyph Mini 2040",
+        "name": "Pcbcupid GLYPH MINI 2040",
         "mcu": "rp2040",
         "max_pin": 29,
     },
@@ -2257,6 +2288,11 @@ BOARDS = {
         "mcu": "rp2350",
         "max_pin": 47,
         "wifi": True,
+    },
+    "weact_rp2350b": {
+        "name": "WeAct Studio RP2350B Core Board",
+        "mcu": "rp2350",
+        "max_pin": 47,
     },
     "wiznet_5100s_evb_pico": {
         "name": "WIZnet W5100S-EVB-Pico",

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -455,7 +455,7 @@
 // rp2/__init__.py codegen also defines USE_RP2040 as a back-compat alias
 // for external custom components that may still test for it.
 #ifdef USE_RP2
-#define USE_ARDUINO_VERSION_CODE VERSION_CODE(3, 3, 0)
+#define USE_ARDUINO_VERSION_CODE VERSION_CODE(6, 0, 0)
 #define USE_RP2_CRASH_HANDLER
 #define USE_HTTP_REQUEST_RESPONSE
 #define USE_I2C

--- a/platformio.ini
+++ b/platformio.ini
@@ -203,10 +203,10 @@ extra_scripts =
 extends = common:arduino
 board_build.filesystem_size = 0.5m
 
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git#v1.4.0-gcc14-arduinopico460
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#9c167c6b8aac4f4cfa6d55a0c4e5b848795150c0
 platform_packages =
     ; earlephilhower/framework-arduinopico@~1.20602.0 ; Cannot use the platformio package until old releases stop getting deleted
-    earlephilhower/framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/5.6.1/rp2040-5.6.1.zip
+    earlephilhower/framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
 
 framework = arduino
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -205,7 +205,8 @@ board_build.filesystem_size = 0.5m
 
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git#9c167c6b8aac4f4cfa6d55a0c4e5b848795150c0
 platform_packages =
-    ; earlephilhower/framework-arduinopico@~1.20602.0 ; Cannot use the platformio package until old releases stop getting deleted
+    ; The framework-arduinopico package is no longer published to the PlatformIO
+    ; registry, so install the framework straight from the GitHub release
     earlephilhower/framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
 
 framework = arduino

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -29,6 +29,28 @@ from helpers import (
 )
 
 
+def gcc_multilib_directory(idedata):
+    """The toolchain's active multilib subdirectory (e.g. "thumb"), if any.
+
+    PlatformIO's idedata lists the generic toolchain include directories; GCC
+    resolves the active multilib subdirectory internally while searching them.
+    Toolchains without a default multilib (pico-quick-toolchain 5.0.0+) ship
+    the libstdc++ target config (bits/c++config.h) only inside the multilib
+    subdirectories, so clang needs the resolved directory spelled out.
+    """
+    machine_flags = [f for f in idedata["cxx_flags"] if f.startswith("-m")]
+    try:
+        multilib = subprocess.run(
+            [idedata["cxx_path"], *machine_flags, "-print-multi-directory"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return None if multilib in ("", ".") else multilib
+
+
 def clang_options(idedata, environment):
     cmd = []
 
@@ -203,9 +225,15 @@ def clang_options(idedata, environment):
     # toolchain include directories, using -isystem to suppress their errors
     # idedata contains include directories for all toolchains of this platform, only use those from the one in use
     toolchain_dir = os.path.normpath(f"{idedata['cxx_path']}/../../")
+    multilib = gcc_multilib_directory(idedata)
     toolchain_includes = []
     for directory in idedata["includes"]["toolchain"]:
         if directory.startswith(toolchain_dir) and "picolibc" not in directory:
+            if (
+                multilib
+                and Path(multilib_dir := os.path.join(directory, multilib)).is_dir()
+            ):
+                toolchain_includes.extend(["-isystem", multilib_dir])
             toolchain_includes.extend(["-isystem", directory])
 
     # library include directories, using -isystem to suppress their errors

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -229,11 +229,8 @@ def clang_options(idedata, environment):
     toolchain_includes = []
     for directory in idedata["includes"]["toolchain"]:
         if directory.startswith(toolchain_dir) and "picolibc" not in directory:
-            if (
-                multilib
-                and Path(multilib_dir := os.path.join(directory, multilib)).is_dir()
-            ):
-                toolchain_includes.extend(["-isystem", multilib_dir])
+            if multilib and (multilib_dir := Path(directory) / multilib).is_dir():
+                toolchain_includes.extend(["-isystem", str(multilib_dir)])
             toolchain_includes.extend(["-isystem", directory])
 
     # library include directories, using -isystem to suppress their errors

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+from typing import Any
 
 import click
 import colorama
@@ -29,7 +30,7 @@ from helpers import (
 )
 
 
-def gcc_multilib_directory(idedata):
+def gcc_multilib_directory(idedata: dict[str, Any]) -> str | None:
     """The toolchain's active multilib subdirectory (e.g. "thumb"), if any.
 
     PlatformIO's idedata lists the generic toolchain include directories; GCC


### PR DESCRIPTION
# What does this implement/fix?

Bumps the arduino-pico framework from 5.6.1 to 6.0.0. This is a large upstream infrastructure update: GCC 16.1, Newlib 4.6.0 with nano-printf, pico-sdk 2.3.0, and the C23/C++23 standards.

The new core requires the new pico-quick-toolchain 5.0.0, which platform-raspberrypi only carries on its develop branch so far; the platform is pinned to the develop commit that wires it up, and can move to a release tag once one is cut. For background, PlatformIO stopped updating the official raspberrypi platform after a disagreement with Raspberry Pi, so the maxgerhardt community fork is the maintained platform and is what ESPHome already uses today.

`boards.py` is regenerated, picking up the iLabs CPico 2350 and WeAct RP2350B boards. The stale `USE_ARDUINO_VERSION_CODE` stub in `defines.h` is synced as well (lint only, real builds derive it from the resolved version).

Checked against the 6.0.0 tree: `lwipopts.h` and the PlatformIO builder script are unchanged from 5.6.1, so the lwIP override injection and tuning table still apply; the `Hash` library, `__inLWIP` guard, and weak `isr_hardfault` symbol are all unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
rp2:
  board: rpipicow
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
