### PR TITLE
[esp32_ble_tracker] Retire the raw listener path and parser-type enum

### DIFF
--- a/esphome/components/bluetooth_connection/bluetooth_connection_esp32.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_esp32.cpp
@@ -479,10 +479,9 @@ esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enabl
   return this->check_and_log_error_("esp_ble_gattc_unregister_for_notify", err);
 }
 
-esp32_ble_tracker::AdvertisementParserType BluetoothConnection::get_advertisement_parser_type() {
-  // RAW keeps the tracker from building parsed ESPBTDevice objects for the
-  // proxy's connections (the proxy itself consumes the hub raw callback).
-  return esp32_ble_tracker::AdvertisementParserType::RAW_ADVERTISEMENTS;
+bool BluetoothConnection::wants_parsed_advertisements() {
+  // The proxy's connections never consume parsed ESPBTDevice objects.
+  return false;
 }
 
 }  // namespace esphome::bluetooth_connection

--- a/esphome/components/bluetooth_connection/bluetooth_connection_esp32.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_esp32.cpp
@@ -479,11 +479,6 @@ esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enabl
   return this->check_and_log_error_("esp_ble_gattc_unregister_for_notify", err);
 }
 
-bool BluetoothConnection::wants_parsed_advertisements() {
-  // The proxy's connections never consume parsed ESPBTDevice objects.
-  return false;
-}
-
 }  // namespace esphome::bluetooth_connection
 
 #endif  // USE_ESP32

