### PR TITLE
[ld24xx] Use MAC address size constants instead of literals

### DIFF
--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -8,6 +8,7 @@
 #endif
 
 #include "esphome/core/application.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome::ld2410 {
 
@@ -178,7 +179,7 @@ static inline bool validate_header_footer(const uint8_t *header_footer, const ui
 }
 
 void LD2410Component::dump_config() {
-  char mac_s[18];
+  char mac_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   char version_s[20];
   const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
   ld24xx::format_version_str(this->version_, version_s);
@@ -511,7 +512,7 @@ bool LD2410Component::handle_ack_data_() {
         std::memcpy(this->mac_address_, &this->buffer_data_[10], sizeof(this->mac_address_));
       }
 
-      char mac_s[18];
+      char mac_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
       const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
       ESP_LOGV(TAG, "MAC address: %s", mac_str);
 #ifdef USE_TEXT_SENSOR

--- a/esphome/components/ld2410/ld2410.h
+++ b/esphome/components/ld2410/ld2410.h
@@ -121,7 +121,7 @@ class LD2410Component final : public Component, public uart::UARTDevice {
   uint8_t out_pin_level_ = 0;
   uint8_t buffer_pos_ = 0;  // where to resume processing/populating buffer
   uint8_t buffer_data_[MAX_LINE_LENGTH];
-  uint8_t mac_address_[6] = {0, 0, 0, 0, 0, 0};
+  uint8_t mac_address_[MAC_ADDRESS_SIZE] = {0, 0, 0, 0, 0, 0};
   uint8_t version_[6] = {0, 0, 0, 0, 0, 0};
   bool bluetooth_on_{false};
 #ifdef USE_NUMBER

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -197,7 +197,7 @@ static inline bool validate_header_footer(const uint8_t *header_footer, const ui
 }
 
 void LD2412Component::dump_config() {
-  char mac_s[18];
+  char mac_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   char version_s[20];
   const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
   ld24xx::format_version_str(this->version_, version_s);
@@ -555,7 +555,7 @@ bool LD2412Component::handle_ack_data_() {
         std::memcpy(this->mac_address_, &this->buffer_data_[10], sizeof(this->mac_address_));
       }
 
-      char mac_s[18];
+      char mac_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
       const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
       ESP_LOGV(TAG, "MAC address: %s", mac_str);
 #ifdef USE_TEXT_SENSOR

--- a/esphome/components/ld2412/ld2412.h
+++ b/esphome/components/ld2412/ld2412.h
@@ -124,7 +124,7 @@ class LD2412Component final : public Component, public uart::UARTDevice {
   uint8_t out_pin_level_ = 0;
   uint8_t buffer_pos_ = 0;  // where to resume processing/populating buffer
   uint8_t buffer_data_[MAX_LINE_LENGTH];
-  uint8_t mac_address_[6] = {0, 0, 0, 0, 0, 0};
+  uint8_t mac_address_[MAC_ADDRESS_SIZE] = {0, 0, 0, 0, 0, 0};
   uint8_t version_[6] = {0, 0, 0, 0, 0, 0};
   bool bluetooth_on_{false};
   bool dynamic_background_correction_active_{false};

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -184,7 +184,7 @@ void LD2450Component::setup() {
 }
 
 void LD2450Component::dump_config() {
-  char mac_s[18];
+  char mac_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   char version_s[20];
   const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
   ld24xx::format_version_str(this->version_, version_s);
@@ -680,7 +680,7 @@ bool LD2450Component::handle_ack_data_() {
         std::memcpy(this->mac_address_, &this->buffer_data_[10], sizeof(this->mac_address_));
       }
 
-      char mac_s[18];
+      char mac_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
       const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
       ESP_LOGV(TAG, "MAC address: %s", mac_str);
 #ifdef USE_TEXT_SENSOR

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -169,7 +169,7 @@ class LD2450Component : public Component, public uart::UARTDevice {
   uint32_t moving_presence_millis_ = 0;
   uint32_t timeout_ = 5;
   uint8_t buffer_data_[MAX_LINE_LENGTH];
-  uint8_t mac_address_[6] = {0, 0, 0, 0, 0, 0};
+  uint8_t mac_address_[MAC_ADDRESS_SIZE] = {0, 0, 0, 0, 0, 0};
   uint8_t version_[6] = {0, 0, 0, 0, 0, 0};
   uint8_t buffer_pos_ = 0;  // where to resume processing/populating buffer
   uint8_t zone_type_ = 0;

--- a/esphome/components/ld24xx/ld24xx.h
+++ b/esphome/components/ld24xx/ld24xx.h
@@ -45,8 +45,7 @@ static const char *const VERSION_FMT = "%u.%02X.%02X%02X%02X%02X";
 
 // Helper function to format MAC address with stack allocation
 // Returns pointer to UNKNOWN_MAC constant or formatted buffer
-// Buffer must be exactly 18 bytes (17 for "XX:XX:XX:XX:XX:XX" + null terminator)
-inline const char *format_mac_str(const uint8_t *mac_address, std::span<char, 18> buffer) {
+inline const char *format_mac_str(const uint8_t *mac_address, std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buffer) {
   if (mac_address_is_valid(mac_address)) {
     format_mac_addr_upper(mac_address, buffer.data());
     return buffer.data();


### PR DESCRIPTION
# What does this implement/fix?

The ld24xx-family components hardcode `6` for their MAC address arrays and `18` for the pretty-printed MAC string buffers. `esphome/core/helpers.h` already defines `MAC_ADDRESS_SIZE` and `MAC_ADDRESS_PRETTY_BUFFER_SIZE` for exactly this, so this swaps the literals for the constants in ld2410, ld2412, ld2450 and the shared ld24xx header.

Both substitutions are value-identical (`MAC_ADDRESS_SIZE == 6`, and `MAC_ADDRESS_PRETTY_BUFFER_SIZE == format_hex_pretty_size(6) == 18`), so there is no behaviour change and no size change. This is purely about the buffer sizes stating what they mean instead of restating a number.

The comment above `format_mac_str` spelling out the 18-byte requirement is dropped too, since the constant and its own doc comment now carry that, and a comment restating a number goes stale.

`ld2410.cpp` gains an `#include "esphome/core/helpers.h"`; it was previously getting the constants transitively. The other six files already included it directly.

Deliberately left alone: `char version_s[20]` and `uint8_t version_[6]` are firmware version buffers rather than MAC addresses, and the `uint8_t cmd_value[6]` / `uint8_t value[18]` arrays are command payloads whose sizes only coincide with the MAC constants.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; existing ld2410/ld2412/ld2450 configs are unaffected.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).