### PR TITLE
[ble_device_base] Migrate BLE sensor platforms to the neutral layer (batch 4: ruuvi_ble, ruuvitag, b_parasite)

### DIFF
--- a/esphome/components/b_parasite/b_parasite.cpp
+++ b/esphome/components/b_parasite/b_parasite.cpp
@@ -1,8 +1,6 @@
 #include "b_parasite.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::b_parasite {
 
 static const char *const TAG = "b_parasite";
@@ -16,7 +14,7 @@ void BParasite::dump_config() {
   LOG_SENSOR("  ", "Illuminance", this->illuminance_);
 }
 
-bool BParasite::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool BParasite::parse_device(const ble_device_base::ESPBTDevice &device) {
   if (device.address_uint64() != address_) {
     ESP_LOGVV(TAG, "parse_device(): unknown MAC address.");
     return false;
@@ -113,5 +111,3 @@ bool BParasite::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
 }
 
 }  // namespace esphome::b_parasite
-
-#endif  // USE_ESP32

--- a/esphome/components/b_parasite/b_parasite.h
+++ b/esphome/components/b_parasite/b_parasite.h
@@ -2,18 +2,16 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
-
-#ifdef USE_ESP32
+#include "esphome/components/ble_device_base/ble_device.h"
 
 namespace esphome::b_parasite {
 
-class BParasite final : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
+class BParasite final : public Component, public ble_device_base::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
   void set_bindkey(const std::string &bindkey);
 
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
   void dump_config() override;
 
   void set_battery_voltage(sensor::Sensor *battery_voltage) { battery_voltage_ = battery_voltage; }
@@ -35,5 +33,3 @@ class BParasite final : public Component, public esp32_ble_tracker::ESPBTDeviceL
 };
 
 }  // namespace esphome::b_parasite
-
-#endif  // USE_ESP32

--- a/esphome/components/b_parasite/sensor.py
+++ b/esphome/components/b_parasite/sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker, sensor
+from esphome.components import ble_device_base, sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BATTERY_VOLTAGE,
@@ -23,14 +23,15 @@ from esphome.const import (
 
 CODEOWNERS = ["@rbaron"]
 
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 
 b_parasite_ns = cg.esphome_ns.namespace("b_parasite")
 BParasite = b_parasite_ns.class_(
-    "BParasite", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
+    "BParasite", ble_device_base.ESPBTDeviceListener, cg.Component
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("b_parasite"),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(BParasite),
@@ -68,15 +69,15 @@ CONFIG_SCHEMA = (
             ),
         }
     )
-    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_device_base.BLE_DEVICE_SCHEMA),
 )
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)
 
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
 

--- a/esphome/components/ruuvi_ble/__init__.py
+++ b/esphome/components/ruuvi_ble/__init__.py
@@ -1,22 +1,25 @@
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker
+from esphome.components import ble_device_base
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 
 ruuvi_ble_ns = cg.esphome_ns.namespace("ruuvi_ble")
 RuuviListener = ruuvi_ble_ns.class_(
-    "RuuviListener", esp32_ble_tracker.ESPBTDeviceListener
+    "RuuviListener", ble_device_base.ESPBTDeviceListener
 )
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(RuuviListener),
-    }
-).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
+CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("ruuvi_ble"),
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(RuuviListener),
+        }
+    ).extend(ble_device_base.BLE_DEVICE_SCHEMA),
+)
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -1,13 +1,11 @@
 #include "ruuvi_ble.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::ruuvi_ble {
 
 static const char *const TAG = "ruuvi_ble";
 
-bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviParseResult &result) {
+bool parse_ruuvi_data_byte(const ble_device_base::adv_data_t &adv_data, RuuviParseResult &result) {
   const uint8_t data_type = adv_data[0];
   const auto *data = &adv_data[1];
   switch (data_type) {
@@ -80,7 +78,7 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       return false;
   }
 }
-optional<RuuviParseResult> parse_ruuvi(const esp32_ble_tracker::ESPBTDevice &device) {
+optional<RuuviParseResult> parse_ruuvi(const ble_device_base::ESPBTDevice &device) {
   bool success = false;
   RuuviParseResult result{};
   for (auto &it : device.get_manufacturer_datas()) {
@@ -96,7 +94,7 @@ optional<RuuviParseResult> parse_ruuvi(const esp32_ble_tracker::ESPBTDevice &dev
   return result;
 }
 
-bool RuuviListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool RuuviListener::parse_device(const ble_device_base::ESPBTDevice &device) {
   auto res = parse_ruuvi(device);
   if (!res.has_value())
     return false;
@@ -142,5 +140,3 @@ bool RuuviListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
 }
 
 }  // namespace esphome::ruuvi_ble
-
-#endif

--- a/esphome/components/ruuvi_ble/ruuvi_ble.h
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
-
-#ifdef USE_ESP32
+#include "esphome/components/ble_device_base/ble_device.h"
 
 namespace esphome::ruuvi_ble {
 
@@ -23,13 +21,11 @@ struct RuuviParseResult {
 
 bool parse_ruuvi_data_byte(uint8_t data_type, const uint8_t *data, uint8_t data_length, RuuviParseResult &result);
 
-optional<RuuviParseResult> parse_ruuvi(const esp32_ble_tracker::ESPBTDevice &device);
+optional<RuuviParseResult> parse_ruuvi(const ble_device_base::ESPBTDevice &device);
 
-class RuuviListener final : public esp32_ble_tracker::ESPBTDeviceListener {
+class RuuviListener final : public ble_device_base::ESPBTDeviceListener {
  public:
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
 };
 
 }  // namespace esphome::ruuvi_ble
-
-#endif

--- a/esphome/components/ruuvitag/ruuvitag.cpp
+++ b/esphome/components/ruuvitag/ruuvitag.cpp
@@ -1,8 +1,6 @@
 #include "ruuvitag.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::ruuvitag {
 
 static const char *const TAG = "ruuvitag";
@@ -23,5 +21,3 @@ void RuuviTag::dump_config() {
 }
 
 }  // namespace esphome::ruuvitag
-
-#endif

--- a/esphome/components/ruuvitag/ruuvitag.h
+++ b/esphome/components/ruuvitag/ruuvitag.h
@@ -2,18 +2,16 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 #include "esphome/components/ruuvi_ble/ruuvi_ble.h"
-
-#ifdef USE_ESP32
 
 namespace esphome::ruuvitag {
 
-class RuuviTag final : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
+class RuuviTag final : public Component, public ble_device_base::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; }
 
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override {
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override {
     if (device.address_uint64() != this->address_)
       return false;
 
@@ -77,5 +75,3 @@ class RuuviTag final : public Component, public esp32_ble_tracker::ESPBTDeviceLi
 };
 
 }  // namespace esphome::ruuvitag
-
-#endif

--- a/esphome/components/ruuvitag/sensor.py
+++ b/esphome/components/ruuvitag/sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker, sensor
+from esphome.components import ble_device_base, sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ACCELERATION,
@@ -35,15 +35,15 @@ from esphome.const import (
     UNIT_VOLT,
 )
 
-DEPENDENCIES = ["esp32_ble_tracker"]
-AUTO_LOAD = ["ruuvi_ble"]
+AUTO_LOAD = ["ble_device_base", "ruuvi_ble"]
 
 ruuvitag_ns = cg.esphome_ns.namespace("ruuvitag")
 RuuviTag = ruuvitag_ns.class_(
-    "RuuviTag", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
+    "RuuviTag", ble_device_base.ESPBTDeviceListener, cg.Component
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("ruuvitag"),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(RuuviTag),
@@ -116,15 +116,15 @@ CONFIG_SCHEMA = (
             ),
         }
     )
-    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_device_base.BLE_DEVICE_SCHEMA),
 )
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)
 
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
 

--- a/tests/components/b_parasite/common-ln.yaml
+++ b/tests/components/b_parasite/common-ln.yaml
@@ -1,0 +1,7 @@
+sensor:
+  - platform: b_parasite
+    mac_address: F0:CA:F0:CA:01:01
+    humidity:
+      name: b-parasite Air Humidity
+    temperature:
+      name: b-parasite Air Temperature