--- a/esphome/components/bluetooth_connection/bluetooth_connection_esp32.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_esp32.h
@@ -21,7 +21,7 @@ class BluetoothConnection final : public esp32_ble_client::BLEClientBase {
   bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
-  esp32_ble_tracker::AdvertisementParserType get_advertisement_parser_type() override;
+  bool wants_parsed_advertisements() override;
 
   esp_err_t read_characteristic(uint16_t handle);
   esp_err_t write_characteristic(uint16_t handle, const uint8_t *data, size_t length, bool response);

--- a/esphome/components/bluetooth_connection/bluetooth_connection_esp32.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_esp32.h
@@ -21,7 +21,8 @@ class BluetoothConnection final : public esp32_ble_client::BLEClientBase {
   bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
-  bool wants_parsed_advertisements() override;
+  // The proxy's connections never consume parsed ESPBTDevice objects.
+  bool wants_parsed_advertisements() override { return false; }
 
   esp_err_t read_characteristic(uint16_t handle);
   esp_err_t write_characteristic(uint16_t handle, const uint8_t *data, size_t length, bool response);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -179,10 +179,7 @@ class BluetoothProxy final : public Component {
     this->hub_->get_adapter_mac(mac);
     // Unavailable -> empty string: some hubs (rp2040's BTstack) only learn
     // the address once the link layer is up, and report all-zero until then.
-    bool nonzero = false;
-    for (uint8_t b : mac)
-      nonzero |= b != 0;
-    if (nonzero) {
+    if (mac_address_is_valid(mac)) {
       format_mac_addr_upper(mac, output.data());
     } else {
       output[0] = '\0';

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -20,9 +20,6 @@
 
 #include "esphome/components/bluetooth_connection/bluetooth_connection_esp32.h"
 
-#ifndef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID
-#include <esp_bt.h>
-#endif
 #else
 #include "esphome/components/ble_device_base/ble_hub.h"
 #ifdef USE_BLE_GATT_CLIENT

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -23,7 +23,6 @@
 #ifndef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID
 #include <esp_bt.h>
 #endif
-#include <esp_bt_device.h>
 #else
 #include "esphome/components/ble_device_base/ble_hub.h"
 #ifdef USE_BLE_GATT_CLIENT
@@ -179,19 +178,10 @@ class BluetoothProxy final : public Component {
   }
 
   void get_bluetooth_mac_address_pretty(std::span<char, 18> output) {
-#ifdef USE_ESP32
-    const uint8_t *mac = esp_bt_dev_get_address();
-    if (mac != nullptr) {
-      format_mac_addr_upper(mac, output.data());
-    } else {
-      output[0] = '\0';
-    }
-#else
     uint8_t mac[6] = {};
     this->hub_->get_adapter_mac(mac);
-    // Mirror the esp32 arm's unavailable -> empty-string fallback: some hubs
-    // (rp2040's BTstack) only learn the address once the link layer is up, and
-    // report all-zero until then.
+    // Unavailable -> empty string: some hubs (rp2040's BTstack) only learn
+    // the address once the link layer is up, and report all-zero until then.
     bool nonzero = false;
     for (uint8_t b : mac)
       nonzero |= b != 0;
@@ -200,7 +190,6 @@ class BluetoothProxy final : public Component {
     } else {
       output[0] = '\0';
     }
-#endif
   }
 
  protected:

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -8,6 +8,7 @@
 
 #ifndef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID
 #include <esp_bt.h>
+#include <esp_mac.h>
 #else
 #include "esphome/components/watchdog/watchdog.h"
 #include <cinttypes>
@@ -673,6 +674,23 @@ void ESP32BLE::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gat
   App.wake_loop_threadsafe();
 }
 #endif
+
+void ESP32BLE::get_mac_msb_first(uint8_t out[6]) {
+#ifdef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID
+  // The adapter MAC lives in the remote chip's efuse, so only the running
+  // stack knows it.
+  const uint8_t *mac = esp_bt_dev_get_address();
+  if (mac != nullptr) {
+    memcpy(out, mac, 6);
+  } else {
+    memset(out, 0, 6);
+  }
+#else
+  // IDF owns the BT-offset derivation (base + 2 with four universal MACs,
+  // base + 1 with two); works before the BT stack is up.
+  esp_read_mac(out, ESP_MAC_BT);
+#endif
+}
 
 float ESP32BLE::get_setup_priority() const { return setup_priority::BLUETOOTH; }
 

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -674,7 +674,7 @@ void ESP32BLE::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gat
 }
 #endif
 
-void ESP32BLE::get_mac_msb_first(uint8_t out[6]) {
+void ESP32BLE::get_mac_msb_first(uint8_t out[6]) const {
   // The running stack owns the address (on hosted controllers it lives in
   // the remote chip's efuse); null before init becomes all-zero.
   const uint8_t *mac = esp_bt_dev_get_address();

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -690,10 +690,7 @@ float ESP32BLE::get_setup_priority() const { return setup_priority::BLUETOOTH; }
 void ESP32BLE::dump_config() {
   uint8_t mac_address[6];
   this->get_mac_msb_first(mac_address);
-  bool mac_known = false;
-  for (uint8_t b : mac_address)
-    mac_known |= b != 0;
-  if (mac_known) {
+  if (mac_address_is_valid(mac_address)) {
     const char *io_capability_s;
     switch (this->io_cap_) {
       case ESP_IO_CAP_OUT:

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -8,7 +8,6 @@
 
 #ifndef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID
 #include <esp_bt.h>
-#include <esp_mac.h>
 #else
 #include "esphome/components/watchdog/watchdog.h"
 #include <cinttypes>
@@ -676,27 +675,25 @@ void ESP32BLE::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gat
 #endif
 
 void ESP32BLE::get_mac_msb_first(uint8_t out[6]) {
-#ifdef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID
-  // The adapter MAC lives in the remote chip's efuse, so only the running
-  // stack knows it.
+  // The running stack owns the address (on hosted controllers it lives in
+  // the remote chip's efuse); null before init becomes all-zero.
   const uint8_t *mac = esp_bt_dev_get_address();
   if (mac != nullptr) {
     memcpy(out, mac, 6);
   } else {
     memset(out, 0, 6);
   }
-#else
-  // IDF owns the BT-offset derivation (base + 2 with four universal MACs,
-  // base + 1 with two); works before the BT stack is up.
-  esp_read_mac(out, ESP_MAC_BT);
-#endif
 }
 
 float ESP32BLE::get_setup_priority() const { return setup_priority::BLUETOOTH; }
 
 void ESP32BLE::dump_config() {
-  const uint8_t *mac_address = esp_bt_dev_get_address();
-  if (mac_address) {
+  uint8_t mac_address[6];
+  this->get_mac_msb_first(mac_address);
+  bool mac_known = false;
+  for (uint8_t b : mac_address)
+    mac_known |= b != 0;
+  if (mac_known) {
     const char *io_capability_s;
     switch (this->io_cap_) {
       case ESP_IO_CAP_OUT:

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -108,8 +108,7 @@ class ESP32BLE final : public Component {
   void setup() override;
   void loop() override;
   void dump_config() override;
-  /// Adapter MAC in printable (MSB-first) order. Hosted controllers only
-  /// know it once the stack is up; all-zero means unavailable.
+  /// Adapter MAC in printable (MSB-first) order; all-zero until the stack is up.
   void get_mac_msb_first(uint8_t out[6]);
   float get_setup_priority() const override;
   void set_name(const char *name) { this->name_ = name; }

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -108,6 +108,9 @@ class ESP32BLE final : public Component {
   void setup() override;
   void loop() override;
   void dump_config() override;
+  /// Adapter MAC in printable (MSB-first) order. Hosted controllers only
+  /// know it once the stack is up; all-zero means unavailable.
+  void get_mac_msb_first(uint8_t out[6]);
   float get_setup_priority() const override;
   void set_name(const char *name) { this->name_ = name; }
 

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -109,7 +109,7 @@ class ESP32BLE final : public Component {
   void loop() override;
   void dump_config() override;
   /// Adapter MAC in printable (MSB-first) order; all-zero until the stack is up.
-  void get_mac_msb_first(uint8_t out[6]);
+  void get_mac_msb_first(uint8_t out[6]) const;
   float get_setup_priority() const override;
   void set_name(const char *name) { this->name_ = name; }
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -271,7 +271,9 @@ void ESP32BLETracker::register_client(ESPBTClient *client) {
   // Safe because ESP32BLETracker (singleton) outlives all registered clients.
   client->set_tracker_state_version(&this->state_version_);
   this->clients_.push_back(client);
-  this->recalculate_parse_advertisements_();
+  // Registration is add-only, so the flag is a monotonic OR.
+  if (client->wants_parsed_advertisements())
+    this->parse_advertisements_ = true;
 #endif
 }
 
@@ -294,30 +296,7 @@ void ESP32BLETracker::register_listener(ESPBTDeviceListener *listener) {
 #ifdef ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT
   listener->set_parent(this);
   this->listeners_.push_back(listener);
-  this->recalculate_parse_advertisements_();
-#endif
-}
-
-void ESP32BLETracker::recalculate_parse_advertisements_() {
-  this->parse_advertisements_ = false;
-#ifdef ESPHOME_BLE_DEVICE_BASE_LISTENER_COUNT
-  // Neutral (BLEHub) listeners are parsed-advertisement consumers and are not in
-  // listeners_; without this, any later esp32-path registration (e.g. the proxy's
-  // GATT clients) would recompute the flag and silently drop parsed dispatch.
-  if (!this->neutral_listeners_.empty())
-    this->parse_advertisements_ = true;
-#endif
-#ifdef ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT
-  for (auto *listener : this->listeners_) {
-    if (listener->wants_parsed_advertisements())
-      this->parse_advertisements_ = true;
-  }
-#endif
-#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
-  for (auto *client : this->clients_) {
-    if (client->wants_parsed_advertisements())
-      this->parse_advertisements_ = true;
-  }
+  this->parse_advertisements_ = true;
 #endif
 }
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -9,9 +9,7 @@
 
 #ifndef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID
 #include <esp_bt.h>
-#include <esp_mac.h>
 #endif
-#include <esp_bt_device.h>
 #include <esp_bt_defs.h>
 #include <esp_bt_main.h>
 #include <esp_gap_ble_api.h>
@@ -20,7 +18,6 @@
 #include <freertos/task.h>
 #include <nvs_flash.h>
 #include <cinttypes>
-#include <cstring>
 
 #ifdef USE_OTA
 #include "esphome/components/ota/ota_backend.h"
@@ -285,24 +282,6 @@ void ESP32BLETracker::register_listener(ble_device_base::ESPBTDeviceListener *li
   // Neutral BLEHub path (migrated sensors): parsed-advertisement consumers only.
   this->neutral_listeners_.push_back(listener);
   this->parse_advertisements_ = true;
-#endif
-}
-
-void ESP32BLETracker::get_adapter_mac(uint8_t out[6]) {
-#ifdef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID
-  // Hosted controller (esp32-p4): the adapter MAC lives in the remote chip's
-  // efuse, so only the running stack knows it; ESP_MAC_BT does not exist
-  // here. Null before init becomes all-zero, the proxy's unavailable state.
-  const uint8_t *mac = esp_bt_dev_get_address();
-  if (mac != nullptr) {
-    memcpy(out, mac, 6);
-  } else {
-    memset(out, 0, 6);
-  }
-#else
-  // IDF owns the BT-offset derivation (base + 2 with four universal MACs,
-  // base + 1 with two); works before the BT stack is up.
-  esp_read_mac(out, ESP_MAC_BT);
 #endif
 }
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -9,6 +9,7 @@
 
 #ifndef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID
 #include <esp_bt.h>
+#include <esp_mac.h>
 #endif
 #include <esp_bt_defs.h>
 #include <esp_bt_main.h>
@@ -286,10 +287,9 @@ void ESP32BLETracker::register_listener(ble_device_base::ESPBTDeviceListener *li
 }
 
 void ESP32BLETracker::get_adapter_mac(uint8_t out[6]) {
-  get_mac_address_raw(out);  // WiFi base MAC, MSB-first
-  // BT MAC = base MAC + 2 on the last octet only, wrapping without carry —
-  // exactly ESP-IDF's esp_read_mac(ESP_MAC_BT): mac[5] += MAC_ADDR_UNIVERSE_BT_OFFSET.
-  out[5] += 2;
+  // IDF owns the BT-offset derivation (base + 2 with four universal MACs,
+  // base + 1 with two); works before the BT stack is up.
+  esp_read_mac(out, ESP_MAC_BT);
 }
 
 void ESP32BLETracker::register_listener(ESPBTDeviceListener *listener) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -271,7 +271,7 @@ void ESP32BLETracker::register_client(ESPBTClient *client) {
   // Safe because ESP32BLETracker (singleton) outlives all registered clients.
   client->set_tracker_state_version(&this->state_version_);
   this->clients_.push_back(client);
-  this->recalculate_advertisement_parser_types();
+  this->recalculate_parse_advertisements_();
 #endif
 }
 
@@ -294,36 +294,29 @@ void ESP32BLETracker::register_listener(ESPBTDeviceListener *listener) {
 #ifdef ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT
   listener->set_parent(this);
   this->listeners_.push_back(listener);
-  this->recalculate_advertisement_parser_types();
+  this->recalculate_parse_advertisements_();
 #endif
 }
 
-void ESP32BLETracker::recalculate_advertisement_parser_types() {
-  this->raw_advertisements_ = false;
+void ESP32BLETracker::recalculate_parse_advertisements_() {
   this->parse_advertisements_ = false;
 #ifdef ESPHOME_BLE_DEVICE_BASE_LISTENER_COUNT
   // Neutral (BLEHub) listeners are parsed-advertisement consumers and are not in
   // listeners_; without this, any later esp32-path registration (e.g. the proxy's
-  // GATT clients) would recompute the flags and silently drop parsed dispatch.
+  // GATT clients) would recompute the flag and silently drop parsed dispatch.
   if (!this->neutral_listeners_.empty())
     this->parse_advertisements_ = true;
 #endif
 #ifdef ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT
   for (auto *listener : this->listeners_) {
-    if (listener->get_advertisement_parser_type() == AdvertisementParserType::PARSED_ADVERTISEMENTS) {
+    if (listener->wants_parsed_advertisements())
       this->parse_advertisements_ = true;
-    } else {
-      this->raw_advertisements_ = true;
-    }
   }
 #endif
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   for (auto *client : this->clients_) {
-    if (client->get_advertisement_parser_type() == AdvertisementParserType::PARSED_ADVERTISEMENTS) {
+    if (client->wants_parsed_advertisements())
       this->parse_advertisements_ = true;
-    } else {
-      this->raw_advertisements_ = true;
-    }
   }
 #endif
 }
@@ -476,20 +469,6 @@ void ESP32BLETracker::process_scan_result_(const BLEScanResult &scan_result) {
     adv.rssi = scan_result.rssi;
     adv.addr_type = scan_result.ble_addr_type;
     this->raw_advertisement_callback_.invoke(adv);
-  }
-
-  // Process raw advertisements
-  if (this->raw_advertisements_) {
-#ifdef ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT
-    for (auto *listener : this->listeners_) {
-      listener->parse_devices(&scan_result, 1);
-    }
-#endif
-#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
-    for (auto *client : this->clients_) {
-      client->parse_devices(&scan_result, 1);
-    }
-#endif
   }
 
   // Process parsed advertisements

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -11,6 +11,7 @@
 #include <esp_bt.h>
 #include <esp_mac.h>
 #endif
+#include <esp_bt_device.h>
 #include <esp_bt_defs.h>
 #include <esp_bt_main.h>
 #include <esp_gap_ble_api.h>
@@ -19,6 +20,7 @@
 #include <freertos/task.h>
 #include <nvs_flash.h>
 #include <cinttypes>
+#include <cstring>
 
 #ifdef USE_OTA
 #include "esphome/components/ota/ota_backend.h"
@@ -287,9 +289,21 @@ void ESP32BLETracker::register_listener(ble_device_base::ESPBTDeviceListener *li
 }
 
 void ESP32BLETracker::get_adapter_mac(uint8_t out[6]) {
+#ifdef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID
+  // Hosted controller (esp32-p4): the adapter MAC lives in the remote chip's
+  // efuse, so only the running stack knows it; ESP_MAC_BT does not exist
+  // here. Null before init becomes all-zero, the proxy's unavailable state.
+  const uint8_t *mac = esp_bt_dev_get_address();
+  if (mac != nullptr) {
+    memcpy(out, mac, 6);
+  } else {
+    memset(out, 0, 6);
+  }
+#else
   // IDF owns the BT-offset derivation (base + 2 with four universal MACs,
   // base + 1 with two); works before the BT stack is up.
   esp_read_mac(out, ESP_MAC_BT);
+#endif
 }
 
 void ESP32BLETracker::register_listener(ESPBTDeviceListener *listener) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -35,11 +35,6 @@ using namespace esp32_ble;
 
 using adv_data_t = ble_device_base::adv_data_t;
 
-enum AdvertisementParserType {
-  PARSED_ADVERTISEMENTS,
-  RAW_ADVERTISEMENTS,
-};
-
 #ifdef USE_ESP32_BLE_UUID
 using ServiceData = ble_device_base::ServiceData;
 #endif
@@ -63,10 +58,9 @@ class ESPBTDeviceListener : public ble_device_base::ESPBTDeviceListener {
   // Raw-only build: no parsed-device support is compiled in.
   bool parse_device(const ble_device_base::ESPBTDevice &device) override { return false; }
 #endif
-  virtual bool parse_devices(const BLEScanResult *scan_results, size_t count) { return false; };
-  virtual AdvertisementParserType get_advertisement_parser_type() {
-    return AdvertisementParserType::PARSED_ADVERTISEMENTS;
-  };
+  /// False keeps the tracker from building parsed ESPBTDevice objects on
+  /// this registrant's account (raw consumers use the hub callback).
+  virtual bool wants_parsed_advertisements() { return true; }
   void set_parent(ESP32BLETracker *parent) { parent_ = parent; }
 
  protected:
@@ -199,7 +193,6 @@ class ESP32BLETracker final : public Component,
   // esp32-flavored path (unmigrated esp32 sensors; sets the tracker back-pointer).
   void register_listener(ESPBTDeviceListener *listener);
   void register_client(ESPBTClient *client);
-  void recalculate_advertisement_parser_types();
 
   // ---- ble_device_base::BLEHub (the platform-neutral tracker contract) ----
   void register_listener(ble_device_base::ESPBTDeviceListener *listener) override;
@@ -257,6 +250,7 @@ class ESP32BLETracker final : public Component,
   void gap_scan_stop_complete_(const esp_ble_gap_cb_param_t::ble_scan_stop_cmpl_evt_param &param);
   /// Called to set the scanner state. Will also call callbacks to let listeners know when state is changed.
   void set_scanner_state_(ScannerState state);
+  void recalculate_parse_advertisements_();
   /// Common cleanup logic when transitioning scanner to IDLE state
   void cleanup_scan_state_(bool is_stop_complete);
   /// Process a single scan result immediately
@@ -355,7 +349,6 @@ class ESP32BLETracker final : public Component,
   bool scan_continuous_before_ota_{false};
 #endif
   bool ble_was_disabled_{true};
-  bool raw_advertisements_{false};
   bool parse_advertisements_{false};
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
   bool coex_prefer_ble_{false};

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -118,7 +118,6 @@ class ESPBTClient : public ESPBTDeviceListener {
   /// this client's account (raw consumers use the hub callback).
   virtual bool wants_parsed_advertisements() { return true; }
 
- public:
   virtual bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                    esp_ble_gattc_cb_param_t *param) = 0;
   virtual void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) = 0;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -206,7 +206,7 @@ class ESP32BLETracker final : public Component,
     return {/* active_scan = */ true, /* merges_scan_response = */ true, /* gatt = */ true,
             /* scan_mode_switch = */ false};
   }
-  void get_adapter_mac(uint8_t out[6]) override;
+  void get_adapter_mac(uint8_t out[6]) override { this->parent_->get_mac_msb_first(out); }
   bool scan_running() override { return this->scanner_state_ == ScannerState::RUNNING; }
   bool scan_active() override { return this->scan_active_; }
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -58,9 +58,6 @@ class ESPBTDeviceListener : public ble_device_base::ESPBTDeviceListener {
   // Raw-only build: no parsed-device support is compiled in.
   bool parse_device(const ble_device_base::ESPBTDevice &device) override { return false; }
 #endif
-  /// False keeps the tracker from building parsed ESPBTDevice objects on
-  /// this registrant's account (raw consumers use the hub callback).
-  virtual bool wants_parsed_advertisements() { return true; }
   void set_parent(ESP32BLETracker *parent) { parent_ = parent; }
 
  protected:
@@ -116,6 +113,11 @@ class BLEScannerStateListener {
 /// increment the counter through this pointer when their state changes.
 /// The pointer may be null if the client is not registered with a tracker.
 class ESPBTClient : public ESPBTDeviceListener {
+ public:
+  /// False keeps the tracker from building parsed ESPBTDevice objects on
+  /// this client's account (raw consumers use the hub callback).
+  virtual bool wants_parsed_advertisements() { return true; }
+
  public:
   virtual bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                    esp_ble_gattc_cb_param_t *param) = 0;
@@ -250,7 +252,6 @@ class ESP32BLETracker final : public Component,
   void gap_scan_stop_complete_(const esp_ble_gap_cb_param_t::ble_scan_stop_cmpl_evt_param &param);
   /// Called to set the scanner state. Will also call callbacks to let listeners know when state is changed.
   void set_scanner_state_(ScannerState state);
-  void recalculate_parse_advertisements_();
   /// Common cleanup logic when transitioning scanner to IDLE state
   void cleanup_scan_state_(bool is_stop_complete);
   /// Process a single scan result immediately


### PR DESCRIPTION
# What does this implement/fix?

Cleanup between steps 2 and 3 of the hub model migration, chained on #18175. After #18173 nothing in the tree overrides parse_devices, so the raw listener dispatch was a per advertisement loop over no op defaults.

**Removed from esp32_ble_tracker**

- The parse_devices virtual, the raw dispatch block in process_scan_result_ and the raw_advertisements_ flag.
- The AdvertisementParserType enum: clients now answer wants_parsed_advertisements() (default true); the proxy's connections return false, which is the only meaning the RAW value still had.
- recalculate_advertisement_parser_types is deleted outright: registration is add only, so the parsed flag is a monotonic OR set at each register site, which also removes the neutral listener special case it existed to defend.
- wants_parsed_advertisements() lives on ESPBTClient, where the only real variation is; plain listener registration always sets the flag (a listener opting out would receive nothing at all).

**Unified in bluetooth_proxy**

- get_bluetooth_mac_address_pretty uses the hub's get_adapter_mac on every platform, dropping the esp_bt_device.h include and the long dead esp_bt.h block. On esp32 the tracker delegates to a new esp32_ble accessor that asks the running stack (the same query dump_config now shares), so there is exactly one esp_bt_dev_get_address call in the tree; before the stack is up the MAC reads all-zero and the proxy reports it as unavailable, matching the old behavior.

parse_devices and the enum were undocumented esp32_ble_tracker surface; an external component overriding them stops compiling and switches to wants_parsed_advertisements() (raw consumers use the hub's raw advertisement callback).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).



