### PR TITLE
[ufm01] Prefix PassiveReadResult enumerators to avoid Realtek SDK macro collision

### DIFF
--- a/esphome/components/ufm01/ufm01.cpp
+++ b/esphome/components/ufm01/ufm01.cpp
@@ -343,7 +343,7 @@ PassiveReadResult UFM01Component::continue_passive_read_() {
   uint8_t active_frame[FRAME_SIZE];
   passive_no_id_to_active_frame(this->passive_frame_, active_frame);
   this->on_active_frame_(active_frame);
-  return PassiveReadResult::SUCCESS;
+  return PassiveReadResult::COMPLETE;
 }
 
 void UFM01Component::loop_startup_() {
@@ -412,7 +412,7 @@ void UFM01Component::loop_startup_() {
       switch (this->continue_passive_read_()) {
         case PassiveReadResult::PENDING:
           return;
-        case PassiveReadResult::SUCCESS:
+        case PassiveReadResult::COMPLETE:
           ESP_LOGI(TAG, "UFM-01 using passive polling");
           this->operating_mode_ = OperatingMode::PASSIVE_POLL;
           this->passive_read_pending_ = false;

--- a/esphome/components/ufm01/ufm01.cpp
+++ b/esphome/components/ufm01/ufm01.cpp
@@ -329,21 +329,21 @@ PassiveReadResult UFM01Component::continue_passive_read_() {
 
   if (this->passive_index_ < PASSIVE_FRAME_SIZE) {
     if (millis() - this->passive_start_ms_ < PASSIVE_READ_TIMEOUT_MS)
-      return PassiveReadResult::PENDING;
+      return PassiveReadResult::PASSIVE_READ_RESULT_PENDING;
     ESP_LOGD(TAG, "passive read timeout (%zu/%zu bytes)", this->passive_index_, PASSIVE_FRAME_SIZE);
-    return PassiveReadResult::FAILURE;
+    return PassiveReadResult::PASSIVE_READ_RESULT_FAILURE;
   }
 
   if (!validate_passive_frame(this->passive_frame_)) {
     log_hex(this->passive_frame_, PASSIVE_FRAME_SIZE);
     ESP_LOGW(TAG, "invalid passive frame");
-    return PassiveReadResult::FAILURE;
+    return PassiveReadResult::PASSIVE_READ_RESULT_FAILURE;
   }
 
   uint8_t active_frame[FRAME_SIZE];
   passive_no_id_to_active_frame(this->passive_frame_, active_frame);
   this->on_active_frame_(active_frame);
-  return PassiveReadResult::COMPLETE;
+  return PassiveReadResult::PASSIVE_READ_RESULT_SUCCESS;
 }
 
 void UFM01Component::loop_startup_() {
@@ -410,15 +410,15 @@ void UFM01Component::loop_startup_() {
 
     case StartupPhase::PASSIVE_WAIT_REPLY:
       switch (this->continue_passive_read_()) {
-        case PassiveReadResult::PENDING:
+        case PassiveReadResult::PASSIVE_READ_RESULT_PENDING:
           return;
-        case PassiveReadResult::COMPLETE:
+        case PassiveReadResult::PASSIVE_READ_RESULT_SUCCESS:
           ESP_LOGI(TAG, "UFM-01 using passive polling");
           this->operating_mode_ = OperatingMode::PASSIVE_POLL;
           this->passive_read_pending_ = false;
           this->last_poll_ms_ = millis();
           return;
-        case PassiveReadResult::FAILURE:
+        case PassiveReadResult::PASSIVE_READ_RESULT_FAILURE:
           ESP_LOGW(TAG, "Startup failed, retrying in %" PRIu32 " ms", STARTUP_RETRY_MS);
           this->startup_wait_ms_ = STARTUP_RETRY_MS;
           this->set_startup_phase_(StartupPhase::WAIT);
@@ -441,10 +441,10 @@ void UFM01Component::loop_active_stream_() {
 void UFM01Component::loop_passive_poll_() {
   if (this->passive_read_pending_) {
     const PassiveReadResult result = this->continue_passive_read_();
-    if (result == PassiveReadResult::PENDING)
+    if (result == PassiveReadResult::PASSIVE_READ_RESULT_PENDING)
       return;
     this->passive_read_pending_ = false;
-    if (result == PassiveReadResult::FAILURE)
+    if (result == PassiveReadResult::PASSIVE_READ_RESULT_FAILURE)
       this->status_set_warning("UFM-01 passive poll failed");
     return;
   }

--- a/esphome/components/ufm01/ufm01.h
+++ b/esphome/components/ufm01/ufm01.h
@@ -41,7 +41,7 @@ enum class StartupPhase : uint8_t {
 
 enum class PassiveReadResult : uint8_t {
   PENDING = 0,
-  SUCCESS = 1,
+  COMPLETE = 1,
   FAILURE = 2,
 };
 

--- a/esphome/components/ufm01/ufm01.h
+++ b/esphome/components/ufm01/ufm01.h
@@ -40,9 +40,9 @@ enum class StartupPhase : uint8_t {
 };
 
 enum class PassiveReadResult : uint8_t {
-  PENDING = 0,
-  COMPLETE = 1,
-  FAILURE = 2,
+  PASSIVE_READ_RESULT_PENDING = 0,
+  PASSIVE_READ_RESULT_SUCCESS = 1,
+  PASSIVE_READ_RESULT_FAILURE = 2,
 };
 
 class UFM01Component : public uart::UARTDevice, public Component {

--- a/tests/components/ufm01/ufm01_frame_test.cpp
+++ b/tests/components/ufm01/ufm01_frame_test.cpp
@@ -35,7 +35,7 @@ TEST_F(UFM01Test, ValidPassiveFrameReadSuccess) {
   this->mock_uart_.enqueue(std::vector<uint8_t>(frame.begin(), frame.end()));
   this->ufm01_.prepare_passive_read();
 
-  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::SUCCESS);
+  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::COMPLETE);
   EXPECT_EQ(this->ufm01_.passive_index(), PASSIVE_FRAME_SIZE);
   EXPECT_NE(this->ufm01_.last_valid_frame_ms(), 0u);
 }
@@ -56,7 +56,7 @@ TEST_F(UFM01Test, PassiveReadResyncsAfterGarbagePrefix) {
   this->mock_uart_.enqueue(std::vector<uint8_t>(frame.begin(), frame.end()));
   this->ufm01_.prepare_passive_read();
 
-  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::SUCCESS);
+  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::COMPLETE);
 }
 
 TEST_F(UFM01Test, PassiveReadResyncsOnSecondStartByte) {
@@ -65,7 +65,7 @@ TEST_F(UFM01Test, PassiveReadResyncsOnSecondStartByte) {
   this->mock_uart_.enqueue(std::vector<uint8_t>(frame.begin(), frame.end()));
   this->ufm01_.prepare_passive_read();
 
-  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::SUCCESS);
+  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::COMPLETE);
 }
 
 TEST_F(UFM01Test, PassiveReadPendingWhenPartial) {
@@ -77,7 +77,7 @@ TEST_F(UFM01Test, PassiveReadPendingWhenPartial) {
   EXPECT_LT(this->ufm01_.passive_index(), PASSIVE_FRAME_SIZE);
 
   this->mock_uart_.enqueue(std::vector<uint8_t>(frame.begin() + 10, frame.end()));
-  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::SUCCESS);
+  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::COMPLETE);
 }
 
 }  // namespace esphome::ufm01::testing

--- a/tests/components/ufm01/ufm01_frame_test.cpp
+++ b/tests/components/ufm01/ufm01_frame_test.cpp
@@ -35,7 +35,7 @@ TEST_F(UFM01Test, ValidPassiveFrameReadSuccess) {
   this->mock_uart_.enqueue(std::vector<uint8_t>(frame.begin(), frame.end()));
   this->ufm01_.prepare_passive_read();
 
-  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::COMPLETE);
+  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::PASSIVE_READ_RESULT_SUCCESS);
   EXPECT_EQ(this->ufm01_.passive_index(), PASSIVE_FRAME_SIZE);
   EXPECT_NE(this->ufm01_.last_valid_frame_ms(), 0u);
 }
@@ -46,7 +46,7 @@ TEST_F(UFM01Test, InvalidPassiveChecksumFails) {
   this->mock_uart_.enqueue(std::vector<uint8_t>(frame.begin(), frame.end()));
   this->ufm01_.prepare_passive_read();
 
-  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::FAILURE);
+  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::PASSIVE_READ_RESULT_FAILURE);
   EXPECT_EQ(this->ufm01_.last_valid_frame_ms(), 0u);
 }
 
