### PR TITLE
[script] Disable queued script polling while the queue is empty

### DIFF
--- a/esphome/components/script/script.h
+++ b/esphome/components/script/script.h
@@ -120,6 +120,16 @@ template<typename... Ts> class RestartScript : public Script<Ts...> {
  */
 template<typename... Ts> class QueueingScript : public Script<Ts...>, public Component {
  public:
+  void setup() override {
+    // Start with loop disabled - only enable when there's work to do
+    // IMPORTANT: Only disable if the queue is empty, otherwise execute() was already
+    // called before our setup() (e.g., from on_boot trigger at same priority level)
+    // and we must not undo its enable_loop() call
+    if (this->num_queued_ == 0) {
+      this->disable_loop();
+    }
+  }
+
   void execute(Ts... x) override {
     if (this->is_action_running() || this->num_queued_ > 0) {
       // num_queued_ is the number of *queued* instances (waiting, not including currently running)
@@ -142,6 +152,9 @@ template<typename... Ts> class QueueingScript : public Script<Ts...>, public Com
       // Use std::make_unique to replace the unique_ptr
       this->var_queue_[write_pos] = std::make_unique<std::tuple<Ts...>>(x...);
       this->num_queued_++;
+      // Enable loop now that there is something to dequeue - don't call loop()
+      // synchronously! Let the event loop call it to avoid reentrancy issues
+      this->enable_loop();
       return;
     }
 
@@ -156,6 +169,7 @@ template<typename... Ts> class QueueingScript : public Script<Ts...>, public Com
     this->var_queue_.reset();
     this->num_queued_ = 0;
     this->queue_front_ = 0;
+    this->disable_loop();
     Script<Ts...>::stop();
   }
 
@@ -167,6 +181,10 @@ template<typename... Ts> class QueueingScript : public Script<Ts...>, public Com
       auto tuple_ptr = std::move(this->var_queue_[this->queue_front_]);
       this->queue_front_ = (this->queue_front_ + 1) % queue_capacity;
       this->trigger_tuple_(*tuple_ptr, std::make_index_sequence<sizeof...(Ts)>{});
+    }
+    if (this->num_queued_ == 0) {
+      // Queue is now empty - disable loop until the next execute()
+      this->disable_loop();
     }
   }
 

--- a/esphome/components/script/script.h
+++ b/esphome/components/script/script.h
@@ -120,16 +120,6 @@ template<typename... Ts> class RestartScript : public Script<Ts...> {
  */
 template<typename... Ts> class QueueingScript : public Script<Ts...>, public Component {
  public:
-  void setup() override {
-    // Start with loop disabled - only enable when there's work to do
-    // IMPORTANT: Only disable if the queue is empty, otherwise execute() was already
-    // called before our setup() (e.g., from on_boot trigger at same priority level)
-    // and we must not undo its enable_loop() call
-    if (this->num_queued_ == 0) {
-      this->disable_loop();
-    }
-  }
-
   void execute(Ts... x) override {
     if (this->is_action_running() || this->num_queued_ > 0) {
       // num_queued_ is the number of *queued* instances (waiting, not including currently running)
@@ -169,7 +159,6 @@ template<typename... Ts> class QueueingScript : public Script<Ts...>, public Com
     this->var_queue_.reset();
     this->num_queued_ = 0;
     this->queue_front_ = 0;
-    this->disable_loop();
     Script<Ts...>::stop();
   }
 
@@ -182,8 +171,10 @@ template<typename... Ts> class QueueingScript : public Script<Ts...>, public Com
       this->queue_front_ = (this->queue_front_ + 1) % queue_capacity;
       this->trigger_tuple_(*tuple_ptr, std::make_index_sequence<sizeof...(Ts)>{});
     }
-    if (this->num_queued_ == 0) {
-      // Queue is now empty - disable loop until the next execute()
+    if (this->num_queued_ == 0 && !this->is_idle()) {
+      // Queue is now empty - disable loop until the next execute() queues an
+      // instance. The inline is_idle() check skips the out-of-line call when
+      // the loop is already disabled (execute() calls loop() synchronously).
       this->disable_loop();
     }
   }

--- a/esphome/components/script/script.h
+++ b/esphome/components/script/script.h
@@ -175,6 +175,9 @@ template<typename... Ts> class QueueingScript : public Script<Ts...>, public Com
       // Queue is now empty - disable loop until the next execute() queues an
       // instance. The inline is_idle() check skips the out-of-line call when
       // the loop is already disabled (execute() calls loop() synchronously).
+      // This can run before this component's setup() (execute() from on_boot),
+      // which leaves the state machine in LOOP_DONE and skips call_setup();
+      // this class therefore must not rely on a setup() override.
       this->disable_loop();
     }
   }

