### PR TITLE
[core] Drop the duplicated FileLock import from a merge collision

### DIFF
--- a/esphome/git.py
+++ b/esphome/git.py
@@ -26,9 +26,6 @@ from esphome.helpers import (
 if TYPE_CHECKING:
     from filelock import FileLock
 
-if TYPE_CHECKING:
-    from filelock import FileLock
-
 _LOGGER = logging.getLogger(__name__)
 
 # Special value to indicate never refresh


### PR DESCRIPTION
# What does this implement/fix?

Two merged PRs each added the guarded FileLock import to `esphome/git.py`, so dev carries the block twice and flake8 (F811) fails the lint job on every open PR; this drops the duplicate.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# Lint only change; no configuration impact.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
