### PR TITLE
[modbus_client] Lambda sugar

### DIFF
--- a/esphome/components/modbus_client/__init__.py
+++ b/esphome/components/modbus_client/__init__.py
@@ -87,9 +87,11 @@ _PDU_BUFFER = modbus.modbus_ns.namespace("helpers").class_("PduBuffer")
 # non-standard, which warns once per device and logs at VERBOSE after that. So a lambda gets no feedback
 # on an ordinary failure - use the modbus_client.* actions whenever the outcome matters, since they carry
 # on_response/on_error/on_no_response/on_not_sent handlers.
+# The id is required, not generated: the device is reachable only through id() in a lambda, so an
+# entry without one builds something nothing can name. Better to say so than to accept dead config.
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(): cv.declare_id(modbus.ModbusClientDevice),
+        cv.Required(CONF_ID): cv.declare_id(modbus.ModbusClientDevice),
     }
 ).extend(modbus.modbus_device_schema(None))
 

--- a/esphome/components/modbus_client/__init__.py
+++ b/esphome/components/modbus_client/__init__.py
@@ -81,9 +81,12 @@ _PDU_BUFFER = modbus.modbus_ns.namespace("helpers").class_("PduBuffer")
 #
 #   - lambda: "id(my_client).write_single_register(0x10, 42);"
 #
-# Replies land on the device's own callbacks, which this component does not override, so the base's
-# default dispatch handles them (logging an unhandled reply once). Use the modbus_client.* actions
-# instead when the reply matters - they carry the on_response/on_error handlers.
+# Nothing here overrides the device callbacks, so every outcome takes the base class default, and those
+# are no-ops: a successful reply, a Modbus exception, a timeout, and a frame that never reached the wire
+# are all discarded without a log. The single exception is a reply the dispatch gate treats as
+# non-standard, which warns once per device and logs at VERBOSE after that. So a lambda gets no feedback
+# on an ordinary failure - use the modbus_client.* actions whenever the outcome matters, since they carry
+# on_response/on_error/on_no_response/on_not_sent handlers.
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(modbus.ModbusClientDevice),

--- a/esphome/components/modbus_client/__init__.py
+++ b/esphome/components/modbus_client/__init__.py
@@ -8,6 +8,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_ADDRESS,
     CONF_COUNT,
+    CONF_ID,
     CONF_ON_ERROR,
     CONF_ON_RESPONSE,
     CONF_VALUE,
@@ -17,6 +18,10 @@ from esphome.types import ConfigType, TemplateArgsType
 
 CODEOWNERS = ["@exciton"]
 DEPENDENCIES = ["modbus"]
+MULTI_CONF = True
+# The modbus hub auto-loads this component to make the actions available. Without this, that auto-load
+# would try to create a device with no address.
+MULTI_CONF_NO_DEFAULT = True
 
 CONF_ON_CUSTOM_RESPONSE = "on_custom_response"
 CONF_ON_NO_RESPONSE = "on_no_response"
@@ -66,6 +71,29 @@ _PDU_SPAN = cg.std_span.template(cg.uint8.operator("const"))
 # The list form below is bounded by cv.Length; a lambda cannot be. PduBuffer drops bytes past
 # modbus.MAX_PDU_SIZE without reporting it, so an over-long lambda PDU is silently truncated.
 _PDU_BUFFER = modbus.modbus_ns.namespace("helpers").class_("PduBuffer")
+
+# A bare modbus::ModbusClientDevice bound to a hub and a device address, and nothing else - no polling,
+# no entities, no automation wiring. It exists so a lambda can talk to a device directly:
+#
+#   modbus_client:
+#     - id: my_client
+#       address: 0x01
+#
+#   - lambda: "id(my_client).write_single_register(0x10, 42);"
+#
+# Replies land on the device's own callbacks, which this component does not override, so the base's
+# default dispatch handles them (logging an unhandled reply once). Use the modbus_client.* actions
+# instead when the reply matters - they carry the on_response/on_error handlers.
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(modbus.ModbusClientDevice),
+    }
+).extend(modbus.modbus_device_schema(None))
+
+
+async def to_code(config: ConfigType) -> None:
+    var = cg.new_Pvariable(config[CONF_ID])
+    await modbus.register_modbus_client_device(var, config)
 
 
 def _packed_bit_bytes(bits: int) -> int:

--- a/tests/component_tests/modbus_client/test_modbus_client.py
+++ b/tests/component_tests/modbus_client/test_modbus_client.py
@@ -16,7 +16,7 @@ from esphome.components.modbus_client import (
     CONFIG_SCHEMA,
     MODBUS_CLIENT_SEND_SCHEMA,
 )
-from esphome.const import CONF_ADDRESS, CONF_ON_ERROR, CONF_ON_RESPONSE
+from esphome.const import CONF_ADDRESS, CONF_ID, CONF_ON_ERROR, CONF_ON_RESPONSE
 from esphome.core import Lambda
 from esphome.types import ConfigType
 
@@ -126,19 +126,25 @@ def test_on_no_response_retry_lambda_accepted() -> None:
 def test_component_requires_an_address() -> None:
     """address identifies the device on the bus, so there is no sensible default."""
     with pytest.raises(cv.Invalid, match=CONF_ADDRESS):
-        CONFIG_SCHEMA({})
+        CONFIG_SCHEMA({CONF_ID: "bare_client"})
 
 
-def test_component_accepts_an_address_alone() -> None:
-    """modbus_id is optional: it resolves to the single hub when only one is declared."""
-    config = CONFIG_SCHEMA({CONF_ADDRESS: 0x01})
+def test_component_requires_an_id() -> None:
+    """The device is reachable only through id() in a lambda, so a generated id would be dead config."""
+    with pytest.raises(cv.Invalid, match=CONF_ID):
+        CONFIG_SCHEMA({CONF_ADDRESS: 0x01})
+
+
+def test_component_accepts_an_id_and_address() -> None:
+    """modbus_id stays optional: it resolves to the single hub when only one is declared."""
+    config = CONFIG_SCHEMA({CONF_ID: "bare_client", CONF_ADDRESS: 0x01})
     assert config[CONF_ADDRESS] == 0x01
 
 
 def test_component_rejects_an_out_of_range_address() -> None:
     """A Modbus device address is one byte."""
     with pytest.raises(cv.Invalid):
-        CONFIG_SCHEMA({CONF_ADDRESS: 0x100})
+        CONFIG_SCHEMA({CONF_ID: "bare_client", CONF_ADDRESS: 0x100})
 
 
 def test_multi_conf_no_default_is_set() -> None:

--- a/tests/component_tests/modbus_client/test_modbus_client.py
+++ b/tests/component_tests/modbus_client/test_modbus_client.py
@@ -7,11 +7,13 @@ guard is a safety property: these tests pin it to every handler slot.
 import pytest
 
 from esphome import config_validation as cv
+from esphome.components import modbus_client
 from esphome.components.modbus_client import (
     CONF_ON_NO_RESPONSE,
     CONF_ON_NOT_SENT,
     CONF_ON_SENT,
     CONF_PDU,
+    CONFIG_SCHEMA,
     MODBUS_CLIENT_SEND_SCHEMA,
 )
 from esphome.const import CONF_ADDRESS, CONF_ON_ERROR, CONF_ON_RESPONSE
@@ -114,3 +116,37 @@ def test_on_no_response_retry_lambda_accepted() -> None:
             },
         }
     )
