### PR TITLE
[core] Only snapshot the user config when esphome config --no-defaults asks for it

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2601,6 +2601,8 @@ def run_esphome(argv):
         config = read_config(
             command_line_substitutions,
             skip_external_update=skip_external,
+            # Snapshot only needed by `esphome config --no-defaults`.
+            snapshot_user_config=getattr(args, "no_defaults", False),
         )
         # Refresh the cache so the next upload/logs hits the fast path
         # instead of re-running read_config. Skip when the storage

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -1108,6 +1108,7 @@ def validate_config(
     config: dict[str, Any],
     command_line_substitutions: dict[str, Any] | None,
     skip_external_update: bool = False,
+    snapshot_user_config: bool = False,
 ) -> Config:
     result = Config()
 
@@ -1218,11 +1219,13 @@ def validate_config(
     # Snapshot the user's config before any schema validation defaults are
     # applied. preload_core_config and later validation steps rewrite entries
     # in-place with defaulted values; deep-copying here preserves the
-    # user-supplied keys for `esphome config --no-defaults`.
-    result.user_config = copy.deepcopy(config)
-    if substitutions is not None:
-        result.user_config[CONF_SUBSTITUTIONS] = copy.deepcopy(substitutions)
-        result.user_config.move_to_end(CONF_SUBSTITUTIONS, last=False)
+    # user-supplied keys for `esphome config --no-defaults`. The deep copy is
+    # expensive, so it is only taken when that command actually asked for it.
+    if snapshot_user_config:
+        result.user_config = copy.deepcopy(config)
+        if substitutions is not None:
+            result.user_config[CONF_SUBSTITUTIONS] = copy.deepcopy(substitutions)
+            result.user_config.move_to_end(CONF_SUBSTITUTIONS, last=False)
 
     # 2. Load partial core config
     import esphome.core.config as core_config
@@ -1335,7 +1338,9 @@ class InvalidYAMLError(EsphomeError):
 
 
 def _load_config(
-    command_line_substitutions: dict[str, Any], skip_external_update: bool = False
+    command_line_substitutions: dict[str, Any],
+    skip_external_update: bool = False,
+    snapshot_user_config: bool = False,
 ) -> Config:
     """Load the configuration file."""
     try:
@@ -1344,7 +1349,12 @@ def _load_config(
         raise InvalidYAMLError(e) from e
 
     try:
-        return validate_config(config, command_line_substitutions, skip_external_update)
+        return validate_config(
+            config,
+            command_line_substitutions,
+            skip_external_update=skip_external_update,
+            snapshot_user_config=snapshot_user_config,
+        )
     except EsphomeError:
         raise
     except Exception:
@@ -1353,10 +1363,16 @@ def _load_config(
 
 
 def load_config(
-    command_line_substitutions: dict[str, Any], skip_external_update: bool = False
+    command_line_substitutions: dict[str, Any],
+    skip_external_update: bool = False,
+    snapshot_user_config: bool = False,
 ) -> Config:
     try:
-        return _load_config(command_line_substitutions, skip_external_update)
+        return _load_config(
+            command_line_substitutions,
+            skip_external_update=skip_external_update,
+            snapshot_user_config=snapshot_user_config,
+        )
     except vol.Invalid as err:
         raise EsphomeError(f"Error while parsing config: {err}") from err
 
@@ -1497,11 +1513,17 @@ def strip_default_ids(config):
 
 
 def read_config(
-    command_line_substitutions: dict[str, Any], skip_external_update: bool = False
+    command_line_substitutions: dict[str, Any],
+    skip_external_update: bool = False,
+    snapshot_user_config: bool = False,
 ) -> Config | None:
     _LOGGER.info("Reading configuration %s...", CORE.config_path)
     try:
-        res = load_config(command_line_substitutions, skip_external_update)
+        res = load_config(
+            command_line_substitutions,
+            skip_external_update=skip_external_update,
+            snapshot_user_config=snapshot_user_config,
+        )
     except EsphomeError as err:
         _LOGGER.error("Error while reading config: %s", err)
         return None

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -6362,6 +6362,26 @@ def test_run_esphome_skip_external_update_per_command(
     assert mock_read.call_args.kwargs["skip_external_update"] is expected_skip
 
 
+@pytest.mark.parametrize(
+    ("argv_extra", "expected"),
+    [(["--no-defaults"], True), ([], False)],
+)
+def test_run_esphome_snapshot_user_config_only_for_no_defaults(
+    tmp_path: Path, argv_extra: list[str], expected: bool
+) -> None:
+    """read_config is invoked with snapshot_user_config=True only when the
+    config command is run with --no-defaults; otherwise the expensive deep
+    copy is skipped."""
+    yaml_file = tmp_path / "device.yaml"
+    yaml_file.write_text("esphome:\n  name: test\n")
+
+    with patch("esphome.config.read_config", return_value=None) as mock_read:
+        run_esphome(["esphome", "config", str(yaml_file), *argv_extra])
+
+    mock_read.assert_called_once()
+    assert mock_read.call_args.kwargs["snapshot_user_config"] is expected
+
+
 def test_get_configured_xtal_freq_reads_sdkconfig(tmp_path: Path) -> None:
     """Test reading XTAL_FREQ from sdkconfig."""
     CORE.name = "test-device"

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -404,6 +404,18 @@ def test_validate_config_user_config_snapshot_is_deep_copy(tmp_path: Path) -> No
     assert result["esphome"] is not result.user_config["esphome"]
 
 
+def test_validate_config_snapshot_without_substitutions(tmp_path: Path) -> None:
+    """The snapshot works for configs that have no substitutions block."""
+    test_config = _get_test_minimal_valid_config(tmp_path)
+    del test_config[CONF_SUBSTITUTIONS]
+
+    result = config_module.validate_config(test_config, None, snapshot_user_config=True)
+
+    assert result.user_config is not None
+    assert CONF_SUBSTITUTIONS not in result.user_config
+    assert result.user_config["esphome"] == {"name": "test_device"}
+
+
 def test_validate_config_skips_user_config_snapshot_by_default(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -370,7 +370,7 @@ def test_validate_config_captures_user_config_snapshot(tmp_path: Path) -> None:
     """
     test_config = _get_test_minimal_valid_config(tmp_path)
 
-    result = config_module.validate_config(test_config, None)
+    result = config_module.validate_config(test_config, None, snapshot_user_config=True)
 
     # Snapshot is populated.
     assert result.user_config is not None
@@ -393,7 +393,7 @@ def test_validate_config_user_config_snapshot_is_deep_copy(tmp_path: Path) -> No
     """
     test_config = _get_test_minimal_valid_config(tmp_path)
 
-    result = config_module.validate_config(test_config, None)
+    result = config_module.validate_config(test_config, None, snapshot_user_config=True)
 
     assert result.user_config is not None
     # preload_core_config injected build_path onto the validated config.
@@ -402,6 +402,20 @@ def test_validate_config_user_config_snapshot_is_deep_copy(tmp_path: Path) -> No
     assert "build_path" not in result.user_config["esphome"]
     # And the two are not aliased.
     assert result["esphome"] is not result.user_config["esphome"]
+
+
+def test_validate_config_skips_user_config_snapshot_by_default(
+    tmp_path: Path,
+) -> None:
+    """Without ``snapshot_user_config`` the deep copy is skipped entirely;
+    only ``esphome config --no-defaults`` needs the snapshot and the copy is
+    too expensive to take on every load.
+    """
+    test_config = _get_test_minimal_valid_config(tmp_path)
+
+    result = config_module.validate_config(test_config, None)
+
+    assert result.user_config is None
 
 
 def test_merge_config_preserves_ordered_dict() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Since #16718 every config load deep copies the whole raw config into `result.user_config` so `esphome config --no-defaults` can dump exactly what the user wrote, but it was never noticed because our CI failed to run the benchmarks on that PR; the benchmarks job is not triggered by top-level `esphome/*.py` changes, so the author never got a signal, which is fixed in #18114. Profiling shows the copy takes about a third of `read_config` time; the config tree is full of dynamically generated node classes carrying source location metadata, so `copy.deepcopy` goes through the slow generic reconstruct path for every node.

Only the `config` command with `--no-defaults` ever reads that snapshot, so take it only when asked: a `snapshot_user_config` flag is threaded from the `read_config` call site down to `validate_config`, defaulting to off. Compile, upload, logs, dashboard and the vscode language server all skip the copy entirely; `--no-defaults` behaves exactly as before, and the existing fallback in `command_config` still covers any path without a snapshot.

CodSpeed measured the win on #18115, a test PR combining this change with the #18114 gating fix: `test_read_config_uncached` went from 111.9 ms to 73 ms, a 53% improvement, with all other benchmarks untouched; full report at https://github.com/esphome/esphome/pull/18115#issuecomment-5199241681.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/pull/16718

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
