### PR TITLE
[ci] Name release runs after the version or dev tag they build

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,0 +1,38 @@
+---
+name: Nightly Dev Release
+
+# Works out the dated dev tag and starts the release workflow with it, so that
+# the release run is named after the tag it builds. A workflow run name is
+# fixed when the run starts and cannot read a file or the current date.
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+
+permissions:
+  contents: read  # actions/checkout to read the version from esphome/const.py
+
+jobs:
+  trigger:
+    name: Start release build
+    if: github.repository == 'esphome/esphome'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # actions/checkout to read the version from esphome/const.py
+      actions: write  # gh workflow run starts release.yml
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Start the release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(sed -n -E "s/^__version__\s+=\s+\"(.+)\"$/\1/p" esphome/const.py)
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::Could not read __version__ from esphome/const.py"
+            exit 1
+          fi
+          TAG="${VERSION}$(date --utc '+%Y%m%d')"
+          echo "Starting release build for ${TAG}"
+          gh workflow run release.yml --ref "${GITHUB_REF_NAME}" --field tag="${TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,22 @@
 ---
 name: Publish Release
 
+# Releases (production and beta) are named after the version they publish.
+# Dev builds are named after the dated dev tag, which is passed in by the
+# nightly workflow because a run name cannot compute it itself.
+run-name: ${{ inputs.tag || github.event.release.tag_name || format('Manual build ({0})', github.ref_name) }}
+
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Tag to build. Leave empty to build the version from
+          esphome/const.py with today's date appended.
+        required: false
+        default: ""
   release:
     types: [published]
-  schedule:
-    - cron: "0 2 * * *"
 
 permissions:
   contents: read  # actions/checkout for all jobs; deploy jobs add their own scopes when they need to write
@@ -23,6 +33,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Get tag
         id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         # yamllint disable rule:line-length
         run: |
           if [[ "${{ github.event_name }}" = "release" ]]; then
@@ -34,12 +46,19 @@ jobs:
               ENVIRONMENT="production"
             fi
           else
-            TAG=$(cat esphome/const.py | sed -n -E "s/^__version__\s+=\s+\"(.+)\"$/\1/p")
-            today="$(date --utc '+%Y%m%d')"
-            TAG="${TAG}${today}"
             BRANCH=${GITHUB_REF#refs/heads/}
+            # The nightly workflow passes the finished tag so that the run name
+            # matches what is built. Without it, work it out here.
+            TAG="${INPUT_TAG}"
+            if [[ -z "$TAG" ]]; then
+              TAG=$(cat esphome/const.py | sed -n -E "s/^__version__\s+=\s+\"(.+)\"$/\1/p")
+              today="$(date --utc '+%Y%m%d')"
+              TAG="${TAG}${today}"
+              if [[ "$BRANCH" != "dev" ]]; then
+                TAG="${TAG}-${BRANCH}"
+              fi
+            fi
             if [[ "$BRANCH" != "dev" ]]; then
-              TAG="${TAG}-${BRANCH}"
               BRANCH_BUILD="true"
               ENVIRONMENT=""
             else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Publish Release
 # Releases (production and beta) are named after the version they publish.
 # Dev builds are named after the dated dev tag, which is passed in by the
 # nightly workflow because a run name cannot compute it itself.
-run-name: ${{ inputs.tag || github.event.release.tag_name || format('Manual build ({0})', github.ref_name) }}
+run-name: ${{ github.event.inputs.tag || github.event.release.tag_name || format('Manual build ({0})', github.ref_name) }}
 
 on:
   workflow_dispatch:
@@ -34,7 +34,7 @@ jobs:
       - name: Get tag
         id: tag
         env:
-          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         # yamllint disable rule:line-length
         run: |
           if [[ "${{ github.event_name }}" = "release" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,9 @@ on:
     inputs:
       tag:
         description: >-
-          Tag to build. Leave empty to build the version from
-          esphome/const.py with today's date appended.
+          Tag to build. Only supported on dev, where the nightly workflow
+          uses it. Leave empty to build the version from esphome/const.py
+          with today's date appended.
         required: false
         default: ""
   release:
@@ -50,6 +51,10 @@ jobs:
             # The nightly workflow passes the finished tag so that the run name
             # matches what is built. Without it, work it out here.
             TAG="${INPUT_TAG}"
+            if [[ -n "$TAG" && "$BRANCH" != "dev" ]]; then
+              echo "::error::The tag input is only supported on dev. A build from ${BRANCH} has to use the tag worked out here, which carries the branch name, so that it cannot publish over the dev, beta, latest or stable images."
+              exit 1
+            fi
             if [[ -z "$TAG" ]]; then
               TAG=$(cat esphome/const.py | sed -n -E "s/^__version__\s+=\s+\"(.+)\"$/\1/p")
               today="$(date --utc '+%Y%m%d')"


### PR DESCRIPTION
# What does this implement/fix?

Gives the release workflow a `run-name`, so the Actions list shows which version each run is publishing instead of the workflow name for every entry. Production and beta releases are named after the release tag (just the version number, e.g. `2026.8.0` or `2026.9.0b1`), and nightly dev builds are named after the dated dev tag they build, e.g. `2026.8.0-dev20260806`.

A workflow run name is fixed when the run is created and can only reference the `github`, `inputs` and `vars` contexts. There is no date function, no way to read the version out of `esphome/const.py`, and no API to rename a run afterwards, so the dev tag cannot be worked out by the run name itself. The nightly cron therefore moves into a small new workflow that reads the version, appends today's UTC date, and starts the release workflow with that tag as an input. The release workflow uses the input for both the run name and the tag it builds, so the title always matches what was published.

The tag is still worked out inside the release workflow when no input is given, so a manual run (including one on a branch, which keeps the `-<branch>` suffix and branch-build behaviour) works exactly as before. Those runs are named `Manual build (<branch>)`.

The new workflow needs `actions: write` to start the release workflow. `GITHUB_TOKEN` is explicitly allowed to trigger `workflow_dispatch` runs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).