### PR TITLE
[midea] Bump MideaUART so its ESP-IDF shims stop shadowing millis()

### DIFF
--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -18,6 +18,11 @@
 
 namespace esphome::midea {
 
+#ifdef USE_ESP_IDF
+using dudanov::Stream;
+using dudanov::String;
+#endif
+
 /* Stream from UART component */
 class UARTStream : public Stream {
  public:

--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -18,7 +18,9 @@
 
 namespace esphome::midea {
 
-#ifdef USE_ESP_IDF
+// Mirrors the ARDUINO switch in MideaUART Helpers/Platform.h: these types
+// exist in the dudanov namespace exactly when the library is not on Arduino
+#ifndef ARDUINO
 using dudanov::Stream;
 using dudanov::String;
 #endif

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -313,5 +313,5 @@ async def to_code(config):
     cg.add_library(
         name="MideaUART",
         version=None,
-        repository="https://github.com/dudanov/MideaUART.git#7a4d1e9a4b6f07a3464c2453ee828c0c7b7e1bcf",
+        repository="https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815",
     )

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,7 +44,7 @@ lib_deps_base =
 
 lib_deps =
     ${common.lib_deps_base}
-    https://github.com/dudanov/MideaUART.git#7a4d1e9a4b6f07a3464c2453ee828c0c7b7e1bcf ; midea
+    https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
     esphome/noise-c@0.1.11                 ; api
     improv/Improv@1.2.6                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image

--- a/tests/components/midea/test.esp32-idf.yaml
+++ b/tests/components/midea/test.esp32-idf.yaml
@@ -6,3 +6,10 @@ packages:
 wifi:
   ssid: MySSID
   password: password1
+
+# Regression test for https://github.com/esphome/esphome/issues/18054: the
+# MideaUART ESP-IDF shims must not make unqualified millis() ambiguous
+interval:
+  - interval: 10s
+    then:
+      - lambda: ESP_LOGD("test", "%u", millis());


### PR DESCRIPTION
# What does this implement/fix?

Since #12646 the MideaUART library's ESP-IDF compatibility layer defined `millis()`, `random()`, `String`, `Stream` and `IPAddress` in the global namespace. ESPHome compiles user lambdas at global scope with `using namespace esphome;`, so any config combining `midea` on ESP-IDF with a lambda calling `millis()` failed with `call of overloaded 'millis()' is ambiguous`.

The library fix is upstream (dudanov/MideaUART#45, merged): the shims moved into the `dudanov` namespace, resolved by library code through its enclosing namespace while Arduino builds keep using the real Arduino globals. This PR:

- bumps the MideaUART pin (in `climate.py` and `platformio.ini`) to the merge commit `eeea6c3e`
- adds `using dudanov::Stream; using dudanov::String;` to the midea adapter under `USE_ESP_IDF`, since it subclasses `Stream` and uses `String` in the logger callback outside the `dudanov` namespace
- adds a `millis()` lambda to the esp32-idf test so this regression stays pinned in CI

Verified by compiling the exact reproduction from the issue (esp32-idf + midea + `millis()` interval lambda) against the new pin - it fails on current dev and builds clean with this change - plus the same config on Arduino.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18054

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf

uart:
  rx_pin: GPIO16
  tx_pin: GPIO17
  baud_rate: 9600

climate:
  - platform: midea
    name: Climate

interval:
  - interval: 10s
    then:
      - lambda: ESP_LOGD("repro", "%u", millis());
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).