### PR TITLE
[rp2040_ble] Add scan arbitration and GATT client hooks

### DIFF
--- a/esphome/components/rp2040_ble/rp2040_ble.cpp
+++ b/esphome/components/rp2040_ble/rp2040_ble.cpp
@@ -57,6 +57,17 @@ void RP2040BLE::enable() {
     l2cap_init();
     sm_init();
 
+#ifdef USE_BLE_GATT_CLIENT
+    gatt_client_init();
+    // The GATT engine kicks the MTU exchange explicitly right after a
+    // connection completes (auto negotiation would only run on the first
+    // query, which a with-cache connection never issues).
+    gatt_client_mtu_enable_auto_negotiation(0);
+    // Just-works security for peripheral-initiated pairing.
+    sm_set_io_capabilities(IO_CAPABILITY_NO_INPUT_NO_OUTPUT);
+    sm_set_authentication_requirements(SM_AUTHREQ_BONDING);
+#endif
+
     this->hci_event_callback_registration_.callback = &RP2040BLE::packet_handler;
     hci_add_event_handler(&this->hci_event_callback_registration_);
 
@@ -215,6 +226,17 @@ bool RP2040BLE::scan_start(uint16_t interval, uint16_t window, bool active) {
     // the moment a tracker retries. Callers retry until the stack is up.
     return false;
   }
+#ifdef USE_BLE_GATT_CLIENT
+  this->scan_interval_ = interval;
+  this->scan_window_ = window;
+  this->scan_active_ = active;
+  this->scan_desired_ = true;
+  if (this->scan_inhibit_count_ > 0) {
+    // A connect attempt owns the radio; the scan starts physically when the
+    // inhibit is released. Report success — the controller will run it.
+    return true;
+  }
+#endif
   // Serialize with the BTstack background worker (arduino-pico's BluetoothHCI
   // takes the same lock around its gap_* calls).
   BluetoothLock lock;
@@ -224,12 +246,41 @@ bool RP2040BLE::scan_start(uint16_t interval, uint16_t window, bool active) {
 }
 
 void RP2040BLE::scan_stop() {
+#ifdef USE_BLE_GATT_CLIENT
+  this->scan_desired_ = false;
+#endif
   if (!this->is_active()) {
     return;  // nothing can be scanning on a stack that is not up
   }
   BluetoothLock lock;
   gap_stop_scan();
 }
+
+#ifdef USE_BLE_GATT_CLIENT
+void RP2040BLE::inhibit_scan() {
+  if (this->scan_inhibit_count_++ != 0) {
+    return;  // another connect attempt already owns the radio
+  }
+  if (this->scan_desired_ && this->is_active()) {
+    BluetoothLock lock;
+    gap_stop_scan();
+  }
+}
+
+void RP2040BLE::release_scan_inhibit() {
+  if (this->scan_inhibit_count_ == 0) {
+    return;
+  }
+  this->scan_inhibit_count_--;
+  if (this->scan_inhibit_count_ != 0) {
+    return;
+  }
+  if (this->scan_desired_) {
+    // One physical-start path: scan_start re-applies the remembered params.
+    this->scan_start(this->scan_interval_, this->scan_window_, this->scan_active_);
+  }
+}
+#endif  // USE_BLE_GATT_CLIENT
 
 }  // namespace esphome::rp2040_ble
 

--- a/esphome/components/rp2040_ble/rp2040_ble.cpp
+++ b/esphome/components/rp2040_ble/rp2040_ble.cpp
@@ -229,11 +229,12 @@ bool RP2040BLE::scan_start(uint16_t interval, uint16_t window, bool active) {
 #ifdef USE_BLE_GATT_CLIENT
   this->scan_interval_ = interval;
   this->scan_window_ = window;
-  this->scan_active_ = active;
+  this->scan_active_mode_ = active;
   this->scan_desired_ = true;
   if (this->scan_inhibit_count_ > 0) {
     // A connect attempt owns the radio; the scan starts physically when the
     // inhibit is released. Report success — the controller will run it.
+    ESP_LOGV(TAG, "Scan start deferred (connect in progress)");
     return true;
   }
 #endif
@@ -277,7 +278,7 @@ void RP2040BLE::release_scan_inhibit() {
   }
   if (this->scan_desired_) {
     // One physical-start path: scan_start re-applies the remembered params.
-    this->scan_start(this->scan_interval_, this->scan_window_, this->scan_active_);
+    this->scan_start(this->scan_interval_, this->scan_window_, this->scan_active_mode_);
   }
 }
 #endif  // USE_BLE_GATT_CLIENT