+
+
+# The standalone component block. The compile fixtures cover the accepted shapes end to end; these pin
+# the parts a fixture cannot express - a rejection, and a module flag whose absence breaks other
+# components rather than this one.
+
+
+def test_component_requires_an_address() -> None:
+    """address identifies the device on the bus, so there is no sensible default."""
+    with pytest.raises(cv.Invalid, match=CONF_ADDRESS):
+        CONFIG_SCHEMA({})
+
+
+def test_component_accepts_an_address_alone() -> None:
+    """modbus_id is optional: it resolves to the single hub when only one is declared."""
+    config = CONFIG_SCHEMA({CONF_ADDRESS: 0x01})
+    assert config[CONF_ADDRESS] == 0x01
+
+
+def test_component_rejects_an_out_of_range_address() -> None:
+    """A Modbus device address is one byte."""
+    with pytest.raises(cv.Invalid):
+        CONFIG_SCHEMA({CONF_ADDRESS: 0x100})
+
+
+def test_multi_conf_no_default_is_set() -> None:
+    """Load-bearing: the modbus hub auto-loads this component to register its actions.
+
+    Without MULTI_CONF_NO_DEFAULT that auto-load builds a default entry, which then fails the required
+    address above - breaking every configuration that uses modbus but never declares a modbus_client
+    block. validate-autoload.esp32-idf.yaml covers the same path end to end; this names the reason.
+    """
+    assert modbus_client.MULTI_CONF is True
+    assert modbus_client.MULTI_CONF_NO_DEFAULT is True

--- a/tests/component_tests/modbus_client/test_modbus_client.py
+++ b/tests/component_tests/modbus_client/test_modbus_client.py
@@ -124,7 +124,7 @@ def test_on_no_response_retry_lambda_accepted() -> None:
 
 
 def test_component_requires_an_address() -> None:
-    """address identifies the device on the bus, so there is no sensible default."""
+    """The address identifies the device on the bus, so there is no sensible default."""
     with pytest.raises(cv.Invalid, match=CONF_ADDRESS):
         CONFIG_SCHEMA({CONF_ID: "bare_client"})
 

--- a/tests/components/modbus_client/common.yaml
+++ b/tests/components/modbus_client/common.yaml
@@ -5,6 +5,18 @@
 # device is retried forever. Reset the counter before the send or on a terminal outcome (on_response)
 # so the cap is per transaction, not per device lifetime. Never reset in on_sent: it fires again on
 # every retry, so the cap would never be reached.
+
+# The standalone component: a bare hub device with nothing but an address, so a lambda can drive the
+# device directly. Two entries cover both hub-binding paths - the auto-resolved single hub and an
+# explicit modbus_id - and the button below calls them, so the generated device has to be usable
+# rather than merely constructed (an unreferenced one is optimised away entirely).
+modbus_client:
+  - id: bare_client
+    address: 0x01
+  - id: bare_client_explicit_hub
+    modbus_id: modbus_bus
+    address: 0x02
+
 globals:
   - id: read_retries
     type: int
@@ -14,6 +26,15 @@ globals:
     initial_value: "0"
 
 button:
+  # The bare modbus_client devices: no handlers, so nothing reports the outcome - see the component
+  # comment. Calls here only pin that the device is bound to its hub and the helpers are reachable.
+  - platform: template
+    name: "Bare Client"
+    on_press:
+      - lambda: |-
+          id(bare_client).write_single_register(0x10, 42);
+          id(bare_client).write_single_coil(0x01, true);
+          id(bare_client_explicit_hub).read_holding_registers(0x20, 4);
   - platform: template
     name: "Send Read"
     on_press:

--- a/tests/components/modbus_client/validate-autoload.esp32-idf.yaml
+++ b/tests/components/modbus_client/validate-autoload.esp32-idf.yaml
@@ -1,0 +1,16 @@
+# The modbus hub auto-loads modbus_client so the modbus_client.* actions are registered. That must not
+# create a device on its own, which is what MULTI_CONF_NO_DEFAULT in the component buys: without it the
+# auto-load builds a default entry and fails on the required address, breaking every modbus config.
+# So this file deliberately declares no modbus_client: block - it is the no-block path, kept as its own
+# fixture because common.yaml now declares one.
+packages:
+  modbus: !include ../../test_build_components/common/modbus/esp32-idf.yaml
+
+button:
+  - platform: template
+    name: "Action without a component block"
+    on_press:
+      - modbus_client.read_holding_registers:
+          address: 0x01
+          start_address: 0x10
+          count: 1


