### PR TITLE
[ota] Enforce the backend contract with a concept

### DIFF
--- a/esphome/components/ota/ota_backend.h
+++ b/esphome/components/ota/ota_backend.h
@@ -4,6 +4,7 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 
+#include <concepts>
 #include <cstdint>
 
 #ifdef USE_OTA_STATE_LISTENER
@@ -76,6 +77,25 @@ enum OTAType : uint8_t {
   OTA_TYPE_UPDATE_APP = 0x00,
   OTA_TYPE_UPDATE_PARTITION_TABLE = 0x01,
   OTA_TYPE_UPDATE_BOOTLOADER = 0x02,
+};
+
+// The OTA backend method surface. Exactly one backend exists per build,
+// selected in ota_backend_factory.h where this concept is asserted on
+// make_ota_backend()'s return type. Semantics beyond the signatures:
+// - begin: prepare for an image of the given size; ota_type defaults to an
+//   app update, so both call forms must be accepted.
+// - set_update_md5: expected digest of the incoming image, hex string.
+// - write: consume the next chunk; end: finalize and mark bootable.
+// - abort: safe to call in any state, including after end().
+template<typename T>
+concept OTABackendContract = requires(T backend, size_t image_size, uint8_t *data, size_t len, const char *md5) {
+  { backend.begin(image_size, OTA_TYPE_UPDATE_APP) } -> std::same_as<OTAResponseTypes>;
+  { backend.begin(image_size) } -> std::same_as<OTAResponseTypes>;
+  backend.set_update_md5(md5);
+  { backend.write(data, len) } -> std::same_as<OTAResponseTypes>;
+  { backend.end() } -> std::same_as<OTAResponseTypes>;
+  backend.abort();
+  { backend.supports_compression() } -> std::same_as<bool>;
 };
 
 /** Listener interface for OTA state changes.

--- a/esphome/components/ota/ota_backend.h
+++ b/esphome/components/ota/ota_backend.h
@@ -5,6 +5,7 @@
 #include "esphome/core/helpers.h"
 
 #include <concepts>
+#include <cstddef>
 #include <cstdint>
 
 #ifdef USE_OTA_STATE_LISTENER

--- a/esphome/components/ota/ota_backend_factory.h
+++ b/esphome/components/ota/ota_backend_factory.h
@@ -17,11 +17,22 @@
 #else
 // Stub for static analysis when no platform is defined
 namespace esphome::ota {
-struct StubOTABackend {};
+struct StubOTABackend {
+  OTAResponseTypes begin(size_t image_size, OTAType ota_type = OTA_TYPE_UPDATE_APP) {
+    return OTA_RESPONSE_ERROR_UNKNOWN;
+  }
+  void set_update_md5(const char *md5) {}
+  OTAResponseTypes write(uint8_t *data, size_t len) { return OTA_RESPONSE_ERROR_UNKNOWN; }
+  OTAResponseTypes end() { return OTA_RESPONSE_ERROR_UNKNOWN; }
+  void abort() {}
+  bool supports_compression() { return false; }
+};
 std::unique_ptr<StubOTABackend> make_ota_backend();
 }  // namespace esphome::ota
 #endif
 
 namespace esphome::ota {
 using OTABackendPtr = decltype(make_ota_backend());
+static_assert(OTABackendContract<OTABackendPtr::element_type>,
+              "The platform's OTA backend is missing part of the backend surface (ota_backend.h)");
 }  // namespace esphome::ota

--- a/tests/components/ota/test_backend_contract.cpp
+++ b/tests/components/ota/test_backend_contract.cpp
@@ -18,34 +18,24 @@ struct MinimalBackend {
 };
 static_assert(OTABackendContract<MinimalBackend>);
 
-// begin() must accept the one-argument form; a backend without the default
-// ota_type argument breaks consumers that only pass the image size.
-struct BackendWithoutDefaultOTAType {
+// Each negative case derives from MinimalBackend and breaks exactly one
+// requirement; the declaration in the derived struct hides the conforming
+// one from the base.
+
+// begin() without the default ota_type argument breaks consumers that only
+// pass the image size.
+struct BackendWithoutDefaultOTAType : MinimalBackend {
   OTAResponseTypes begin(size_t image_size, OTAType ota_type) { return OTA_RESPONSE_OK; }
-  void set_update_md5(const char *md5) {}
-  OTAResponseTypes write(uint8_t *data, size_t len) { return OTA_RESPONSE_OK; }
-  OTAResponseTypes end() { return OTA_RESPONSE_OK; }
-  void abort() {}
-  bool supports_compression() { return false; }
 };
 static_assert(!OTABackendContract<BackendWithoutDefaultOTAType>);
 
-struct BackendMissingAbort {
-  OTAResponseTypes begin(size_t image_size, OTAType ota_type = OTA_TYPE_UPDATE_APP) { return OTA_RESPONSE_OK; }
-  void set_update_md5(const char *md5) {}
-  OTAResponseTypes write(uint8_t *data, size_t len) { return OTA_RESPONSE_OK; }
-  OTAResponseTypes end() { return OTA_RESPONSE_OK; }
-  bool supports_compression() { return false; }
+struct BackendMissingAbort : MinimalBackend {
+  void abort() = delete;
 };
 static_assert(!OTABackendContract<BackendMissingAbort>);
 
-struct BackendWrongWriteReturn {
-  OTAResponseTypes begin(size_t image_size, OTAType ota_type = OTA_TYPE_UPDATE_APP) { return OTA_RESPONSE_OK; }
-  void set_update_md5(const char *md5) {}
+struct BackendWrongWriteReturn : MinimalBackend {
   bool write(uint8_t *data, size_t len) { return true; }
-  OTAResponseTypes end() { return OTA_RESPONSE_OK; }
-  void abort() {}
-  bool supports_compression() { return false; }
 };
 static_assert(!OTABackendContract<BackendWrongWriteReturn>);
 

--- a/tests/components/ota/test_backend_contract.cpp
+++ b/tests/components/ota/test_backend_contract.cpp
@@ -1,0 +1,65 @@
+// Pins the OTA backend contract concept so the surface it enforces cannot
+// drift unnoticed: a minimal conforming type must satisfy it, and a type
+// missing a method or returning the wrong type must not.
+
+#include "esphome/components/ota/ota_backend.h"
+
+#include <gtest/gtest.h>
+
+namespace esphome::ota::testing {
+
+struct MinimalBackend {
+  OTAResponseTypes begin(size_t image_size, OTAType ota_type = OTA_TYPE_UPDATE_APP) { return OTA_RESPONSE_OK; }
+  void set_update_md5(const char *md5) {}
+  OTAResponseTypes write(uint8_t *data, size_t len) { return OTA_RESPONSE_OK; }
+  OTAResponseTypes end() { return OTA_RESPONSE_OK; }
+  void abort() {}
+  bool supports_compression() { return false; }
+};
+static_assert(OTABackendContract<MinimalBackend>);
+
+// begin() must accept the one-argument form; a backend without the default
+// ota_type argument breaks consumers that only pass the image size.
+struct BackendWithoutDefaultOTAType {
+  OTAResponseTypes begin(size_t image_size, OTAType ota_type) { return OTA_RESPONSE_OK; }
+  void set_update_md5(const char *md5) {}
+  OTAResponseTypes write(uint8_t *data, size_t len) { return OTA_RESPONSE_OK; }
+  OTAResponseTypes end() { return OTA_RESPONSE_OK; }
+  void abort() {}
+  bool supports_compression() { return false; }
+};
+static_assert(!OTABackendContract<BackendWithoutDefaultOTAType>);
+
+struct BackendMissingAbort {
+  OTAResponseTypes begin(size_t image_size, OTAType ota_type = OTA_TYPE_UPDATE_APP) { return OTA_RESPONSE_OK; }
+  void set_update_md5(const char *md5) {}
+  OTAResponseTypes write(uint8_t *data, size_t len) { return OTA_RESPONSE_OK; }
+  OTAResponseTypes end() { return OTA_RESPONSE_OK; }
+  bool supports_compression() { return false; }
+};
+static_assert(!OTABackendContract<BackendMissingAbort>);
+
+struct BackendWrongWriteReturn {
+  OTAResponseTypes begin(size_t image_size, OTAType ota_type = OTA_TYPE_UPDATE_APP) { return OTA_RESPONSE_OK; }
+  void set_update_md5(const char *md5) {}
+  bool write(uint8_t *data, size_t len) { return true; }
+  OTAResponseTypes end() { return OTA_RESPONSE_OK; }
+  void abort() {}
+  bool supports_compression() { return false; }
+};
+static_assert(!OTABackendContract<BackendWrongWriteReturn>);
+
+TEST(OTABackendContract, MinimalBackendDrivesTheConsumerCallSequence) {
+  // Exercise the surface the way ota_esphome does: begin, md5, write, end,
+  // then an unconditional abort, which must be safe after end().
+  MinimalBackend backend;
+  uint8_t chunk[4] = {1, 2, 3, 4};
+  EXPECT_EQ(backend.begin(sizeof(chunk)), OTA_RESPONSE_OK);
+  backend.set_update_md5("00000000000000000000000000000000");
+  EXPECT_EQ(backend.write(chunk, sizeof(chunk)), OTA_RESPONSE_OK);
+  EXPECT_EQ(backend.end(), OTA_RESPONSE_OK);
+  backend.abort();
+  EXPECT_FALSE(backend.supports_compression());
+}
+
+}  // namespace esphome::ota::testing

--- a/tests/components/ota/test_backend_contract.cpp
+++ b/tests/components/ota/test_backend_contract.cpp
@@ -1,10 +1,10 @@
 // Pins the OTA backend contract concept so the surface it enforces cannot
-// drift unnoticed: a minimal conforming type must satisfy it, and a type
-// missing a method or returning the wrong type must not.
+// drift unnoticed: the build's real backend and a minimal conforming type
+// must satisfy it, and a type missing a method or returning the wrong type
+// must not.
 
 #include "esphome/components/ota/ota_backend.h"
-
-#include <gtest/gtest.h>
+#include "esphome/components/ota/ota_backend_host.h"
 
 namespace esphome::ota::testing {
 
@@ -49,17 +49,11 @@ struct BackendWrongWriteReturn {
 };
 static_assert(!OTABackendContract<BackendWrongWriteReturn>);
 
-TEST(OTABackendContract, MinimalBackendDrivesTheConsumerCallSequence) {
-  // Exercise the surface the way ota_esphome does: begin, md5, write, end,
-  // then an unconditional abort, which must be safe after end().
-  MinimalBackend backend;
-  uint8_t chunk[4] = {1, 2, 3, 4};
-  EXPECT_EQ(backend.begin(sizeof(chunk)), OTA_RESPONSE_OK);
-  backend.set_update_md5("00000000000000000000000000000000");
-  EXPECT_EQ(backend.write(chunk, sizeof(chunk)), OTA_RESPONSE_OK);
-  EXPECT_EQ(backend.end(), OTA_RESPONSE_OK);
-  backend.abort();
-  EXPECT_FALSE(backend.supports_compression());
-}
+// Pin the build's real backend, not just local mocks: the unit test harness
+// builds for the host platform, so this is the same check the factory's
+// static_assert performs in a firmware compile.
+#ifdef USE_HOST
+static_assert(OTABackendContract<HostOTABackend>);
+#endif
 
 }  // namespace esphome::ota::testing


### PR DESCRIPTION
# What does this implement/fix?

The OTA backend is already bound at compile time; ota_backend_factory.h selects the platform's backend and make_ota_backend() returns it, but the method surface was only implied, so a backend that drifts from it fails at some distant call site instead of one clear error.

This adds an OTABackendContract concept in ota_backend.h and static_asserts it on make_ota_backend()'s return type in the factory, the same pattern #18181 uses for BLEHub. The static analysis stub gains the full surface so the assert holds in every arm. A host unit test pins the concept with minimal conforming and nonconforming types, including the one argument begin() form consumers rely on. No behavior changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
