### PR TITLE
[ota] Use PSA crypto for signature verification on ESP-IDF 6

### DIFF
--- a/esphome/components/ota/ota_rsa_der.h
+++ b/esphome/components/ota/ota_rsa_der.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace esphome::ota {
+
+// The PSA Crypto API imports an RSA public key as a DER RSAPublicKey
+// (RFC 3279 2.3.1), not as raw bignums:
+//
+//   RSAPublicKey ::= SEQUENCE { modulus INTEGER, publicExponent INTEGER }
+//
+// The Secure Boot v2 signature block stores the modulus and exponent raw, so
+// they are wrapped here. Only RSA-3072 exists in that format, which fixes both
+// headers: a 3072-bit modulus always has its top bit set, so its INTEGER is
+// always tag + 2-byte length (0x181 = 385) + the sign pad; and the SEQUENCE
+// body is always 391..396 bytes, so its header is always tag + 2-byte length.
+// Only the exponent varies in width.
+constexpr size_t RSA_3072_MODULUS_BYTES = 384;
+constexpr uint8_t RSA_DER_MODULUS_PREFIX[] = {0x02, 0x82, 0x01, 0x81, 0x00};
+constexpr size_t RSA_DER_MODULUS_LEN = sizeof(RSA_DER_MODULUS_PREFIX) + RSA_3072_MODULUS_BYTES;  // 389
+// 4-byte SEQUENCE header + modulus + the widest exponent INTEGER (tag, length,
+// sign pad, 4 bytes).
+constexpr size_t RSA_DER_PUBKEY_MAX = 4 + RSA_DER_MODULUS_LEN + 7;
+
+/// Wrap a raw RSA-3072 modulus and exponent as a DER RSAPublicKey.
+///
+/// @param modulus_be   Big-endian modulus, RSA_3072_MODULUS_BYTES long.
+/// @param exponent_be  Big-endian exponent, exponent_len bytes, leading zeros allowed.
+/// @return the encoded length, or 0 if the exponent is zero or the buffer is too small.
+inline size_t rsa_der_public_key(const uint8_t *modulus_be, const uint8_t *exponent_be, size_t exponent_len,
+                                 uint8_t *out, size_t out_len) {
+  // A DER INTEGER is signed: drop leading zero bytes, then prepend one back if
+  // the value would otherwise read as negative.
+  while (exponent_len > 0 && exponent_be[0] == 0x00) {
+    exponent_be++;
+    exponent_len--;
+  }
+  if (exponent_len == 0) {
+    return 0;  // a zero exponent is not a usable key
+  }
+  const bool pad = (exponent_be[0] & 0x80) != 0;
+  const size_t exponent_der_len = 2 + (pad ? 1 : 0) + exponent_len;
+  const size_t body_len = RSA_DER_MODULUS_LEN + exponent_der_len;
+  const size_t total_len = 4 + body_len;
+  if (total_len > out_len) {
+    return 0;
+  }
+
+  size_t i = 0;
+  out[i++] = 0x30;  // SEQUENCE
+  out[i++] = 0x82;  // 2-byte length follows
+  out[i++] = static_cast<uint8_t>(body_len >> 8);
+  out[i++] = static_cast<uint8_t>(body_len);
+  memcpy(out + i, RSA_DER_MODULUS_PREFIX, sizeof(RSA_DER_MODULUS_PREFIX));
+  i += sizeof(RSA_DER_MODULUS_PREFIX);
+  memcpy(out + i, modulus_be, RSA_3072_MODULUS_BYTES);
+  i += RSA_3072_MODULUS_BYTES;
+  out[i++] = 0x02;  // INTEGER
+  out[i++] = static_cast<uint8_t>(exponent_len + (pad ? 1 : 0));
+  if (pad) {
+    out[i++] = 0x00;
+  }
+  memcpy(out + i, exponent_be, exponent_len);
+  return total_len;
+}
+
+}  // namespace esphome::ota

