### PR TITLE
[epaper] Add support for Waveshare EPaper 2.66in B

### DIFF
--- a/esphome/components/epaper_spi/epaper_waveshare_b.h
+++ b/esphome/components/epaper_spi/epaper_waveshare_b.h
@@ -5,7 +5,8 @@ namespace esphome::epaper_spi {
 
 /**
  * Waveshare (B) series BWR e-paper displays using SSD1680-compatible controllers.
- * Waveshare uses 0=red, 1=no-red, the inverse of EPaperWeAct3C
+ * Adds the soft reset the controller expects after a hardware reset. Red plane polarity
+ * varies between panels in this series and is set per model via set_invert_red().
  */
 class EpaperWaveshareB : public EPaperWeAct3C {
  public:
@@ -13,7 +14,6 @@ class EpaperWaveshareB : public EPaperWeAct3C {
 
  protected:
   bool reset() override;
-  uint8_t transform_red_byte(uint8_t byte) const override { return static_cast<uint8_t>(~byte); }
 };
 
 }  // namespace esphome::epaper_spi

--- a/esphome/components/epaper_spi/epaper_weact_3c.h
+++ b/esphome/components/epaper_spi/epaper_weact_3c.h
@@ -24,6 +24,7 @@ class EPaperWeAct3C : public EPaperBase {
 
   void fill(Color color) override;
   void clear() override;
+  void set_invert_red(bool invert_red) { this->invert_red_ = invert_red; }
 
  protected:
   void set_window_();
@@ -35,8 +36,12 @@ class EPaperWeAct3C : public EPaperBase {
 
   bool transfer_data() override;
 
-  // Hook for subclasses to transform red plane bytes before they go on the wire.
-  virtual uint8_t transform_red_byte(uint8_t byte) const { return byte; }
+  // Some panels wire the red plane the other way round; models declare which.
+  uint8_t transform_red_byte(uint8_t byte) const {
+    return this->invert_red_ ? static_cast<uint8_t>(~byte) : byte;
+  }
+
+  bool invert_red_{false};
 };
 
 }  // namespace esphome::epaper_spi

--- a/esphome/components/epaper_spi/epaper_weact_3c.h
+++ b/esphome/components/epaper_spi/epaper_weact_3c.h
@@ -37,9 +37,7 @@ class EPaperWeAct3C : public EPaperBase {
   bool transfer_data() override;
 
   // Some panels wire the red plane the other way round; models declare which.
-  uint8_t transform_red_byte(uint8_t byte) const {
-    return this->invert_red_ ? static_cast<uint8_t>(~byte) : byte;
-  }
+  uint8_t transform_red_byte(uint8_t byte) const { return this->invert_red_ ? static_cast<uint8_t>(~byte) : byte; }
 
   bool invert_red_{false};
 };

--- a/esphome/components/epaper_spi/models/waveshare_b.py
+++ b/esphome/components/epaper_spi/models/waveshare_b.py
@@ -15,7 +15,11 @@ class WaveshareB(EpaperModel):
             (0x11, 0x03),  # Data entry mode
             (0x3C, 0x05),  # Border waveform
             (0x18, 0x80),  # Internal temperature sensor
-            (0x21, self.get_default("ram_option", 0x80), 0x80),  # Display update control
+            (
+                0x21,
+                self.get_default("ram_option", 0x80),
+                0x80,
+            ),  # Display update control
         )
 
     async def to_code(self, var, config):

--- a/esphome/components/epaper_spi/models/waveshare_b.py
+++ b/esphome/components/epaper_spi/models/waveshare_b.py
@@ -1,3 +1,5 @@
+import esphome.codegen as cg
+
 from . import EpaperModel
 
 
@@ -13,8 +15,12 @@ class WaveshareB(EpaperModel):
             (0x11, 0x03),  # Data entry mode
             (0x3C, 0x05),  # Border waveform
             (0x18, 0x80),  # Internal temperature sensor
-            (0x21, 0x80, 0x80),  # Display update control
+            (0x21, self.get_default("ram_option", 0x80), 0x80),  # Display update control
         )