--- a/tests/integration/fixtures/script_queued.yaml
+++ b/tests/integration/fixtures/script_queued.yaml
@@ -1,10 +1,9 @@
 esphome:
   name: test-script-queued
   on_boot:
-    # Default priority (600.0) runs before QueueingScript::setup()
-    # This tests that executing and queueing before setup() survives the
-    # idle-loop disabling in setup() (the loop must stay enabled so the
-    # queued instance still gets dequeued)
+    # Default priority (600.0) runs before the script component is set up
+    # This tests that an instance queued during boot still gets dequeued
+    # once the main loop starts (the idle-loop disabling must not eat it)
     then:
       - logger.log: "=== BOOT: Executing queued script twice ==="
       - script.execute:
@@ -111,8 +110,8 @@ api:
         - script.execute: no_params_script
         - script.execute: no_params_script
 
-    # Test 6: Script still runs after its queue fully drained and after stop
-    # (the idle loop is disabled in both states and must re-enable on demand)
+    # Test 6: Re-execute after stop() cleared the queue
+    # (the idle loop must re-enable on demand)
     - action: test_after_stop
       then:
         - logger.log: "=== TEST 6: Re-execute after stop ==="

--- a/tests/integration/fixtures/script_queued.yaml
+++ b/tests/integration/fixtures/script_queued.yaml
@@ -1,5 +1,18 @@
 esphome:
   name: test-script-queued
+  on_boot:
+    # Default priority (600.0) runs before QueueingScript::setup()
+    # This tests that executing and queueing before setup() survives the
+    # idle-loop disabling in setup() (the loop must stay enabled so the
+    # queued instance still gets dequeued)
+    then:
+      - logger.log: "=== BOOT: Executing queued script twice ==="
+      - script.execute:
+          id: boot_script
+          tag: 1
+      - script.execute:
+          id: boot_script
+          tag: 2
 
 host:
 api:
@@ -98,6 +111,15 @@ api:
         - script.execute: no_params_script
         - script.execute: no_params_script
 
+    # Test 6: Script still runs after its queue fully drained and after stop
+    # (the idle loop is disabled in both states and must re-enable on demand)
+    - action: test_after_stop
+      then:
+        - logger.log: "=== TEST 6: Re-execute after stop ==="
+        - script.execute:
+            id: stop_script
+            num: 9
+
 logger:
   level: DEBUG
 
@@ -168,3 +190,18 @@ script:
       - logger.log: "No params: START"
       - delay: 50ms
       - logger.log: "No params: END"
+
+  # Boot script: executed twice from on_boot before setup()
+  - id: boot_script
+    mode: queued
+    max_runs: 3
+    parameters:
+      tag: int
+    then:
+      - logger.log:
+          format: "Boot queued: START %d"
+          args: ['tag']
+      - delay: 50ms
+      - logger.log:
+          format: "Boot queued: END %d"
+          args: ['tag']

