### PR TITLE
[ble_device_base] Document the None output for unset UUIDs in to_str()

### DIFF
--- a/esphome/components/ble_device_base/ble_device.h
+++ b/esphome/components/ble_device_base/ble_device.h
@@ -85,8 +85,8 @@ class ESPBTUUID {
   bool operator==(const ESPBTUUID &other) const;
   bool operator!=(const ESPBTUUID &other) const { return !(*this == other); }
 
-  /// Write "0xABCD" / "0xABCDEF01" / the dashed 128-bit form into buf
-  /// (>= UUID_STR_LEN bytes) and return buf.
+  /// Write "0xABCD" / "0xABCDEF01" / the dashed 128-bit form, or "None" for an
+  /// unset UUID, into buf (>= UUID_STR_LEN bytes) and return buf.
   const char *to_str(char *buf) const;
 #if defined(__cpp_lib_span)
   const char *to_str(std::span<char, UUID_STR_LEN> output) const { return this->to_str(output.data()); }


### PR DESCRIPTION
# What does this implement/fix?

Since #18098, `to_str()` writes `None` for an unset UUID, but the doc comment above the declaration still listed only the hex and dashed 128 bit output formats. Update the comment so component authors see the full contract. Follow up to a Copilot review note on #18098.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/pull/18098

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
