### PR TITLE
[modbus] Make sure we log on no accepting device

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -445,8 +445,8 @@ void ModbusServerHub::process_broadcast_frame_(uint8_t function_code, std::span<
   if (status.has_value()) {
     return;
   }
-  // A broadcast is never answered, so a rejecting device has no other feedback channel. With several
-  // devices only one is expected to accept, but nobody accepting is always a misconfiguration.
+  // A broadcast is never answered, so a rejecting device has no other feedback channel: report the
+  // per-device outcome at V, and warn once if the write reached nobody at all.
   bool accepted = false;
   for (auto *device : this->devices_) {
     if (ResponseStatus device_status = device->on_broadcast_write_registers(start_address, registers);
@@ -458,7 +458,16 @@ void ModbusServerHub::process_broadcast_frame_(uint8_t function_code, std::span<
     }
   }
   if (!accepted && !this->devices_.empty()) {
-    ESP_LOGW(TAG, "No device accepted broadcast write of %zu registers at 0x%04X", registers.size(), start_address);
+    // Warn once per start address, then drop to VERBOSE: on a shared bus a broadcast aimed at other nodes
+    // repeats forever, so warning per frame would flood the log. Addresses past the tracked set stay at VERBOSE.
+    auto &warned = this->unaccepted_broadcast_warned_;
+    if (std::find(warned.begin(), warned.end(), start_address) == warned.end() &&
+        warned.size() < MAX_UNACCEPTED_BROADCAST_WARNINGS) {
+      warned.push_back(start_address);
+      ESP_LOGW(TAG, "No device accepted broadcast write of %zu registers at 0x%04X", registers.size(), start_address);
+    } else {
+      ESP_LOGV(TAG, "No device accepted broadcast write at 0x%04X (repeat)", start_address);
+    }
   }
 }
 

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -445,14 +445,20 @@ void ModbusServerHub::process_broadcast_frame_(uint8_t function_code, std::span<
   if (status.has_value()) {
     return;
   }
+  // A broadcast is never answered, so a rejecting device has no other feedback channel. With several
+  // devices only one is expected to accept, but nobody accepting is always a misconfiguration.
+  bool accepted = false;
   for (auto *device : this->devices_) {
-    // A broadcast is never answered, so a rejecting device has no other feedback channel; log it so a
-    // misconfigured register map is diagnosable instead of looking identical to a successful write.
     if (ResponseStatus device_status = device->on_broadcast_write_registers(start_address, registers);
         device_status.has_value()) {
       ESP_LOGV(TAG, "Device %" PRIu8 " rejected broadcast write with exception %" PRIu8, device->get_address(),
                static_cast<uint8_t>(device_status.value()));
+    } else {
+      accepted = true;
     }
+  }
+  if (!accepted && !this->devices_.empty()) {
+    ESP_LOGW(TAG, "No device accepted broadcast write of %zu registers at 0x%04X", registers.size(), start_address);
   }
 }
 

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -15,6 +15,9 @@ static constexpr uint32_t MODBUS_BITS_PER_CHAR = 11;
 // Milliseconds per second
 static constexpr uint32_t MS_PER_SEC = 1000;
 
+// Shortest gap between two "no device accepted broadcast" warnings
+static constexpr uint32_t UNACCEPTED_BROADCAST_WARN_INTERVAL_MS = 60 * MS_PER_SEC;
+
 void Modbus::setup() {
   if (this->flow_control_pin_ != nullptr) {
     this->flow_control_pin_->setup();
@@ -446,7 +449,7 @@ void ModbusServerHub::process_broadcast_frame_(uint8_t function_code, std::span<
     return;
   }
   // A broadcast is never answered, so a rejecting device has no other feedback channel: report the
-  // per-device outcome at V, and warn once if the write reached nobody at all.
+  // per-device outcome at V, and warn if the write reached nobody at all.
   bool accepted = false;
   for (auto *device : this->devices_) {
     if (ResponseStatus device_status = device->on_broadcast_write_registers(start_address, registers);
@@ -458,15 +461,15 @@ void ModbusServerHub::process_broadcast_frame_(uint8_t function_code, std::span<
     }
   }
   if (!accepted && !this->devices_.empty()) {
-    // Warn once per start address, then drop to VERBOSE: on a shared bus a broadcast aimed at other nodes
-    // repeats forever, so warning per frame would flood the log. Addresses past the tracked set stay at VERBOSE.
-    auto &warned = this->unaccepted_broadcast_warned_;
-    if (std::find(warned.begin(), warned.end(), start_address) == warned.end() &&
-        warned.size() < MAX_UNACCEPTED_BROADCAST_WARNINGS) {
-      warned.push_back(start_address);
+    // Warn at most once per interval, then drop to VERBOSE: on a shared bus a broadcast aimed at other nodes
+    // repeats forever, so warning per frame would flood the log.
+    const uint32_t now = millis();
+    if (this->last_unaccepted_broadcast_warn_ == 0 ||
+        now - this->last_unaccepted_broadcast_warn_ > UNACCEPTED_BROADCAST_WARN_INTERVAL_MS) {
+      this->last_unaccepted_broadcast_warn_ = now;
       ESP_LOGW(TAG, "No device accepted broadcast write of %zu registers at 0x%04X", registers.size(), start_address);
     } else {
-      ESP_LOGV(TAG, "No device accepted broadcast write at 0x%04X (repeat)", start_address);
+      ESP_LOGV(TAG, "No device accepted broadcast write of %zu registers at 0x%04X", registers.size(), start_address);
     }
   }
 }

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -361,10 +361,9 @@ class ModbusServerHub : public Modbus {
   uint8_t expecting_peer_response_{0};
   std::vector<ModbusServerDevice *> devices_;
 
-  // Start addresses whose broadcast reached no device and already warned, so each warns once instead of
-  // once per frame. Bounded because a shared bus can carry broadcasts for arbitrarily many addresses.
-  static constexpr size_t MAX_UNACCEPTED_BROADCAST_WARNINGS = 8;
-  StaticVector<uint16_t, MAX_UNACCEPTED_BROADCAST_WARNINGS> unaccepted_broadcast_warned_;
+  // Stamp of the last "broadcast reached no device" warning, 0 until the first one is logged. Rate limiting
+  // on time rather than on address keeps the log bounded no matter how many addresses a shared bus carries.
+  uint32_t last_unaccepted_broadcast_warn_{0};
 
   // Holds the raw payload of a single reply deferred for sending when tx was blocked at send time.
   // Only one server reply can be waiting at once, so a single fixed buffer avoids heap allocation.

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -361,6 +361,11 @@ class ModbusServerHub : public Modbus {
   uint8_t expecting_peer_response_{0};
   std::vector<ModbusServerDevice *> devices_;
 
+  // Start addresses whose broadcast reached no device and already warned, so each warns once instead of
+  // once per frame. Bounded because a shared bus can carry broadcasts for arbitrarily many addresses.
+  static constexpr size_t MAX_UNACCEPTED_BROADCAST_WARNINGS = 8;
+  StaticVector<uint16_t, MAX_UNACCEPTED_BROADCAST_WARNINGS> unaccepted_broadcast_warned_;
+
   // Holds the raw payload of a single reply deferred for sending when tx was blocked at send time.
   // Only one server reply can be waiting at once, so a single fixed buffer avoids heap allocation.
   std::array<uint8_t, MAX_RAW_SIZE> deferred_payload_;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Follow up to esphome/esphome#17387: Make sure that if no device accepts a broadcast we still log at WARN.
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