--- a/tests/components/b_parasite/test.ln882x-ard.yaml
+++ b/tests/components/b_parasite/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  b_parasite: !include common-ln.yaml

--- a/tests/components/b_parasite/validate.bk72xx-ard.yaml
+++ b/tests/components/b_parasite/validate.bk72xx-ard.yaml
@@ -1,4 +1,7 @@
-esp32_ble_tracker:
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
   id: ble_tracker_hub
 
 sensor:
@@ -16,3 +19,8 @@ sensor:
       name: b-parasite Battery Voltage
     illuminance:
       name: b-parasite Illuminance
+  # No ble_hub_id: exercises the generated binding real configs use.
+  - platform: b_parasite
+    mac_address: F0:CA:F0:CA:01:02
+    temperature:
+      name: BK b-parasite Implicit Temperature

--- a/tests/components/ruuvi_ble/common-ln.yaml
+++ b/tests/components/ruuvi_ble/common-ln.yaml
@@ -1,0 +1,1 @@
+ruuvi_ble:

--- a/tests/components/ruuvi_ble/common.yaml
+++ b/tests/components/ruuvi_ble/common.yaml
@@ -1,3 +1,6 @@
 esp32_ble_tracker:
+  id: ble_tracker_hub
 
+# Explicit ble_hub_id: pins the neutral binding as a declared key.
 ruuvi_ble:
+  ble_hub_id: ble_tracker_hub

--- a/tests/components/ruuvi_ble/test.ln882x-ard.yaml
+++ b/tests/components/ruuvi_ble/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  ruuvi_ble: !include common-ln.yaml

--- a/tests/components/ruuvi_ble/validate.bk72xx-ard.yaml
+++ b/tests/components/ruuvi_ble/validate.bk72xx-ard.yaml
@@ -1,0 +1,9 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_tracker_hub
+
+# Explicit ble_hub_id: pins the neutral binding as a declared key.
+ruuvi_ble:
+  ble_hub_id: ble_tracker_hub

--- a/tests/components/ruuvitag/common-ln.yaml
+++ b/tests/components/ruuvitag/common-ln.yaml
@@ -1,0 +1,7 @@
+sensor:
+  - platform: ruuvitag
+    mac_address: FF:56:D3:2F:7D:E8
+    humidity:
+      name: RuuviTag Humidity
+    temperature:
+      name: RuuviTag Temperature

--- a/tests/components/ruuvitag/test.ln882x-ard.yaml
+++ b/tests/components/ruuvitag/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  ruuvitag: !include common-ln.yaml

--- a/tests/components/ruuvitag/validate.bk72xx-ard.yaml
+++ b/tests/components/ruuvitag/validate.bk72xx-ard.yaml
@@ -1,4 +1,7 @@
-esp32_ble_tracker:
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
   id: ble_tracker_hub
 
 sensor:
@@ -28,3 +31,8 @@ sensor:
       name: RuuviTag Movement Counter
     measurement_sequence_number:
       name: RuuviTag Measurement Sequence Number
+  # No ble_hub_id: exercises the generated binding real configs use.
+  - platform: ruuvitag
+    mac_address: FF:56:D3:2F:7D:E9
+    temperature:
+      name: BK RuuviTag Implicit Temperature


### PR DESCRIPTION
# What does this implement/fix?

**Batch 4 of 13** of the neutral-layer BLE sensor migration — the series is defined and reviewed in #17716 (batch 1, merged). The shared `ble_device_base` enablers landed in #18081. This branch is cut against merged dev and carries only the three platform migrations. Per review direction: batches of up to 3 similar platforms, **one PR open for review at a time** — 

## What migrates in this batch

**`ruuvi_ble`** (the shared advertisement parser), **`ruuvitag`** and **`b_parasite`**.

Same uniform recipe as #17716: python `DEPENDENCIES` → `AUTO_LOAD ["ble_device_base"]`, schema extends `ble_device_base.BLE_DEVICE_SCHEMA` with `rename_legacy_hub_id` prepended, registration via `ble_device_base.register_ble_device`, C++ `esp32_ble_tracker::` → `ble_device_base::`, `USE_ESP32` guards dropped.

