### PR TITLE
[ble_device_base] Migrate BLE sensor platforms to the neutral layer (batch 5: airthings_ble, inkbird_ibsth1_mini, radon_eye_ble)

### DIFF
--- a/esphome/components/airthings_ble/__init__.py
+++ b/esphome/components/airthings_ble/__init__.py
@@ -1,23 +1,26 @@
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker
+from esphome.components import ble_device_base
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 CODEOWNERS = ["@jeromelaban"]
 
 airthings_ble_ns = cg.esphome_ns.namespace("airthings_ble")
 AirthingsListener = airthings_ble_ns.class_(
-    "AirthingsListener", esp32_ble_tracker.ESPBTDeviceListener
+    "AirthingsListener", ble_device_base.ESPBTDeviceListener
 )
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(AirthingsListener),
-    }
-).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
+CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("airthings_ble"),
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(AirthingsListener),
+        }
+    ).extend(ble_device_base.BLE_DEVICE_SCHEMA),
+)
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)

--- a/esphome/components/airthings_ble/airthings_listener.cpp
+++ b/esphome/components/airthings_ble/airthings_listener.cpp
@@ -2,15 +2,13 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-#ifdef USE_ESP32
-
 namespace esphome::airthings_ble {
 
 static const char *const TAG = "airthings_ble";
 
-bool AirthingsListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool AirthingsListener::parse_device(const ble_device_base::ESPBTDevice &device) {
   for (auto &it : device.get_manufacturer_datas()) {
-    if (it.uuid == esp32_ble_tracker::ESPBTUUID::from_uint32(0x0334)) {
+    if (it.uuid == ble_device_base::ESPBTUUID::from_uint32(0x0334)) {
       if (it.data.size() < 4)
         continue;
 
@@ -29,5 +27,3 @@ bool AirthingsListener::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
 }
 
 }  // namespace esphome::airthings_ble
-
-#endif

--- a/esphome/components/airthings_ble/airthings_listener.h
+++ b/esphome/components/airthings_ble/airthings_listener.h
@@ -1,17 +1,13 @@
 #pragma once
 
-#ifdef USE_ESP32
-
 #include "esphome/core/component.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 
 namespace esphome::airthings_ble {
 
-class AirthingsListener final : public esp32_ble_tracker::ESPBTDeviceListener {
+class AirthingsListener final : public ble_device_base::ESPBTDeviceListener {
  public:
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
 };
 
 }  // namespace esphome::airthings_ble
-
-#endif

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -1,8 +1,6 @@
 #include "inkbird_ibsth1_mini.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::inkbird_ibsth1_mini {
 
 static const char *const TAG = "inkbird_ibsth1_mini";
@@ -15,7 +13,7 @@ void InkbirdIbstH1Mini::dump_config() {
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);
 }
 
-bool InkbirdIbstH1Mini::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool InkbirdIbstH1Mini::parse_device(const ble_device_base::ESPBTDevice &device) {
   // The below is based on my research and reverse engineering of a single device
   // It is entirely possible that some of that may be inaccurate or incomplete
 
@@ -32,7 +30,7 @@ bool InkbirdIbstH1Mini::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
     ESP_LOGVV(TAG, "parse_device(): unknown MAC address.");
     return false;
   }
-  if (device.get_address_type() != BLE_ADDR_TYPE_PUBLIC) {
+  if (device.get_address_type() != ble_device_base::BLE_ADDR_TYPE_PUBLIC) {
     ESP_LOGVV(TAG, "parse_device(): address is not public");
     return false;
   }
@@ -46,7 +44,7 @@ bool InkbirdIbstH1Mini::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
     return false;
   }
   const auto &mnf_data = mnf_datas[0];
-  if (mnf_data.uuid.get_uuid().len != ESP_UUID_LEN_16) {
+  if (mnf_data.uuid.type() != ble_device_base::ESPBTUUID::Type::UUID16) {
     ESP_LOGVV(TAG, "parse_device(): manufacturer data element is expected to have uuid of length 16");
     return false;
   }
@@ -71,7 +69,7 @@ bool InkbirdIbstH1Mini::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
   auto external_temperature = NAN;
 
   // Read bluetooth data into variable
-  auto measured_temperature = ((int16_t) mnf_data.uuid.get_uuid().uuid.uuid16) / 100.0f;
+  auto measured_temperature = ((int16_t) mnf_data.uuid.uuid16()) / 100.0f;
 
   // Set temperature or external_temperature based on which sensor is in use
   if (mnf_data.data[2] == 0) {
@@ -104,5 +102,3 @@ bool InkbirdIbstH1Mini::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
 }
 
 }  // namespace esphome::inkbird_ibsth1_mini
-
-#endif

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
@@ -2,17 +2,15 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
-
-#ifdef USE_ESP32
+#include "esphome/components/ble_device_base/ble_device.h"
 
 namespace esphome::inkbird_ibsth1_mini {
 
-class InkbirdIbstH1Mini final : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
+class InkbirdIbstH1Mini final : public Component, public ble_device_base::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; }
 
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
 
   void dump_config() override;
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
@@ -29,5 +27,3 @@ class InkbirdIbstH1Mini final : public Component, public esp32_ble_tracker::ESPB
 };
 
 }  // namespace esphome::inkbird_ibsth1_mini
-
-#endif

--- a/esphome/components/inkbird_ibsth1_mini/sensor.py
+++ b/esphome/components/inkbird_ibsth1_mini/sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker, sensor
+from esphome.components import ble_device_base, sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BATTERY_LEVEL,
@@ -18,14 +18,15 @@ from esphome.const import (
 )
 
 CODEOWNERS = ["@fkirill"]
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 
 inkbird_ibsth1_mini_ns = cg.esphome_ns.namespace("inkbird_ibsth1_mini")
 InkbirdIbstH1Mini = inkbird_ibsth1_mini_ns.class_(
-    "InkbirdIbstH1Mini", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
+    "InkbirdIbstH1Mini", ble_device_base.ESPBTDeviceListener, cg.Component
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("inkbird_ibsth1_mini"),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(InkbirdIbstH1Mini),
@@ -57,15 +58,15 @@ CONFIG_SCHEMA = (
             ),
         }
     )
