### PR TITLE
[core] Resolve GCC multilib include dirs for clang-tidy

### DIFF
--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -5,11 +5,13 @@ import os
 from pathlib import Path
 import queue
 import re
+import shlex
 import shutil
 import subprocess
 import sys
 import tempfile
 import threading
+from typing import Any
 
 import click
 import colorama
@@ -27,6 +29,36 @@ from helpers import (
     root_path,
     temp_header_file,
 )
+
+
+def gcc_multilib_directory(idedata: dict[str, Any]) -> str | None:
+    """The toolchain's active multilib subdirectory (e.g. "thumb"), if any.
+
+    PlatformIO's idedata lists the generic toolchain include directories; GCC
+    resolves the active multilib subdirectory internally while searching them.
+    Toolchains without a default multilib (pico-quick-toolchain 5.0.0+) ship
+    the libstdc++ target config (bits/c++config.h) only inside the multilib
+    subdirectories, so clang needs the resolved directory spelled out.
+    """
+    machine_flags = [f for f in idedata["cxx_flags"] if f.startswith("-m")]
+    cmd = [idedata["cxx_path"], *machine_flags, "-print-multi-directory"]
+    try:
+        multilib = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError) as err:
+        # Without the multilib dir, toolchains lacking a default multilib fail
+        # later with "bits/c++config.h not found"; point at the probe instead.
+        stderr = getattr(err, "stderr", "") or ""
+        print(
+            f"WARNING: multilib probe failed ({shlex.join(cmd)}): {err} {stderr}".strip(),
+            file=sys.stderr,
+        )
+        return None
+    return None if multilib in ("", ".") else multilib
 
 
 def clang_options(idedata, environment):
@@ -203,9 +235,12 @@ def clang_options(idedata, environment):
     # toolchain include directories, using -isystem to suppress their errors
     # idedata contains include directories for all toolchains of this platform, only use those from the one in use
     toolchain_dir = os.path.normpath(f"{idedata['cxx_path']}/../../")
+    multilib = gcc_multilib_directory(idedata)
     toolchain_includes = []
     for directory in idedata["includes"]["toolchain"]:
         if directory.startswith(toolchain_dir) and "picolibc" not in directory:
+            if multilib and (multilib_dir := Path(directory) / multilib).is_dir():
+                toolchain_includes.extend(["-isystem", str(multilib_dir)])
             toolchain_includes.extend(["-isystem", directory])
 
     # library include directories, using -isystem to suppress their errors

--- a/script/clang_tidy_hash.py
+++ b/script/clang_tidy_hash.py
@@ -18,6 +18,7 @@ from pathlib import Path
 # Root-relative paths whose contents affect clang-tidy results.
 CLANG_TIDY_GLOBAL_FILES = (
     ".clang-tidy",
+    "script/clang-tidy",
     "platformio.ini",
     "requirements_dev.txt",
     "esphome/idf_component.yml",


### PR DESCRIPTION
# What does this implement/fix?

`script/clang-tidy` builds the analysis include path from PlatformIO idedata, which lists only the generic toolchain include directories; GCC resolves the active multilib subdirectory internally while searching them. Toolchains without a default multilib ship the libstdc++ target config (`bits/c++config.h`) only inside the multilib subdirectories, so clang cannot find it and the whole standard library fails to parse. The resulting error recovery produces nonsense findings (function declarations flagged as non-const global variables, identifier-naming fixes inside `requires` clauses).

This surfaced while testing the arduino-pico 6.0.0 bump (#18101): pico-quick-toolchain 5.0.0 (GCC 16.1) keeps `bits/c++config.h` only under `arm-none-eabi/thumb/`. Split out of that PR since the change runs for every clang-tidy environment.

The fix asks the toolchain's own compiler for the resolved multilib (`-print-multi-directory` with the build's `-m*` flags) and inserts that subdirectory ahead of each generic toolchain include when it exists on disk. On toolchains with a default multilib this is a no-op. A failed probe prints a warning with the exact command and stderr, so it cannot silently degrade back into thousands of missing-header errors.

`script/clang-tidy` is also added to `CLANG_TIDY_GLOBAL_FILES`, so future changes to the script itself invalidate the clang-tidy cache and get exercised by CI.

Verified with the rp2-tidy environment on both the current GCC 14 toolchain (unchanged behavior) and the new GCC 16.1 toolchain from #18101 (previously failing files now analyze cleanly), plus the full CI invocation (`--grep USE_RP2`) on the new toolchain.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# Not applicable; developer tooling change only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