--- a/esphome/components/rp2040_ble/rp2040_ble.h
+++ b/esphome/components/rp2040_ble/rp2040_ble.h
@@ -91,12 +91,23 @@ class RP2040BLE final : public Component {
   /// (0.625 ms). Returns false until the stack is ACTIVE (callers retry — the
   /// tracker's rate-limited retry loop); powering the stack on stays with the
   /// user (enable_on_boot or an explicit enable() call). The controller keeps
-  /// no scan state: a disable()/enable() power cycle ends the scan, and the
-  /// caller must call scan_start() again once the stack is back to ACTIVE
-  /// (the tracker's loop() reconciliation does exactly that).
+  /// no scan state across power cycles: a disable()/enable() cycle ends the
+  /// scan, and the caller must call scan_start() again once the stack is back
+  /// to ACTIVE (the tracker's loop() reconciliation does exactly that).
+  /// While a GATT connect attempt has the scan inhibited, the desired scan is
+  /// remembered and started physically when the inhibit is released.
   bool scan_start(uint16_t interval, uint16_t window, bool active);
   /// Stop the controller scan (no-op when not scanning).
   void scan_stop();
+
+#ifdef USE_BLE_GATT_CLIENT
+  /// Pause the physical scan for the duration of a GATT connect attempt
+  /// (initiating and scanning contend for the radio). The desired scan state
+  /// set through scan_start()/scan_stop() is remembered and reconciled by
+  /// release_scan_inhibit().
+  void inhibit_scan();
+  void release_scan_inhibit();
+#endif
 
  protected:
   static void packet_handler(uint8_t type, uint16_t channel, uint8_t *packet, uint16_t size);
@@ -128,6 +139,16 @@ class RP2040BLE final : public Component {
   bool enable_on_boot_{true};
   bool btstack_initialized_{false};
   bool active_logged_{false};
+#ifdef USE_BLE_GATT_CLIENT
+  // Remembered scan intent, so connect attempts can pause the physical scan
+  // and restore it afterwards without involving the tracker. Counted so
+  // overlapping connect attempts compose once multiple slots exist.
+  uint16_t scan_interval_{0};
+  uint16_t scan_window_{0};
+  uint8_t scan_inhibit_count_{0};
+  bool scan_active_{false};
+  bool scan_desired_{false};
+#endif
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/rp2040_ble/rp2040_ble.h
+++ b/esphome/components/rp2040_ble/rp2040_ble.h
@@ -104,7 +104,8 @@ class RP2040BLE final : public Component {
   /// Pause the physical scan for the duration of a GATT connect attempt
   /// (initiating and scanning contend for the radio). The desired scan state
   /// set through scan_start()/scan_stop() is remembered and reconciled by
-  /// release_scan_inhibit().
+  /// release_scan_inhibit(). Holders must guarantee the release on every
+  /// abort path (the GATT engine reclaims via its connect timeout).
   void inhibit_scan();
   void release_scan_inhibit();
 #endif
@@ -146,7 +147,7 @@ class RP2040BLE final : public Component {
   uint16_t scan_interval_{0};
   uint16_t scan_window_{0};
   uint8_t scan_inhibit_count_{0};
-  bool scan_active_{false};
+  bool scan_active_mode_{false};
   bool scan_desired_{false};
 #endif
 };


### PR DESCRIPTION
# What does this implement/fix?

Prepares rp2040_ble for the BTstack GATT client backend in the next PR of this series. Scan arbitration lets a connect attempt pause the scanner and hand the radio back afterwards through one physical start path that reapplies the remembered parameters; the enable hooks initialize the GATT client with auto MTU negotiation disabled and configure just works security. Everything is compiled out unless a backend defines USE_BLE_GATT_CLIENT, so current builds are unchanged. Split out of #18131, which consumes these hooks; the series is #18130 (platform neutral GATT dispatch), #18131 (BTstack backend) and #18132 (enable active on rp2), building on the merged #18127, #18142, #18128, #18129 and #18150/#18154.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