+
+    async def to_code(self, var, config):
+        cg.add(var.set_invert_red(self.get_default("invert_red", False)))
+        return config
 
 
 WaveshareB(
@@ -23,4 +29,16 @@ WaveshareB(
     height=250,
     data_rate="10MHz",
     minimum_update_interval="1s",
+    invert_red=True,
+)
+
+# Waveshare 2.66" B, SSD1680Z8. The red plane is not inverted on this panel, and byte A of
+# the display update control differs from the 2.13" model.
+WaveshareB(
+    "waveshare-2.66in-b",
+    width=152,
+    height=296,
+    data_rate="10MHz",
+    minimum_update_interval="30s",  # a full tri-color refresh takes ~15s at 23C
+    ram_option=0x00,
 )

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -31,6 +31,9 @@ WaveshareEPaperTypeA = waveshare_epaper_ns.class_(
 WaveshareEpaper1P54INBV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper1P54InBV2", WaveshareEPaperBWR
 )
+WaveshareEPaper2P66InB = waveshare_epaper_ns.class_(
+    "WaveshareEPaper2P66InB", WaveshareEPaperBWR
+)
 WaveshareEPaper2P7In = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P7In", WaveshareEPaper
 )
@@ -140,6 +143,7 @@ MODELS = {
     "2.90in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN),
     "2.90inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN_V2),
     "gdew029t5": ("c", GDEW029T5),
+    "2.66in-b": ("b", WaveshareEPaper2P66InB),
     "2.70in": ("b", WaveshareEPaper2P7In),
     "2.70in-b": ("b", WaveshareEPaper2P7InB),
     "2.70in-bv2": ("b", WaveshareEPaper2P7InBV2),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -773,6 +773,100 @@ uint32_t WaveshareEPaperTypeA::idle_timeout_() {
 }
 
 // ========================================================
+//                          2.66inch_e-paper_b
+// ========================================================
+// Datasheet:
+//  - https://www.waveshare.com/wiki/2.66inch_e-Paper_Module_(B)
+//  - https://files.waveshare.com/upload/e/ec/2.66inch-e-paper-b-specification.pdf
+//  - https://github.com/waveshareteam/Pico_ePaper_Code/blob/main/c/lib/e-Paper/EPD_2in66b.c
+
+void HOT WaveshareEPaper2P66InB::draw_absolute_pixel_internal(int x, int y, Color color) {
+  // this panel's source outputs run right-to-left with respect to the RAM bit order
+  WaveshareEPaperBWR::draw_absolute_pixel_internal(this->get_width_internal() - 1 - x, y, color);
+}
+
+void WaveshareEPaper2P66InB::reset_cursor_() {
+  // SetCursor(0, 0)
+  this->command(0x4E);  // SET_RAM_X_ADDRESS_COUNTER
+  this->data(0x00);
+
+  this->command(0x4F);  // SET_RAM_Y_ADDRESS_COUNTER
+  this->data(0x00);
+  this->data(0x00);
+}
+
+void WaveshareEPaper2P66InB::initialize() {
+  this->reset_();
+
+  this->wait_until_idle_();
+  this->command(0x12);  // soft reset
+  this->wait_until_idle_();
+
+  this->command(0x11);  // data entry mode
+  this->data(0x03);
+
+  // SetWindows(0, 0, width - 1, height - 1)
+  uint32_t xend = this->get_width_controller() - 1;
+  uint32_t yend = this->get_height_internal() - 1;
+
+  this->command(0x44);  // SET_RAM_X_ADDRESS_START_END_POSITION
+  this->data(0x00);
+  this->data((xend >> 3) & 0x1f);
+
+  this->command(0x45);  // SET_RAM_Y_ADDRESS_START_END_POSITION
+  this->data(0x00);
+  this->data(0x00);
+  this->data(yend & 0xff);
+  this->data((yend >> 8) & 0x01);
+
+  this->command(0x21);  // display update control
+  this->data(0x00);
+  this->data(0x80);
+
+  this->reset_cursor_();
+  this->wait_until_idle_();
+}
+
+void HOT WaveshareEPaper2P66InB::display() {
+  const uint32_t buf_half_len = this->get_buffer_length_() / 2u;
+
+  // the address counters have advanced past the end of RAM after the previous refresh
+  this->reset_cursor_();
+
+  // COMMAND DATA START TRANSMISSION 1 (BLACK)
+  // both the buffer and the panel treat a set bit as white, so no inversion
+  this->command(0x24);
+  delay(2);
+  for (uint32_t i = 0; i < buf_half_len; i++) {
+    this->data(this->buffer_[i]);
+  }
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2 (RED)
+  this->command(0x26);
+  delay(2);
+  for (uint32_t i = 0; i < buf_half_len; i++) {
+    this->data(this->buffer_[buf_half_len + i]);
+  }
+  delay(2);
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x20);
+  this->wait_until_idle_();
+}
+int WaveshareEPaper2P66InB::get_width_internal() { return 152; }
+int WaveshareEPaper2P66InB::get_height_internal() { return 296; }
+uint32_t WaveshareEPaper2P66InB::idle_timeout_() { return 20000; }
+void WaveshareEPaper2P66InB::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.66in B");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
 //                          Type B
 // ========================================================
 // Datasheet:

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -780,11 +780,6 @@ uint32_t WaveshareEPaperTypeA::idle_timeout_() {
 //  - https://files.waveshare.com/upload/e/ec/2.66inch-e-paper-b-specification.pdf
 //  - https://github.com/waveshareteam/Pico_ePaper_Code/blob/main/c/lib/e-Paper/EPD_2in66b.c
 
-void HOT WaveshareEPaper2P66InB::draw_absolute_pixel_internal(int x, int y, Color color) {
-  // this panel's source outputs run right-to-left with respect to the RAM bit order
-  WaveshareEPaperBWR::draw_absolute_pixel_internal(this->get_width_internal() - 1 - x, y, color);
-}
-
 void WaveshareEPaper2P66InB::reset_cursor_() {
   // SetCursor(0, 0)
   this->command(0x4E);  // SET_RAM_X_ADDRESS_COUNTER
@@ -802,8 +797,14 @@ void WaveshareEPaper2P66InB::initialize() {
   this->command(0x12);  // soft reset
   this->wait_until_idle_();
 
+  // driver output control: MUX = gate lines - 1 = 295 (0x0127), little endian
+  this->command(0x01);
+  this->data((this->get_height_internal() - 1) & 0xff);
+  this->data(((this->get_height_internal() - 1) >> 8) & 0x01);
+  this->data(0x00);
+
   this->command(0x11);  // data entry mode
-  this->data(0x03);
+  this->data(0x03);     // AM=0 (X first), Y increment, X increment
 
   // SetWindows(0, 0, width - 1, height - 1)
   uint32_t xend = this->get_width_controller() - 1;
@@ -819,9 +820,13 @@ void WaveshareEPaper2P66InB::initialize() {
   this->data(yend & 0xff);
   this->data((yend >> 8) & 0x01);
 
-  this->command(0x21);  // display update control
+  // POR selects the external temperature sensor; this module has none
+  this->command(0x18);  // temperature sensor control
+  this->data(0x80);     // use the built-in sensor
+
+  this->command(0x21);  // display update control 1
   this->data(0x00);
-  this->data(0x80);
+  this->data(0x80);  // source output mode: S8 to S167
 
   this->reset_cursor_();
   this->wait_until_idle_();
@@ -850,13 +855,18 @@ void HOT WaveshareEPaper2P66InB::display() {
   }
   delay(2);
 
+  // the update sequence 0x20 runs is the one selected here, so set it explicitly
+  this->command(0x22);  // display update control 2
+  this->data(0xf7);     // enable clock and analog, load temperature, display mode 1
+
   // COMMAND DISPLAY REFRESH
   this->command(0x20);
   this->wait_until_idle_();
 }
 int WaveshareEPaper2P66InB::get_width_internal() { return 152; }
 int WaveshareEPaper2P66InB::get_height_internal() { return 296; }
-uint32_t WaveshareEPaper2P66InB::idle_timeout_() { return 20000; }
+// a full tri-color refresh takes ~15s at 23C and slows down when cold
+uint32_t WaveshareEPaper2P66InB::idle_timeout_() { return 30000; }
 void WaveshareEPaper2P66InB::dump_config() {
   LOG_DISPLAY("", "Waveshare E-Paper", this);
   ESP_LOGCONFIG(TAG, "  Model: 2.66in B");

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -216,7 +216,6 @@ class WaveshareEPaper2P66InB : public WaveshareEPaperBWR {
   }
 
  protected:
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
   void reset_cursor_();
   int get_width_internal() override;
   int get_height_internal() override;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -201,6 +201,28 @@ class WaveshareEPaper1P54InBV2 : public WaveshareEPaperBWR {
   int get_height_internal() override;
 };
 
+class WaveshareEPaper2P66InB : public WaveshareEPaperBWR {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND DEEP SLEEP
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+ protected:
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void reset_cursor_();
+  int get_width_internal() override;
+  int get_height_internal() override;
+  uint32_t idle_timeout_() override;
+};
+
 class WaveshareEPaper2P7In : public WaveshareEPaper {
  public:
   void initialize() override;

--- a/tests/components/epaper_spi/test.esp32-s3-idf.yaml
+++ b/tests/components/epaper_spi/test.esp32-s3-idf.yaml
@@ -191,6 +191,27 @@ display:
       it.circle(it.get_width() / 2, it.get_height() / 2, 20, Color::BLACK);
       it.circle(it.get_width() / 2, it.get_height() / 2, 15, Color(255, 0, 0));
 
+  # Waveshare 2.66" B series 3-color e-paper (152x296, BWR, SSD1680)
+  - platform: epaper_spi
+    spi_id: spi_bus
+    model: waveshare-2.66in-b
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO5
+    dc_pin:
+      allow_other_uses: true
+      number: GPIO17
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO16
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO4
+    lambda: |-
+      it.filled_rectangle(0, 0, it.get_width(), it.get_height(), Color::WHITE);
+      it.circle(it.get_width() / 2, it.get_height() / 2, 20, Color::BLACK);
+      it.circle(it.get_width() / 2, it.get_height() / 2, 15, Color(255, 0, 0));
+
   # Soldered Inkplate 2 3-color e-paper (104x212, BWR)
   - platform: epaper_spi
     spi_id: spi_bus

--- a/tests/components/waveshare_epaper/common.yaml
+++ b/tests/components/waveshare_epaper/common.yaml
@@ -247,6 +247,24 @@ display:
       it.rectangle(0, 0, it.get_width(), it.get_height());
 
   - platform: waveshare_epaper
+    id: epd_2_66b
+    model: 2.66in-b
+    cs_pin:
+      allow_other_uses: true
+      number: ${cs_pin}
+    dc_pin:
+      allow_other_uses: true
+      number: ${dc_pin}
+    busy_pin:
+      allow_other_uses: true
+      number: ${busy_pin}
+    reset_pin:
+      allow_other_uses: true
+      number: ${reset_pin}
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
+
+  - platform: waveshare_epaper
     id: epd_2_70b
     model: 2.70in-b
     cs_pin:


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the Waveshare 2.66in E-Paper B display (black/white/red) to the `waveshare_epaper` component. This is the same panel used on the Waveshare Pico-ePaper-2.66-B, driven over SPI with separate black and red data transmission commands.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- [esphome/esphome.io#<esphome.io PR number goes here>](https://github.com/esphome/esphome.io/pull/7124)

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
font:
  - file: 'gfonts://Michroma'
    id: font1
    size: 20

spi:
  clk_pin: GPIO04
  mosi_pin: GPIO05

display:
  - platform: waveshare_epaper
    cs_pin: GPIO03
    dc_pin: GPIO02
    rotation: 90
    busy_pin: 
      number: GPIO07
      inverted: true
    reset_pin: GPIO06
    model: 2.66in-b
    update_interval: 40s
    lambda: |-
      const auto BLACK   = Color(0,   0,   0,   0);
      const auto RED     = Color(255, 0,   0,   0);
      const auto WHITE   = Color(255, 255, 255, 0);

      it.fill(COLOR_ON);
      it.filled_rectangle(20, 40, 250, 50, BLACK);
      it.print(0, 0, id(font1), BLACK, "Hello World black!");
      it.print(20, 20, id(font1), RED, "Hello World red!");
      it.print(40, 40, id(font1), WHITE, "Hello World white!");
```
<img width="4032" height="3024" alt="IMG_6971" src="https://github.com/user-attachments/assets/9b934cb7-e0a8-40da-a26e-170ffb527e20" />

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
