### PR TITLE
[ble_client] Reject descriptor_uuid combined with notify at validation time

### DIFF
--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -24,18 +24,22 @@ CODEOWNERS = ["@buxtronix", "@clydebarrow"]
 DEPENDENCIES = ["esp32_ble_tracker"]
 
 CONF_DESCRIPTOR_UUID = "descriptor_uuid"
+CONF_ON_NOTIFY = "on_notify"
 
 
 def validate_descriptor_not_notify(config: ConfigType) -> ConfigType:
-    """Reject descriptor_uuid combined with notify.
+    """Reject descriptor_uuid combined with notify or on_notify.
 
     BLE descriptors cannot send notifications; only characteristics can, and
     ESP-IDF has no descriptor variant of esp_ble_gattc_register_for_notify.
     """
-    if config.get(CONF_NOTIFY) and CONF_DESCRIPTOR_UUID in config:
+    if CONF_DESCRIPTOR_UUID in config and (
+        config.get(CONF_NOTIFY) or CONF_ON_NOTIFY in config
+    ):
         raise cv.Invalid(
-            f"'{CONF_DESCRIPTOR_UUID}' cannot be used with '{CONF_NOTIFY}': BLE descriptors "
-            f"cannot send notifications; remove '{CONF_NOTIFY}' to poll the descriptor instead"
+            f"'{CONF_DESCRIPTOR_UUID}' cannot be used with '{CONF_NOTIFY}' or "
+            f"'{CONF_ON_NOTIFY}': BLE descriptors cannot send notifications and "
+            f"can only be polled"
         )
     return config
 

--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_ID,
     CONF_MAC_ADDRESS,
     CONF_NAME,
+    CONF_NOTIFY,
     CONF_ON_CONNECT,
     CONF_ON_DISCONNECT,
     CONF_SERVICE_UUID,
@@ -16,10 +17,28 @@ from esphome.const import (
     CONF_VALUE,
 )
 from esphome.core import ID
+from esphome.types import ConfigType
 
 AUTO_LOAD = ["esp32_ble_client"]
 CODEOWNERS = ["@buxtronix", "@clydebarrow"]
 DEPENDENCIES = ["esp32_ble_tracker"]
+
+CONF_DESCRIPTOR_UUID = "descriptor_uuid"
+
+
+def validate_descriptor_not_notify(config: ConfigType) -> ConfigType:
+    """Reject descriptor_uuid combined with notify.
+
+    BLE descriptors cannot send notifications; only characteristics can, and
+    ESP-IDF has no descriptor variant of esp_ble_gattc_register_for_notify.
+    """
+    if config.get(CONF_NOTIFY) and CONF_DESCRIPTOR_UUID in config:
+        raise cv.Invalid(
+            f"'{CONF_DESCRIPTOR_UUID}' cannot be used with '{CONF_NOTIFY}': BLE descriptors "
+            f"cannot send notifications; remove '{CONF_NOTIFY}' to poll the descriptor instead"
+        )
+    return config
+
 
 ble_client_ns = cg.esphome_ns.namespace("ble_client")
 BLEClient = ble_client_ns.class_("BLEClient", esp32_ble_client.BLEClientBase)

--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -38,8 +38,9 @@ def validate_descriptor_not_notify(config: ConfigType) -> ConfigType:
     ):
         raise cv.Invalid(
             f"'{CONF_DESCRIPTOR_UUID}' cannot be used with '{CONF_NOTIFY}' or "
-            f"'{CONF_ON_NOTIFY}': BLE descriptors cannot send notifications and "
-            f"can only be polled"
+            f"'{CONF_ON_NOTIFY}': BLE descriptors cannot send notifications; remove "
+            f"'{CONF_DESCRIPTOR_UUID}' to receive characteristic notifications, or "
+            f"remove '{CONF_NOTIFY}' and '{CONF_ON_NOTIFY}' to poll the descriptor"
         )
     return config
 

--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -45,6 +45,18 @@ def validate_descriptor_not_notify(config: ConfigType) -> ConfigType:
     return config
 
 
+def notify_from_on_notify(config: ConfigType) -> ConfigType:
+    """Enable notifications when an on_notify automation is configured.
+
+    The triggers have no registration path of their own; without notify the
+    automation would validate but never fire.
+    """
+    if CONF_ON_NOTIFY in config and not config[CONF_NOTIFY]:
+        config = config.copy()
+        config[CONF_NOTIFY] = True
+    return config
+
+
 ble_client_ns = cg.esphome_ns.namespace("ble_client")
 BLEClient = ble_client_ns.class_("BLEClient", esp32_ble_client.BLEClientBase)
 BLEClientNode = ble_client_ns.class_("BLEClientNode")

--- a/esphome/components/ble_client/sensor/__init__.py
+++ b/esphome/components/ble_client/sensor/__init__.py
@@ -14,11 +14,9 @@ from esphome.const import (
     UNIT_DECIBEL_MILLIWATT,
 )
 
-from .. import ble_client_ns
+from .. import CONF_DESCRIPTOR_UUID, ble_client_ns, validate_descriptor_not_notify
 
 DEPENDENCIES = ["ble_client"]
-
-CONF_DESCRIPTOR_UUID = "descriptor_uuid"
 
 CONF_ON_NOTIFY = "on_notify"
 TYPE_CHARACTERISTIC = "characteristic"
@@ -85,6 +83,7 @@ CONFIG_SCHEMA = cv.All(
         },
         lower=True,
     ),
+    validate_descriptor_not_notify,
 )
 
 

--- a/esphome/components/ble_client/sensor/__init__.py
+++ b/esphome/components/ble_client/sensor/__init__.py
@@ -14,11 +14,15 @@ from esphome.const import (
     UNIT_DECIBEL_MILLIWATT,
 )
 
-from .. import CONF_DESCRIPTOR_UUID, ble_client_ns, validate_descriptor_not_notify
+from .. import (
+    CONF_DESCRIPTOR_UUID,
+    CONF_ON_NOTIFY,
+    ble_client_ns,
+    validate_descriptor_not_notify,
+)
 
 DEPENDENCIES = ["ble_client"]
 
-CONF_ON_NOTIFY = "on_notify"
 TYPE_CHARACTERISTIC = "characteristic"
 TYPE_RSSI = "rssi"
 

--- a/esphome/components/ble_client/sensor/__init__.py
+++ b/esphome/components/ble_client/sensor/__init__.py
@@ -18,6 +18,7 @@ from .. import (
     CONF_DESCRIPTOR_UUID,
     CONF_ON_NOTIFY,
     ble_client_ns,
+    notify_from_on_notify,
     validate_descriptor_not_notify,
 )
 
@@ -88,6 +89,7 @@ CONFIG_SCHEMA = cv.All(
         lower=True,
     ),
     validate_descriptor_not_notify,
+    notify_from_on_notify,
 )
 
 

--- a/esphome/components/ble_client/text_sensor/__init__.py
+++ b/esphome/components/ble_client/text_sensor/__init__.py
@@ -9,11 +9,15 @@ from esphome.const import (
     CONF_TRIGGER_ID,
 )
 
-from .. import CONF_DESCRIPTOR_UUID, ble_client_ns, validate_descriptor_not_notify
+from .. import (
+    CONF_DESCRIPTOR_UUID,
+    CONF_ON_NOTIFY,
+    ble_client_ns,
+    validate_descriptor_not_notify,
+)
 
 DEPENDENCIES = ["ble_client"]
 
-CONF_ON_NOTIFY = "on_notify"
 
 adv_data_t = cg.std_vector.template(cg.uint8)
 adv_data_t_const_ref = adv_data_t.operator("ref").operator("const")

--- a/esphome/components/ble_client/text_sensor/__init__.py
+++ b/esphome/components/ble_client/text_sensor/__init__.py
@@ -9,11 +9,9 @@ from esphome.const import (
     CONF_TRIGGER_ID,
 )
 
-from .. import ble_client_ns
+from .. import CONF_DESCRIPTOR_UUID, ble_client_ns, validate_descriptor_not_notify
 
 DEPENDENCIES = ["ble_client"]
-
-CONF_DESCRIPTOR_UUID = "descriptor_uuid"
 
 CONF_ON_NOTIFY = "on_notify"
 
@@ -48,7 +46,8 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("60s"))
-    .extend(ble_client.BLE_CLIENT_SCHEMA)
+    .extend(ble_client.BLE_CLIENT_SCHEMA),
+    validate_descriptor_not_notify,
 )
 
 

--- a/esphome/components/ble_client/text_sensor/__init__.py
+++ b/esphome/components/ble_client/text_sensor/__init__.py
@@ -13,6 +13,7 @@ from .. import (
     CONF_DESCRIPTOR_UUID,
     CONF_ON_NOTIFY,
     ble_client_ns,
+    notify_from_on_notify,
     validate_descriptor_not_notify,
 )
 
@@ -52,6 +53,7 @@ CONFIG_SCHEMA = cv.All(
     .extend(cv.polling_component_schema("60s"))
     .extend(ble_client.BLE_CLIENT_SCHEMA),
     validate_descriptor_not_notify,
+    notify_from_on_notify,
 )
 
 

--- a/tests/component_tests/ble_client/test_validation.py
+++ b/tests/component_tests/ble_client/test_validation.py
@@ -6,6 +6,7 @@ from esphome import config_validation as cv
 from esphome.components.ble_client import (
     CONF_DESCRIPTOR_UUID,
     CONF_ON_NOTIFY,
+    notify_from_on_notify,
     validate_descriptor_not_notify,
 )
 from esphome.components.ble_client.sensor import CONFIG_SCHEMA as SENSOR_SCHEMA
@@ -73,3 +74,13 @@ def test_sensor_schema_allows_descriptor_polling() -> None:
 
 def test_text_sensor_schema_allows_descriptor_polling() -> None:
     assert TEXT_SENSOR_SCHEMA(dict(DESCRIPTOR_CONFIG))
+
+
+def test_on_notify_implies_notify() -> None:
+    config: ConfigType = {CONF_NOTIFY: False, CONF_ON_NOTIFY: [{}]}
+    assert notify_from_on_notify(config)[CONF_NOTIFY] is True
+
+
+def test_notify_unchanged_without_on_notify() -> None:
+    config: ConfigType = {CONF_NOTIFY: False}
+    assert notify_from_on_notify(config)[CONF_NOTIFY] is False

--- a/tests/component_tests/ble_client/test_validation.py
+++ b/tests/component_tests/ble_client/test_validation.py
@@ -1,0 +1,27 @@
+"""Tests for ble_client config validation."""
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components.ble_client import (
+    CONF_DESCRIPTOR_UUID,
+    validate_descriptor_not_notify,
+)
+from esphome.const import CONF_NOTIFY
+from esphome.types import ConfigType
+
+
+def test_notify_with_descriptor_uuid_rejected() -> None:
+    config: ConfigType = {CONF_NOTIFY: True, CONF_DESCRIPTOR_UUID: "2902"}
+    with pytest.raises(cv.Invalid, match="cannot send notifications"):
+        validate_descriptor_not_notify(config)
+
+
+def test_descriptor_uuid_without_notify_allowed() -> None:
+    config: ConfigType = {CONF_NOTIFY: False, CONF_DESCRIPTOR_UUID: "2902"}
+    assert validate_descriptor_not_notify(config) is config
+
+
+def test_notify_without_descriptor_uuid_allowed() -> None:
+    config: ConfigType = {CONF_NOTIFY: True}
+    assert validate_descriptor_not_notify(config) is config

--- a/tests/component_tests/ble_client/test_validation.py
+++ b/tests/component_tests/ble_client/test_validation.py
@@ -5,14 +5,42 @@ import pytest
 from esphome import config_validation as cv
 from esphome.components.ble_client import (
     CONF_DESCRIPTOR_UUID,
+    CONF_ON_NOTIFY,
     validate_descriptor_not_notify,
 )
-from esphome.const import CONF_NOTIFY
+from esphome.components.ble_client.sensor import CONFIG_SCHEMA as SENSOR_SCHEMA
+from esphome.components.ble_client.text_sensor import (
+    CONFIG_SCHEMA as TEXT_SENSOR_SCHEMA,
+)
+from esphome.const import (
+    CONF_CHARACTERISTIC_UUID,
+    CONF_NAME,
+    CONF_NOTIFY,
+    CONF_SERVICE_UUID,
+    CONF_TYPE,
+)
 from esphome.types import ConfigType
+
+DESCRIPTOR_CONFIG: ConfigType = {
+    CONF_NAME: "test",
+    CONF_SERVICE_UUID: "6E400001-B5A3-F393-E0A9-E50E24DCCA9E",
+    CONF_CHARACTERISTIC_UUID: "6E400003-B5A3-F393-E0A9-E50E24DCCA9E",
+    CONF_DESCRIPTOR_UUID: "2902",
+}
 
 
 def test_notify_with_descriptor_uuid_rejected() -> None:
     config: ConfigType = {CONF_NOTIFY: True, CONF_DESCRIPTOR_UUID: "2902"}
+    with pytest.raises(cv.Invalid, match="cannot send notifications"):
+        validate_descriptor_not_notify(config)
+
+
+def test_on_notify_with_descriptor_uuid_rejected() -> None:
+    config: ConfigType = {
+        CONF_NOTIFY: False,
+        CONF_ON_NOTIFY: [{}],
+        CONF_DESCRIPTOR_UUID: "2902",
+    }
     with pytest.raises(cv.Invalid, match="cannot send notifications"):
         validate_descriptor_not_notify(config)
 
@@ -25,3 +53,23 @@ def test_descriptor_uuid_without_notify_allowed() -> None:
 def test_notify_without_descriptor_uuid_allowed() -> None:
     config: ConfigType = {CONF_NOTIFY: True}
     assert validate_descriptor_not_notify(config) is config
+
+
+def test_sensor_schema_rejects_notify_with_descriptor() -> None:
+    config = {**DESCRIPTOR_CONFIG, CONF_TYPE: "characteristic", CONF_NOTIFY: True}
+    with pytest.raises(cv.Invalid, match="cannot send notifications"):
+        SENSOR_SCHEMA(config)
+
+
+def test_text_sensor_schema_rejects_notify_with_descriptor() -> None:
+    config = {**DESCRIPTOR_CONFIG, CONF_NOTIFY: True}
+    with pytest.raises(cv.Invalid, match="cannot send notifications"):
+        TEXT_SENSOR_SCHEMA(config)
+
+
+def test_sensor_schema_allows_descriptor_polling() -> None:
+    assert SENSOR_SCHEMA({**DESCRIPTOR_CONFIG, CONF_TYPE: "characteristic"})
+
+
+def test_text_sensor_schema_allows_descriptor_polling() -> None:
+    assert TEXT_SENSOR_SCHEMA(dict(DESCRIPTOR_CONFIG))


### PR DESCRIPTION
# What does this implement/fix?

Using `descriptor_uuid` together with `notify: true` on a ble_client sensor or text_sensor has never worked and cannot work; BLE has no descriptor notification PDU and ESP-IDF has no descriptor variant of `esp_ble_gattc_register_for_notify`, descriptors can only be read or written. At runtime the descriptor handle overwrote the handle used to filter notify events, so the sensor never reached the established state and produced no data. This was the second half of the report in #18096.

Reject the combination at validation time with a message explaining that descriptors can only be polled; `on_notify` is rejected alongside `notify` since the automation also never fires without notifications. In addition, `on_notify` now implies `notify: true`; previously an `on_notify` automation without `notify` validated but never fired because nothing registered for notifications. The `descriptor_uuid` and `on_notify` constants and the validators move to the ble_client package so the sensor and text_sensor platforms share them; unit tests cover both validators and the schema wiring.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/18096

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
ble_client:
  - mac_address: "AA:BB:CC:DD:EE:FF"
    id: myclient

text_sensor:
  - platform: ble_client
    ble_client_id: myclient
    name: "Descriptor value"
    service_uuid: "6E400001-B5A3-F393-E0A9-E50E24DCCA9E"
    characteristic_uuid: "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
    descriptor_uuid: "2902"
    # notify: true would now fail validation, descriptors can only be polled
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