### PR DESCRIPTION
This PR is part of a series of fixes for modbus and related components.

Core modbus architecture:
- #8032 -- in [2026.3.0](https://esphome.io/changelog/2026.3.0/)
- #15291 in [2026.4.0](https://esphome.io/changelog/2026.4.0/)
- #14172 in [2026.4.0](https://esphome.io/changelog/2026.4.0/)
- #15509 in [2026.5.0](https://esphome.io/changelog/2026.5.0/)
- #11969 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #11987 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #12376 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17378 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17282 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17434 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17377 (merged)
- #17844 (merged)
- #17846 (merged)
- #17854 (merged)
- #17848 (merged)
- #17859 (merged)
- #17435 (merged)
- #17888 (merged)
- #17886 (merged)
- #17922 (merged)
- #12421 (merge after 11781 & 12376)
- #12614 (merge after 17922)

Overhaul of modbus_controller
- #17677 (merged)
- #11781 (merge after 17435)
- #18071 (merge after 11781)
- #18080 (merge after 18071)
- #18082 (merge after 18080)
- #18085 (merge after 18082)

New features for server mode
- #17205 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17387 (merge ready)
- #17357 (merge ready)
- #17264 (merge ready)
- #17464 (merge after 17264)

New features for client mode
- #17467 (merge after 17434, 17387)
- #17676 (merge after 17922)
- #18078 (merge after 17676)
- #18146 (merge after 18078)

There are associated tests
- #14395 (tests 8032 above)
- #14845 (tests 11969 above)
- #17345 (tests 11781 above)

---

# What does this implement/fix?

Adds a `modbus_client:` configuration block that declares a bare
`modbus::ModbusClientDevice` bound to a hub and a device address — nothing else.
No polling, no entities, no automation wiring.

It exists so a lambda can talk to a device directly, without an entity or an
action wrapping every call:

```yaml
- lambda: "id(my_client).write_single_register(0x10, 42);"
```

The `modbus_client.*` actions remain the right choice when the reply matters, since
they carry the `on_response` / `on_error` handlers. This component does not override
the reply callbacks, so the base dispatch handles them and logs an unhandled reply
once per device.

No new C++ was needed: `ModbusClientDevice` is default-constructible with no pure
virtuals, so the existing `modbus_device_schema()` and
`register_modbus_client_device()` do all the wiring. The change is Python-only.

One detail worth flagging for review: `MULTI_CONF_NO_DEFAULT` is set because the
`modbus` hub carries `AUTO_LOAD = ["modbus_client"]` to publish the actions. Once
this component gained a `CONFIG_SCHEMA`, that auto-load would otherwise try to build
a device with no address and fail every existing modbus configuration. It is load-bearing,
not boilerplate.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- https://github.com/esphome/esphome.io/pull/7126

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Verified by compiling and linking the example below for the `host` platform, and by
inspecting the generated `main.cpp`:

```cpp
new(my_client) modbus::ModbusClientDevice();
my_client->set_parent(mb);
my_client->set_address(0x01);
```

Also confirmed that configurations which never declare a `modbus_client:` block still
validate, so the auto-load path is unaffected.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
uart:
  id: uart_bus
  tx_pin: 17
  rx_pin: 16
  baud_rate: 9600

modbus:
  uart_id: uart_bus
  id: mb

modbus_client:
  - id: my_client
    address: 0x01
  - id: other_client
    address: 0x02

button:
  - platform: template
    name: "Ad-hoc write"
    on_press:
      - lambda: |-
          id(my_client).write_single_register(0x10, 42);
          id(my_client).write_single_coil(0x01, true);
          id(other_client).read_holding_registers(0x20, 4);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).