@@ -56,7 +56,7 @@ TEST_F(UFM01Test, PassiveReadResyncsAfterGarbagePrefix) {
   this->mock_uart_.enqueue(std::vector<uint8_t>(frame.begin(), frame.end()));
   this->ufm01_.prepare_passive_read();
 
-  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::COMPLETE);
+  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::PASSIVE_READ_RESULT_SUCCESS);
 }
 
 TEST_F(UFM01Test, PassiveReadResyncsOnSecondStartByte) {
@@ -65,7 +65,7 @@ TEST_F(UFM01Test, PassiveReadResyncsOnSecondStartByte) {
   this->mock_uart_.enqueue(std::vector<uint8_t>(frame.begin(), frame.end()));
   this->ufm01_.prepare_passive_read();
 
-  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::COMPLETE);
+  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::PASSIVE_READ_RESULT_SUCCESS);
 }
 
 TEST_F(UFM01Test, PassiveReadPendingWhenPartial) {
@@ -73,11 +73,11 @@ TEST_F(UFM01Test, PassiveReadPendingWhenPartial) {
   this->mock_uart_.enqueue(std::vector<uint8_t>(frame.begin(), frame.begin() + 10));
   this->ufm01_.prepare_passive_read();
 
-  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::PENDING);
+  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::PASSIVE_READ_RESULT_PENDING);
   EXPECT_LT(this->ufm01_.passive_index(), PASSIVE_FRAME_SIZE);
 
   this->mock_uart_.enqueue(std::vector<uint8_t>(frame.begin() + 10, frame.end()));
-  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::COMPLETE);
+  EXPECT_EQ(this->ufm01_.continue_passive_read(), PassiveReadResult::PASSIVE_READ_RESULT_SUCCESS);
 }
 
 }  // namespace esphome::ufm01::testing


### PR DESCRIPTION
# What does this implement/fix?

Prefixes the `PassiveReadResult` enumerators with the enum name (`PASSIVE_READ_RESULT_PENDING`, `PASSIVE_READ_RESULT_SUCCESS`, `PASSIVE_READ_RESULT_FAILURE`), following the same convention as `UARTFlushResult`. The Realtek SDKs used by LibreTiny define `SUCCESS` as a macro in `basic_types.h`, so the bare `SUCCESS` name breaks clang-tidy for LibreTiny on any PR that touches this header; the existing tests are updated to match, no functional change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
