### PR TITLE
[core] Extend '/' in names deprecation window to 2027.7.0

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -2331,13 +2331,13 @@ def _validate_no_slash(value):
     the visually similar Unicode FRACTION SLASH (U+2044) character.
     """
     if "/" in value:
-        # Remove before 2026.7.0
+        # Remove before 2027.7.0
         new_value = value.replace("/", FRACTION_SLASH)
         _LOGGER.warning(
             "'%s' contains '/' which is reserved as a URL path separator. "
             "Automatically replacing with '%s' (Unicode FRACTION SLASH). "
             "Please update your configuration. "
-            "This will become an error in ESPHome 2026.7.0.",
+            "This will become an error in ESPHome 2027.7.0.",
             value,
             new_value,
         )

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -932,7 +932,7 @@ def test_string_no_slash__slash_replaced_with_warning(
     actual = cv.string_no_slash(value)
     assert actual == expected
     assert "reserved as a URL path separator" in caplog.text
-    assert "will become an error in ESPHome 2026.7.0" in caplog.text
+    assert "will become an error in ESPHome 2027.7.0" in caplog.text
 
 
 def test_string_no_slash__long_string_allowed() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Extends the deprecation window for `/` in entity, device, and area names by another year, from 2026.7.0 to 2027.7.0; users need more time to migrate, and this one is very cheap to carry since it is just a warning with an automatic replacement.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: template
    name: "Airflow Up/Down Test"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
