### PR TITLE
[ci] Raise runner-concurrency caps for the OHF enterprise pool

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -182,6 +182,8 @@ jobs:
       contents: read  # actions/checkout to load the test configs
     strategy:
       fail-fast: false
+      # Modest cap so this smoke test leaves room on the shared runner pool.
+      max-parallel: 10
       matrix:
         # One entry per distinct toolchain. ESP32 variants (c3/c6/s2/s3/p4)
         # share a toolchain bundle, so esp32 is exercised on the base variant

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -183,7 +183,7 @@ jobs:
     strategy:
       fail-fast: false
       # Modest cap so this smoke test leaves room on the shared runner pool.
-      max-parallel: 10
+      max-parallel: 8
       matrix:
         # One entry per distinct toolchain. ESP32 variants (c3/c6/s2/s3/p4)
         # share a toolchain bundle, so esp32 is exercised on the base variant

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -182,8 +182,6 @@ jobs:
       contents: read  # actions/checkout to load the test configs
     strategy:
       fail-fast: false
-      # Cap concurrency so this smoke test doesn't hog all the shared runners.
-      max-parallel: 2
       matrix:
         # One entry per distinct toolchain. ESP32 variants (c3/c6/s2/s3/p4)
         # share a toolchain bundle, so esp32 is exercised on the base variant

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -706,7 +706,6 @@ jobs:
       ESPHOME_ESP_IDF_PREFIX: ~/.esphome-idf
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         include:
           - id: clang-tidy
@@ -786,7 +785,6 @@ jobs:
       ESPHOME_ESP_IDF_PREFIX: ~/.esphome-idf
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         include:
           - id: clang-tidy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,7 +516,6 @@ jobs:
       ESPHOME_SDK_NRF_PREFIX: ~/.esphome-sdk-nrf
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         include:
           - id: clang-tidy
@@ -874,7 +873,7 @@ jobs:
       ESPHOME_SDK_NRF_PREFIX: ~/.esphome-sdk-nrf
     strategy:
       fail-fast: false
-      max-parallel: ${{ (startsWith(github.base_ref, 'beta') || startsWith(github.base_ref, 'release')) && 8 || 4 }}
+      max-parallel: ${{ (startsWith(github.base_ref, 'beta') || startsWith(github.base_ref, 'release')) && 50 || 25 }}
       matrix:
         batch: ${{ fromJson(needs.determine-jobs.outputs.component-test-batches) }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -871,7 +871,7 @@ jobs:
       ESPHOME_SDK_NRF_PREFIX: ~/.esphome-sdk-nrf
     strategy:
       fail-fast: false
-      max-parallel: ${{ (startsWith(github.base_ref, 'beta') || startsWith(github.base_ref, 'release')) && 50 || 25 }}
+      max-parallel: ${{ (startsWith(github.base_ref, 'beta') || startsWith(github.base_ref, 'release')) && 40 || 20 }}
       matrix:
         batch: ${{ fromJson(needs.determine-jobs.outputs.component-test-batches) }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -871,7 +871,7 @@ jobs:
       ESPHOME_SDK_NRF_PREFIX: ~/.esphome-sdk-nrf
     strategy:
       fail-fast: false
-      max-parallel: ${{ (startsWith(github.base_ref, 'beta') || startsWith(github.base_ref, 'release')) && 40 || 20 }}
+      max-parallel: ${{ (startsWith(github.base_ref, 'beta') || startsWith(github.base_ref, 'release')) && 32 || 16 }}
       matrix:
         batch: ${{ fromJson(needs.determine-jobs.outputs.component-test-batches) }}
     steps:


### PR DESCRIPTION
# What does this implement/fix?

esphome now runs under the Open Home Foundation GitHub enterprise, which raises the concurrent-job limit from 20 to 500. The `max-parallel` caps in the CI workflows were tuned for the old 20-runner limit, so they throttle jobs far more than necessary now.

This relaxes them:

- **Bounded matrices lose their caps entirely** — their matrix size is the natural limit:
  - clang-tidy base (5 entries): `max-parallel: 2` removed
  - clang-tidy IDF-split (3 entries): `max-parallel: 3` removed (was a no-op — cap equalled the matrix size)
  - clang-tidy variant / S3·P4·C6 (3 entries): `max-parallel: 3` removed (also a no-op)
- **docker smoke test** (15 entries): kept a modest `max-parallel: 8` so it leaves room on the shared pool.
- **test-build-components-split** (the only dynamically sized matrix): `4` → **16**, and `8` → **32** for beta/release. The component-test matrix maxes out at ~24 batches on a full run today, so this keeps a real ceiling — 16 lightly throttles a full-touch refactor, 32 covers a beta/release full run with headroom as the component count grows.

Starting conservative on the two remaining caps; they're a one-line bump each if the shared pool proves to have more headroom.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A (CI infrastructure)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI workflow change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).