### PR TITLE
Normalize marker-wrapped callable keys in the schema dump

### DIFF
--- a/script/build_language_schema.py
+++ b/script/build_language_schema.py
@@ -1134,12 +1134,28 @@ def convert_keys(converted, schema, path):
         else:
             converted["key"] = "String"
             key_string_match = re.search(
-                r"<function (\w*) at \w*>", str(k), re.IGNORECASE
+                r"<function ([^ ]+) at \w+>", str(k), re.IGNORECASE
             )
             if key_string_match:
                 converted["key_type"] = key_string_match.group(1)
             else:
                 converted["key_type"] = str(k)
+
+        # A marker-wrapped callable key (e.g. script.execute's
+        # ``cv.Optional(validate_parameter_name)``) is a wildcard matcher;
+        # ``str(marker)`` is the function repr, whose heap address would
+        # churn the dump every build. Normalize like the bare-callable
+        # branch above: record the validator name in ``key_type`` and file
+        # the config var under ``string``.
+        key_name = str(k)
+        if isinstance(k, vol.Marker) and callable(k.schema):
+            key_string_match = re.search(
+                r"<function ([^ ]+) at \w+>", key_name, re.IGNORECASE
+            )
+            result["key_type"] = (
+                key_string_match.group(1) if key_string_match else key_name
+            )
+            key_name = "string"
 
         # ``cv.OnlyWith`` / ``cv.OnlyWithout`` expose ``default`` as
         # a property that returns ``vol.UNDEFINED`` when the gating
@@ -1220,7 +1236,7 @@ def convert_keys(converted, schema, path):
         for base_k, base_v in get_overridden_config(k, converted).items():
             if base_k in result and base_v == result[base_k]:
                 result.pop(base_k)
-        converted["schema"][S_CONFIG_VARS][str(k)] = result
+        converted["schema"][S_CONFIG_VARS][key_name] = result
         if "key" in converted and converted["key"] == "String":
             config_vars = converted["schema"]["config_vars"]
             assert len(config_vars) == 1

--- a/tests/script/test_build_language_schema.py
+++ b/tests/script/test_build_language_schema.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import Callable
 import importlib.util
 import json
 from pathlib import Path
 import subprocess
 import sys
+from typing import Any
 
 import pytest
 
@@ -205,7 +207,7 @@ def test_convert_keys_no_marker_for_non_sensitive_field() -> None:
     assert "sensitive_source" not in entry
 
 
-def _wildcard_validator(value):
+def _wildcard_validator(value: Any) -> Any:
     return value
 
 
@@ -231,8 +233,8 @@ def test_convert_keys_marker_wrapped_callable_beside_fixed_keys() -> None:
 
 
 def test_convert_keys_bare_callable_dotted_qualname() -> None:
-    def make_validator():
-        def validator(value):
+    def make_validator() -> Callable[[Any], Any]:
+        def validator(value: Any) -> Any:
             return value
 
         return validator

--- a/tests/script/test_build_language_schema.py
+++ b/tests/script/test_build_language_schema.py
@@ -205,6 +205,47 @@ def test_convert_keys_no_marker_for_non_sensitive_field() -> None:
     assert "sensitive_source" not in entry
 
 
+def _wildcard_validator(value):
+    return value
+
+
+def test_convert_keys_marker_wrapped_callable_key_normalizes() -> None:
+    converted: dict = {}
+    _bls.convert_keys(converted, {cv.Optional(_wildcard_validator): cv.string}, "/root")
+
+    config_vars = converted["schema"]["config_vars"]
+    assert set(config_vars) == {"string"}
+    assert config_vars["string"]["key"] == "Optional"
+    assert config_vars["string"]["key_type"] == "_wildcard_validator"
+
+
+def test_convert_keys_marker_wrapped_callable_beside_fixed_keys() -> None:
+    converted: dict = {}
+    _bls.convert_keys(
+        converted,
+        {cv.Required("id"): cv.string, cv.Optional(_wildcard_validator): cv.string},
+        "/root",
+    )
+
+    assert set(converted["schema"]["config_vars"]) == {"id", "string"}
+
+
+def test_convert_keys_bare_callable_dotted_qualname() -> None:
+    def make_validator():
+        def validator(value):
+            return value
+
+        return validator
+
+    converted: dict = {}
+    _bls.convert_keys(converted, {make_validator(): cv.string}, "/root")
+
+    assert converted["key"] == "String"
+    assert converted["key_type"].endswith("make_validator.<locals>.validator")
+    assert "at 0x" not in converted["key_type"]
+    assert set(converted["schema"]["config_vars"]) == {"string"}
+
+
 # ---------------------------------------------------------------------------
 # Regression tests for the lvgl schema dump.
 #


### PR DESCRIPTION
# What does this implement/fix?

`script/build_language_schema.py` normalizes a bare callable schema key to `key_type` plus a `string` config var, but a marker wrapped callable key falls into the `isinstance(k, cv.Optional)` branch and is stored under raw `str(k)`; `script.execute`'s `cv.Optional(validate_parameter_name)` therefore ships as `"<function validate_parameter_name at 0x7f...>"` in the published bundle, and the heap address churns every rebuild. The dump now files such keys under `string` with `key_type` naming the validator, matching the bare callable shape. The name extraction regex also accepts dotted qualnames, so prometheus `relabel`'s `key_type` becomes the stable `use_id.<locals>.validator` instead of a repr with an address. After both changes the dump contains no heap addresses at all; verified by regenerating all 713 files before and after, only `script.json` and `prometheus.json` change semantically. The churn is visible in the device builder catalog refresh PRs, each carrying a one line address only diff in `script.execute.json`: esphome/device-builder#2279, esphome/device-builder#2399, esphome/device-builder#2516.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/device-builder#2531 (consumer side; its guard stays for released bundles)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
