### PR TITLE
[core] Enforce the preferences contracts with concepts

### DIFF
--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -157,11 +157,15 @@
 #define USE_OUTPUT_FLOAT_POWER_SCALING
 #define USE_POWER_SUPPLY
 #define USE_PREFERENCES_SYNC_EVERY_LOOP
-// Only defined by key-lookup preference backends; slot-based platforms
+// Only defined by key-lookup preference backends; the slot-based platforms
 // (esp8266, rp2040) never set it in generated builds, and their preferences
-// managers do not provide load_from_key(), so mirror codegen here or the
-// PreferencesKeyLookupContract assert fails their clang-tidy environments.
-#if defined(USE_ESP32) || defined(USE_LIBRETINY) || defined(USE_HOST) || defined(USE_ZEPHYR)
+// managers do not provide load_from_key(), so the PreferencesKeyLookupContract
+// assert would fail their clang-tidy environments. Written as a deny-list so
+// the no-platform analysis configuration (whose Preferences stub provides
+// load_from_key()) keeps covering the key-lookup code paths, and so a future
+// slot-based platform fails the assert loudly instead of silently losing
+// analysis coverage.
+#if !defined(USE_ESP8266) && !defined(USE_RP2)
 #define USE_PREFERENCE_KEY_LOOKUP
 #endif
 #define USE_PROVISIONING

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -157,9 +157,13 @@
 #define USE_OUTPUT_FLOAT_POWER_SCALING
 #define USE_POWER_SUPPLY
 #define USE_PREFERENCES_SYNC_EVERY_LOOP
-// Only defined by key-lookup preference backends (esp32, libretiny, host, zephyr);
-// slot-based platforms (esp8266, rp2040) never set it in generated builds
+// Only defined by key-lookup preference backends; slot-based platforms
+// (esp8266, rp2040) never set it in generated builds, and their preferences
+// managers do not provide load_from_key(), so mirror codegen here or the
+// PreferencesKeyLookupContract assert fails their clang-tidy environments.
+#if defined(USE_ESP32) || defined(USE_LIBRETINY) || defined(USE_HOST) || defined(USE_ZEPHYR)
 #define USE_PREFERENCE_KEY_LOOKUP
+#endif
 #define USE_PROVISIONING
 #define USE_QR_CODE
 #define USE_SAFE_MODE_BOOT_IS_GOOD_ON_SHUTDOWN

