### PR TITLE
[epaper_spi] Add Waveshare 2.13in-G (JD79660) display models

### DIFF
--- a/esphome/components/epaper_spi/models/jd79660.py
+++ b/esphome/components/epaper_spi/models/jd79660.py
@@ -85,6 +85,77 @@ jd79660.extend(
     ),
 )
 
+# Waveshare 2.13-G (V2 hardware/init revision, PCB marked "rev 2.1" or later)
+#
+# Vendor init derived from vendor sample code
+# <https://github.com/waveshareteam/e-Paper/blob/master/E-paper_Separate_Program/2in13_e-Paper_G/ESP32/EPD_2in13g_V2.cpp>
+# Compatible MIT license, see esphome/LICENSE file.
+#
+# Note: busy pin uses LOW=busy, HIGH=idle. Configure with inverted: true in YAML.
+# Note: panel is 122px wide, but the TRES register needs a multiple of 4, so the
+# vendor code declares 124 (the 2 extra columns fall outside the visible glass).
+# width=124 (not 122) is declared here (as with the V1 variant below) so the driver's
+# per-pixel byte addressing stays aligned to whole bytes on every row; declaring the
+# true 122 causes row boundaries to fall mid-byte and shears the image diagonally.
+#
+# fmt: off
+jd79660.extend(
+    "Waveshare-2.13in-G",
+    width=124,
+    height=250,
+
+    initsequence=(
+        (0x61, 0x00, 0x7C, 0x00, 0xFA,),  # TRES: 124x250 fixed (124 = 122 rounded up to a multiple of 4)
+        (0xE9, 0x01,),
+        # Power On (0x04): Must be early part of init seq = Disabled later!
+        (0x04,),
+    ),
+    fast_update=(
+        (0xE0, 0x02,),
+        (0xE6, 0x5A,),
+        (0xA5,),
+    ),
+)
+
+# Waveshare 2.13-G (V1 hardware/init revision, older stock)
+#
+# Vendor init derived from vendor sample code
+# <https://github.com/waveshareteam/e-Paper/blob/master/E-paper_Separate_Program/2in13_e-Paper_G/ESP32/EPD_2in13g.cpp>
+# Compatible MIT license, see esphome/LICENSE file.
+#
+# Note: busy pin uses LOW=busy, HIGH=idle. Configure with inverted: true in YAML.
+# Note: vendor code forces the TRES register to a fixed 128 (rather than 122) on this
+# revision, since this IC apparently needs a value >=128 in that field. width=128 is
+# declared here (rather than 122) purely so the transferred bytes-per-row matches what
+# the vendor init tells the IC to expect; the extra 6 columns fall outside the visible
+# glass. No fast-update sequence exists in the vendor sample for this revision.
+#
+# fmt: off
+jd79660.extend(
+    "Waveshare-2.13in-G-V1",
+    width=128,
+    height=250,
+
+    initsequence=(
+        (0x4D, 0x78,),
+        (0x00, 0x0F, 0x29,),
+        (0x01, 0x07, 0x00,),
+        (0x03, 0x10, 0x54, 0x44,),
+        (0x06, 0x05, 0x00, 0x3F, 0x0A, 0x25, 0x12, 0x1A,),
+        (0x50, 0x37,),
+        (0x60, 0x02, 0x02,),
+        (0x61, 0x00, 0x80, 0x00, 0xFA,),  # TRES: 128x250 fixed (IC requires width >=128)
+        (0xE7, 0x1C,),
+        (0xE3, 0x22,),
+        (0xB4, 0xD0,),
+        (0xB5, 0x03,),
+        (0xE9, 0x01,),
+        (0x30, 0x08,),
+        # Power On (0x04): Must be early part of init seq = Disabled later!
+        (0x04,),
+    ),
+)
+
 # Waveshare 7.5-H
 #
 # Vendor init derived from vendor sample code

--- a/tests/components/epaper_spi/test.esp32-s3-idf.yaml
+++ b/tests/components/epaper_spi/test.esp32-s3-idf.yaml
@@ -75,6 +75,40 @@ display:
       inverted: true
 
   - platform: epaper_spi
+    spi_id: spi_bus
+    model: waveshare-2.13in-g
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO5
+    dc_pin:
+      allow_other_uses: true
+      number: GPIO17
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO16
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO4
+      inverted: true
+
+  - platform: epaper_spi
+    spi_id: spi_bus
+    model: waveshare-2.13in-g-v1
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO5
+    dc_pin:
+      allow_other_uses: true
+      number: GPIO17
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO16
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO4
+      inverted: true
+
+  - platform: epaper_spi
     model: seeed-reterminal-e1002
   - platform: epaper_spi
     model: seeed-reterminal-e1004


### PR DESCRIPTION
# What does this implement/fix?

Adds two new `epaper_spi` display models for the Waveshare 2.13" e-Paper HAT (G), a 4-colour (black/white/red/yellow) panel driven by the JD79660/JD79661 controller family:

- `waveshare-2.13in-g`: the current (V2) hardware/init revision, including a fast-update sequence.
- `waveshare-2.13in-g-v1`: an older, longer-init revision, for earlier stock of the same panel.

Both init sequences are derived from Waveshare's own vendor sample code for each revision. Both declare a `width` padded up to the nearest multiple of 4 (124 and 128 respectively) rather than the panel's true 122 visible columns — this is required so the driver's per-pixel byte addressing (`x + y * width`) stays aligned to whole bytes on every row. Declaring the true 122 causes row boundaries to fall mid-byte, which visibly shears the displayed image diagonally. This same class of issue would affect any JD79660-family panel whose true width isn't already a multiple of 4 (the two existing models in this file, 1.54"-G and 7.5"-H, both happen to have widths that already are, so it hadn't come up before).

The `waveshare-2.13in-g` (V2) model has been verified against real hardware (an ESP32 driving the panel over SPI), including confirming the row-alignment fix above resolves a diagonal image-shear artifact. `waveshare-2.13in-g-v1` has not been tested against physical V1 hardware — it's a direct port of Waveshare's vendor init sequence for that revision, included for completeness since both revisions are in circulation, but flagged here in case a reviewer wants it split out or confirmed separately.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7127

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23

display:
  - platform: epaper_spi
    model: waveshare-2.13in-g
    cs_pin: GPIO5
    dc_pin: GPIO17
    reset_pin: GPIO16
    busy_pin:
      number: GPIO4
      inverted: true          # this IC reports busy=LOW, idle=HIGH
    update_interval: 10min
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
