### PR TITLE
[opentherm] Initialize output state before the first write

### DIFF
--- a/esphome/components/opentherm/output/opentherm_output.h
+++ b/esphome/components/opentherm/output/opentherm_output.h
@@ -14,8 +14,6 @@ class OpenthermOutput final : public output::FloatOutput, public Component, publ
   float min_value_, max_value_;
 
  public:
-  // Read by the generated write-request builders every cycle, including before the first
-  // write_state(), so it needs a defined value: zero is "no demand" for every output.
   float state{0.0f};
 
   void set_id(const char *id) { this->id_ = id; }

--- a/esphome/components/opentherm/output/opentherm_output.h
+++ b/esphome/components/opentherm/output/opentherm_output.h
@@ -14,7 +14,9 @@ class OpenthermOutput final : public output::FloatOutput, public Component, publ
   float min_value_, max_value_;
 
  public:
-  float state;
+  // Read by the generated write-request builders every cycle, including before the first
+  // write_state(), so it needs a defined value: zero is "no demand" for every output.
+  float state{0.0f};
 
   void set_id(const char *id) { this->id_ = id; }
 


### PR DESCRIPTION
# What does this implement/fix?

`OpenthermOutput::state` had no initializer. The generated write-request builders read it directly (`OPENTHERM_MESSAGE_WRITE_ENTITY` in `opentherm_macros.h` expands to `message_data::write_##msg_data(this->key->state, data)`) without consulting `has_state()`, so from boot until something calls `write_state()` the value sent to the boiler is whatever happened to be in that memory - once per request cycle. For an output mapped to a control setpoint that means a random setpoint is commanded after every reboot.

Initializing it to zero makes the pre-write value defined, and zero is "no demand" for these outputs. `has_state_` is left as is for consumers that want to distinguish "never written".

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
opentherm:
  in_pin: GPIO4
  out_pin: GPIO5

output:
  - platform: opentherm
    t_set:
      id: ch_setpoint
      min_value: 20
      max_value: 65
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).