Fixtures: all three `common.yaml` files gain `id: ble_tracker_hub` and pin `ble_hub_id:` on one entry; new per-platform `common-ln.yaml` + `test.ln882x-ard.yaml` compile the guard-free C++ on LN882H (`ruuvitag` build verified, exit 0); new config-only `validate.bk72xx-ard.yaml` fixtures, with `ruuvitag` and `b_parasite` also covering the generated binding.

## Batch roadmap

| Batch | Where | Platforms |
|---|---|---|
| 1 | #17716 (merged) | `ble_presence`, `ble_rssi`, `ble_scanner` + shared `ble_device_base` enablers |
| 2 | #17950 (merged) | `atc_mithermometer`, `pvvx_mithermometer`, `bthome_mithermometer` |
| 3 | #17951 (merged) | `mopeka_ble`, `mopeka_pro_check`, `mopeka_std_check` |
| 4 | this PR | `ruuvi_ble`, `ruuvitag`, `b_parasite` |
| 5 | branch [`ble-sensors-batch5`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch5) | `airthings_ble`, `inkbird_ibsth1_mini`, `radon_eye_ble` |
| 6 | branch [`ble-sensors-batch6`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch6) | `thermopro_ble`, `exposure_notifications`, `xiaomi_ble` (shared hub; portable AES-CCM) |
| 7 | branch [`ble-sensors-batch7`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch7) | `xiaomi_cgd1`, `xiaomi_cgdk2`, `xiaomi_cgg1` |
| 8 | branch [`ble-sensors-batch8`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch8) | `xiaomi_cgpr1`, `xiaomi_gcls002`, `xiaomi_hhccjcy01` |
| 9 | branch [`ble-sensors-batch9`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch9) | `xiaomi_hhccjcy10`, `xiaomi_hhccpot002`, `xiaomi_jqjcy01ym` |
| 10 | branch [`ble-sensors-batch10`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch10) | `xiaomi_lywsd02`, `xiaomi_lywsd02mmc`, `xiaomi_lywsd03mmc` |
| 11 | branch [`ble-sensors-batch11`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch11) | `xiaomi_lywsdcgq`, `xiaomi_mhoc303`, `xiaomi_mhoc401` |
| 12 | branch [`ble-sensors-batch12`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch12) | `xiaomi_miscale`, `xiaomi_mjyd02yla`, `xiaomi_mue4094rt` |
| 13 | branch [`ble-sensors-batch13`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch13) | `xiaomi_rtcgq02lm`, `xiaomi_wx08zm`, `xiaomi_xmwsdj04mmc` |

Each batch is a single commit cut from the same validated full-migration tree, so the series is complete by construction (batch 1 + batches 2–13 = all 39 platforms). A batch PR flips from draft to ready only when the previous one merges — one PR open for review at a time per the direction on #17716.

## Breaking changes and migration

Same as the rest of the series: the auto-generated per-sensor tracker reference `esp32_ble_id:` becomes `ble_hub_id:` on the migrated platforms. Most configurations are unaffected: the key is auto-generated and only written explicitly to disambiguate multiple trackers. Configurations that do set it rename the key:

```yaml
# before
sensor:
  - platform: ruuvitag
    esp32_ble_id: my_tracker
    mac_address: "FF:56:D3:2F:7D:E8"
    temperature:
      name: "RuuviTag Temperature"

# after
sensor:
  - platform: ruuvitag
    ble_hub_id: my_tracker
    mac_address: "FF:56:D3:2F:7D:E8"
    temperature:
      name: "RuuviTag Temperature"
```

The transitional alias (`ble_device_base.rename_legacy_hub_id`) warns and auto-migrates an explicit `esp32_ble_id:` until 2027.2.0, so existing configurations keep validating through the rename window.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Design discussion: https://github.com/esphome/esphome/discussions/3758
- Series: #17716

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7128
- esphome/esphome.io#7024

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#164

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: ruuvitag
    mac_address: "FF:56:D3:2F:7D:E8"
    temperature:
      name: "RuuviTag Temperature"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).





