### PR TITLE
[bluetooth_proxy] Finish the connection scan before reserving a slot

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -198,6 +198,10 @@ void BluetoothProxy::reset_connection_slot_(BluetoothConnection *connection, con
 }
 
 BluetoothConnection *BluetoothProxy::get_connection_(uint64_t address, bool reserve) {
+  // Finish the scan before reserving: a free slot earlier in the array must
+  // not win over a later slot that already holds the address, or one device
+  // ends up on two slots with a second connection attempt racing the first.
+  BluetoothConnection *free_slot = nullptr;
   for (uint8_t i = 0; i < this->connection_count_; i++) {
     auto *connection = this->connections_[i];
     uint64_t conn_addr = connection->get_address();
@@ -205,18 +209,19 @@ BluetoothConnection *BluetoothProxy::get_connection_(uint64_t address, bool rese
     if (conn_addr == address)
       return connection;
 
-    if (reserve && conn_addr == 0) {
-      connection->send_service_ = INIT_SENDING_SERVICES;
-      connection->set_address(address);
-      // All connections must start at INIT
-      // We only set the state if we allocate the connection
-      // to avoid a race where multiple connection attempts
-      // are made.
-      connection->set_state(ClientState::INIT);
-      return connection;
-    }
+    if (free_slot == nullptr && conn_addr == 0)
+      free_slot = connection;
   }
-  return nullptr;
+  if (!reserve || free_slot == nullptr)
+    return nullptr;
+  free_slot->send_service_ = INIT_SENDING_SERVICES;
+  free_slot->set_address(address);
+  // All connections must start at INIT
+  // We only set the state if we allocate the connection
+  // to avoid a race where multiple connection attempts
+  // are made.
+  free_slot->set_state(ClientState::INIT);
+  return free_slot;
 }
 
 void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest &msg) {


### PR DESCRIPTION
# What does this implement/fix?

get_connection_ reserved the first free slot it met while scanning, so a connect request for an address a later slot already held created a second slot for the same device; that starts a second connection attempt racing the first, and the idempotent already connected answer for the existing slot never fires. This matters on the newest subscriber wins path, where a reconnecting client adopts surviving connections by re-requesting them.

The fix remembers the first free slot, finishes the scan, and reserves only when no slot holds the address. Flagged during review of #18225, which independently defends its retry latches against the duplicate state; the fixes are independent and merge in either order.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
