### PR TITLE
[core] Add EventPool::warm()

### DIFF
--- a/esphome/components/rp2040_ble/rp2040_ble.cpp
+++ b/esphome/components/rp2040_ble/rp2040_ble.cpp
@@ -19,7 +19,8 @@ void RP2040BLE::setup() {
   global_ble = this;
 
   // Pre-create every pool entry so the packet handler's allocate() is always a
-  // free-list pop — the IRQ path must never reach malloc(). Deliberately
+  // free-list pop — the IRQ path must never reach malloc() (the newlib malloc
+  // lock is not IRQ-safe). Deliberately
   // unconditional: warming lazily on the first scan would move the allocations
   // after setup, and doing it here keeps the pool's RAM cost visible at
   // startup instead of appearing once scanning begins. On an incomplete warm,

--- a/esphome/components/rp2040_ble/rp2040_ble.cpp
+++ b/esphome/components/rp2040_ble/rp2040_ble.cpp
@@ -15,29 +15,17 @@ static const char *const TAG = "rp2040_ble";
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 RP2040BLE *global_ble = nullptr;
 
-// The analyzer cannot see that release() always retains the pointer here: the
-// pool's free list is sized SIZE + 1, so its push cannot hit the ring-full
-// drop branch for at most SIZE releases.
-// NOLINTBEGIN(clang-analyzer-unix.Malloc)
 void RP2040BLE::setup() {
   global_ble = this;
 
   // Pre-create every pool entry so the packet handler's allocate() is always a
-  // free-list pop — the IRQ path must never reach malloc() (heap allocation
-  // after setup is forbidden, and the newlib malloc lock is not IRQ-safe).
-  // Deliberately unconditional: warming lazily on the first scan would move
-  // the allocations after setup, and doing it here keeps the pool's RAM cost
-  // visible at startup instead of appearing once scanning begins.
-  BLEScanReport *warm[MAX_SCAN_REPORT_QUEUE_SIZE - 1];
-  size_t warmed = 0;
-  while (warmed < MAX_SCAN_REPORT_QUEUE_SIZE - 1 && (warm[warmed] = this->report_pool_.allocate()) != nullptr)
-    warmed++;
-  for (size_t i = 0; i < warmed; i++)
-    this->report_pool_.release(warm[i]);
-  if (warmed != MAX_SCAN_REPORT_QUEUE_SIZE - 1) {
-    // An incomplete warm would silently put malloc() back on the IRQ path once
-    // the free list runs dry; refuse to run instead (the stack is never
-    // enabled, so the packet handler cannot fire).
+  // free-list pop — the IRQ path must never reach malloc(). Deliberately
+  // unconditional: warming lazily on the first scan would move the allocations
+  // after setup, and doing it here keeps the pool's RAM cost visible at
+  // startup instead of appearing once scanning begins. On an incomplete warm,
+  // refuse to run instead (the stack is never enabled, so the packet handler
+  // cannot fire).
+  if (!this->report_pool_.warm()) {
     ESP_LOGE(TAG, "Scan report pool warm-up failed");
     this->mark_failed();
     return;
@@ -49,7 +37,6 @@ void RP2040BLE::setup() {
     this->state_ = BLEComponentState::DISABLED;
   }
 }
-// NOLINTEND(clang-analyzer-unix.Malloc)
 
 void RP2040BLE::enable() {
   if (this->state_ == BLEComponentState::ACTIVE || this->state_ == BLEComponentState::ENABLING) {

--- a/esphome/core/event_pool.h
+++ b/esphome/core/event_pool.h
@@ -10,7 +10,8 @@
 namespace esphome {
 
 // Event Pool - On-demand pool of objects to avoid heap fragmentation
-// Events are allocated on first use and reused thereafter, growing to peak usage
+// Events are allocated on first use and reused thereafter, growing to peak
+// usage; warm() pre-creates every entry up front for malloc-free producers
 // @tparam T The type of objects managed by the pool (must have a release() method)
 // @tparam SIZE The maximum number of objects in the pool (1-254, limited by uint8_t and the +1 free-list slot)
 //
@@ -53,26 +54,7 @@ template<class T, uint8_t SIZE> class EventPool {
     T *event = this->free_list_.pop();
     if (event != nullptr)
       return event;
-
-    // Need to create a new event
-    if (this->total_created_ >= SIZE) {
-      // Pool is at capacity
-      return nullptr;
-    }
-
-    // Use internal RAM for better performance
-    RAMAllocator<T> allocator(RAMAllocator<T>::ALLOC_INTERNAL);
-    event = allocator.allocate(1);
-
-    if (event == nullptr) {
-      // Memory allocation failed
-      return nullptr;
-    }
-
-    // Placement new to construct the object
-    new (event) T();
-    this->total_created_++;
-    return event;
+    return this->create_();
   }
 
   // Return an event to the pool for reuse
@@ -88,22 +70,38 @@ template<class T, uint8_t SIZE> class EventPool {
   // (for producers that must never malloc, e.g. IRQ-context handlers).
   // Call from setup(); on false the heap could not supply every entry and
   // the caller should mark_failed() — an incomplete warm puts malloc()
-  // back on the producer path. Tops the pool up from any state: entries
-  // that already exist (free or checked out) are counted, not re-created.
+  // back on the producer path. Tops the pool up from any quiescent state
+  // (entries that already exist are counted, not re-created); must not run
+  // concurrently with allocate()/release().
   bool warm() {
-    RAMAllocator<T> allocator(RAMAllocator<T>::ALLOC_INTERNAL);
     while (this->total_created_ < SIZE) {
-      T *event = allocator.allocate(1);
+      T *event = this->create_();
       if (event == nullptr)
         return false;
-      new (event) T();
-      this->total_created_++;
       this->free_list_.push(event);
     }
     return true;
   }
 
  private:
+  // Create and count one new object (shared by allocate() and warm()).
+  // Returns nullptr at capacity or when the heap is exhausted.
+  T *create_() {
+    if (this->total_created_ >= SIZE) {
+      return nullptr;
+    }
+    // Use internal RAM for better performance
+    RAMAllocator<T> allocator(RAMAllocator<T>::ALLOC_INTERNAL);
+    T *event = allocator.allocate(1);
+    if (event == nullptr) {
+      return nullptr;
+    }
+    // Placement new to construct the object
+    new (event) T();
+    this->total_created_++;
+    return event;
+  }
+
   // SIZE + 1 slots so all SIZE objects fit when the pool is fully drained
   // (the ring reserves one slot); otherwise the last release() of a
   // completely returned pool would drop, permanently orphaning one object.

--- a/esphome/core/event_pool.h
+++ b/esphome/core/event_pool.h
@@ -54,6 +54,7 @@ template<class T, uint8_t SIZE> class EventPool {
     T *event = this->free_list_.pop();
     if (event != nullptr)
       return event;
+    // Need to create a new event
     return this->create_();
   }
 
@@ -89,12 +90,14 @@ template<class T, uint8_t SIZE> class EventPool {
   // Returns nullptr at capacity or when the heap is exhausted.
   T *create_() {
     if (this->total_created_ >= SIZE) {
+      // Pool is at capacity
       return nullptr;
     }
     // Use internal RAM for better performance
     RAMAllocator<T> allocator(RAMAllocator<T>::ALLOC_INTERNAL);
     T *event = allocator.allocate(1);
     if (event == nullptr) {
+      // Memory allocation failed
       return nullptr;
     }
     // Placement new to construct the object

--- a/esphome/core/event_pool.h
+++ b/esphome/core/event_pool.h
@@ -86,21 +86,22 @@ template<class T, uint8_t SIZE> class EventPool {
 
   // Pre-create every pool entry so allocate() is always a free-list pop
   // (for producers that must never malloc, e.g. IRQ-context handlers).
-  // Call from setup(); on false the caller should mark_failed() — an
-  // incomplete warm puts malloc() back on the producer path.
-  // The NOLINT: the free list is sized SIZE + 1, so release() cannot hit
-  // the ring-full drop branch during warm-up.
-  // NOLINTBEGIN(clang-analyzer-unix.Malloc)
+  // Call from setup(); on false the heap could not supply every entry and
+  // the caller should mark_failed() — an incomplete warm puts malloc()
+  // back on the producer path. Tops the pool up from any state: entries
+  // that already exist (free or checked out) are counted, not re-created.
   bool warm() {
-    T *warm[SIZE];
-    uint8_t warmed = 0;
-    while (warmed < SIZE && (warm[warmed] = this->allocate()) != nullptr)
-      warmed++;
-    for (uint8_t i = 0; i < warmed; i++)
-      this->release(warm[i]);
-    return warmed == SIZE;
+    RAMAllocator<T> allocator(RAMAllocator<T>::ALLOC_INTERNAL);
+    while (this->total_created_ < SIZE) {
+      T *event = allocator.allocate(1);
+      if (event == nullptr)
+        return false;
+      new (event) T();
+      this->total_created_++;
+      this->free_list_.push(event);
+    }
+    return true;
   }
-  // NOLINTEND(clang-analyzer-unix.Malloc)
 
  private:
   // SIZE + 1 slots so all SIZE objects fit when the pool is fully drained

--- a/esphome/core/event_pool.h
+++ b/esphome/core/event_pool.h
@@ -74,6 +74,7 @@ template<class T, uint8_t SIZE> class EventPool {
   // (entries that already exist are counted, not re-created); must not run
   // concurrently with allocate()/release().
   bool warm() {
+    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc) -- ownership transfers to the free list
     while (this->total_created_ < SIZE) {
       T *event = this->create_();
       if (event == nullptr)

--- a/esphome/core/event_pool.h
+++ b/esphome/core/event_pool.h
@@ -84,15 +84,12 @@ template<class T, uint8_t SIZE> class EventPool {
     }
   }
 
-  // Pre-create every pool entry so later allocate() calls are always a
-  // free-list pop — for producers that must never reach malloc() (IRQ-context
-  // packet handlers; the newlib malloc lock is not IRQ-safe). Call from
-  // setup(); returns false when the heap could not supply all SIZE entries
-  // (callers should mark_failed(), as an incomplete warm would silently put
-  // malloc() back on the producer path once the free list runs dry).
-  // The analyzer cannot see that release() always retains the pointer here:
-  // the free list is sized SIZE + 1, so its push cannot hit the ring-full
-  // drop branch during warm-up.
+  // Pre-create every pool entry so allocate() is always a free-list pop
+  // (for producers that must never malloc, e.g. IRQ-context handlers).
+  // Call from setup(); on false the caller should mark_failed() — an
+  // incomplete warm puts malloc() back on the producer path.
+  // The NOLINT: the free list is sized SIZE + 1, so release() cannot hit
+  // the ring-full drop branch during warm-up.
   // NOLINTBEGIN(clang-analyzer-unix.Malloc)
   bool warm() {
     T *warm[SIZE];

--- a/esphome/core/event_pool.h
+++ b/esphome/core/event_pool.h
@@ -84,6 +84,27 @@ template<class T, uint8_t SIZE> class EventPool {
     }
   }
 
+  // Pre-create every pool entry so later allocate() calls are always a
+  // free-list pop — for producers that must never reach malloc() (IRQ-context
+  // packet handlers; the newlib malloc lock is not IRQ-safe). Call from
+  // setup(); returns false when the heap could not supply all SIZE entries
+  // (callers should mark_failed(), as an incomplete warm would silently put
+  // malloc() back on the producer path once the free list runs dry).
+  // The analyzer cannot see that release() always retains the pointer here:
+  // the free list is sized SIZE + 1, so its push cannot hit the ring-full
+  // drop branch during warm-up.
+  // NOLINTBEGIN(clang-analyzer-unix.Malloc)
+  bool warm() {
+    T *warm[SIZE];
+    uint8_t warmed = 0;
+    while (warmed < SIZE && (warm[warmed] = this->allocate()) != nullptr)
+      warmed++;
+    for (uint8_t i = 0; i < warmed; i++)
+      this->release(warm[i]);
+    return warmed == SIZE;
+  }
+  // NOLINTEND(clang-analyzer-unix.Malloc)
+
  private:
   // SIZE + 1 slots so all SIZE objects fit when the pool is fully drained
   // (the ring reserves one slot); otherwise the last release() of a

--- a/tests/components/core/test_event_pool.cpp
+++ b/tests/components/core/test_event_pool.cpp
@@ -70,4 +70,67 @@ TEST(EventPool, ReleaseNullptrIsSafe) {
   EXPECT_NE(pool.allocate(), nullptr);
 }
 
+TEST(EventPool, WarmFullyPopulatesThePool) {
+  // warm()'s guarantee is invisible at runtime: no later allocate() may touch
+  // malloc(). Fully populated means SIZE allocations succeed from the free
+  // list and the SIZE + 1-th refuses.
+  esphome::EventPool<PoolItem, 4> pool;
+  ASSERT_TRUE(pool.warm());
+  PoolItem *items[4];
+  for (auto *&item : items) {
+    item = pool.allocate();
+    ASSERT_NE(item, nullptr);
+  }
+  EXPECT_EQ(pool.allocate(), nullptr);
+}
+
+TEST(EventPool, WarmIsIdempotent) {
+  esphome::EventPool<PoolItem, 3> pool;
+  ASSERT_TRUE(pool.warm());
+  ASSERT_TRUE(pool.warm());
+  // Still exactly SIZE objects: no growth past capacity.
+  PoolItem *items[3];
+  for (auto *&item : items) {
+    item = pool.allocate();
+    ASSERT_NE(item, nullptr);
+  }
+  EXPECT_EQ(pool.allocate(), nullptr);
+}
+
+TEST(EventPool, AllocateAfterWarmRecyclesTheWarmedObjects) {
+  // The objects handed out after warm() are the ones warm() created,
+  // recycled rather than re-created.
+  esphome::EventPool<PoolItem, 4> pool;
+  ASSERT_TRUE(pool.warm());
+  std::set<PoolItem *> first_round;
+  PoolItem *items[4];
+  for (auto *&item : items) {
+    item = pool.allocate();
+    first_round.insert(item);
+  }
+  for (auto *item : items)
+    pool.release(item);
+  for (int i = 0; i < 4; i++) {
+    PoolItem *item = pool.allocate();
+    ASSERT_NE(item, nullptr);
+    EXPECT_TRUE(first_round.count(item) == 1);
+  }
+}
+
+TEST(EventPool, WarmTopsUpWithEntriesOutstanding) {
+  // warm() counts existing entries (free or checked out) instead of failing
+  // when some are outstanding: it tops the pool up from any state.
+  esphome::EventPool<PoolItem, 4> pool;
+  PoolItem *held = pool.allocate();
+  ASSERT_NE(held, nullptr);
+  ASSERT_TRUE(pool.warm());
+  // The held object plus three more accounts for all SIZE entries.
+  PoolItem *items[3];
+  for (auto *&item : items) {
+    item = pool.allocate();
+    ASSERT_NE(item, nullptr);
+  }
+  EXPECT_EQ(pool.allocate(), nullptr);
+}
+
 }  // namespace esphome::core::testing


### PR DESCRIPTION
# What does this implement/fix?

Adds a warm() helper to EventPool that pre-creates every pool entry, and uses it for the rp2040_ble scan report pool. The hand rolled warm up loop existed only in rp2040_ble; upcoming BTstack GATT client work needs the same pattern, so it moves into the pool itself.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
