### PR TITLE
[epaper] Add Waveshare 2.66in B epaper diaplay handling

### DIFF
--- a/esphome/components/epaper_spi/epaper_waveshare_b.h
+++ b/esphome/components/epaper_spi/epaper_waveshare_b.h
@@ -5,7 +5,8 @@ namespace esphome::epaper_spi {
 
 /**
  * Waveshare (B) series BWR e-paper displays using SSD1680-compatible controllers.
- * Waveshare uses 0=red, 1=no-red, the inverse of EPaperWeAct3C
+ * Adds the soft reset the controller expects after a hardware reset. Red plane polarity
+ * varies between panels in this series and is set per model via set_invert_red().
  */
 class EpaperWaveshareB : public EPaperWeAct3C {
  public:
@@ -13,7 +14,6 @@ class EpaperWaveshareB : public EPaperWeAct3C {
 
  protected:
   bool reset() override;
-  uint8_t transform_red_byte(uint8_t byte) const override { return static_cast<uint8_t>(~byte); }
 };
 
 }  // namespace esphome::epaper_spi

--- a/esphome/components/epaper_spi/epaper_weact_3c.h
+++ b/esphome/components/epaper_spi/epaper_weact_3c.h
@@ -24,6 +24,7 @@ class EPaperWeAct3C : public EPaperBase {
 
   void fill(Color color) override;
   void clear() override;
+  void set_invert_red(bool invert_red) { this->invert_red_ = invert_red; }
 
  protected:
   void set_window_();
@@ -35,8 +36,12 @@ class EPaperWeAct3C : public EPaperBase {
 
   bool transfer_data() override;
 
-  // Hook for subclasses to transform red plane bytes before they go on the wire.
-  virtual uint8_t transform_red_byte(uint8_t byte) const { return byte; }
+  // Some panels wire the red plane the other way round; models declare which.
+  uint8_t transform_red_byte(uint8_t byte) const {
+    return this->invert_red_ ? static_cast<uint8_t>(~byte) : byte;
+  }
+
+  bool invert_red_{false};
 };
 
 }  // namespace esphome::epaper_spi

--- a/esphome/components/epaper_spi/epaper_weact_3c.h
+++ b/esphome/components/epaper_spi/epaper_weact_3c.h
@@ -37,9 +37,7 @@ class EPaperWeAct3C : public EPaperBase {
   bool transfer_data() override;
 
   // Some panels wire the red plane the other way round; models declare which.
-  uint8_t transform_red_byte(uint8_t byte) const {
-    return this->invert_red_ ? static_cast<uint8_t>(~byte) : byte;
-  }
+  uint8_t transform_red_byte(uint8_t byte) const { return this->invert_red_ ? static_cast<uint8_t>(~byte) : byte; }
 
   bool invert_red_{false};
 };

--- a/esphome/components/epaper_spi/models/waveshare_b.py
+++ b/esphome/components/epaper_spi/models/waveshare_b.py
@@ -15,7 +15,11 @@ class WaveshareB(EpaperModel):
             (0x11, 0x03),  # Data entry mode
             (0x3C, 0x05),  # Border waveform
             (0x18, 0x80),  # Internal temperature sensor
-            (0x21, self.get_default("ram_option", 0x80), 0x80),  # Display update control
+            (
+                0x21,
+                self.get_default("ram_option", 0x80),
+                0x80,
+            ),  # Display update control
         )
 
     async def to_code(self, var, config):

--- a/esphome/components/epaper_spi/models/waveshare_b.py
+++ b/esphome/components/epaper_spi/models/waveshare_b.py
@@ -1,3 +1,5 @@
+import esphome.codegen as cg
+
 from . import EpaperModel
 
 
@@ -13,8 +15,12 @@ class WaveshareB(EpaperModel):
             (0x11, 0x03),  # Data entry mode
             (0x3C, 0x05),  # Border waveform
             (0x18, 0x80),  # Internal temperature sensor
