### PR TITLE
[pn532] Fix NDEF parsing greater than 255 bytes

### DIFF
--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -85,7 +85,7 @@ class PN532 : public PollingComponent {
   bool read_mifare_ultralight_bytes_(uint8_t start_page, uint16_t num_bytes, std::vector<uint8_t> &data);
   bool is_mifare_ultralight_formatted_(const std::vector<uint8_t> &page_3_to_6);
   uint16_t read_mifare_ultralight_capacity_();
-  bool find_mifare_ultralight_ndef_(const std::vector<uint8_t> &page_3_to_6, uint8_t &message_length,
+  bool find_mifare_ultralight_ndef_(const std::vector<uint8_t> &page_3_to_6, uint32_t &message_length,
                                     uint8_t &message_start_index);
   bool write_mifare_ultralight_page_(uint8_t page_num, const uint8_t *write_data, size_t len);
   bool write_mifare_ultralight_tag_(nfc::NfcTagUid &uid, nfc::NdefMessage *message);

--- a/esphome/components/pn532/pn532_mifare_ultralight.cpp
+++ b/esphome/components/pn532/pn532_mifare_ultralight.cpp
@@ -33,8 +33,15 @@ std::unique_ptr<nfc::NfcTag> PN532::read_mifare_ultralight_tag_(nfc::NfcTagUid &
   if (message_length == 0) {
     return make_unique<nfc::NfcTag>(uid, nfc::NFC_FORUM_TYPE_2);
   }
-  // we already read pages 3-6 earlier -- pick up where we left off so we're not re-reading pages
+
+  // data[2] is the CC byte read earlier as part of pages 3-6, same value used by read_mifare_ultralight_capacity_()
+  const uint32_t capacity = data[2] * 8U;
   const uint32_t total_length = message_length + message_start_index;
+  if (total_length > capacity) {
+    ESP_LOGW(TAG, "NDEF message length %" PRIu32 " exceeds tag capacity %" PRIu32, message_length, capacity);
+    return make_unique<nfc::NfcTag>(uid, nfc::NFC_FORUM_TYPE_2);
+  }
+  // we already read pages 3-6 earlier -- pick up where we left off so we're not re-reading pages
   const uint16_t read_length = total_length > 12 ? static_cast<uint16_t>(total_length - 12) : 0;
   if (read_length) {
     if (!read_mifare_ultralight_bytes_(nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE + 3, read_length, data)) {
@@ -115,7 +122,12 @@ bool PN532::find_mifare_ultralight_ndef_(const std::vector<uint8_t> &page_3_to_6
 
   // Long-form TLV length: 0x03 0xFF LEN_HI LEN_LO, used whenever the message is >= 255 bytes.
   // Short-form is just 0x03 LEN. See NFC Forum Type 2 Tag Operation spec section 2.3.
-  if (page_3_to_6[p4_offset + tlv_offset + 1] == 0xFF && page_3_to_6.size() > p4_offset + tlv_offset + 3) {
+  if (page_3_to_6[p4_offset + tlv_offset + 1] == 0xFF) {
+    if (page_3_to_6.size() <= p4_offset + tlv_offset + 3) {
+      // long-form marker present but the length bytes weren't read -- fail explicitly instead of
+      // misreporting a 255-byte short-form message
+      return false;
+    }
     message_length =
         (static_cast<uint32_t>(page_3_to_6[p4_offset + tlv_offset + 2]) << 8) | page_3_to_6[p4_offset + tlv_offset + 3];
     message_start_index = tlv_offset + 4;

--- a/esphome/components/pn532/pn532_mifare_ultralight.cpp
+++ b/esphome/components/pn532/pn532_mifare_ultralight.cpp
@@ -1,4 +1,5 @@
 #include <array>
+#include <cinttypes>
 #include <memory>
 
 #include "pn532.h"
@@ -21,19 +22,20 @@ std::unique_ptr<nfc::NfcTag> PN532::read_mifare_ultralight_tag_(nfc::NfcTagUid &
     return make_unique<nfc::NfcTag>(uid, nfc::NFC_FORUM_TYPE_2);
   }
 
-  uint8_t message_length;
+  uint32_t message_length;
   uint8_t message_start_index;
   if (!this->find_mifare_ultralight_ndef_(data, message_length, message_start_index)) {
     ESP_LOGW(TAG, "Couldn't find NDEF message");
     return make_unique<nfc::NfcTag>(uid, nfc::NFC_FORUM_TYPE_2);
   }
-  ESP_LOGVV(TAG, "NDEF message length: %u, start: %u", message_length, message_start_index);
+  ESP_LOGVV(TAG, "NDEF message length: %" PRIu32 ", start: %u", message_length, message_start_index);
 
   if (message_length == 0) {
     return make_unique<nfc::NfcTag>(uid, nfc::NFC_FORUM_TYPE_2);
   }
   // we already read pages 3-6 earlier -- pick up where we left off so we're not re-reading pages
-  const uint8_t read_length = message_length + message_start_index > 12 ? message_length + message_start_index - 12 : 0;
+  const uint32_t total_length = message_length + message_start_index;
+  const uint16_t read_length = total_length > 12 ? static_cast<uint16_t>(total_length - 12) : 0;
   if (read_length) {
     if (!read_mifare_ultralight_bytes_(nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE + 3, read_length, data)) {
       ESP_LOGE(TAG, "Error reading tag data");
@@ -94,7 +96,7 @@ uint16_t PN532::read_mifare_ultralight_capacity_() {
   return 0;
 }
 
-bool PN532::find_mifare_ultralight_ndef_(const std::vector<uint8_t> &page_3_to_6, uint8_t &message_length,
+bool PN532::find_mifare_ultralight_ndef_(const std::vector<uint8_t> &page_3_to_6, uint32_t &message_length,
                                          uint8_t &message_start_index) {
   const uint8_t p4_offset = nfc::MIFARE_ULTRALIGHT_PAGE_SIZE;  // page 4 will begin 4 bytes into the vector
 
@@ -102,16 +104,26 @@ bool PN532::find_mifare_ultralight_ndef_(const std::vector<uint8_t> &page_3_to_6
     return false;
   }
 
+  uint8_t tlv_offset;
   if (page_3_to_6[p4_offset + 0] == 0x03) {
-    message_length = page_3_to_6[p4_offset + 1];
-    message_start_index = 2;
-    return true;
+    tlv_offset = 0;
   } else if (page_3_to_6[p4_offset + 5] == 0x03) {
-    message_length = page_3_to_6[p4_offset + 6];
-    message_start_index = 7;
-    return true;
+    tlv_offset = 5;
+  } else {
+    return false;
   }
-  return false;
+
+  // Long-form TLV length: 0x03 0xFF LEN_HI LEN_LO, used whenever the message is >= 255 bytes.
+  // Short-form is just 0x03 LEN. See NFC Forum Type 2 Tag Operation spec section 2.3.
+  if (page_3_to_6[p4_offset + tlv_offset + 1] == 0xFF && page_3_to_6.size() > p4_offset + tlv_offset + 3) {
+    message_length =
+        (static_cast<uint32_t>(page_3_to_6[p4_offset + tlv_offset + 2]) << 8) | page_3_to_6[p4_offset + tlv_offset + 3];
+    message_start_index = tlv_offset + 4;
+  } else {
+    message_length = page_3_to_6[p4_offset + tlv_offset + 1];
+    message_start_index = tlv_offset + 2;
+  }
+  return true;
 }
 
 bool PN532::write_mifare_ultralight_tag_(nfc::NfcTagUid &uid, nfc::NdefMessage *message) {

--- a/tests/components/pn532/test_mifare_ultralight_ndef.cpp
+++ b/tests/components/pn532/test_mifare_ultralight_ndef.cpp
@@ -1,0 +1,158 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "esphome/components/nfc/ndef_message.h"
+#include "esphome/components/nfc/ndef_record.h"
+#include "esphome/components/nfc/nfc.h"
+#include "esphome/components/pn532/pn532.h"
+
+namespace esphome::pn532::testing {
+
+/// Exposes the protected TLV parser so it can be driven directly with synthetic tag memory.
+class TestablePN532 : public PN532 {
+ public:
+  using PN532::find_mifare_ultralight_ndef_;
+
+  bool is_read_ready() override { return false; }
+  bool write_data(const std::vector<uint8_t> &data) override { return false; }
+  bool read_data(std::vector<uint8_t> &data, uint8_t len) override { return false; }
+  bool read_response(uint8_t command, std::vector<uint8_t> &data) override { return false; }
+};
+
+// Builds a 16-byte page_3_to_6 buffer: 4 filler bytes for page 3 (unused by this function),
+// followed by the given bytes starting at page 4, zero-padded out to the real 4-page read size.
+std::vector<uint8_t> make_page_3_to_6(std::initializer_list<uint8_t> page4_onward) {
+  std::vector<uint8_t> data = {0x00, 0x00, 0x00, 0x00};
+  data.insert(data.end(), page4_onward);
+  data.resize(16, 0x00);
+  return data;
+}
+
+TEST(FindMifareUltralightNdef, ShortFormAtPage4Start) {
+  TestablePN532 pn532;
+  // 0x03 LEN -- message starts right after.
+  auto data = make_page_3_to_6({0x03, 0x20});
+
+  uint32_t message_length = 0;
+  uint8_t message_start_index = 0;
+  ASSERT_TRUE(pn532.find_mifare_ultralight_ndef_(data, message_length, message_start_index));
+  EXPECT_EQ(message_length, 0x20u);
+  EXPECT_EQ(message_start_index, 2);
+}
+
+TEST(FindMifareUltralightNdef, ShortFormAfterLeadingPadding) {
+  TestablePN532 pn532;
+  // A non-0x03 byte at page 4 (e.g. a lock/CC TLV) pushes the message TLV to offset 5.
+  auto data = make_page_3_to_6({0x01, 0x00, 0x00, 0x00, 0x00, 0x03, 0x10});
+
+  uint32_t message_length = 0;
+  uint8_t message_start_index = 0;
+  ASSERT_TRUE(pn532.find_mifare_ultralight_ndef_(data, message_length, message_start_index));
+  EXPECT_EQ(message_length, 0x10u);
+  EXPECT_EQ(message_start_index, 7);
+}
+
+// Regression test: prior to this fix, a >=255 byte NDEF message's TLV length was always read as
+// a single byte, so the 0xFF long-form marker was mistaken for a length of 255 and the two real
+// length bytes were mistaken for message content. That misalignment is what produced the
+// "Corrupt record encountered; NdefMessage constructor aborting" error for large tags
+TEST(FindMifareUltralightNdef, LongFormAtPage4Start) {
+  TestablePN532 pn532;
+  // 0x03 FF 01 2C -> long-form length = 0x012C = 300
+  auto data = make_page_3_to_6({0x03, 0xFF, 0x01, 0x2C, 0xD1, 0x01, 0x0C, 0x55});
+
+  uint32_t message_length = 0;
+  uint8_t message_start_index = 0;
+  ASSERT_TRUE(pn532.find_mifare_ultralight_ndef_(data, message_length, message_start_index));
+  EXPECT_EQ(message_length, 300u);
+  EXPECT_EQ(message_start_index, 4);
+}
+
+TEST(FindMifareUltralightNdef, LongFormAfterLeadingPadding) {
+  TestablePN532 pn532;
+  auto data = make_page_3_to_6({0x01, 0x00, 0x00, 0x00, 0x00, 0x03, 0xFF, 0x02, 0x00});
+
+  uint32_t message_length = 0;
+  uint8_t message_start_index = 0;
+  ASSERT_TRUE(pn532.find_mifare_ultralight_ndef_(data, message_length, message_start_index));
+  EXPECT_EQ(message_length, 0x0200u);  // 512
+  EXPECT_EQ(message_start_index, 9);
+}
+
+TEST(FindMifareUltralightNdef, TooShortBufferIsRejected) {
+  TestablePN532 pn532;
+  std::vector<uint8_t> data = {0x00, 0x00, 0x00, 0x00, 0x03, 0x05};  // well under the size floor
+
+  uint32_t message_length = 0;
+  uint8_t message_start_index = 0;
+  EXPECT_FALSE(pn532.find_mifare_ultralight_ndef_(data, message_length, message_start_index));
+}
+
+TEST(FindMifareUltralightNdef, NoTlvTagIsRejected) {
+  TestablePN532 pn532;
+  auto data = make_page_3_to_6({0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00});
+
+  uint32_t message_length = 0;
+  uint8_t message_start_index = 0;
+  EXPECT_FALSE(pn532.find_mifare_ultralight_ndef_(data, message_length, message_start_index));
+}
+
+/// End-to-end regression guard: builds a real 3-record NDEF message (URL, text, and a MIME
+/// record) padded past 255 bytes and wraps it in a Type 2 Tag TLV the way a real tag stores it, 
+/// then runs the wrapper through find_mifare_ultralight_ndef_ to locate it, and feeds the located slice back
+/// into NdefMessage to confirm all three records survive the round trip.
+TEST(FindMifareUltralightNdef, LongFormMessageRoundTripsThroughNdefMessage) {
+  nfc::NdefMessage message;
+  message.add_uri_record("https://esphome.io/");
+  message.add_text_record("Hello, ESPHome!");
+
+  std::string json_payload = "{\"key\":\"value\",\"pad\":\"" + std::string(255, 'x') + "\"}";
+  auto json_record = make_unique<nfc::NdefRecord>();
+  json_record->set_tnf(nfc::TNF_MIME_MEDIA);
+  json_record->set_type("application/json");
+  json_record->set_payload(json_payload);
+  message.add_record(std::move(json_record));
+
+  auto encoded = message.encode();
+  ASSERT_GE(encoded.size(), 255u) << "test fixture must exercise the long-form TLV path";
+
+  // Wrap exactly like write_mifare_ultralight_tag_ does: 0x03 FF LEN_HI LEN_LO ... 0xFE
+  std::vector<uint8_t> wrapped = {0x03, 0xFF, static_cast<uint8_t>((encoded.size() >> 8) & 0xFF),
+                                  static_cast<uint8_t>(encoded.size() & 0xFF)};
+  wrapped.insert(wrapped.end(), encoded.begin(), encoded.end());
+  wrapped.push_back(0xFE);
+
+  // Real tag memory is [page 3 (4 bytes, unused here)] [wrapped TLV ...].
+  std::vector<uint8_t> tag_memory = {0x00, 0x00, 0x00, 0x00};
+  tag_memory.insert(tag_memory.end(), wrapped.begin(), wrapped.end());
+
+  // find_mifare_ultralight_ndef_ only ever sees the first 16 bytes (pages 3-6) when locating the
+  // TLV header -- exactly what read_mifare_ultralight_tag_'s first, fixed-size read provides.
+  std::vector<uint8_t> page_3_to_6(tag_memory.begin(), tag_memory.begin() + 16);
+
+  TestablePN532 pn532;
+  uint32_t message_length = 0;
+  uint8_t message_start_index = 0;
+  ASSERT_TRUE(pn532.find_mifare_ultralight_ndef_(page_3_to_6, message_length, message_start_index));
+  EXPECT_EQ(message_length, encoded.size());
+  EXPECT_EQ(message_start_index, 4);
+
+  // Reconstruct what read_mifare_ultralight_tag_ hands to NdefMessage: page 3 trimmed off, then
+  // sliced to [message_start_index, message_start_index + message_length).
+  std::vector<uint8_t> full_tag_data(tag_memory.begin() + 4, tag_memory.end());
+  std::vector<uint8_t> message_bytes(full_tag_data.begin() + message_start_index,
+                                     full_tag_data.begin() + message_start_index + message_length);
+
+  nfc::NdefMessage parsed(message_bytes);
+  const auto &records = parsed.get_records();
+  ASSERT_EQ(records.size(), 3u);
+  EXPECT_EQ(records[0]->get_type(), "U");
+  EXPECT_EQ(records[0]->get_payload(), "https://esphome.io/");
+  EXPECT_EQ(records[1]->get_type(), "T");
+  EXPECT_EQ(records[1]->get_payload(), "Hello, ESPHome!");
+  EXPECT_EQ(records[2]->get_type(), "application/json");
+  EXPECT_EQ(records[2]->get_payload(), json_payload);
+}
+
+}  // namespace esphome::pn532::testing

--- a/tests/components/pn532/test_mifare_ultralight_ndef.cpp
+++ b/tests/components/pn532/test_mifare_ultralight_ndef.cpp
@@ -98,6 +98,21 @@ TEST(FindMifareUltralightNdef, NoTlvTagIsRejected) {
   EXPECT_FALSE(pn532.find_mifare_ultralight_ndef_(data, message_length, message_start_index));
 }
 
+// Regression test: the entry size guard (page_3_to_6.size() > p4_offset + 6) is loose enough to admit
+// buffers that are too short to hold the two long-form length bytes once the TLV is offset by leading
+// padding (tlv_offset == 5). Before this fix, that case silently fell through to the short-form branch
+// and reported a bogus 255-byte message instead of failing.
+TEST(FindMifareUltralightNdef, LongFormMarkerWithMissingLengthBytesIsRejected) {
+  TestablePN532 pn532;
+  // Padding pushes the TLV to offset 5; 0x03 FF present, but the two length bytes are missing (size 11).
+  std::vector<uint8_t> data = {0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x03, 0xFF};
+  ASSERT_EQ(data.size(), 11u);
+
+  uint32_t message_length = 0;
+  uint8_t message_start_index = 0;
+  EXPECT_FALSE(pn532.find_mifare_ultralight_ndef_(data, message_length, message_start_index));
+}
+
 /// End-to-end regression guard: builds a real 3-record NDEF message (URL, text, and a MIME
 /// record) padded past 255 bytes and wraps it in a Type 2 Tag TLV the way a real tag stores it,
 /// then runs the wrapper through find_mifare_ultralight_ndef_ to locate it, and feeds the located slice back

--- a/tests/components/pn532/test_mifare_ultralight_ndef.cpp
+++ b/tests/components/pn532/test_mifare_ultralight_ndef.cpp
@@ -107,7 +107,7 @@ TEST(FindMifareUltralightNdef, LongFormMessageRoundTripsThroughNdefMessage) {
   message.add_uri_record("https://esphome.io/");
   message.add_text_record("Hello, ESPHome!");
 
-  std::string json_payload = "{\"key\":\"value\",\"pad\":\"" + std::string(255, 'x') + "\"}";
+  std::string json_payload = R"({"key":"value","pad":")" + std::string(255, 'x') + R"("})";
   auto json_record = make_unique<nfc::NdefRecord>();
   json_record->set_tnf(nfc::TNF_MIME_MEDIA);
   json_record->set_type("application/json");

--- a/tests/components/pn532/test_mifare_ultralight_ndef.cpp
+++ b/tests/components/pn532/test_mifare_ultralight_ndef.cpp
@@ -99,7 +99,7 @@ TEST(FindMifareUltralightNdef, NoTlvTagIsRejected) {
 }
 
 /// End-to-end regression guard: builds a real 3-record NDEF message (URL, text, and a MIME
-/// record) padded past 255 bytes and wraps it in a Type 2 Tag TLV the way a real tag stores it, 
+/// record) padded past 255 bytes and wraps it in a Type 2 Tag TLV the way a real tag stores it,
 /// then runs the wrapper through find_mifare_ultralight_ndef_ to locate it, and feeds the located slice back
 /// into NdefMessage to confirm all three records survive the round trip.
 TEST(FindMifareUltralightNdef, LongFormMessageRoundTripsThroughNdefMessage) {


### PR DESCRIPTION
# What does this implement/fix?

Reading Mifare Ultralight tags (like NTAG215) that currently store more than 255 total bytes across multiple NDEF records produces the following error and prevents parsing of all NDEF records:
```
[01:02:03.360][E][nfc.ndef_message:062]: Corrupt record encountered; NdefMessage constructor aborting
```

This PR fixes that so such tags are parsed correctly just like tags containing less data.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: pn532-ndef-fix-test

esp32:
  board: esp32dev
  framework:
    type: arduino

logger:
  level: DEBUG

spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23
  miso_pin: GPIO19

pn532_spi:
  cs_pin: GPIO5
  update_interval: 1s
```

(configured for SPI wiring)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] (N/A) Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