--- a/esphome/components/ota/ota_rsa_der.h
+++ b/esphome/components/ota/ota_rsa_der.h
@@ -15,7 +15,7 @@ namespace esphome::ota {
 // they are wrapped here. Only RSA-3072 exists in that format, which fixes both
 // headers: a 3072-bit modulus always has its top bit set, so its INTEGER is
 // always tag + 2-byte length (0x181 = 385) + the sign pad; and the SEQUENCE
-// body is always 391..396 bytes, so its header is always tag + 2-byte length.
+// body is always 392..396 bytes, so its header is always tag + 2-byte length.
 // Only the exponent varies in width.
 constexpr size_t RSA_3072_MODULUS_BYTES = 384;
 constexpr uint8_t RSA_DER_MODULUS_PREFIX[] = {0x02, 0x82, 0x01, 0x81, 0x00};
@@ -28,6 +28,7 @@ constexpr size_t RSA_DER_PUBKEY_MAX = 4 + RSA_DER_MODULUS_LEN + 7;
 ///
 /// @param modulus_be   Big-endian modulus, RSA_3072_MODULUS_BYTES long.
 /// @param exponent_be  Big-endian exponent, exponent_len bytes, leading zeros allowed.
+///                     Rejected if the significant bytes would not fit a short-form length.
 /// @return the encoded length, or 0 if the exponent is zero or the buffer is too small.
 inline size_t rsa_der_public_key(const uint8_t *modulus_be, const uint8_t *exponent_be, size_t exponent_len,
                                  uint8_t *out, size_t out_len) {
@@ -41,7 +42,11 @@ inline size_t rsa_der_public_key(const uint8_t *modulus_be, const uint8_t *expon
     return 0;  // a zero exponent is not a usable key
   }
   const bool pad = (exponent_be[0] & 0x80) != 0;
-  const size_t exponent_der_len = 2 + (pad ? 1 : 0) + exponent_len;
+  const size_t exponent_content_len = exponent_len + (pad ? 1 : 0);
+  if (exponent_content_len > 0x7F) {
+    return 0;  // would need a long-form length, which this encoder does not write
+  }
+  const size_t exponent_der_len = 2 + exponent_content_len;
   const size_t body_len = RSA_DER_MODULUS_LEN + exponent_der_len;
   const size_t total_len = 4 + body_len;
   if (total_len > out_len) {
@@ -58,7 +63,7 @@ inline size_t rsa_der_public_key(const uint8_t *modulus_be, const uint8_t *expon
   memcpy(out + i, modulus_be, RSA_3072_MODULUS_BYTES);
   i += RSA_3072_MODULUS_BYTES;
   out[i++] = 0x02;  // INTEGER
-  out[i++] = static_cast<uint8_t>(exponent_len + (pad ? 1 : 0));
+  out[i++] = static_cast<uint8_t>(exponent_content_len);
   if (pad) {
     out[i++] = 0x00;
   }

--- a/esphome/components/ota/ota_signature_esp_idf.cpp
+++ b/esphome/components/ota/ota_signature_esp_idf.cpp
@@ -21,6 +21,7 @@
 // crypto is auto-initialized by ESP-IDF at startup (esp_psa_crypto_init.c,
 // priority 104), so no psa_crypto_init() call is needed.
 #define USE_OTA_SIG_PSA
+#include "ota_rsa_der.h"
 #include <psa/crypto.h>
 #else
 #include <mbedtls/md.h>
@@ -151,76 +152,6 @@ bool image_digest(const esp_partition_t *part, size_t image_padded_len, uint8_t 
 // block's modulus and signature are stored little-endian; reverse them in place
 // -- block is the caller's scratch buffer, overwritten on the next iteration --
 // rather than stacking a second 384-byte copy of each bignum.
-#ifdef USE_OTA_SIG_PSA
-// PSA imports RSA public keys as a DER RSAPublicKey (RFC 8017 A.1.1):
-//   SEQUENCE { modulus INTEGER, publicExponent INTEGER }
-// The signature block stores both as raw bignums, so wrap them here. A DER
-// INTEGER is signed, so an unsigned value whose top bit is set needs a leading
-// zero byte, and leading zero bytes are otherwise dropped. The sizes are fixed
-// by the format (RSA-3072): 4 (SEQUENCE header) + 389 (modulus) + at most 7
-// (exponent) bytes.
-constexpr size_t DER_PUBKEY_MAX = 400;
-
-// Writes one DER INTEGER; returns its length, or 0 if the value is zero or does not fit.
-size_t der_write_integer(uint8_t *out, size_t out_len, const uint8_t *value, size_t value_len) {
-  while (value_len > 0 && value[0] == 0x00) {
-    value++;
-    value_len--;
-  }
-  if (value_len == 0) {
-    return 0;  // A zero modulus or exponent is not a usable key
-  }
-  const bool pad = (value[0] & 0x80) != 0;
-  const size_t content_len = value_len + (pad ? 1 : 0);
-  const size_t len_bytes = content_len < 0x80 ? 1 : (content_len <= 0xFF ? 2 : 3);
-  if (1 + len_bytes + content_len > out_len) {
-    return 0;
-  }
-  size_t i = 0;
-  out[i++] = 0x02;  // INTEGER
-  if (len_bytes == 2) {
-    out[i++] = 0x81;
-  } else if (len_bytes == 3) {
-    out[i++] = 0x82;
-    out[i++] = static_cast<uint8_t>(content_len >> 8);
-  }
-  out[i++] = static_cast<uint8_t>(content_len);
-  if (pad) {
-    out[i++] = 0x00;
-  }
-  memcpy(out + i, value, value_len);
-  return i + value_len;
-}
-
-// Builds the DER RSAPublicKey; returns its length, or 0 on failure.
-size_t der_public_key(const uint8_t *modulus_be, const uint8_t *exponent_be, uint8_t *out, size_t out_len) {
-  // Encode the two INTEGERs after the largest possible SEQUENCE header, then
-  // shift them down once the real header length is known.
-  constexpr size_t HEADER_MAX = 4;
-  size_t body = der_write_integer(out + HEADER_MAX, out_len - HEADER_MAX, modulus_be, RSA_3072_BYTES);
-  if (body == 0) {
-    return 0;
-  }
-  const size_t exponent = der_write_integer(out + HEADER_MAX + body, out_len - HEADER_MAX - body, exponent_be, 4);
-  if (exponent == 0) {
-    return 0;
-  }
-  body += exponent;
-  uint8_t header[HEADER_MAX];
-  size_t header_len = 0;
-  header[header_len++] = 0x30;  // SEQUENCE
-  if (body >= 0x80) {
-    header[header_len++] = body <= 0xFF ? 0x81 : 0x82;
-    if (body > 0xFF) {
-      header[header_len++] = static_cast<uint8_t>(body >> 8);
-    }
-  }
-  header[header_len++] = static_cast<uint8_t>(body);
-  memmove(out + header_len, out + HEADER_MAX, body);
-  memcpy(out, header, header_len);
-  return header_len + body;
-}
-#endif  // USE_OTA_SIG_PSA
 
 bool rsa_pss_verify(uint8_t *block, const uint8_t *digest) {
   std::reverse(block + OFFSET_MODULUS, block + OFFSET_MODULUS + RSA_3072_BYTES);
@@ -231,15 +162,16 @@ bool rsa_pss_verify(uint8_t *block, const uint8_t *digest) {
                             static_cast<uint8_t>(exponent_le >> 8), static_cast<uint8_t>(exponent_le)};
 
 #ifdef USE_OTA_SIG_PSA
-  uint8_t der[DER_PUBKEY_MAX];
-  const size_t der_len = der_public_key(block + OFFSET_MODULUS, exponent_be, der, sizeof(der));
+  uint8_t der[RSA_DER_PUBKEY_MAX];
+  const size_t der_len = rsa_der_public_key(block + OFFSET_MODULUS, exponent_be, sizeof(exponent_be), der, sizeof(der));
   psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
   psa_set_key_type(&attr, PSA_KEY_TYPE_RSA_PUBLIC_KEY);
   psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_VERIFY_HASH);
   // ANY_SALT preserves the salt-length acceptance of mbedtls_rsa_rsassa_pss_verify(),
-  // which this replaces; espsecure signs with a 32-byte salt.
+  // which this replaces; espsecure signs with a 32-byte salt. TF-PSA-Crypto defines
+  // PSA_WANT_ALG_RSA_PSS_ANY_SALT from PSA_WANT_ALG_RSA_PSS, which IDF enables.
   psa_set_key_algorithm(&attr, PSA_ALG_RSA_PSS_ANY_SALT(PSA_ALG_SHA_256));
-  psa_key_id_t key = PSA_KEY_ID_NULL;
+  mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
   const bool key_ok = der_len != 0 && psa_import_key(&attr, der, der_len, &key) == PSA_SUCCESS;
 #else
   mbedtls_rsa_context rsa;

--- a/esphome/components/ota/ota_signature_esp_idf.cpp
+++ b/esphome/components/ota/ota_signature_esp_idf.cpp
@@ -162,6 +162,7 @@ bool rsa_pss_verify(uint8_t *block, const uint8_t *digest) {
                             static_cast<uint8_t>(exponent_le >> 8), static_cast<uint8_t>(exponent_le)};
 
 #ifdef USE_OTA_SIG_PSA
+  static_assert(RSA_3072_BYTES == RSA_3072_MODULUS_BYTES, "signature block and DER encoder disagree on modulus size");
   uint8_t der[RSA_DER_PUBKEY_MAX];
   const size_t der_len = rsa_der_public_key(block + OFFSET_MODULUS, exponent_be, sizeof(exponent_be), der, sizeof(der));
   psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;

--- a/esphome/components/ota/ota_signature_esp_idf.cpp
+++ b/esphome/components/ota/ota_signature_esp_idf.cpp
@@ -14,9 +14,19 @@
 #include <esp_partition.h>
 #include <esp_rom_crc.h>
 
+#include <esp_idf_version.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+// mbedtls 4.0 (IDF 6.0) made the legacy mbedtls_rsa_*/mbedtls_sha256_* headers
+// private. Use the PSA Crypto API instead, like the sha256 component does. PSA
+// crypto is auto-initialized by ESP-IDF at startup (esp_psa_crypto_init.c,
+// priority 104), so no psa_crypto_init() call is needed.
+#define USE_OTA_SIG_PSA
+#include <psa/crypto.h>
+#else
 #include <mbedtls/md.h>
 #include <mbedtls/rsa.h>
 #include <mbedtls/sha256.h>
+#endif
 
 namespace esphome::ota {
 
@@ -70,7 +80,14 @@ bool block_is_valid(const uint8_t *block) {
 }
 
 bool key_digest_of(const uint8_t *block, KeyDigest &out) {
+#ifdef USE_OTA_SIG_PSA
+  size_t out_len = 0;
+  return psa_hash_compute(PSA_ALG_SHA_256, block + OFFSET_KEY, KEY_REGION_LEN, out.data(), out.size(), &out_len) ==
+             PSA_SUCCESS &&
+         out_len == out.size();
+#else
   return mbedtls_sha256(block + OFFSET_KEY, KEY_REGION_LEN, out.data(), /*is224=*/0) == 0;
+#endif
 }
 
 // The offset of the signature sector: the app length rounded up to 4 KiB.
@@ -93,20 +110,40 @@ bool signature_sector_offset(const esp_partition_t *part, size_t &out_offset) {
 // Returns false on a read or hash error so a hash failure is not later
 // misreported as a signature mismatch.
 bool image_digest(const esp_partition_t *part, size_t image_padded_len, uint8_t *out) {
+#ifdef USE_OTA_SIG_PSA
+  psa_hash_operation_t ctx = PSA_HASH_OPERATION_INIT;
+  bool ok = psa_hash_setup(&ctx, PSA_ALG_SHA_256) == PSA_SUCCESS;
+#else
   mbedtls_sha256_context ctx;
   mbedtls_sha256_init(&ctx);
   bool ok = mbedtls_sha256_starts(&ctx, /*is224=*/0) == 0;
+#endif
   uint8_t buf[512];
   for (size_t off = 0; ok && off < image_padded_len; off += sizeof(buf)) {
     size_t chunk = std::min(sizeof(buf), image_padded_len - off);
-    if (esp_partition_read(part, off, buf, chunk) != ESP_OK || mbedtls_sha256_update(&ctx, buf, chunk) != 0) {
+    if (esp_partition_read(part, off, buf, chunk) != ESP_OK) {
       ok = false;
+      break;
     }
+#ifdef USE_OTA_SIG_PSA
+    ok = psa_hash_update(&ctx, buf, chunk) == PSA_SUCCESS;
+#else
+    ok = mbedtls_sha256_update(&ctx, buf, chunk) == 0;
+#endif
   }
+#ifdef USE_OTA_SIG_PSA
+  size_t out_len = 0;
+  if (ok) {
+    ok = psa_hash_finish(&ctx, out, SHA256_BYTES, &out_len) == PSA_SUCCESS && out_len == SHA256_BYTES;
+  }
+  // A no-op once the operation has been finished
+  psa_hash_abort(&ctx);
+#else
   if (ok) {
     ok = mbedtls_sha256_finish(&ctx, out) == 0;
   }
   mbedtls_sha256_free(&ctx);
+#endif
   return ok;
 }
 
@@ -114,6 +151,77 @@ bool image_digest(const esp_partition_t *part, size_t image_padded_len, uint8_t 
 // block's modulus and signature are stored little-endian; reverse them in place
 // -- block is the caller's scratch buffer, overwritten on the next iteration --
 // rather than stacking a second 384-byte copy of each bignum.
+#ifdef USE_OTA_SIG_PSA
+// PSA imports RSA public keys as a DER RSAPublicKey (RFC 8017 A.1.1):
+//   SEQUENCE { modulus INTEGER, publicExponent INTEGER }
+// The signature block stores both as raw bignums, so wrap them here. A DER
+// INTEGER is signed, so an unsigned value whose top bit is set needs a leading
+// zero byte, and leading zero bytes are otherwise dropped. The sizes are fixed
+// by the format (RSA-3072): 4 (SEQUENCE header) + 389 (modulus) + at most 7
+// (exponent) bytes.
+constexpr size_t DER_PUBKEY_MAX = 400;
+
+// Writes one DER INTEGER; returns its length, or 0 if the value is zero or does not fit.
+size_t der_write_integer(uint8_t *out, size_t out_len, const uint8_t *value, size_t value_len) {
+  while (value_len > 0 && value[0] == 0x00) {
+    value++;
+    value_len--;
+  }
+  if (value_len == 0) {
+    return 0;  // A zero modulus or exponent is not a usable key
+  }
+  const bool pad = (value[0] & 0x80) != 0;
+  const size_t content_len = value_len + (pad ? 1 : 0);
+  const size_t len_bytes = content_len < 0x80 ? 1 : (content_len <= 0xFF ? 2 : 3);
+  if (1 + len_bytes + content_len > out_len) {
+    return 0;
+  }
+  size_t i = 0;
+  out[i++] = 0x02;  // INTEGER
+  if (len_bytes == 2) {
+    out[i++] = 0x81;
+  } else if (len_bytes == 3) {
+    out[i++] = 0x82;
+    out[i++] = static_cast<uint8_t>(content_len >> 8);
+  }
+  out[i++] = static_cast<uint8_t>(content_len);
+  if (pad) {
+    out[i++] = 0x00;
+  }
+  memcpy(out + i, value, value_len);
+  return i + value_len;
+}
+
+// Builds the DER RSAPublicKey; returns its length, or 0 on failure.
+size_t der_public_key(const uint8_t *modulus_be, const uint8_t *exponent_be, uint8_t *out, size_t out_len) {
+  // Encode the two INTEGERs after the largest possible SEQUENCE header, then
+  // shift them down once the real header length is known.
+  constexpr size_t HEADER_MAX = 4;
+  size_t body = der_write_integer(out + HEADER_MAX, out_len - HEADER_MAX, modulus_be, RSA_3072_BYTES);
+  if (body == 0) {
+    return 0;
+  }
+  const size_t exponent = der_write_integer(out + HEADER_MAX + body, out_len - HEADER_MAX - body, exponent_be, 4);
+  if (exponent == 0) {
+    return 0;
+  }
+  body += exponent;
+  uint8_t header[HEADER_MAX];
+  size_t header_len = 0;
+  header[header_len++] = 0x30;  // SEQUENCE
+  if (body >= 0x80) {
+    header[header_len++] = body <= 0xFF ? 0x81 : 0x82;
+    if (body > 0xFF) {
+      header[header_len++] = static_cast<uint8_t>(body >> 8);
+    }
+  }
+  header[header_len++] = static_cast<uint8_t>(body);
+  memmove(out + header_len, out + HEADER_MAX, body);
+  memcpy(out, header, header_len);
+  return header_len + body;
+}
+#endif  // USE_OTA_SIG_PSA
+
 bool rsa_pss_verify(uint8_t *block, const uint8_t *digest) {
   std::reverse(block + OFFSET_MODULUS, block + OFFSET_MODULUS + RSA_3072_BYTES);
   std::reverse(block + OFFSET_SIGNATURE, block + OFFSET_SIGNATURE + RSA_3072_BYTES);
@@ -122,22 +230,46 @@ bool rsa_pss_verify(uint8_t *block, const uint8_t *digest) {
   uint8_t exponent_be[4] = {static_cast<uint8_t>(exponent_le >> 24), static_cast<uint8_t>(exponent_le >> 16),
                             static_cast<uint8_t>(exponent_le >> 8), static_cast<uint8_t>(exponent_le)};
 
+#ifdef USE_OTA_SIG_PSA
+  uint8_t der[DER_PUBKEY_MAX];
+  const size_t der_len = der_public_key(block + OFFSET_MODULUS, exponent_be, der, sizeof(der));
+  psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+  psa_set_key_type(&attr, PSA_KEY_TYPE_RSA_PUBLIC_KEY);
+  psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_VERIFY_HASH);
+  // ANY_SALT preserves the salt-length acceptance of mbedtls_rsa_rsassa_pss_verify(),
+  // which this replaces; espsecure signs with a 32-byte salt.
+  psa_set_key_algorithm(&attr, PSA_ALG_RSA_PSS_ANY_SALT(PSA_ALG_SHA_256));
+  psa_key_id_t key = PSA_KEY_ID_NULL;
+  const bool key_ok = der_len != 0 && psa_import_key(&attr, der, der_len, &key) == PSA_SUCCESS;
+#else
   mbedtls_rsa_context rsa;
   mbedtls_rsa_init(&rsa);
-  bool key_ok = mbedtls_rsa_import_raw(&rsa, block + OFFSET_MODULUS, RSA_3072_BYTES, nullptr, 0, nullptr, 0, nullptr, 0,
-                                       exponent_be, sizeof(exponent_be)) == 0 &&
-                mbedtls_rsa_complete(&rsa) == 0 &&
-                mbedtls_rsa_set_padding(&rsa, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256) == 0;
+  const bool key_ok = mbedtls_rsa_import_raw(&rsa, block + OFFSET_MODULUS, RSA_3072_BYTES, nullptr, 0, nullptr, 0,
+                                             nullptr, 0, exponent_be, sizeof(exponent_be)) == 0 &&
+                      mbedtls_rsa_complete(&rsa) == 0 &&
+                      mbedtls_rsa_set_padding(&rsa, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256) == 0;
+#endif
   bool verified = false;
   if (!key_ok) {
     // A setup/allocation failure (e.g. OOM right after the download) is not a
     // signature mismatch -- log it distinctly so it isn't read as "wrong key".
     OTA_IDF_SIG_LOG(ESP_LOGE, "RSA key setup failed");
   } else {
+#ifdef USE_OTA_SIG_PSA
+    verified = psa_verify_hash(key, PSA_ALG_RSA_PSS_ANY_SALT(PSA_ALG_SHA_256), digest, SHA256_BYTES,
+                               block + OFFSET_SIGNATURE, RSA_3072_BYTES) == PSA_SUCCESS;
+#else
     verified =
         mbedtls_rsa_rsassa_pss_verify(&rsa, MBEDTLS_MD_SHA256, SHA256_BYTES, digest, block + OFFSET_SIGNATURE) == 0;
+#endif
   }
+#ifdef USE_OTA_SIG_PSA
+  if (key_ok) {
+    psa_destroy_key(key);
+  }
+#else
   mbedtls_rsa_free(&rsa);
+#endif
   return verified;
 }
 

--- a/tests/components/ota/test_rsa_der.cpp
+++ b/tests/components/ota/test_rsa_der.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <vector>
+
+#include "esphome/components/ota/ota_rsa_der.h"
+
+namespace esphome::ota::testing {
+
+namespace {
+
+// A modulus with the top bit set, as every real 3072-bit modulus has.
+std::array<uint8_t, RSA_3072_MODULUS_BYTES> make_modulus(uint8_t first = 0xC5) {
+  std::array<uint8_t, RSA_3072_MODULUS_BYTES> modulus{};
+  modulus.fill(0xAB);
+  modulus[0] = first;
+  modulus[RSA_3072_MODULUS_BYTES - 1] = 0x01;  // odd, like a real modulus
+  return modulus;
+}
+
+}  // namespace
+
+// e = 65537, the exponent espsecure uses.
+TEST(RsaDerPublicKey, StandardExponent) {
+  const auto modulus = make_modulus();
+  const uint8_t exponent[4] = {0x00, 0x01, 0x00, 0x01};
+  uint8_t der[RSA_DER_PUBKEY_MAX];
+  const size_t len = rsa_der_public_key(modulus.data(), exponent, sizeof(exponent), der, sizeof(der));
+
+  // 4 (SEQUENCE header) + 389 (modulus) + 5 (exponent) = 398
+  ASSERT_EQ(len, 398u);
+  // SEQUENCE, 2-byte length of the 394-byte body
+  EXPECT_EQ(der[0], 0x30);
+  EXPECT_EQ(der[1], 0x82);
+  EXPECT_EQ((der[2] << 8) | der[3], 394);
+  // INTEGER, 2-byte length 385, sign pad, then the modulus
+  EXPECT_EQ(der[4], 0x02);
+  EXPECT_EQ(der[5], 0x82);
+  EXPECT_EQ((der[6] << 8) | der[7], 385);
+  EXPECT_EQ(der[8], 0x00);
+  EXPECT_EQ(0, memcmp(der + 9, modulus.data(), modulus.size()));
+  // INTEGER, 3 bytes, leading zero of the input dropped
+  const size_t exp_at = 9 + RSA_3072_MODULUS_BYTES;
+  EXPECT_EQ(der[exp_at], 0x02);
+  EXPECT_EQ(der[exp_at + 1], 0x03);
+  EXPECT_EQ(der[exp_at + 2], 0x01);
+  EXPECT_EQ(der[exp_at + 3], 0x00);
+  EXPECT_EQ(der[exp_at + 4], 0x01);
+}
+
+// An exponent whose top bit is set needs a 0x00 sign pad, widening the body.
+TEST(RsaDerPublicKey, ExponentNeedingSignPad) {
+  const auto modulus = make_modulus();
+  const uint8_t exponent[4] = {0x00, 0x00, 0x00, 0x81};
+  uint8_t der[RSA_DER_PUBKEY_MAX];
+  const size_t len = rsa_der_public_key(modulus.data(), exponent, sizeof(exponent), der, sizeof(der));
+
+  ASSERT_EQ(len, 397u);  // 4 + 389 + 4
+  const size_t exp_at = 9 + RSA_3072_MODULUS_BYTES;
+  EXPECT_EQ(der[exp_at], 0x02);
+  EXPECT_EQ(der[exp_at + 1], 0x02);  // pad + one value byte
+  EXPECT_EQ(der[exp_at + 2], 0x00);
+  EXPECT_EQ(der[exp_at + 3], 0x81);
+}
+
+// The widest exponent still fits the documented buffer size.
+TEST(RsaDerPublicKey, WidestExponentFitsBuffer) {
+  const auto modulus = make_modulus();
+  const uint8_t exponent[4] = {0xFF, 0xFF, 0xFF, 0xFF};
+  uint8_t der[RSA_DER_PUBKEY_MAX];
+  const size_t len = rsa_der_public_key(modulus.data(), exponent, sizeof(exponent), der, sizeof(der));
+
+  ASSERT_EQ(len, RSA_DER_PUBKEY_MAX);  // 4 + 389 + 7
+  EXPECT_LE(len, sizeof(der));
+}
+
+TEST(RsaDerPublicKey, ZeroExponentRejected) {
+  const auto modulus = make_modulus();
+  const uint8_t exponent[4] = {0x00, 0x00, 0x00, 0x00};
+  uint8_t der[RSA_DER_PUBKEY_MAX];
+  EXPECT_EQ(rsa_der_public_key(modulus.data(), exponent, sizeof(exponent), der, sizeof(der)), 0u);
+}
+
+// A buffer that cannot hold the result must be refused, not overrun. Sized
+// against a heap vector so ASAN catches a write past the end.
+TEST(RsaDerPublicKey, ShortBufferRejected) {
+  const auto modulus = make_modulus();
+  const uint8_t exponent[4] = {0x00, 0x01, 0x00, 0x01};
+  for (size_t out_len : {size_t(0), size_t(1), size_t(4), size_t(100), size_t(397)}) {
+    std::vector<uint8_t> der(out_len);
+    EXPECT_EQ(rsa_der_public_key(modulus.data(), exponent, sizeof(exponent), der.data(), out_len), 0u)
+        << "out_len=" << out_len;
+  }
+}
+
+}  // namespace esphome::ota::testing


### PR DESCRIPTION
# What does this implement/fix?

`ota_signature_esp_idf.cpp` does not compile on ESP-IDF 6.0:

```
esphome/components/ota/ota_signature_esp_idf.cpp:18:10:
error: 'mbedtls/rsa.h' file not found [clang-diagnostic-error]
```

IDF 6.0 ships mbedtls 4.x, which moved the legacy crypto primitives into the TF-PSA-Crypto tree and made them private: in the pinned submodule `rsa.h` and `sha256.h` now live at `tf-psa-crypto/drivers/builtin/include/mbedtls/private/`, and that directory is not among the mbedtls component's public `INCLUDE_DIRS`. Only `mbedtls/md.h`, `pk.h`, `asn1*.h` and friends stayed public, so `<mbedtls/rsa.h>` and `<mbedtls/sha256.h>` cannot be included by an application any more.

This follows the pattern the `sha256` component already uses for the same breakage: keep the existing mbedtls path for IDF < 6.0 and add a PSA Crypto path for IDF >= 6.0, gated on `ESP_IDF_VERSION`. PSA is auto-initialized by ESP-IDF at startup (`esp_psa_crypto_init.c`, priority 104), so no `psa_crypto_init()` call is needed.

Three call sites change on the new path:

- one-shot key-region hash -> `psa_hash_compute()`
- streaming image hash -> `psa_hash_operation_t` + `psa_hash_setup/update/finish`
- RSA-3072 PSS verify -> `psa_import_key()` + `psa_verify_hash()`

PSA imports RSA public keys as a DER `RSAPublicKey` (RFC 8017 A.1.1) rather than as raw bignums, so the new path wraps the block's modulus and exponent in DER. `PSA_ALG_RSA_PSS_ANY_SALT` is used to preserve the salt-length acceptance of the `mbedtls_rsa_rsassa_pss_verify()` it replaces.

**Behavior on IDF 5.x, which is what everything ships with today, is unchanged** - the preprocessor selects the existing code verbatim.

## Verification

- `script/test_build_components -e compile -c esp32 -t esp32-s3-idf` passes (5/5), including `test-signed_ota_external` which is the config that enables this verifier.
- The PSA branch was also compiled by temporarily forcing the gate on, so both sides of the `#if` are known to build and link (`psa/crypto.h` is public on IDF 5.5.5 too).
- The DER encoder was differentially tested against `cryptography`'s PKCS#1 DER output for randomly generated RSA-3072 keys; encodings match byte for byte, and the maximum length (398) fits the 400-byte buffer.

**Not verified on hardware:** I have no device set up with a signed image, so the PSA path has not been exercised against a real signature block. Given this is signature verification, someone with an IDF 6 build and a signed OTA should confirm that a valid image still verifies and a tampered one still fails before this is relied on. The salt-length choice and the DER import are the two places worth the closest review.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Found by the ESP-IDF 6.0 testing branch (#14770), where the ESP32 IDF clang-tidy job fails on this file.

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  variant: esp32s3
  framework:
    type: esp-idf
    advanced:
      signed_ota_verification:
        verification_keys:
          - my_signing_key.pub.pem

ota:
  - platform: esphome
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).