-            (0x21, 0x80, 0x80),  # Display update control
+            (0x21, self.get_default("ram_option", 0x80), 0x80),  # Display update control
         )
+
+    async def to_code(self, var, config):
+        cg.add(var.set_invert_red(self.get_default("invert_red", False)))
+        return config
 
 
 WaveshareB(
@@ -23,4 +29,16 @@ WaveshareB(
     height=250,
     data_rate="10MHz",
     minimum_update_interval="1s",
+    invert_red=True,
+)
+
+# Waveshare 2.66" B, SSD1680Z8. The red plane is not inverted on this panel, and byte A of
+# the display update control differs from the 2.13" model.
+WaveshareB(
+    "waveshare-2.66in-b",
+    width=152,
+    height=296,
+    data_rate="10MHz",
+    minimum_update_interval="30s",  # a full tri-color refresh takes ~15s at 23C
+    ram_option=0x00,
 )

--- a/tests/components/epaper_spi/test.esp32-s3-idf.yaml
+++ b/tests/components/epaper_spi/test.esp32-s3-idf.yaml
@@ -191,6 +191,27 @@ display:
       it.circle(it.get_width() / 2, it.get_height() / 2, 20, Color::BLACK);
       it.circle(it.get_width() / 2, it.get_height() / 2, 15, Color(255, 0, 0));
 
+  # Waveshare 2.66" B series 3-color e-paper (152x296, BWR, SSD1680)
+  - platform: epaper_spi
+    spi_id: spi_bus
+    model: waveshare-2.66in-b
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO5
+    dc_pin:
+      allow_other_uses: true
+      number: GPIO17
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO16
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO4
+    lambda: |-
+      it.filled_rectangle(0, 0, it.get_width(), it.get_height(), Color::WHITE);
+      it.circle(it.get_width() / 2, it.get_height() / 2, 20, Color::BLACK);
+      it.circle(it.get_width() / 2, it.get_height() / 2, 15, Color(255, 0, 0));
+
   # Soldered Inkplate 2 3-color e-paper (104x212, BWR)
   - platform: epaper_spi
     spi_id: spi_bus


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the Waveshare 2.66in E-Paper B display (black/white/red) to the `epaper_spi` component. This is the same panel used on the Waveshare Pico-ePaper-2.66-B, driven over SPI with separate black and red data transmission commands.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- [esphome/esphome.io#7124](https://github.com/esphome/esphome.io/pull/7124)

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
font:
  - file: 'gfonts://Michroma'
    id: font1
    size: 20

spi:
  clk_pin: GPIO04
  mosi_pin: GPIO05

display:
  - platform: waveshare_epaper
    cs_pin: GPIO03
    dc_pin: GPIO02
    rotation: 90
    busy_pin: 
      number: GPIO07
      inverted: true
    reset_pin: GPIO06
    model: 2.66in-b
    update_interval: 40s
    lambda: |-
          const auto BLACK = Color(0,   0,   0,   0);
          const auto RED   = Color(255, 0,   0,   0);

          it.fill(COLOR_ON);

          const int W = it.get_width();
          const int H = it.get_height();

          it.rectangle(0, 0, W, H, BLACK);

          for (int x = 0; x < W; x += 10) {
            it.line(x, 0, x, (x % 50 == 0) ? 9 : 4, BLACK);
          }

          for (int y = 0; y < H; y += 10) {
            it.line(0, y, (y % 50 == 0) ? 9 : 4, y, BLACK);
          }


          it.line(0, 0, W - 1, H - 1, BLACK);


          it.filled_rectangle(0, 0, 8, 8, RED);
          it.filled_rectangle(W - 8, H - 8, 8, 8, BLACK);


          it.printf(W / 2, H / 2, id(font_lg), BLACK, TextAlign::CENTER,
                    "%dx%d", W, H);
```
<img width="3024" height="4032" alt="IMG_6972" src="https://github.com/user-attachments/assets/a6a32ba5-de90-49c2-bd67-d29ab8a506bd" />


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
