### PR TITLE
[wifi] Save fast connect settings and reset roaming bookkeeping after driver initiated roams

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -2416,6 +2416,21 @@ void WiFiComponent::clear_roaming_state_() {
   this->roaming_state_ = RoamingState::IDLE;
 }
 
+#ifdef USE_ESP32
+void WiFiComponent::handle_driver_roam_() {
+  // A driver-initiated roam (e.g. 802.11v BTM) re-associates without the state
+  // machine ever leaving STA_CONNECTED, so check_connecting_finished() never runs.
+  // Redo its post-connect bookkeeping here. roaming_state_ is deliberately left
+  // untouched so an in-flight roaming scan is not orphaned.
+  this->roaming_last_check_ = App.get_loop_component_start_time();
+  this->roaming_attempts_ = 0;
+  this->clear_all_bssid_priorities_();
+#ifdef USE_WIFI_FAST_CONNECT
+  this->save_fast_connect_settings_();
+#endif
+}
+#endif
+
 void WiFiComponent::release_scan_results_() {
   if (!this->keep_scan_results_) {
     ScanResultsLock lock(this);

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -2425,6 +2425,7 @@ void WiFiComponent::handle_driver_roam_(const bssid_t &bssid, uint8_t channel) {
   // event may have moved the driver on again by the time this one is processed.
   this->roaming_last_check_ = App.get_loop_component_start_time();
   this->roaming_attempts_ = 0;
+  this->roaming_scan_end_ = 0;
   this->clear_all_bssid_priorities_();
 #ifdef USE_WIFI_FAST_CONNECT
   this->save_fast_connect_settings_(bssid, channel);

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1676,7 +1676,7 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
     this->clear_all_bssid_priorities_();
 
 #ifdef USE_WIFI_FAST_CONNECT
-    this->save_fast_connect_settings_();
+    this->save_fast_connect_settings_(get_wifi_channel());
 #endif
 
     this->release_scan_results_();
@@ -2301,9 +2301,8 @@ bool WiFiComponent::load_fast_connect_settings_(WiFiAP &params) {
   return false;
 }
 
-void WiFiComponent::save_fast_connect_settings_() {
+void WiFiComponent::save_fast_connect_settings_(uint8_t channel) {
   bssid_t bssid = wifi_bssid();
-  uint8_t channel = get_wifi_channel();
   // selected_sta_index_ is always valid here (called only after successful connection)
   // Fallback to 0 is defensive programming for robustness
   int8_t ap_index = this->selected_sta_index_ >= 0 ? this->selected_sta_index_ : 0;
@@ -2417,16 +2416,18 @@ void WiFiComponent::clear_roaming_state_() {
 }
 
 #ifdef USE_ESP32
-void WiFiComponent::handle_driver_roam_() {
+void WiFiComponent::handle_driver_roam_(uint8_t channel) {
   // A driver-initiated roam (e.g. 802.11v BTM) re-associates without the state
   // machine ever leaving STA_CONNECTED, so check_connecting_finished() never runs.
   // Redo its post-connect bookkeeping here. roaming_state_ is deliberately left
-  // untouched so an in-flight roaming scan is not orphaned.
+  // untouched so an in-flight roaming scan is not orphaned. The channel comes
+  // from the connected event because the radio may be off-channel during a
+  // roaming scan, making the driver's current channel unreliable.
   this->roaming_last_check_ = App.get_loop_component_start_time();
   this->roaming_attempts_ = 0;
   this->clear_all_bssid_priorities_();
 #ifdef USE_WIFI_FAST_CONNECT
-  this->save_fast_connect_settings_();
+  this->save_fast_connect_settings_(channel);
 #endif
 }
 #endif

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1676,7 +1676,7 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
     this->clear_all_bssid_priorities_();
 
 #ifdef USE_WIFI_FAST_CONNECT
-    this->save_fast_connect_settings_(get_wifi_channel());
+    this->save_fast_connect_settings_(this->wifi_bssid(), get_wifi_channel());
 #endif
 
     this->release_scan_results_();
@@ -2301,8 +2301,7 @@ bool WiFiComponent::load_fast_connect_settings_(WiFiAP &params) {
   return false;
 }
 
-void WiFiComponent::save_fast_connect_settings_(uint8_t channel) {
-  bssid_t bssid = wifi_bssid();
+void WiFiComponent::save_fast_connect_settings_(const bssid_t &bssid, uint8_t channel) {
   // selected_sta_index_ is always valid here (called only after successful connection)
   // Fallback to 0 is defensive programming for robustness
   int8_t ap_index = this->selected_sta_index_ >= 0 ? this->selected_sta_index_ : 0;
@@ -2416,18 +2415,19 @@ void WiFiComponent::clear_roaming_state_() {
 }
 
 #ifdef USE_ESP32
-void WiFiComponent::handle_driver_roam_(uint8_t channel) {
+void WiFiComponent::handle_driver_roam_(const bssid_t &bssid, uint8_t channel) {
   // A driver-initiated roam (e.g. 802.11v BTM) re-associates without the state
   // machine ever leaving STA_CONNECTED, so check_connecting_finished() never runs.
   // Redo its post-connect bookkeeping here. roaming_state_ is deliberately left
-  // untouched so an in-flight roaming scan is not orphaned. The channel comes
-  // from the connected event because the radio may be off-channel during a
-  // roaming scan, making the driver's current channel unreliable.
+  // untouched so an in-flight roaming scan is not orphaned. The BSSID and
+  // channel both come from the connected event so the saved pair is consistent:
+  // the radio may be off-channel during a roaming scan, and a later queued
+  // event may have moved the driver on again by the time this one is processed.
   this->roaming_last_check_ = App.get_loop_component_start_time();
   this->roaming_attempts_ = 0;
   this->clear_all_bssid_priorities_();
 #ifdef USE_WIFI_FAST_CONNECT
-  this->save_fast_connect_settings_(channel);
+  this->save_fast_connect_settings_(bssid, channel);
 #endif
 }
 #endif

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -781,7 +781,7 @@ class WiFiComponent final : public Component {
 
 #ifdef USE_WIFI_FAST_CONNECT
   bool load_fast_connect_settings_(WiFiAP &params);
-  void save_fast_connect_settings_(uint8_t channel);
+  void save_fast_connect_settings_(const bssid_t &bssid, uint8_t channel);
 #endif
 
   // Post-connect roaming methods
@@ -790,8 +790,9 @@ class WiFiComponent final : public Component {
   void clear_roaming_state_();
 #ifdef USE_ESP32
   /// Redo post-connect bookkeeping after a driver-initiated roam (e.g. 802.11v BTM)
+  /// @param bssid The new AP's BSSID, taken from the connected event
   /// @param channel The new AP's channel, taken from the connected event
-  void handle_driver_roam_(uint8_t channel);
+  void handle_driver_roam_(const bssid_t &bssid, uint8_t channel);
 #endif
 
   /// Returns true if a component has requested that roaming scans be suppressed (e.g. during audio playback).

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -788,6 +788,10 @@ class WiFiComponent final : public Component {
   void check_roaming_(uint32_t now);
   void process_roaming_scan_();
   void clear_roaming_state_();
+#ifdef USE_ESP32
+  /// Redo post-connect bookkeeping after a driver-initiated roam (e.g. 802.11v BTM)
+  void handle_driver_roam_();
+#endif
 
   /// Returns true if a component has requested that roaming scans be suppressed (e.g. during audio playback).
   bool roaming_suppressed_() const {

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -781,7 +781,7 @@ class WiFiComponent final : public Component {
 
 #ifdef USE_WIFI_FAST_CONNECT
   bool load_fast_connect_settings_(WiFiAP &params);
-  void save_fast_connect_settings_();
+  void save_fast_connect_settings_(uint8_t channel);
 #endif
 
   // Post-connect roaming methods
@@ -790,7 +790,8 @@ class WiFiComponent final : public Component {
   void clear_roaming_state_();
 #ifdef USE_ESP32
   /// Redo post-connect bookkeeping after a driver-initiated roam (e.g. 802.11v BTM)
-  void handle_driver_roam_();
+  /// @param channel The new AP's channel, taken from the connected event
+  void handle_driver_roam_(uint8_t channel);
 #endif
 
   /// Returns true if a component has requested that roaming scans be suppressed (e.g. during audio playback).

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -828,7 +828,11 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     if (this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED) {
       // Driver-initiated roam: the WIFI_REASON_ROAMING disconnect was ignored,
       // so the state machine never left STA_CONNECTED.
-      this->handle_driver_roam_();
+      char roam_bssid_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+      format_mac_addr_upper(it.bssid, roam_bssid_s);
+      ESP_LOGI(TAG, "Roamed ssid='%.*s' bssid=" LOG_SECRET("%s") " channel=%u", it.ssid_len, (const char *) it.ssid,
+               roam_bssid_s, it.channel);
+      this->handle_driver_roam_(it.channel);
     }
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
     // Defer listener notification until state machine reaches STA_CONNECTED

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -828,11 +828,15 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     if (this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED) {
       // Driver-initiated roam: the WIFI_REASON_ROAMING disconnect was ignored,
       // so the state machine never left STA_CONNECTED.
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_INFO
       char roam_bssid_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
       format_mac_addr_upper(it.bssid, roam_bssid_s);
       ESP_LOGI(TAG, "Roamed ssid='%.*s' bssid=" LOG_SECRET("%s") " channel=%u", it.ssid_len, (const char *) it.ssid,
                roam_bssid_s, it.channel);
-      this->handle_driver_roam_(it.channel);
+#endif
+      bssid_t roam_bssid;
+      std::copy(it.bssid, it.bssid + 6, roam_bssid.begin());
+      this->handle_driver_roam_(roam_bssid, it.channel);
     }
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
     // Defer listener notification until state machine reaches STA_CONNECTED

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -825,6 +825,11 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
              (const char *) it.ssid, bssid_buf, it.channel, get_auth_mode_str(it.authmode));
 #endif
     s_sta_connected = true;
+    if (this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED) {
+      // Driver-initiated roam: the WIFI_REASON_ROAMING disconnect was ignored,
+      // so the state machine never left STA_CONNECTED.
+      this->handle_driver_roam_();
+    }
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
     // Defer listener notification until state machine reaches STA_CONNECTED
     // This ensures wifi.connected condition returns true in listener automations


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #18034. When the ESP-IDF driver roams to another AP (802.11v BTM), the state machine never leaves STA_CONNECTED and check_connecting_finished() never runs. #18034 fixed the listener notification; still skipped were the fast_connect save, so the stored BSSID and channel kept naming the old AP and the next boot wasted a connect attempt on it, plus the roaming timer, attempt counter and BSSID failure penalty resets.

The connected event is processed in main loop context, and during a driver roam the state is already STA_CONNECTED; that is how the roam is detected, and the handler now runs the normal post-connect bookkeeping directly. roaming_state_ is left untouched so an in-flight roaming scan is not orphaned.

Compile tested on ESP32 IDF with fast_connect and on ESP8266; other platforms treat every disconnect as an error path and always re-enter check_connecting_finished(), so they are unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/pull/18034, identified in https://github.com/esphome/esphome/pull/18034#issuecomment-5168811960

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