-    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_device_base.BLE_DEVICE_SCHEMA),
 )
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)
 
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
 

--- a/esphome/components/radon_eye_ble/__init__.py
+++ b/esphome/components/radon_eye_ble/__init__.py
@@ -1,23 +1,26 @@
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker
+from esphome.components import ble_device_base
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 CODEOWNERS = ["@jeffeb3"]
 
 radon_eye_ble_ns = cg.esphome_ns.namespace("radon_eye_ble")
 RadonEyeListener = radon_eye_ble_ns.class_(
-    "RadonEyeListener", esp32_ble_tracker.ESPBTDeviceListener
+    "RadonEyeListener", ble_device_base.ESPBTDeviceListener
 )
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(RadonEyeListener),
-    }
-).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
+CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("radon_eye_ble"),
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(RadonEyeListener),
+        }
+    ).extend(ble_device_base.BLE_DEVICE_SCHEMA),
+)
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)

--- a/esphome/components/radon_eye_ble/radon_eye_listener.cpp
+++ b/esphome/components/radon_eye_ble/radon_eye_listener.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::radon_eye_ble {
 
 static const char *const TAG = "radon_eye_ble";
 
-bool RadonEyeListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool RadonEyeListener::parse_device(const ble_device_base::ESPBTDevice &device) {
   // Radon Eye devices have names starting with "FR:"
   if (device.get_name().starts_with("FR:")) {
     char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
@@ -19,5 +17,3 @@ bool RadonEyeListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device
 }
 
 }  // namespace esphome::radon_eye_ble
-
-#endif

--- a/esphome/components/radon_eye_ble/radon_eye_listener.h
+++ b/esphome/components/radon_eye_ble/radon_eye_listener.h
@@ -1,17 +1,13 @@
 #pragma once
 
-#ifdef USE_ESP32
-
 #include "esphome/core/component.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 
 namespace esphome::radon_eye_ble {
 
-class RadonEyeListener final : public esp32_ble_tracker::ESPBTDeviceListener {
+class RadonEyeListener final : public ble_device_base::ESPBTDeviceListener {
  public:
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
 };
 
 }  // namespace esphome::radon_eye_ble
-
-#endif

--- a/tests/components/airthings_ble/common-ln.yaml
+++ b/tests/components/airthings_ble/common-ln.yaml
@@ -1,0 +1,1 @@
+airthings_ble:

--- a/tests/components/airthings_ble/common.yaml
+++ b/tests/components/airthings_ble/common.yaml
@@ -2,5 +2,5 @@ esp32_ble_tracker:
   id: ble_tracker_hub
 
 # Explicit ble_hub_id: pins the neutral binding as a declared key.
-radon_eye_ble:
+airthings_ble:
   ble_hub_id: ble_tracker_hub

--- a/tests/components/airthings_ble/test.esp32-idf.yaml
+++ b/tests/components/airthings_ble/test.esp32-idf.yaml
@@ -1,2 +1,3 @@
 packages:
+  ble: !include ../../test_build_components/common/ble/esp32-idf.yaml
   airthings_ble: !include common.yaml

--- a/tests/components/airthings_ble/test.esp32-idf.yaml
+++ b/tests/components/airthings_ble/test.esp32-idf.yaml
@@ -1,0 +1,2 @@
+packages:
+  airthings_ble: !include common.yaml

--- a/tests/components/airthings_ble/test.ln882x-ard.yaml
+++ b/tests/components/airthings_ble/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  airthings_ble: !include common-ln.yaml

--- a/tests/components/airthings_ble/validate.bk72xx-ard.yaml
+++ b/tests/components/airthings_ble/validate.bk72xx-ard.yaml
@@ -1,0 +1,8 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_tracker_hub
+
+airthings_ble:
+  ble_hub_id: ble_tracker_hub

--- a/tests/components/inkbird_ibsth1_mini/common-ln.yaml
+++ b/tests/components/inkbird_ibsth1_mini/common-ln.yaml
@@ -1,0 +1,7 @@
+sensor:
+  - platform: inkbird_ibsth1_mini
+    mac_address: 38:81:D7:0A:9C:11
+    temperature:
+      name: Inkbird IBS-TH1 Temperature
+    humidity:
+      name: Inkbird IBS-TH1 Humidity

--- a/tests/components/inkbird_ibsth1_mini/common.yaml
+++ b/tests/components/inkbird_ibsth1_mini/common.yaml
@@ -1,7 +1,10 @@
 esp32_ble_tracker:
+  id: ble_tracker_hub
 
 sensor:
+  # Explicit ble_hub_id: pins the neutral binding as a declared key.
   - platform: inkbird_ibsth1_mini
+    ble_hub_id: ble_tracker_hub
     mac_address: 38:81:D7:0A:9C:11
     temperature:
       name: Inkbird IBS-TH1 Temperature

--- a/tests/components/inkbird_ibsth1_mini/test.ln882x-ard.yaml
+++ b/tests/components/inkbird_ibsth1_mini/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  inkbird_ibsth1_mini: !include common-ln.yaml

--- a/tests/components/inkbird_ibsth1_mini/validate.bk72xx-ard.yaml
+++ b/tests/components/inkbird_ibsth1_mini/validate.bk72xx-ard.yaml
@@ -1,0 +1,22 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_tracker_hub
+
+sensor:
+  # Explicit ble_hub_id: pins the neutral binding as a declared key.
+  - platform: inkbird_ibsth1_mini
+    ble_hub_id: ble_tracker_hub
+    mac_address: 38:81:D7:0A:9C:11
+    temperature:
+      name: Inkbird IBS-TH1 Temperature
+    humidity:
+      name: Inkbird IBS-TH1 Humidity
+    battery_level:
+      name: Inkbird IBS-TH1 Battery Level
+  # No ble_hub_id: exercises the generated binding real configs use.
+  - platform: inkbird_ibsth1_mini
+    mac_address: 38:81:D7:0A:9C:12
+    temperature:
+      name: BK Inkbird Implicit Temperature

--- a/tests/components/radon_eye_ble/common-ln.yaml
+++ b/tests/components/radon_eye_ble/common-ln.yaml
@@ -1,0 +1,1 @@
+radon_eye_ble:

--- a/tests/components/radon_eye_ble/test.ln882x-ard.yaml
+++ b/tests/components/radon_eye_ble/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  radon_eye_ble: !include common-ln.yaml

--- a/tests/components/radon_eye_ble/validate.bk72xx-ard.yaml
+++ b/tests/components/radon_eye_ble/validate.bk72xx-ard.yaml
@@ -1,0 +1,9 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_tracker_hub
+
+# Explicit ble_hub_id: pins the neutral binding as a declared key.
+radon_eye_ble:
+  ble_hub_id: ble_tracker_hub


### PR DESCRIPTION
# What does this implement/fix?

**Batch 5 of 13** of the neutral-layer BLE sensor migration — the series is defined and reviewed in #17716 (batch 1, merged). The shared `ble_device_base` enablers landed in #18081. This branch is cut against merged dev and carries only the three platform migrations. Per review direction: batches of up to 3 similar platforms, **one PR open for review at a time** — 

## What migrates in this batch

**`airthings_ble`** and **`radon_eye_ble`** (shared advertisement parsers) and **`inkbird_ibsth1_mini`**.

Same uniform recipe as #17716: python `DEPENDENCIES` → `AUTO_LOAD ["ble_device_base"]`, schema extends `ble_device_base.BLE_DEVICE_SCHEMA` with `rename_legacy_hub_id` prepended, registration via `ble_device_base.register_ble_device`, C++ `esp32_ble_tracker::` → `ble_device_base::`, `USE_ESP32` guards dropped.

Fixtures: all three `common.yaml` files gain `id: ble_tracker_hub` and pin `ble_hub_id:` on one entry; new per-platform `common-ln.yaml` + `test.ln882x-ard.yaml` compile the guard-free C++ on LN882H (`inkbird_ibsth1_mini` build verified, exit 0); new config-only `validate.bk72xx-ard.yaml` fixtures, with `inkbird_ibsth1_mini` also covering the generated binding.

## Batch roadmap

| Batch | Where | Platforms |
|---|---|---|
| 1 | #17716 (merged) | `ble_presence`, `ble_rssi`, `ble_scanner` + shared `ble_device_base` enablers |
| 2 | #17950 (merged) | `atc_mithermometer`, `pvvx_mithermometer`, `bthome_mithermometer` |
| 3 | #17951 (merged) | `mopeka_ble`, `mopeka_pro_check`, `mopeka_std_check` |
| 4 | #18161 (merged) | `ruuvi_ble`, `ruuvitag`, `b_parasite` |
| 5 | this PR | `airthings_ble`, `inkbird_ibsth1_mini`, `radon_eye_ble` |
| 6 | branch [`ble-sensors-batch6`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch6) | `thermopro_ble`, `exposure_notifications`, `xiaomi_ble` (shared hub; portable AES-CCM) |
| 7 | branch [`ble-sensors-batch7`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch7) | `xiaomi_cgd1`, `xiaomi_cgdk2`, `xiaomi_cgg1` |
| 8 | branch [`ble-sensors-batch8`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch8) | `xiaomi_cgpr1`, `xiaomi_gcls002`, `xiaomi_hhccjcy01` |
| 9 | branch [`ble-sensors-batch9`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch9) | `xiaomi_hhccjcy10`, `xiaomi_hhccpot002`, `xiaomi_jqjcy01ym` |
| 10 | branch [`ble-sensors-batch10`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch10) | `xiaomi_lywsd02`, `xiaomi_lywsd02mmc`, `xiaomi_lywsd03mmc` |
| 11 | branch [`ble-sensors-batch11`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch11) | `xiaomi_lywsdcgq`, `xiaomi_mhoc303`, `xiaomi_mhoc401` |
| 12 | branch [`ble-sensors-batch12`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch12) | `xiaomi_miscale`, `xiaomi_mjyd02yla`, `xiaomi_mue4094rt` |
| 13 | branch [`ble-sensors-batch13`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch13) | `xiaomi_rtcgq02lm`, `xiaomi_wx08zm`, `xiaomi_xmwsdj04mmc` |

Each batch is a single commit cut from the same validated full-migration tree, so the series is complete by construction (batch 1 + batches 2–13 = all 39 platforms). A batch PR flips from draft to ready only when the previous one merges — one PR open for review at a time per the direction on #17716.

## Breaking changes and migration

Same as the rest of the series: the auto-generated per-sensor tracker reference `esp32_ble_id:` becomes `ble_hub_id:` on the migrated platforms. Most configurations are unaffected: the key is auto-generated and only written explicitly to disambiguate multiple trackers. Configurations that do set it rename the key:

```yaml
# before
sensor:
  - platform: inkbird_ibsth1_mini
    esp32_ble_id: my_tracker
    mac_address: "38:81:D7:0A:9C:11"
    temperature:
      name: "Inkbird Temperature"

# after
sensor:
  - platform: inkbird_ibsth1_mini
    ble_hub_id: my_tracker
    mac_address: "38:81:D7:0A:9C:11"
    temperature:
      name: "Inkbird Temperature"
```

The transitional alias (`ble_device_base.rename_legacy_hub_id`) warns and auto-migrates an explicit `esp32_ble_id:` until 2027.2.0, so existing configurations keep validating through the rename window.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Design discussion: https://github.com/esphome/esphome/discussions/3758
- Series: #17716

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7128
- esphome/esphome.io#7024

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#164

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: inkbird_ibsth1_mini
    mac_address: "38:81:D7:0A:9C:11"
    temperature:
      name: "Inkbird Temperature"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).