--- a/tests/integration/fixtures/script_queued_idle_loop.yaml
+++ b/tests/integration/fixtures/script_queued_idle_loop.yaml
@@ -1,0 +1,25 @@
+esphome:
+  name: test-script-queued-idle
+
+host:
+api:
+  actions:
+    # Execute twice: the first runs immediately, the second gets queued,
+    # which must re-enable the loop; draining must disable it again
+    - action: run_twice
+      then:
+        - script.execute: idle_script
+        - script.execute: idle_script
+
+# VERY_VERBOSE exposes the component framework's "loop disabled" and
+# "loop enabled" messages that this test asserts on
+logger:
+  level: VERY_VERBOSE
+
+script:
+  - id: idle_script
+    mode: queued
+    then:
+      - logger.log: "idle_script: START"
+      - delay: 50ms
+      - logger.log: "idle_script: END"

--- a/tests/integration/test_script_queued.py
+++ b/tests/integration/test_script_queued.py
@@ -27,7 +27,6 @@ async def test_script_queued(
         "rejection": {"processed": [], "rejections": 0},
         "no_params": {"executions": 0},
         "boot": {"ended": []},
-        "after_stop": {"ended": []},
     }
 
     # Patterns for Test 1: Queue depth
@@ -133,31 +132,24 @@ async def test_script_queued(
         # Test 5: No params
         if no_params_end.search(line):
             test_results["no_params"]["executions"] += 1
-            if (
-                test_results["no_params"]["executions"] == 3
-                and not test5_complete.done()
-            ):
-                test5_complete.set_result(True)
-            if (
-                test_results["no_params"]["executions"] == 6
-                and not test5_again_complete.done()
-            ):
-                test5_again_complete.set_result(True)
+            executions = test_results["no_params"]["executions"]
+            for count, future in ((3, test5_complete), (6, test5_again_complete)):
+                if executions == count and not future.done():
+                    future.set_result(True)
 
         # Boot script (queued from on_boot before setup)
         if match := boot_end.search(line):
-            item = int(match.group(1))
-            if item not in test_results["boot"]["ended"]:
-                test_results["boot"]["ended"].append(item)
+            test_results["boot"]["ended"].append(int(match.group(1)))
             if len(test_results["boot"]["ended"]) == 2 and not boot_complete.done():
                 boot_complete.set_result(True)
 
         # Test 6: Re-execute after stop
-        if match := after_stop_end.search(line):
-            item = int(match.group(1))
-            test_results["after_stop"]["ended"].append(item)
-            if item == 9 and not test6_complete.done():
-                test6_complete.set_result(True)
+        if (
+            (match := after_stop_end.search(line))
+            and int(match.group(1)) == 9
+            and not test6_complete.done()
+        ):
+            test6_complete.set_result(True)
 
     async with (
         run_compiled(yaml_config, line_callback=check_output),
@@ -251,11 +243,8 @@ async def test_script_queued(
         )
 
         # Test 6: a stopped script (queue cleared, loop disabled) must run
-        # again on the next execute
+        # again on the next execute; the future resolves only on "END 9"
         test_service = next((s for s in services if s.name == "test_after_stop"), None)
         assert test_service is not None, "test_after_stop service not found"
         await client.execute_service(test_service, {})
         await asyncio.wait_for(test6_complete, timeout=2.0)
-        assert 9 in test_results["after_stop"]["ended"], (
-            f"Test 6: Expected item 9 to run after stop, got {test_results['after_stop']['ended']}"
-        )

--- a/tests/integration/test_script_queued.py
+++ b/tests/integration/test_script_queued.py
@@ -26,6 +26,8 @@ async def test_script_queued(
         "stop": {"processed": [], "stop_logged": False},
         "rejection": {"processed": [], "rejections": 0},
         "no_params": {"executions": 0},
+        "boot": {"ended": []},
+        "after_stop": {"ended": []},
     }
 
     # Patterns for Test 1: Queue depth
@@ -49,12 +51,21 @@ async def test_script_queued(
     # Patterns for Test 5: No params
     no_params_end = re.compile(r"No params: END")
 
+    # Patterns for boot script (executed twice from on_boot before setup)
+    boot_end = re.compile(r"Boot queued: END (\d+)")
+
+    # Patterns for Test 6: Re-execute after stop
+    after_stop_end = re.compile(r"Stop test: END (\d+)")
+
     # Test completion futures
+    boot_complete = loop.create_future()
     test1_complete = loop.create_future()
     test2_complete = loop.create_future()
     test3_complete = loop.create_future()
     test4_complete = loop.create_future()
     test5_complete = loop.create_future()
+    test5_again_complete = loop.create_future()
+    test6_complete = loop.create_future()
 
     def check_output(line: str) -> None:
         """Check log output for all test messages."""
@@ -127,6 +138,26 @@ async def test_script_queued(
                 and not test5_complete.done()
             ):
                 test5_complete.set_result(True)
+            if (
+                test_results["no_params"]["executions"] == 6
+                and not test5_again_complete.done()
+            ):
+                test5_again_complete.set_result(True)
+
+        # Boot script (queued from on_boot before setup)
+        if match := boot_end.search(line):
+            item = int(match.group(1))
+            if item not in test_results["boot"]["ended"]:
+                test_results["boot"]["ended"].append(item)
+            if len(test_results["boot"]["ended"]) == 2 and not boot_complete.done():
+                boot_complete.set_result(True)
+
+        # Test 6: Re-execute after stop
+        if match := after_stop_end.search(line):
+            item = int(match.group(1))
+            test_results["after_stop"]["ended"].append(item)
+            if item == 9 and not test6_complete.done():
+                test6_complete.set_result(True)
 
     async with (
         run_compiled(yaml_config, line_callback=check_output),
@@ -134,6 +165,13 @@ async def test_script_queued(
     ):
         # Get services
         _, services = await client.list_entities_services()
+
+        # Boot: both executions from on_boot must complete, including the one
+        # that was queued before QueueingScript::setup() ran
+        await asyncio.wait_for(boot_complete, timeout=2.0)
+        assert sorted(test_results["boot"]["ended"]) == [1, 2], (
+            f"Boot: Expected both on_boot executions to complete, got {sorted(test_results['boot']['ended'])}"
+        )
 
         # Test 1: Queue depth limit
         test_service = next((s for s in services if s.name == "test_queue_depth"), None)
@@ -202,4 +240,22 @@ async def test_script_queued(
         # Verify Test 5
         assert test_results["no_params"]["executions"] == 3, (
             f"Test 5: Expected 3 executions, got {test_results['no_params']['executions']}"
+        )
+
+        # Test 5 again: after the queue fully drained (loop disabled while
+        # idle), executing again must still work
+        await client.execute_service(test_service, {})
+        await asyncio.wait_for(test5_again_complete, timeout=2.0)
+        assert test_results["no_params"]["executions"] == 6, (
+            f"Test 5 again: Expected 6 executions total, got {test_results['no_params']['executions']}"
+        )
+
+        # Test 6: a stopped script (queue cleared, loop disabled) must run
+        # again on the next execute
+        test_service = next((s for s in services if s.name == "test_after_stop"), None)
+        assert test_service is not None, "test_after_stop service not found"
+        await client.execute_service(test_service, {})
+        await asyncio.wait_for(test6_complete, timeout=2.0)
+        assert 9 in test_results["after_stop"]["ended"], (
+            f"Test 6: Expected item 9 to run after stop, got {test_results['after_stop']['ended']}"
         )

--- a/tests/integration/test_script_queued.py
+++ b/tests/integration/test_script_queued.py
@@ -236,6 +236,8 @@ async def test_script_queued(
 
         # Test 5 again: after the queue fully drained (loop disabled while
         # idle), executing again must still work
+        test_service = next((s for s in services if s.name == "test_no_params"), None)
+        assert test_service is not None, "test_no_params service not found"
         await client.execute_service(test_service, {})
         await asyncio.wait_for(test5_again_complete, timeout=2.0)
         assert test_results["no_params"]["executions"] == 6, (

--- a/tests/integration/test_script_queued_idle_loop.py
+++ b/tests/integration/test_script_queued_idle_loop.py
@@ -1,0 +1,85 @@
+"""Test that an idle queued script disables its loop and re-enables on demand."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_script_queued_idle_loop(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Assert the loop state transitions of a queued script via VV logs.
+
+    Expected sequence: the idle script disables its loop on the first
+    iteration after boot, re-enables it when an instance gets queued,
+    and disables it again once the queue drains.
+    """
+    loop = asyncio.get_running_loop()
+
+    loop_state = re.compile(r"\bscript loop (disabled|enabled)\b")
+    script_end = re.compile(r"idle_script: END")
+
+    transitions: list[str] = []
+    end_count = 0
+
+    boot_disabled = loop.create_future()
+    enabled_after_queue = loop.create_future()
+    disabled_after_drain = loop.create_future()
+    runs_complete = loop.create_future()
+
+    def check_output(line: str) -> None:
+        nonlocal end_count
+        if match := loop_state.search(line):
+            transitions.append(match.group(1))
+            if transitions == ["disabled"] and not boot_disabled.done():
+                boot_disabled.set_result(True)
+            elif (
+                transitions == ["disabled", "enabled"]
+                and not enabled_after_queue.done()
+            ):
+                enabled_after_queue.set_result(True)
+            elif (
+                transitions
+                == [
+                    "disabled",
+                    "enabled",
+                    "disabled",
+                ]
+                and not disabled_after_drain.done()
+            ):
+                disabled_after_drain.set_result(True)
+
+        if script_end.search(line):
+            end_count += 1
+            if end_count == 2 and not runs_complete.done():
+                runs_complete.set_result(True)
+
+    async with (
+        run_compiled(yaml_config, line_callback=check_output),
+        api_client_connected() as client,
+    ):
+        # The idle script must disable its loop on the first iteration
+        await asyncio.wait_for(boot_disabled, timeout=5.0)
+
+        _, services = await client.list_entities_services()
+        run_twice = next((s for s in services if s.name == "run_twice"), None)
+        assert run_twice is not None, "run_twice service not found"
+        await client.execute_service(run_twice, {})
+
+        # Queueing the second instance must re-enable the loop
+        await asyncio.wait_for(enabled_after_queue, timeout=2.0)
+        # Both runs must complete and the drained queue must disable it again
+        await asyncio.wait_for(runs_complete, timeout=2.0)
+        await asyncio.wait_for(disabled_after_drain, timeout=2.0)
+
+        assert transitions == ["disabled", "enabled", "disabled"], (
+            f"Unexpected loop state sequence: {transitions}"
+        )


### PR DESCRIPTION
# What does this implement/fix?

Queued mode scripts override loop() to dequeue the next pending run, but the loop was never disabled, so every `mode: queued` script polled an empty queue on every main loop iteration for the life of the device; this showed up in runtime_stats as a constant per script entry firing at the loop interval.

The loop now disables itself once the queue is empty and is re enabled when execute() queues an instance, the same on demand pattern ScriptWaitAction already uses; idle queued scripts no longer appear in the main loop at all.

The integration test gains three cases: executing a queued script twice from on_boot before setup so the instance queued during boot must survive the idle disabling, re executing a script after its queue fully drained, and re executing after script.stop cleared the queue. A separate fixture asserts the loop state transitions themselves through the framework's verbose logs, disabled at boot, enabled when an instance is queued, disabled again after the drain; it fails without this change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
script:
  - id: my_queued_script
    mode: queued
    then:
      - delay: 100ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
