### PR TITLE
[ld2412] Fix crash when only some gate thresholds are configured

### DIFF
--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -597,7 +597,8 @@ bool LD2412Component::handle_ack_data_() {
 
     case CMD_QUERY_MOTION_GATE_SENS: {
 #ifdef USE_NUMBER
-      for (size_t i = 0; i < this->gate_move_threshold_numbers_.size() && (10 + i) < this->buffer_pos_; i++) {
+      for (size_t i = 0; i < this->gate_move_thresholds_.size() && (10 + i) < this->buffer_pos_; i++) {
+        this->gate_move_thresholds_[i] = this->buffer_data_[10 + i];
         set_number_value(this->gate_move_threshold_numbers_[i], this->buffer_data_[10 + i]);
       }
 #endif
@@ -606,7 +607,8 @@ bool LD2412Component::handle_ack_data_() {
 
     case CMD_QUERY_STATIC_GATE_SENS: {
 #ifdef USE_NUMBER
-      for (size_t i = 0; i < this->gate_still_threshold_numbers_.size() && (10 + i) < this->buffer_pos_; i++) {
+      for (size_t i = 0; i < this->gate_still_thresholds_.size() && (10 + i) < this->buffer_pos_; i++) {
+        this->gate_still_thresholds_[i] = this->buffer_data_[10 + i];
         set_number_value(this->gate_still_threshold_numbers_[i], this->buffer_data_[10 + i]);
       }
 #endif
@@ -805,24 +807,30 @@ void LD2412Component::set_basic_config() {
 }
 
 #ifdef USE_NUMBER
+void LD2412Component::send_gate_thresholds_(uint8_t command, const std::array<number::Number *, TOTAL_GATES> &numbers,
+                                            const std::array<uint8_t, TOTAL_GATES> &last_read) {
+  uint8_t value[TOTAL_GATES];
+  bool any_configured = false;
+  for (uint8_t i = 0; i < TOTAL_GATES; i++) {
+    number::Number *n = numbers[i];
+    if (n != nullptr && n->has_state()) {
+      value[i] = lowbyte(static_cast<int>(n->state));
+      any_configured = true;
+    } else {
+      // Gates the configuration left out, and gates still waiting for their first read back, keep the module value
+      value[i] = last_read[i];
+    }
+  }
+  if (!any_configured) {
+    return;  // Nothing to change in this group
+  }
+  this->send_command_(command, value, sizeof(value));
+}
+
 void LD2412Component::set_gate_threshold() {
-  if (this->gate_move_threshold_numbers_.empty() && this->gate_still_threshold_numbers_.empty()) {
-    return;  // No gate threshold numbers set; nothing to do here
-  }
-  uint8_t value[TOTAL_GATES] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   this->set_config_mode_(true);
-  if (!this->gate_move_threshold_numbers_.empty()) {
-    for (size_t i = 0; i < this->gate_move_threshold_numbers_.size(); i++) {
-      value[i] = lowbyte(static_cast<int>(this->gate_move_threshold_numbers_[i]->state));
-    }
-    this->send_command_(CMD_MOTION_GATE_SENS, value, sizeof(value));
-  }
-  if (!this->gate_still_threshold_numbers_.empty()) {
-    for (size_t i = 0; i < this->gate_still_threshold_numbers_.size(); i++) {
-      value[i] = lowbyte(static_cast<int>(this->gate_still_threshold_numbers_[i]->state));
-    }
-    this->send_command_(CMD_STATIC_GATE_SENS, value, sizeof(value));
-  }
+  this->send_gate_thresholds_(CMD_MOTION_GATE_SENS, this->gate_move_threshold_numbers_, this->gate_move_thresholds_);
+  this->send_gate_thresholds_(CMD_STATIC_GATE_SENS, this->gate_still_threshold_numbers_, this->gate_still_thresholds_);
   this->set_config_mode_(false);
 }
 

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -75,6 +75,7 @@ enum PeriodicDataValue : uint8_t {
 enum AckData : uint8_t {
   COMMAND = 6,
   COMMAND_STATUS = 7,
+  ACK_PAYLOAD = 10,
 };
 
 // Memory-efficient lookup tables
@@ -191,6 +192,8 @@ static constexpr uint8_t DATA_FRAME_HEADER[HEADER_FOOTER_SIZE] = {0xF4, 0xF3, 0x
 static constexpr uint8_t DATA_FRAME_FOOTER[HEADER_FOOTER_SIZE] = {0xF8, 0xF7, 0xF6, 0xF5};
 // MAC address the module uses when Bluetooth is disabled
 static constexpr uint8_t NO_MAC[] = {0x08, 0x05, 0x04, 0x03, 0x02, 0x01};
+// A gate threshold answer carries one byte per gate, so the whole frame is the payload offset, the gates and the footer
+static constexpr uint8_t GATE_SENS_ACK_SIZE = ACK_PAYLOAD + TOTAL_GATES + HEADER_FOOTER_SIZE;
 
 static inline bool validate_header_footer(const uint8_t *header_footer, const uint8_t *buffer) {
   return std::memcmp(header_footer, buffer, HEADER_FOOTER_SIZE) == 0;
@@ -597,20 +600,29 @@ bool LD2412Component::handle_ack_data_() {
 
     case CMD_QUERY_MOTION_GATE_SENS: {
 #ifdef USE_NUMBER
-      for (size_t i = 0; i < this->gate_move_thresholds_.size() && (10 + i) < this->buffer_pos_; i++) {
-        this->gate_move_thresholds_[i] = this->buffer_data_[10 + i];
-        set_number_value(this->gate_move_threshold_numbers_[i], this->buffer_data_[10 + i]);
+      // buffer_pos_ counts the footer, so a frame that stops short of the full size is not a complete answer
+      if (this->buffer_pos_ < GATE_SENS_ACK_SIZE) {
+        return false;
       }
+      for (size_t i = 0; i < this->gate_move_thresholds_.size(); i++) {
+        this->gate_move_thresholds_[i] = this->buffer_data_[ACK_PAYLOAD + i];
+        set_number_value(this->gate_move_threshold_numbers_[i], this->buffer_data_[ACK_PAYLOAD + i]);
+      }
+      this->gate_move_thresholds_read_ = true;
 #endif
       break;
     }
 
     case CMD_QUERY_STATIC_GATE_SENS: {
 #ifdef USE_NUMBER
-      for (size_t i = 0; i < this->gate_still_thresholds_.size() && (10 + i) < this->buffer_pos_; i++) {
-        this->gate_still_thresholds_[i] = this->buffer_data_[10 + i];
-        set_number_value(this->gate_still_threshold_numbers_[i], this->buffer_data_[10 + i]);
+      if (this->buffer_pos_ < GATE_SENS_ACK_SIZE) {
+        return false;
       }
+      for (size_t i = 0; i < this->gate_still_thresholds_.size(); i++) {
+        this->gate_still_thresholds_[i] = this->buffer_data_[ACK_PAYLOAD + i];
+        set_number_value(this->gate_still_threshold_numbers_[i], this->buffer_data_[ACK_PAYLOAD + i]);
+      }
+      this->gate_still_thresholds_read_ = true;
 #endif
       break;
     }
@@ -808,9 +820,10 @@ void LD2412Component::set_basic_config() {
 
 #ifdef USE_NUMBER
 void LD2412Component::send_gate_thresholds_(uint8_t command, const std::array<number::Number *, TOTAL_GATES> &numbers,
-                                            const std::array<uint8_t, TOTAL_GATES> &last_read) {
+                                            const std::array<uint8_t, TOTAL_GATES> &last_read, bool last_read_valid) {
   uint8_t value[TOTAL_GATES];
   bool any_configured = false;
+  bool any_from_module = false;
   for (uint8_t i = 0; i < TOTAL_GATES; i++) {
     number::Number *n = numbers[i];
     if (n != nullptr && n->has_state()) {
@@ -819,18 +832,26 @@ void LD2412Component::send_gate_thresholds_(uint8_t command, const std::array<nu
     } else {
       // Gates the configuration left out, and gates still waiting for their first read back, keep the module value
       value[i] = last_read[i];
+      any_from_module = true;
     }
   }
   if (!any_configured) {
     return;  // Nothing to change in this group
+  }
+  if (any_from_module && !last_read_valid) {
+    // The module never reported what it holds, so those gates would be sent as zero, which is maximum sensitivity
+    ESP_LOGW(TAG, "Command %02X not sent, the module has not reported its gate thresholds yet", command);
+    return;
   }
   this->send_command_(command, value, sizeof(value));
 }
 
 void LD2412Component::set_gate_threshold() {
   this->set_config_mode_(true);
-  this->send_gate_thresholds_(CMD_MOTION_GATE_SENS, this->gate_move_threshold_numbers_, this->gate_move_thresholds_);
-  this->send_gate_thresholds_(CMD_STATIC_GATE_SENS, this->gate_still_threshold_numbers_, this->gate_still_thresholds_);
+  this->send_gate_thresholds_(CMD_MOTION_GATE_SENS, this->gate_move_threshold_numbers_, this->gate_move_thresholds_,
+                              this->gate_move_thresholds_read_);
+  this->send_gate_thresholds_(CMD_STATIC_GATE_SENS, this->gate_still_threshold_numbers_, this->gate_still_thresholds_,
+                              this->gate_still_thresholds_read_);
   this->set_config_mode_(false);
 }
 

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -598,31 +598,22 @@ bool LD2412Component::handle_ack_data_() {
       ESP_LOGV(TAG, "Handled set light control command");
       break;
 
-    case CMD_QUERY_MOTION_GATE_SENS: {
+    case CMD_QUERY_MOTION_GATE_SENS:
+    case CMD_QUERY_STATIC_GATE_SENS: {
 #ifdef USE_NUMBER
       // buffer_pos_ counts the footer, so a frame that stops short of the full size is not a complete answer
       if (this->buffer_pos_ < GATE_SENS_ACK_SIZE) {
         return false;
       }
-      for (size_t i = 0; i < this->gate_move_thresholds_.size(); i++) {
-        this->gate_move_thresholds_[i] = this->buffer_data_[ACK_PAYLOAD + i];
-        set_number_value(this->gate_move_threshold_numbers_[i], this->buffer_data_[ACK_PAYLOAD + i]);
+      const bool motion = this->buffer_data_[COMMAND] == CMD_QUERY_MOTION_GATE_SENS;
+      auto &thresholds = motion ? this->gate_move_thresholds_ : this->gate_still_thresholds_;
+      const auto &numbers = motion ? this->gate_move_threshold_numbers_ : this->gate_still_threshold_numbers_;
+      bool &thresholds_read = motion ? this->gate_move_thresholds_read_ : this->gate_still_thresholds_read_;
+      for (size_t i = 0; i < thresholds.size(); i++) {
+        thresholds[i] = this->buffer_data_[ACK_PAYLOAD + i];
+        set_number_value(numbers[i], this->buffer_data_[ACK_PAYLOAD + i]);
       }
-      this->gate_move_thresholds_read_ = true;
-#endif
-      break;
-    }
-
-    case CMD_QUERY_STATIC_GATE_SENS: {
-#ifdef USE_NUMBER
-      if (this->buffer_pos_ < GATE_SENS_ACK_SIZE) {
-        return false;
-      }
-      for (size_t i = 0; i < this->gate_still_thresholds_.size(); i++) {
-        this->gate_still_thresholds_[i] = this->buffer_data_[ACK_PAYLOAD + i];
-        set_number_value(this->gate_still_threshold_numbers_[i], this->buffer_data_[ACK_PAYLOAD + i]);
-      }
-      this->gate_still_thresholds_read_ = true;
+      thresholds_read = true;
 #endif
       break;
     }

--- a/esphome/components/ld2412/ld2412.h
+++ b/esphome/components/ld2412/ld2412.h
@@ -118,6 +118,10 @@ class LD2412Component final : public Component, public uart::UARTDevice {
   void query_light_control_();
   void restart_();
   void query_dynamic_background_correction_();
+#ifdef USE_NUMBER
+  void send_gate_thresholds_(uint8_t command, const std::array<number::Number *, TOTAL_GATES> &numbers,
+                             const std::array<uint8_t, TOTAL_GATES> &last_read);
+#endif
 
   uint8_t light_function_ = 0;
   uint8_t light_threshold_ = 0;
@@ -131,6 +135,11 @@ class LD2412Component final : public Component, public uart::UARTDevice {
 #ifdef USE_NUMBER
   std::array<number::Number *, TOTAL_GATES> gate_move_threshold_numbers_{};
   std::array<number::Number *, TOTAL_GATES> gate_still_threshold_numbers_{};
+  // Thresholds last read back from the module, one per gate
+  // A threshold command carries all of the gates at once, so a gate with no configured number still needs a value
+  // Sending back what the module reported leaves that gate alone, where a zero would mean maximum sensitivity
+  std::array<uint8_t, TOTAL_GATES> gate_move_thresholds_{};
+  std::array<uint8_t, TOTAL_GATES> gate_still_thresholds_{};
 #endif
 #ifdef USE_SENSOR
   std::array<SensorWithDedup<uint8_t>, TOTAL_GATES> gate_move_sensors_{};

--- a/esphome/components/ld2412/ld2412.h
+++ b/esphome/components/ld2412/ld2412.h
@@ -120,7 +120,7 @@ class LD2412Component final : public Component, public uart::UARTDevice {
   void query_dynamic_background_correction_();
 #ifdef USE_NUMBER
   void send_gate_thresholds_(uint8_t command, const std::array<number::Number *, TOTAL_GATES> &numbers,
-                             const std::array<uint8_t, TOTAL_GATES> &last_read);
+                             const std::array<uint8_t, TOTAL_GATES> &last_read, bool last_read_valid);
 #endif
 
   uint8_t light_function_ = 0;
@@ -140,6 +140,9 @@ class LD2412Component final : public Component, public uart::UARTDevice {
   // Sending back what the module reported leaves that gate alone, where a zero would mean maximum sensitivity
   std::array<uint8_t, TOTAL_GATES> gate_move_thresholds_{};
   std::array<uint8_t, TOTAL_GATES> gate_still_thresholds_{};
+  // Set once the module has answered the matching query, until then there is nothing to fill an unconfigured gate with
+  bool gate_move_thresholds_read_{false};
+  bool gate_still_thresholds_read_{false};
 #endif
 #ifdef USE_SENSOR
   std::array<SensorWithDedup<uint8_t>, TOTAL_GATES> gate_move_sensors_{};

--- a/tests/integration/fixtures/uart_mock_ld2412_gate_thresholds.yaml
+++ b/tests/integration/fixtures/uart_mock_ld2412_gate_thresholds.yaml
@@ -1,0 +1,85 @@
+esphome:
+  name: uart-mock-ld2412-thresholds
+
+host:
+api:
+  batch_delay: 0ms  # Disable batching to receive all state updates
+logger:
+  level: VERBOSE
+
+external_components:
+  - source:
+      type: local
+      path: EXTERNAL_COMPONENT_PATH
+
+# Dummy uart entry to satisfy ld2412's DEPENDENCIES = ["uart"]
+# The actual UART bus used is the uart_mock component below
+uart:
+  baud_rate: 115200
+  port: /dev/null
+
+uart_mock:
+  id: mock_uart
+  baud_rate: 256000
+  # Answer the two threshold queries that read_all_info() sends during setup, so the component learns what
+  # the module holds for every gate before the test writes a new threshold
+  #
+  # Query frame sent by the component (12 bytes):
+  #   FD FC FB FA = command frame header
+  #   02 00       = length 2
+  #   13 00       = CMD_QUERY_MOTION_GATE_SENS (0x14 for static)
+  #   04 03 02 01 = command frame footer
+  #
+  # Answer frame (28 bytes):
+  #   FD FC FB FA = command frame header
+  #   12 00       = length 18
+  #   13          = command being answered
+  #   01          = status OK
+  #   00 00       = required zero bytes
+  #   14 bytes    = one threshold per gate, gate 0 first
+  #   04 03 02 01 = command frame footer
+  responses:
+    # Motion thresholds: gate 0 through 13 hold 10 through 23
+    - expect_tx: [0xFD, 0xFC, 0xFB, 0xFA, 0x02, 0x00, 0x13, 0x00, 0x04, 0x03, 0x02, 0x01]
+      inject_rx:
+        [
+          0xFD, 0xFC, 0xFB, 0xFA,
+          0x12, 0x00,
+          0x13, 0x01,
+          0x00, 0x00,
+          0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+          0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+          0x04, 0x03, 0x02, 0x01,
+        ]
+    # Still thresholds: gate 0 through 13 hold 40 through 53
+    - expect_tx: [0xFD, 0xFC, 0xFB, 0xFA, 0x02, 0x00, 0x14, 0x00, 0x04, 0x03, 0x02, 0x01]
+      inject_rx:
+        [
+          0xFD, 0xFC, 0xFB, 0xFA,
+          0x12, 0x00,
+          0x14, 0x01,
+          0x00, 0x00,
+          0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E,
+          0x2F, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+          0x04, 0x03, 0x02, 0x01,
+        ]
+
+ld2412:
+  id: ld2412_dev
+  uart_id: mock_uart
+
+# Only 2 of the 14 gates are configured, which is the case that used to crash: set_gate_threshold() walked
+# all 14 entries of both arrays and dereferenced the 12 gates that have no number
+number:
+  - platform: ld2412
+    ld2412_id: ld2412_dev
+    gate_0:
+      move_threshold:
+        name: "Gate 0 Move Threshold"
+      still_threshold:
+        name: "Gate 0 Still Threshold"
+    gate_5:
+      move_threshold:
+        name: "Gate 5 Move Threshold"
+      still_threshold:
+        name: "Gate 5 Still Threshold"

--- a/tests/integration/fixtures/uart_mock_ld2412_gate_thresholds.yaml
+++ b/tests/integration/fixtures/uart_mock_ld2412_gate_thresholds.yaml
@@ -33,9 +33,8 @@ uart_mock:
   # Answer frame (28 bytes):
   #   FD FC FB FA = command frame header
   #   12 00       = length 18
-  #   13          = command being answered
-  #   01          = status OK
-  #   00 00       = required zero bytes
+  #   13 01       = command word, the low byte is the command and the high byte 01 marks the answer
+  #   00 00       = ack status, 00 00 is success
   #   14 bytes    = one threshold per gate, gate 0 first
   #   04 03 02 01 = command frame footer
   responses:

--- a/tests/integration/fixtures/uart_mock_ld2412_thresholds_not_read.yaml
+++ b/tests/integration/fixtures/uart_mock_ld2412_thresholds_not_read.yaml
@@ -1,0 +1,45 @@
+esphome:
+  name: uart-mock-ld2412-unread
+
+host:
+api:
+  batch_delay: 0ms  # Disable batching to receive all state updates
+logger:
+  level: VERBOSE
+
+external_components:
+  - source:
+      type: local
+      path: EXTERNAL_COMPONENT_PATH
+
+# Dummy uart entry to satisfy ld2412's DEPENDENCIES = ["uart"]
+# The actual UART bus used is the uart_mock component below
+uart:
+  baud_rate: 115200
+  port: /dev/null
+
+# The mock answers nothing, so the threshold queries that read_all_info() sends during setup go unanswered
+# and the component never learns what the module holds for any gate
+uart_mock:
+  id: mock_uart
+  baud_rate: 256000
+
+ld2412:
+  id: ld2412_dev
+  uart_id: mock_uart
+
+# Same 2 gate configuration as the gate threshold test, so writing a threshold needs a value for the other
+# 12 gates, and here there is nothing to fill them with
+number:
+  - platform: ld2412
+    ld2412_id: ld2412_dev
+    gate_0:
+      move_threshold:
+        name: "Gate 0 Move Threshold"
+      still_threshold:
+        name: "Gate 0 Still Threshold"
+    gate_5:
+      move_threshold:
+        name: "Gate 5 Move Threshold"
+      still_threshold:
+        name: "Gate 5 Still Threshold"

--- a/tests/integration/test_uart_mock_ld2412.py
+++ b/tests/integration/test_uart_mock_ld2412.py
@@ -25,6 +25,11 @@ test_uart_mock_ld2412_gate_thresholds (partial gate threshold config):
   1. Threshold queries are answered, so every gate has a known module value
   2. Writing one threshold does not crash when most gates have no number
   3. Gates without a number are written back with the module value, not a zero
+
+test_uart_mock_ld2412_thresholds_not_read (module never reports its thresholds):
+  1. The threshold queries go unanswered, so no gate has a module value
+  2. Writing a threshold holds the command back instead of writing zeros
+  3. The group where no gate has a value at all is not sent either
 """
 
 from __future__ import annotations
@@ -32,7 +37,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-from aioesphomeapi import ButtonInfo, EntityState, NumberInfo
+from aioesphomeapi import ButtonInfo, NumberInfo
 import pytest
 
 from .state_utils import InitialStateHelper, SensorStateCollector, find_entity
@@ -441,8 +446,6 @@ async def test_uart_mock_ld2412_gate_thresholds(
         if expected_still in line and not still_written.done():
             still_written.set_result(True)
 
-    states: dict[int, float] = {}
-
     async with (
         run_compiled(yaml_config, line_callback=line_callback),
         api_client_connected() as client,
@@ -451,10 +454,7 @@ async def test_uart_mock_ld2412_gate_thresholds(
 
         initial_state_helper = InitialStateHelper(entities)
 
-        def on_state(state: EntityState) -> None:
-            states[state.key] = state.state
-
-        client.subscribe_states(initial_state_helper.on_state_wrapper(on_state))
+        client.subscribe_states(initial_state_helper.on_state_wrapper(lambda s: None))
 
         try:
             await initial_state_helper.wait_for_initial_states()
@@ -501,6 +501,86 @@ async def test_uart_mock_ld2412_gate_thresholds(
                 f"  expected motion payload: {expected_motion}\n"
                 f"  expected still payload:  {expected_still}"
             )
+
+        # A round trip proves the device is still running after the write
+        entities_after, _ = await client.list_entities_services()
+        assert len(entities_after) == len(entities)
+
+
+@pytest.mark.asyncio
+async def test_uart_mock_ld2412_thresholds_not_read(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test writing a threshold before the module has reported the values it holds.
+
+    The gates without a number are filled from the last values read back from the module. When the
+    module never answers the setup query there is nothing to fill them with, and sending the command
+    anyway would write a zero to every one of those gates, which is maximum sensitivity. The command
+    has to be held back instead. The still group has no gate with a value at all, so it is not sent
+    either.
+    """
+    external_components_path = str(
+        Path(__file__).parent / "fixtures" / "external_components"
+    )
+    yaml_config = yaml_config.replace(
+        "EXTERNAL_COMPONENT_PATH", external_components_path
+    )
+
+    loop = asyncio.get_running_loop()
+
+    # The length and command bytes of a threshold command, as the mock logs them
+    # Length 16 (2 command bytes and one byte per gate), then the command, motion is 0x03 and still is 0x04
+    motion_command = "10:00:03:00"
+    still_command = "10:00:04:00"
+    # Length 2 and command 0xFE, the frame that leaves configuration mode at the end of the write
+    config_mode_left = "02:00:FE:00"
+    motion_held_back = loop.create_future()
+    write_finished = loop.create_future()
+    tx_lines: list[str] = []
+
+    def line_callback(line: str) -> None:
+        # The component logs the command it did not send in place of sending it
+        if "Command 03 not sent" in line and not motion_held_back.done():
+            motion_held_back.set_result(True)
+            return
+        if "uart_mock" not in line or "TX " not in line:
+            return
+        tx_lines.append(line)
+        # Configuration mode is left once both groups have been dealt with
+        if (
+            motion_held_back.done()
+            and config_mode_left in line
+            and not write_finished.done()
+        ):
+            write_finished.set_result(True)
+
+    async with (
+        run_compiled(yaml_config, line_callback=line_callback),
+        api_client_connected() as client,
+    ):
+        entities, _ = await client.list_entities_services()
+
+        gate_0_move = find_entity(entities, "gate_0_move_threshold", NumberInfo)
+        assert gate_0_move is not None, "gate_0_move_threshold number not found"
+
+        client.number_command(gate_0_move.key, 77.0)
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(motion_held_back, write_finished), timeout=5.0
+            )
+        except TimeoutError:
+            pytest.fail("Timeout waiting for the write to be handled")
+
+        # Neither threshold command reached the module, so no gate was reconfigured
+        assert not [line for line in tx_lines if motion_command in line], (
+            "motion threshold command was sent without a value for the gates that have no number"
+        )
+        assert not [line for line in tx_lines if still_command in line], (
+            "still threshold command was sent when no gate had a value to write"
+        )
 
         # A round trip proves the device is still running after the write
         entities_after, _ = await client.list_entities_services()

--- a/tests/integration/test_uart_mock_ld2412.py
+++ b/tests/integration/test_uart_mock_ld2412.py
@@ -20,6 +20,11 @@ test_uart_mock_ld2412_engineering_truncated (truncated engineering mode):
   2. Truncated engineering frame (24 bytes) is rejected — gate/light sensors
      must not receive garbage from stale buffer data or frame footer bytes
   3. Recovery frame with different values proves the component survived
+
+test_uart_mock_ld2412_gate_thresholds (partial gate threshold config):
+  1. Threshold queries are answered, so every gate has a known module value
+  2. Writing one threshold does not crash when most gates have no number
+  3. Gates without a number are written back with the module value, not a zero
 """
 
 from __future__ import annotations
@@ -27,7 +32,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-from aioesphomeapi import ButtonInfo
+from aioesphomeapi import ButtonInfo, EntityState, NumberInfo
 import pytest
 
 from .state_utils import InitialStateHelper, SensorStateCollector, find_entity
@@ -397,3 +402,106 @@ async def test_uart_mock_ld2412_engineering_truncated(
                 f"truncated frame likely leaked stale buffer data. "
                 f"All values: {collector.sensor_states['gate_0_move_energy']}"
             )
+
+
+@pytest.mark.asyncio
+async def test_uart_mock_ld2412_gate_thresholds(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test writing a threshold when only 2 of the 14 gates have numbers configured.
+
+    The threshold commands carry all 14 gates, so the component has to produce a value for every gate.
+    It used to dereference the numbers of gates that were never configured, which crashed on the first
+    write. The gates without a number must be written back with the value read from the module.
+    """
+    external_components_path = str(
+        Path(__file__).parent / "fixtures" / "external_components"
+    )
+    yaml_config = yaml_config.replace(
+        "EXTERNAL_COMPONENT_PATH", external_components_path
+    )
+
+    loop = asyncio.get_running_loop()
+
+    # Payloads the component is expected to write, as the mock logs them
+    # Motion: gate 0 becomes 77 (0x4D), every other gate keeps the module value (11 to 23)
+    expected_motion = "4D:0B:0C:0D:0E:0F:10:11:12:13:14:15:16:17"
+    # Still: nothing was changed, so every gate keeps the module value (40 to 53)
+    expected_still = "28:29:2A:2B:2C:2D:2E:2F:30:31:32:33:34:35"
+    motion_written = loop.create_future()
+    still_written = loop.create_future()
+
+    def line_callback(line: str) -> None:
+        if "uart_mock" not in line or "TX " not in line:
+            return
+        if expected_motion in line and not motion_written.done():
+            motion_written.set_result(True)
+        if expected_still in line and not still_written.done():
+            still_written.set_result(True)
+
+    states: dict[int, float] = {}
+
+    async with (
+        run_compiled(yaml_config, line_callback=line_callback),
+        api_client_connected() as client,
+    ):
+        entities, _ = await client.list_entities_services()
+
+        initial_state_helper = InitialStateHelper(entities)
+
+        def on_state(state: EntityState) -> None:
+            states[state.key] = state.state
+
+        client.subscribe_states(initial_state_helper.on_state_wrapper(on_state))
+
+        try:
+            await initial_state_helper.wait_for_initial_states()
+        except TimeoutError:
+            pytest.fail("Timeout waiting for initial states")
+
+        numbers = {
+            name: find_entity(entities, name, NumberInfo)
+            for name in (
+                "gate_0_move_threshold",
+                "gate_0_still_threshold",
+                "gate_5_move_threshold",
+                "gate_5_still_threshold",
+            )
+        }
+        for name, entity in numbers.items():
+            assert entity is not None, f"{name} number not found"
+
+        # The setup queries were answered, so the 2 configured gates show the module values
+        initial_states = initial_state_helper.initial_states
+        assert initial_states[numbers["gate_0_move_threshold"].key].state == (
+            pytest.approx(10.0)
+        )
+        assert initial_states[numbers["gate_5_move_threshold"].key].state == (
+            pytest.approx(15.0)
+        )
+        assert initial_states[numbers["gate_0_still_threshold"].key].state == (
+            pytest.approx(40.0)
+        )
+        assert initial_states[numbers["gate_5_still_threshold"].key].state == (
+            pytest.approx(45.0)
+        )
+
+        # Write one threshold; this is what used to crash the device
+        client.number_command(numbers["gate_0_move_threshold"].key, 77.0)
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(motion_written, still_written), timeout=5.0
+            )
+        except TimeoutError:
+            pytest.fail(
+                "Timeout waiting for the threshold commands.\n"
+                f"  expected motion payload: {expected_motion}\n"
+                f"  expected still payload:  {expected_still}"
+            )
+
+        # A round trip proves the device is still running after the write
+        entities_after, _ = await client.list_entities_services()
+        assert len(entities_after) == len(entities)


### PR DESCRIPTION
# What does this implement/fix?

Fixes a crash when only some of the 14 LD2412 gate thresholds are configured.

`LD2412Component::set_gate_threshold()` walked all 14 entries of `gate_move_threshold_numbers_` and
`gate_still_threshold_numbers_` and read `->state` from each without a null check. Both are
`std::array<number::Number *, TOTAL_GATES>`, so the `.empty()` guards meant to prevent this are always
false — `std::array::empty()` is `constexpr` and returns `N == 0` — and the early return is dead code.
Any gate left out of the YAML stays null, so the first threshold write from Home Assistant faulted with
`LoadProhibited`. The configuration validates and compiles, so it only failed at runtime on user
interaction. Both arrays are walked in one call, so declaring only the move thresholds still dereferenced
the still array.

This is the same shape as the crash fixed by #15893 for `set_basic_config()`, one function over. That fix
guarded each pointer and fell back to a default; this function was left alone, most likely because the
`.empty()` guards looked like they already did the job.

The payload is now built from the gates that have a number with a state, and the remaining gates are
filled from the values last read back from the module, which are retained when a threshold query is
answered. This matters beyond the crash: the threshold command carries all 14 gates at once, so an
unconfigured gate has to send *something*, and the old zero-initialised `value[]` would have set that
gate to maximum sensitivity. Sending the module's own value leaves it alone instead. A group with no
configured gate at all is not sent, which is what the `.empty()` guards were reaching for.

The two loops are also now one `send_gate_thresholds_()` helper rather than two near-identical blocks.
Cost is two `std::array<uint8_t, 14>` members, measured on device as +32 bytes of `.bss` (28 bytes
rounded up to 4-byte alignment) and +72 bytes of flash, with no runtime heap growth.

Known limit, unchanged behaviour and out of scope here: a module that never answers the threshold query
sent during `read_all_info()` leaves those retained values at zero, so a write before any answer still
sends zeros. `setup()` issues that query, so the window is the boot query round trip.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #18195

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#N/A — no user-facing configuration or documented behaviour changes

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#N/A — no developer-facing API changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF (ESP32-S3)
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Hardware: ESP32-S3 (SmartHomeShop CeilSense v1), ESP-IDF v5.5.5, flashed OTA, with 2 of the 14 gates
declared (`gate_0` and `gate_5`). Both the crash and the fix were verified there — details below.

Also run without hardware:

- New integration test on the `host` platform, which reproduces the crash against the old code: the
  process dies on the threshold write and the test times out waiting for the command frames.
- All four `test_uart_mock_ld2412` integration tests pass.
- `script/test_build_components -c ld2412 -e config` — passes for esp32-idf, esp8266-ard and rp2040-ard.
- The CI jobs that `script/determine-jobs.py` selects for this diff, run locally: `script/ci-custom.py`
  and its sibling `--check` scripts, `prek` over the changed files, and `pytest tests --ignore=tests/integration`.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# Only 2 of the 14 gates configured; changing either threshold from Home Assistant
# used to crash the device, and now writes the module's own values back to the
# 12 gates that have no number
number:
  - platform: ld2412
    gate_0:
      move_threshold:
        name: "Gate 0 Move Threshold"
      still_threshold:
        name: "Gate 0 Still Threshold"
    gate_5:
      move_threshold:
        name: "Gate 5 Move Threshold"
      still_threshold:
        name: "Gate 5 Still Threshold"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

---

## Hardware verification

Two controls make the comparison valid, both checked by diff rather than assumed: the stock 2026.7.3
build's `ld2412` component is byte-identical to this PR's base commit, so it is a valid unfixed control,
and the component fetched through `external_components: source: github://pr#18194` is byte-identical to
this branch, so the fixed build really is this PR and not a stale cache.

**The crash reproduces on the unfixed component.** Setup completes, both boot threshold queries are
answered, and the device runs normally; writing `Gate 0 Move Threshold` from Home Assistant kills it
immediately. `Reason: Fault - LoadProhibited`, and the decoded frame lands exactly where this PR says:

```text
0x4201612e: LD2412Component::set_gate_threshold()       at ld2412.cpp:816
0x4201664e: GateThresholdNumber::control(float)         at number/gate_threshold_number.cpp:9
0x42021c1d: number::NumberCall::perform()               at number/number_call.cpp:114
0x4201e2a5: APIConnection::on_number_command_request(…) at api/api_connection.cpp:863
```

Worth stating plainly: the fault is on the **write only**. A partial gate configuration boots and runs
fine, so there is no boot loop and nothing warns the user until they touch a threshold.

**The fix holds.** Same device, same 2-of-14 configuration, component pointed at this PR: the identical
write that crashed the unfixed build completed with no fault, and 17 threshold writes across the session
(5 single, then 12 in batches of 4) produced zero reboots, zero `CRASH DETECTED`, and zero unexpected API
disconnects over a 4m10s continuous capture.

**Gates without a number keep the module's values.** Baseline captured before the test, then the writes
were run on the 2-gate configuration, then the full 14-gate configuration was reflashed to read all 28
numbers back off the module:

| Gate | Baseline (move/still) | After the test | Result |
| --- | --- | --- | --- |
| 0 | 0 / 0 | last written value | declared, written as expected |
| 1 | 50 / 100 | 50 / 100 | unchanged |
| 2 | 45 / 35 | 45 / 35 | unchanged |
| 3 | 35 / 15 | 35 / 15 | unchanged |
| 4 | 50 / 15 | 50 / 15 | unchanged |
| 5 | 25 / 15 | last written value | declared, written as expected |
| 6-13 | 25 / 15 | 25 / 15 | unchanged |

All 12 gates with no number came back bit-for-bit identical, including three hand-tuned ones. Under the
old zero-initialised `value[]` each would have been driven to 0, which is maximum sensitivity.

**Memory, measured on device.** Two builds of the same configuration differing only by the
`external_components` block: `.bss` 33200 → 33232 (+32 B), DIRAM used 111327 → 111359 (+32 B), flash
image 874923 → 874995 (+72 B). For runtime heap, 26 samples over 4m10s with 12 writes fired mid-run: free
heap idles at 252192-252420 B before and after, with a single transient dip to 250668 B during the burst
that recovers on the next sample, and largest free block returns to 208896 B and holds. No downward trend
across the writes and no fragmentation, so no per-call leak.

**Not exercised:** the zero-retention window described above. This module answered both boot queries on
every boot, and the two declared gates were confirmed to be showing the module's values before each write
run, which is what proves retention was populated.

## Notes on the test, for reviewers

`tests/integration/test_uart_mock_ld2412.py::test_uart_mock_ld2412_gate_thresholds` with
`tests/integration/fixtures/uart_mock_ld2412_gate_thresholds.yaml` configures 2 of the 14 gates and uses
the mock UART's `responses:` mechanism to answer both threshold queries sent during `read_all_info()`,
so every gate has a known module value: motion gates hold 10 through 23, still gates hold 40 through 53.

The two configured gates therefore come up showing the module values (10/40 for gate 0, 15/45 for gate 5),
which is asserted from the initial states. The test then writes 77 to gate 0's move threshold and asserts
the exact frames the component sends:

- motion `4D:0B:0C:0D:0E:0F:10:11:12:13:14:15:16:17` — gate 0 changed, every other gate carries the
  module value rather than a zero
- still `28:29:2A:2B:2C:2D:2E:2F:30:31:32:33:34:35` — nothing changed, so every gate is written back
  unaltered

A final round trip over the API confirms the device is still running. Against the old code the write
kills the process before any of this, so the test fails.

That last claim was checked rather than assumed: re-running this same test with `ld2412` pinned to this
PR's base commit through a local `external_components` entry **fails** at the threshold-command timeout,
with the enable-config frame as the device's last output and no threshold frame ever emitted. The test
asserts the crash it names rather than passing for an incidental reason.