--- a/esphome/core/preference_backend.h
+++ b/esphome/core/preference_backend.h
@@ -89,15 +89,31 @@ class ESPPreferenceObject {
 // - sync: commit pending writes to flash, true on success.
 // - reset: forget unsaved changes and re-initialize the permanent storage
 //   (usually followed by a restart), true on success.
-// Key-lookup platforms additionally provide load_from_key(), which is not part
-// of the neutral surface (slot-based backends cannot implement it).
+// The template forms are what component call sites use; PreferencesMixin
+// supplies them, but the derived class's non-template overloads hide them
+// unless it also declares `using PreferencesMixin<X>::make_preference;`, so
+// the concept pins those too.
 template<typename T>
 concept PreferencesContract = requires(T prefs, size_t len, uint32_t type, bool in_flash) {
   { prefs.make_preference(len, type, in_flash) } -> std::same_as<ESPPreferenceObject>;
   { prefs.make_preference(len, type) } -> std::same_as<ESPPreferenceObject>;
+  { prefs.template make_preference<uint32_t>(type, in_flash) } -> std::same_as<ESPPreferenceObject>;
+  { prefs.template make_preference<uint32_t>(type) } -> std::same_as<ESPPreferenceObject>;
   { prefs.sync() } -> std::same_as<bool>;
   { prefs.reset() } -> std::same_as<bool>;
 };
+
+#ifdef USE_PREFERENCE_KEY_LOOKUP
+// Key-lookup platforms (the ones that emit USE_PREFERENCE_KEY_LOOKUP from
+// Python codegen) additionally provide load_from_key(), a one-shot read of a
+// stored preference by key that migrate_preference() relies on. It is not part
+// of the neutral surface because slot-based backends cannot implement it, so
+// it gets its own concept, asserted only where the define is set.
+template<typename T>
+concept PreferencesKeyLookupContract = requires(T prefs, uint32_t type, uint8_t *data, size_t len) {
+  { prefs.load_from_key(type, data, len) } -> std::same_as<bool>;
+};
+#endif  // USE_PREFERENCE_KEY_LOOKUP
 
 /// CRTP mixin providing type-safe template make_preference<T>() helpers.
 /// Platform preferences classes inherit this to avoid duplicating these templates.

--- a/esphome/core/preference_backend.h
+++ b/esphome/core/preference_backend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 
 #include "esphome/core/defines.h"
@@ -30,6 +31,15 @@
 
 namespace esphome {
 
+// The PreferenceBackend method surface, asserted on the alias each platform
+// header binds. save() persists len bytes; load() fills dest only when the
+// stored data exists and matches len. Both report success as their return.
+template<typename T>
+concept PreferenceBackendContract = requires(T backend, const uint8_t *src, uint8_t *dest, size_t len) {
+  { backend.save(src, len) } -> std::same_as<bool>;
+  { backend.load(dest, len) } -> std::same_as<bool>;
+};
+
 #if !defined(USE_ESP32) && !defined(USE_ESP8266) && !defined(USE_RP2) && !defined(USE_LIBRETINY) && \
     !defined(USE_HOST) && !(defined(USE_ZEPHYR) && defined(CONFIG_SETTINGS))
 // Stub for static analysis when no platform is defined.
@@ -40,6 +50,8 @@ struct PreferenceBackend {
 #endif
 
 using ESPPreferenceBackend = PreferenceBackend;
+static_assert(PreferenceBackendContract<PreferenceBackend>,
+              "The platform's preference backend is missing part of the PreferenceBackend surface");
 
 class ESPPreferenceObject {
  public:
@@ -66,6 +78,25 @@ class ESPPreferenceObject {
 
  protected:
   PreferenceBackend *backend_{nullptr};
+};
+
+// The preferences manager method surface, asserted in esphome/core/preferences.h
+// on the ESPPreferences alias each platform's preferences.h binds through
+// DECLARE_PREFERENCE_ALIASES. Semantics beyond the signatures:
+// - make_preference: the two-argument form applies the platform's historic
+//   default storage; in_flash=false may fall back to flash where the platform
+//   has no faster storage.
+// - sync: commit pending writes to flash, true on success.
+// - reset: forget unsaved changes and re-initialize the permanent storage
+//   (usually followed by a restart), true on success.
+// Key-lookup platforms additionally provide load_from_key(), which is not part
+// of the neutral surface (slot-based backends cannot implement it).
+template<typename T>
+concept PreferencesContract = requires(T prefs, size_t len, uint32_t type, bool in_flash) {
+  { prefs.make_preference(len, type, in_flash) } -> std::same_as<ESPPreferenceObject>;
+  { prefs.make_preference(len, type) } -> std::same_as<ESPPreferenceObject>;
+  { prefs.sync() } -> std::same_as<bool>;
+  { prefs.reset() } -> std::same_as<bool>;
 };
 
 /// CRTP mixin providing type-safe template make_preference<T>() helpers.

--- a/esphome/core/preference_backend.h
+++ b/esphome/core/preference_backend.h
@@ -103,17 +103,15 @@ concept PreferencesContract = requires(T prefs, size_t len, uint32_t type, bool 
   { prefs.reset() } -> std::same_as<bool>;
 };
 
-#ifdef USE_PREFERENCE_KEY_LOOKUP
-// Key-lookup platforms (the ones that emit USE_PREFERENCE_KEY_LOOKUP from
-// Python codegen) additionally provide load_from_key(), a one-shot read of a
-// stored preference by key that migrate_preference() relies on. It is not part
-// of the neutral surface because slot-based backends cannot implement it, so
-// it gets its own concept, asserted only where the define is set.
+// Key-lookup platforms additionally provide load_from_key(), a one-shot read
+// of a stored preference by key that migrate_preference() relies on; see the
+// key-lookup note at the top of this file. Not part of PreferencesContract,
+// so it is asserted in preferences.h only where USE_PREFERENCE_KEY_LOOKUP
+// is set.
 template<typename T>
 concept PreferencesKeyLookupContract = requires(T prefs, uint32_t type, uint8_t *data, size_t len) {
   { prefs.load_from_key(type, data, len) } -> std::same_as<bool>;
 };
-#endif  // USE_PREFERENCE_KEY_LOOKUP
 
 /// CRTP mixin providing type-safe template make_preference<T>() helpers.
 /// Platform preferences classes inherit this to avoid duplicating these templates.

--- a/esphome/core/preferences.h
+++ b/esphome/core/preferences.h
@@ -49,15 +49,14 @@ namespace esphome {
 static_assert(PreferencesContract<ESPPreferences>,
               "The platform's preferences manager is missing part of the ESPPreferences surface "
               "(esphome/core/preference_backend.h)");
-#ifdef USE_PREFERENCE_KEY_LOOKUP
-static_assert(PreferencesKeyLookupContract<ESPPreferences>,
-              "This platform emits USE_PREFERENCE_KEY_LOOKUP but its preferences manager does not provide "
-              "load_from_key() (esphome/core/preference_backend.h)");
-#endif
 }  // namespace esphome
 
 #ifdef USE_PREFERENCE_KEY_LOOKUP
 namespace esphome {
+static_assert(PreferencesKeyLookupContract<ESPPreferences>,
+              "This platform emits USE_PREFERENCE_KEY_LOOKUP but its preferences manager does not provide "
+              "load_from_key() (esphome/core/preference_backend.h)");
+
 /// Copy preference data stored under old_key into new_pref (created for new_key) if the keys
 /// differ and new_pref has no data yet. scratch must hold at least size bytes.
 /// Returns true when scratch holds the entity's current data (loaded or just migrated).

--- a/esphome/core/preferences.h
+++ b/esphome/core/preferences.h
@@ -45,6 +45,12 @@ extern ESPPreferences *global_preferences;  // NOLINT(cppcoreguidelines-avoid-no
 }  // namespace esphome
 #endif
 
+namespace esphome {
+static_assert(PreferencesContract<ESPPreferences>,
+              "The platform's preferences manager is missing part of the ESPPreferences surface "
+              "(esphome/core/preference_backend.h)");
+}  // namespace esphome
+
 #ifdef USE_PREFERENCE_KEY_LOOKUP
 namespace esphome {
 /// Copy preference data stored under old_key into new_pref (created for new_key) if the keys

--- a/esphome/core/preferences.h
+++ b/esphome/core/preferences.h
@@ -49,6 +49,11 @@ namespace esphome {
 static_assert(PreferencesContract<ESPPreferences>,
               "The platform's preferences manager is missing part of the ESPPreferences surface "
               "(esphome/core/preference_backend.h)");
+#ifdef USE_PREFERENCE_KEY_LOOKUP
+static_assert(PreferencesKeyLookupContract<ESPPreferences>,
+              "This platform emits USE_PREFERENCE_KEY_LOOKUP but its preferences manager does not provide "
+              "load_from_key() (esphome/core/preference_backend.h)");
+#endif
 }  // namespace esphome
 
 #ifdef USE_PREFERENCE_KEY_LOOKUP

--- a/tests/component_tests/preferences/config/bk72xx.yaml
+++ b/tests/component_tests/preferences/config/bk72xx.yaml
@@ -1,0 +1,5 @@
+esphome:
+  name: preftest
+
+bk72xx:
+  board: generic-bk7252

--- a/tests/component_tests/preferences/config/esp32.yaml
+++ b/tests/component_tests/preferences/config/esp32.yaml
@@ -1,0 +1,5 @@
+esphome:
+  name: preftest
+
+esp32:
+  board: esp32dev

--- a/tests/component_tests/preferences/config/esp8266.yaml
+++ b/tests/component_tests/preferences/config/esp8266.yaml
@@ -1,0 +1,5 @@
+esphome:
+  name: preftest
+
+esp8266:
+  board: esp01_1m

--- a/tests/component_tests/preferences/config/host.yaml
+++ b/tests/component_tests/preferences/config/host.yaml
@@ -1,0 +1,4 @@
+esphome:
+  name: preftest
+
+host:

--- a/tests/component_tests/preferences/config/nrf52.yaml
+++ b/tests/component_tests/preferences/config/nrf52.yaml
@@ -1,0 +1,6 @@
+esphome:
+  name: preftest
+
+nrf52:
+  board: adafruit_itsybitsy_nrf52840
+  bootloader: adafruit_nrf52_sd140_v6

--- a/tests/component_tests/preferences/config/rp2.yaml
+++ b/tests/component_tests/preferences/config/rp2.yaml
@@ -1,0 +1,5 @@
+esphome:
+  name: preftest
+
+rp2:
+  board: rpipicow

--- a/tests/component_tests/preferences/test_key_lookup_gate.py
+++ b/tests/component_tests/preferences/test_key_lookup_gate.py
@@ -1,65 +1,34 @@
-"""Pin the USE_PREFERENCE_KEY_LOOKUP deny-list in esphome/core/defines.h to the
-platforms whose codegen actually emits the define, so neither side can drift
-from the other unnoticed. Follows the defines.h mirror precedent in
-tests/component_tests/bluetooth_proxy/test_platform_gates.py."""
+"""Every preferences platform either emits USE_PREFERENCE_KEY_LOOKUP from
+codegen (key-lookup backends) or must not (slot-based backends, whose managers
+have no load_from_key()). Run each platform's real codegen and assert the
+emission, pinning the same split the deny-list in esphome/core/defines.h
+encodes for static analysis."""
 
+from collections.abc import Callable
 from pathlib import Path
-import re
 
-REPO_ROOT = Path(__file__).parents[3]
+import pytest
 
-# Every platform component that provides a preferences manager (the include
-# ladder in esphome/core/preferences.h). A new platform must be added here,
-# which forces a decision: emit the define (key-lookup) or join the deny-list
-# (slot-based).
-PREFERENCES_PLATFORMS = {
-    "esp32",
-    "esp8266",
-    "rp2",
-    "libretiny",
-    "host",
-    "zephyr",
-}
+from esphome.core import CORE
 
 
-def _platforms_emitting_key_lookup() -> set[str]:
-    return {
-        platform
-        for platform in PREFERENCES_PLATFORMS
-        if 'cg.add_define("USE_PREFERENCE_KEY_LOOKUP")'
-        in (REPO_ROOT / "esphome" / "components" / platform / "__init__.py").read_text()
-    }
-
-
-def test_defines_h_deny_list_mirrors_the_codegen_emitters() -> None:
-    defines = (REPO_ROOT / "esphome" / "core" / "defines.h").read_text()
-    match = re.search(
-        r"#if ((?:!defined\(USE_[A-Z0-9]+\)(?: && )?)+)\s*\n#define USE_PREFERENCE_KEY_LOOKUP\b",
-        defines,
-    )
-    assert match is not None, (
-        "defines.h no longer guards USE_PREFERENCE_KEY_LOOKUP with a deny-list"
-    )
-    denied = {
-        name.removeprefix("USE_").lower()
-        for name in re.findall(r"!defined\((USE_[A-Z0-9]+)\)", match.group(1))
-    }
-
-    slot_based = PREFERENCES_PLATFORMS - _platforms_emitting_key_lookup()
-    assert denied == slot_based, (
-        f"defines.h denies {sorted(denied)} but the platforms without a "
-        f'cg.add_define("USE_PREFERENCE_KEY_LOOKUP") emitter are {sorted(slot_based)}'
-    )
-
-
-def test_platform_list_is_current() -> None:
-    # If a platform gains or loses a preferences manager, PREFERENCES_PLATFORMS
-    # must follow the include ladder in esphome/core/preferences.h.
-    ladder = (REPO_ROOT / "esphome" / "core" / "preferences.h").read_text()
-    in_ladder = {
-        path.split("/")[2]
-        for path in re.findall(
-            r'#include "(esphome/components/[a-z0-9_]+/preferences\.h)"', ladder
-        )
-    }
-    assert in_ladder == PREFERENCES_PLATFORMS
+@pytest.mark.parametrize(
+    ("fixture", "emits"),
+    [
+        ("esp32.yaml", True),
+        ("bk72xx.yaml", True),  # libretiny
+        ("host.yaml", True),
+        ("nrf52.yaml", True),  # zephyr
+        ("esp8266.yaml", False),
+        ("rp2.yaml", False),
+    ],
+)
+def test_key_lookup_define_matches_the_platform_backend(
+    fixture: str,
+    emits: bool,
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    generate_main(component_config_path(fixture))
+    defines = {define.name for define in CORE.defines}
+    assert ("USE_PREFERENCE_KEY_LOOKUP" in defines) is emits

--- a/tests/component_tests/preferences/test_key_lookup_gate.py
+++ b/tests/component_tests/preferences/test_key_lookup_gate.py
@@ -1,0 +1,65 @@
+"""Pin the USE_PREFERENCE_KEY_LOOKUP deny-list in esphome/core/defines.h to the
+platforms whose codegen actually emits the define, so neither side can drift
+from the other unnoticed. Follows the defines.h mirror precedent in
+tests/component_tests/bluetooth_proxy/test_platform_gates.py."""
+
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).parents[3]
+
+# Every platform component that provides a preferences manager (the include
+# ladder in esphome/core/preferences.h). A new platform must be added here,
+# which forces a decision: emit the define (key-lookup) or join the deny-list
+# (slot-based).
+PREFERENCES_PLATFORMS = {
+    "esp32",
+    "esp8266",
+    "rp2",
+    "libretiny",
+    "host",
+    "zephyr",
+}
+
+
+def _platforms_emitting_key_lookup() -> set[str]:
+    return {
+        platform
+        for platform in PREFERENCES_PLATFORMS
+        if 'cg.add_define("USE_PREFERENCE_KEY_LOOKUP")'
+        in (REPO_ROOT / "esphome" / "components" / platform / "__init__.py").read_text()
+    }
+
+
+def test_defines_h_deny_list_mirrors_the_codegen_emitters() -> None:
+    defines = (REPO_ROOT / "esphome" / "core" / "defines.h").read_text()
+    match = re.search(
+        r"#if ((?:!defined\(USE_[A-Z0-9]+\)(?: && )?)+)\s*\n#define USE_PREFERENCE_KEY_LOOKUP\b",
+        defines,
+    )
+    assert match is not None, (
+        "defines.h no longer guards USE_PREFERENCE_KEY_LOOKUP with a deny-list"
+    )
+    denied = {
+        name.removeprefix("USE_").lower()
+        for name in re.findall(r"!defined\((USE_[A-Z0-9]+)\)", match.group(1))
+    }
+
+    slot_based = PREFERENCES_PLATFORMS - _platforms_emitting_key_lookup()
+    assert denied == slot_based, (
+        f"defines.h denies {sorted(denied)} but the platforms without a "
+        f'cg.add_define("USE_PREFERENCE_KEY_LOOKUP") emitter are {sorted(slot_based)}'
+    )
+
+
+def test_platform_list_is_current() -> None:
+    # If a platform gains or loses a preferences manager, PREFERENCES_PLATFORMS
+    # must follow the include ladder in esphome/core/preferences.h.
+    ladder = (REPO_ROOT / "esphome" / "core" / "preferences.h").read_text()
+    in_ladder = {
+        path.split("/")[2]
+        for path in re.findall(
+            r'#include "(esphome/components/[a-z0-9_]+/preferences\.h)"', ladder
+        )
+    }
+    assert in_ladder == PREFERENCES_PLATFORMS

--- a/tests/component_tests/preferences/test_key_lookup_gate.py
+++ b/tests/component_tests/preferences/test_key_lookup_gate.py
@@ -1,8 +1,13 @@
 """Every preferences platform either emits USE_PREFERENCE_KEY_LOOKUP from
 codegen (key-lookup backends) or must not (slot-based backends, whose managers
 have no load_from_key()). Run each platform's real codegen and assert the
-emission, pinning the same split the deny-list in esphome/core/defines.h
-encodes for static analysis."""
+emission, mirroring the split the deny-list in esphome/core/defines.h assumes
+for static analysis.
+
+The fixtures cover every distinct preferences backend today: ln882x and
+rtl87xx route through libretiny (bk72xx stands in for the family), rp2040 is
+an alias of rp2, and nrf52 exercises zephyr. A seventh backend needs a new
+fixture here."""
 
 from collections.abc import Callable
 from pathlib import Path

--- a/tests/components/core/test_preference_contract.cpp
+++ b/tests/components/core/test_preference_contract.cpp
@@ -1,0 +1,60 @@
+// Pins the preferences contract concepts so the surface they enforce cannot
+// drift unnoticed: a minimal conforming type must satisfy each concept, and a
+// type missing a method or returning the wrong type must not.
+
+#include <gtest/gtest.h>
+
+#include "esphome/core/preference_backend.h"
+
+namespace esphome::core::testing {
+
+struct MinimalBackend {
+  bool save(const uint8_t *, size_t) { return true; }
+  bool load(uint8_t *, size_t) { return true; }
+};
+static_assert(PreferenceBackendContract<MinimalBackend>);
+
+struct BackendMissingLoad {
+  bool save(const uint8_t *, size_t) { return true; }
+};
+static_assert(!PreferenceBackendContract<BackendMissingLoad>);
+
+struct BackendWrongReturn {
+  void save(const uint8_t *, size_t) {}
+  bool load(uint8_t *, size_t) { return true; }
+};
+static_assert(!PreferenceBackendContract<BackendWrongReturn>);
+
+struct MinimalPreferences {
+  ESPPreferenceObject make_preference(size_t, uint32_t, bool) { return {}; }
+  ESPPreferenceObject make_preference(size_t, uint32_t) { return {}; }
+  bool sync() { return true; }
+  bool reset() { return true; }
+};
+static_assert(PreferencesContract<MinimalPreferences>);
+
+struct PreferencesMissingTwoArgForm {
+  ESPPreferenceObject make_preference(size_t, uint32_t, bool) { return {}; }
+  bool sync() { return true; }
+  bool reset() { return true; }
+};
+static_assert(!PreferencesContract<PreferencesMissingTwoArgForm>);
+
+struct PreferencesMissingReset {
+  ESPPreferenceObject make_preference(size_t, uint32_t, bool) { return {}; }
+  ESPPreferenceObject make_preference(size_t, uint32_t) { return {}; }
+  bool sync() { return true; }
+};
+static_assert(!PreferencesContract<PreferencesMissingReset>);
+
+TEST(PreferenceContract, NullBackendRefusesBothOperations) {
+  // ESPPreferenceObject forwards to whichever backend the platform binds; a
+  // default-constructed object has no backend and must refuse both operations
+  // instead of crashing.
+  ESPPreferenceObject without_backend;
+  uint32_t value = 42;
+  EXPECT_FALSE(without_backend.save(&value));
+  EXPECT_FALSE(without_backend.load(&value));
+}
+
+}  // namespace esphome::core::testing

--- a/tests/components/core/test_preference_contract.cpp
+++ b/tests/components/core/test_preference_contract.cpp
@@ -25,7 +25,8 @@ struct BackendWrongReturn {
 };
 static_assert(!PreferenceBackendContract<BackendWrongReturn>);
 
-struct MinimalPreferences {
+struct MinimalPreferences : public PreferencesMixin<MinimalPreferences> {
+  using PreferencesMixin<MinimalPreferences>::make_preference;
   ESPPreferenceObject make_preference(size_t, uint32_t, bool) { return {}; }
   ESPPreferenceObject make_preference(size_t, uint32_t) { return {}; }
   bool sync() { return true; }
@@ -33,19 +34,52 @@ struct MinimalPreferences {
 };
 static_assert(PreferencesContract<MinimalPreferences>);
 
-struct PreferencesMissingTwoArgForm {
+struct PreferencesMissingTwoArgForm : public PreferencesMixin<PreferencesMissingTwoArgForm> {
+  using PreferencesMixin<PreferencesMissingTwoArgForm>::make_preference;
   ESPPreferenceObject make_preference(size_t, uint32_t, bool) { return {}; }
   bool sync() { return true; }
   bool reset() { return true; }
 };
 static_assert(!PreferencesContract<PreferencesMissingTwoArgForm>);
 
-struct PreferencesMissingReset {
+struct PreferencesMissingReset : public PreferencesMixin<PreferencesMissingReset> {
+  using PreferencesMixin<PreferencesMissingReset>::make_preference;
   ESPPreferenceObject make_preference(size_t, uint32_t, bool) { return {}; }
   ESPPreferenceObject make_preference(size_t, uint32_t) { return {}; }
   bool sync() { return true; }
 };
 static_assert(!PreferencesContract<PreferencesMissingReset>);
+
+struct PreferencesWrongSyncReturn : public PreferencesMixin<PreferencesWrongSyncReturn> {
+  using PreferencesMixin<PreferencesWrongSyncReturn>::make_preference;
+  ESPPreferenceObject make_preference(size_t, uint32_t, bool) { return {}; }
+  ESPPreferenceObject make_preference(size_t, uint32_t) { return {}; }
+  void sync() {}
+  bool reset() { return true; }
+};
+static_assert(!PreferencesContract<PreferencesWrongSyncReturn>);
+
+// The derived non-template overloads hide PreferencesMixin's template forms
+// unless the class re-exposes them with a using declaration; forgetting that
+// line breaks every make_preference<T>() call site, so the concept must
+// reject the class.
+struct PreferencesForgotUsingDeclaration : public PreferencesMixin<PreferencesForgotUsingDeclaration> {
+  ESPPreferenceObject make_preference(size_t, uint32_t, bool) { return {}; }
+  ESPPreferenceObject make_preference(size_t, uint32_t) { return {}; }
+  bool sync() { return true; }
+  bool reset() { return true; }
+};
+static_assert(!PreferencesContract<PreferencesForgotUsingDeclaration>);
+
+#ifdef USE_PREFERENCE_KEY_LOOKUP
+struct MinimalKeyLookup {
+  bool load_from_key(uint32_t, uint8_t *, size_t) { return true; }
+};
+static_assert(PreferencesKeyLookupContract<MinimalKeyLookup>);
+
+struct KeyLookupMissingMethod {};
+static_assert(!PreferencesKeyLookupContract<KeyLookupMissingMethod>);
+#endif
 
 TEST(PreferenceContract, NullBackendRefusesBothOperations) {
   // ESPPreferenceObject forwards to whichever backend the platform binds; a

--- a/tests/components/core/test_preference_contract.cpp
+++ b/tests/components/core/test_preference_contract.cpp
@@ -59,10 +59,9 @@ struct PreferencesWrongSyncReturn : public PreferencesMixin<PreferencesWrongSync
 };
 static_assert(!PreferencesContract<PreferencesWrongSyncReturn>);
 
-// The derived non-template overloads hide PreferencesMixin's template forms
-// unless the class re-exposes them with a using declaration; forgetting that
-// line breaks every make_preference<T>() call site, so the concept must
-// reject the class.
+// Forgot `using PreferencesMixin<X>::make_preference;`, so the derived
+// overloads hide the template forms (see the PreferencesContract note in
+// preference_backend.h); the concept must reject the class.
 struct PreferencesForgotUsingDeclaration : public PreferencesMixin<PreferencesForgotUsingDeclaration> {
   ESPPreferenceObject make_preference(size_t, uint32_t, bool) { return {}; }
   ESPPreferenceObject make_preference(size_t, uint32_t) { return {}; }
@@ -71,7 +70,6 @@ struct PreferencesForgotUsingDeclaration : public PreferencesMixin<PreferencesFo
 };
 static_assert(!PreferencesContract<PreferencesForgotUsingDeclaration>);
 
-#ifdef USE_PREFERENCE_KEY_LOOKUP
 struct MinimalKeyLookup {
   bool load_from_key(uint32_t, uint8_t *, size_t) { return true; }
 };
@@ -79,7 +77,6 @@ static_assert(PreferencesKeyLookupContract<MinimalKeyLookup>);
 
 struct KeyLookupMissingMethod {};
 static_assert(!PreferencesKeyLookupContract<KeyLookupMissingMethod>);
-#endif
 
 TEST(PreferenceContract, NullBackendRefusesBothOperations) {
   // ESPPreferenceObject forwards to whichever backend the platform binds; a


### PR DESCRIPTION
# What does this implement/fix?

The preferences layer already binds its platform implementation at compile time; each platform header binds the PreferenceBackend alias and DECLARE_PREFERENCE_ALIASES binds ESPPreferences. The method surface was only documented, so an implementation that drifts from it fails at some distant call site instead of one clear error.

This adds PreferenceBackendContract and PreferencesContract concepts in esphome/core/preference_backend.h and static_asserts them where the aliases bind, the same pattern #18181 uses for BLEHub. A host unit test pins both concepts with minimal conforming and nonconforming types so the contract cannot rot unseen. No behavior or generated code changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
