### PR TITLE
[ble_device_base] Treat a partially bound merger as unbound

### DIFF
--- a/esphome/components/ble_device_base/scan_response_merger.cpp
+++ b/esphome/components/ble_device_base/scan_response_merger.cpp
@@ -8,7 +8,8 @@ namespace esphome::ble_device_base {
 
 void ScanResponseMerger::deliver_(const uint8_t *mac, int8_t rssi, uint8_t addr_type, const uint8_t *data,
                                   uint8_t data_len, bool raw_only) {
-  if (this->dispatcher_ == nullptr)
+  // A partial bind is treated as unbound; never dereference half a binding.
+  if (this->dispatcher_ == nullptr || this->scan_continuous_ == nullptr)
     return;
   this->dispatcher_->dispatch(mac, rssi, addr_type, data, data_len, raw_only,
                               *this->scan_continuous_ ? nullptr : this->log_tag_);

--- a/tests/components/ble_device_base/test_scan_response_merger.cpp
+++ b/tests/components/ble_device_base/test_scan_response_merger.cpp
@@ -179,5 +179,15 @@ TEST_F(ScanResponseMergerTest, UnboundMergerDropsInsteadOfCrashing) {
   EXPECT_TRUE(unbound.empty());
 }
 
+TEST_F(ScanResponseMergerTest, PartialBindIsTreatedAsUnbound) {
+  ScanResponseMerger partial;
+  partial.bind(&this->dispatcher_, nullptr, "test");
+  std::vector<uint8_t> data(20, 0xAA);
+  partial.submit_scan_rsp(MAC_A, -70, 0, data.data(), data.size());
+  partial.stash_adv(MAC_A, -40, 0, data.data(), data.size(), 0);
+  partial.flush();  // dropped, not dispatched through half a binding
+  EXPECT_TRUE(this->raw_.frames.empty());
+}
+
 }  // namespace
 }  // namespace esphome::ble_device_base::testing


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #18217, from review feedback there. ScanResponseMerger::deliver_() guarded the dispatcher pointer but then dereferenced scan_continuous_ unguarded, so a caller that passed a null pointer to bind() would crash on the first delivered frame instead of dropping it. The guard now treats a partial bind the same as no bind, and a host test pins that.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
