### PR TITLE
[rp2] Allocate lwIP pools from the shared heap

### DIFF
--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -149,7 +149,7 @@ class APIFrameHelper {
   // holding data too long waiting for Nagle's timer causes buffer exhaustion
   // and dropped messages.
   //
-  // ESP32 (TCP_SND_BUF=4×MSS+) / RP2040 (8×MSS) / LibreTiny (4×MSS): 4 logs per cycle
+  // ESP32 (TCP_SND_BUF=4×MSS+) / RP2040 (4×MSS) / LibreTiny (4×MSS): 4 logs per cycle
   // ESP8266 (2×MSS): 3 logs per cycle (tightest buffers)
   //
   // Flow (ESP32/RP2040/LT): Log 1 (Nagle on) -> Log 2 -> Log 3 -> Log 4 (NODELAY, flush)
@@ -312,7 +312,7 @@ class APIFrameHelper {
   // Values 1..LOG_NAGLE_COUNT count log messages in the current Nagle batch.
   // After LOG_NAGLE_COUNT logs, we flush by re-enabling NODELAY and resetting to 0.
   // ESP8266 has the tightest TCP send buffer (2×MSS) and needs conservative batching.
-  // ESP32 (4×MSS+), RP2040 (8×MSS), and LibreTiny (4×MSS) can coalesce more.
+  // ESP32 (4×MSS+), RP2040 (4×MSS), and LibreTiny (4×MSS) can coalesce more.
 #ifdef USE_ESP8266
   static constexpr uint8_t LOG_NAGLE_COUNT = 2;
 #else

--- a/esphome/components/rp2/__init__.py
+++ b/esphome/components/rp2/__init__.py
@@ -394,7 +394,7 @@ def _configure_lwip() -> None:
     header fully controls the compiled lwIP behavior.
 
     RP2040 uses NO_SYS=1 (polling, no RTOS thread), LWIP_SOCKET=0, LWIP_NETCONN=0.
-    DHCP/DNS use raw udp_new() which allocates from MEMP_NUM_UDP_PCB.
+    DHCP/DNS use raw udp_new() which allocates from the lwIP heap.
 
     Comparison of arduino-pico defaults vs ESPHome targets (TCP_MSS=1460):
 
@@ -402,27 +402,33 @@ def _configure_lwip() -> None:
     ────────────────────────────────────────────────────────────────
     TCP_SND_BUF               2×MSS   4×MSS  8×MSS         4×MSS
     TCP_WND                   4×MSS   4×MSS  8×MSS         4×MSS
-    MEM_LIBC_MALLOC           1       1      0             0*
-    MEMP_MEM_MALLOC           1       1      0             0**
-    MEM_SIZE                  N/A***  N/A*** 16KB          16KB
-    PBUF_POOL_SIZE            10      16     24            16
-    MEMP_NUM_TCP_SEG          10      16     32            17
-    MEMP_NUM_TCP_PCB          5       16     5             dynamic
-    MEMP_NUM_TCP_PCB_LISTEN   4       16     8****         dynamic
-    MEMP_NUM_UDP_PCB          4       16     7             dynamic
     TCP_SND_QUEUELEN          ~8      17     32            17
+    MEM_LIBC_MALLOC           1       1      0             0*
+    MEMP_MEM_MALLOC           1       1      0             1
+    MEM_SIZE                  N/A**   N/A**  16KB          40KB
+    PBUF_POOL_SIZE            10      16     24            n/a***
+    MEMP_NUM_TCP_SEG          10      16     32            n/a***
+    MEMP_NUM_TCP_PCB          5       16     5             n/a***
+    MEMP_NUM_TCP_PCB_LISTEN   4       16     8             n/a***
+    MEMP_NUM_UDP_PCB          4       16     7             n/a***
 
     * MEM_LIBC_MALLOC must stay 0: arduino-pico uses
       PICO_CYW43_ARCH_THREADSAFE_BACKGROUND which runs lwIP callbacks from
       a low-priority pendsv IRQ. The pico-sdk explicitly blocks
       MEM_LIBC_MALLOC=1 because libc malloc uses mutexes (unsafe in IRQ).
-    ** MEMP_MEM_MALLOC must stay 0: the dedicated lwIP heap (MEM_SIZE=16KB)
-      is too small to hold all pools dynamically. The PBUF_POOL alone needs
-      ~24KB (16 × 1524 bytes). Increasing MEM_SIZE would negate BSS savings.
-    *** ESP8266/ESP32 use MEM_LIBC_MALLOC=1 (system heap, no dedicated pool).
-    **** opt.h default; arduino-pico doesn't override MEMP_NUM_TCP_PCB_LISTEN.
-    "dynamic" = auto-calculated from component socket registrations via
-    socket.get_socket_counts() with minimums of 8 TCP / 6 UDP / 2 TCP_LISTEN.
+      MEMP_MEM_MALLOC=1 is fine there: it routes through lwIP's own
+      mem_malloc(), which is guarded by SYS_ARCH_PROTECT (noInterrupts()).
+    ** ESP8266/ESP32 use MEM_LIBC_MALLOC=1 (system heap, no dedicated pool).
+    *** MEMP_MEM_MALLOC=1 allocates every pool entry from the lwIP heap on
+      demand, so the MEMP_NUM_* counts and PBUF_POOL_SIZE are no longer
+      limits — the same reason ESP8266/ESP32 ignore their own values. We
+      still emit them so the sizing stays correct if the flag is reverted.
+
+    Why the counts are not simply raised instead: they are per-pool rations
+    that cannot lend to each other. MEMP_NUM_TCP_SEG in particular is a
+    *global* pool while TCP_SND_QUEUELEN is *per-PCB*, so one busy connection
+    could starve every other PCB while the 24KB receive pbuf pool sat idle.
+    One shared heap removes that whole class of failure.
     """
     from esphome.components.socket import (
         MIN_TCP_LISTEN_SOCKETS,
@@ -446,35 +452,44 @@ def _configure_lwip() -> None:
     # TCP_WND: receive window. 4×MSS matches ESP32. Down from arduino-pico's 8×MSS.
     tcp_wnd = "(4*TCP_MSS)"
 
-    # TCP_SND_QUEUELEN: max pbufs queued for send buffer
+    # TCP_SND_QUEUELEN: max pbufs queued per PCB for the send buffer. Stays
+    # live under MEMP_MEM_MALLOC — it is a counter in the PCB, not a pool.
     # ESP-IDF formula: (4 * TCP_SND_BUF + (TCP_MSS - 1)) / TCP_MSS
     # With 4×MSS: (4*5840 + 1459) / 1460 = 17 — match ESP32
     tcp_snd_queuelen = 17
-    # MEMP_NUM_TCP_SEG: segment pool, must be >= TCP_SND_QUEUELEN (lwIP sanity check)
+    # MEMP_NUM_TCP_SEG: segment pool. Inert while MEMP_MEM_MALLOC=1; kept at
+    # TCP_SND_QUEUELEN, the floor lwIP's sanity check demands without it.
     memp_num_tcp_seg = tcp_snd_queuelen
 
-    # PBUF_POOL_SIZE: RP2040 has 264KB RAM, more generous than LibreTiny.
-    # 16 matches ESP32 (vs arduino-pico's 24). With MEMP_MEM_MALLOC=1,
-    # this is a max count (allocated on demand from heap).
+    # PBUF_POOL_SIZE: 16 matches ESP32 (vs arduino-pico's 24). Inert while
+    # MEMP_MEM_MALLOC=1 — receive pbufs come from the heap on demand.
     pbuf_pool_size = 16
+
+    # MEM_SIZE: the single lwIP heap, which now backs every pool as well as
+    # the PBUF_RAM chunks tcp_write() copies into. 40KB replaces the 16KB heap
+    # plus ~27KB of static pools it absorbs (PBUF_POOL alone was 16 × 1532),
+    # so this is roughly RAM-neutral but fully shareable.
+    #
+    # Sized for the send path: TCP_OVERSIZE defaults to TCP_MSS, so a
+    # connection holding a full TCP_SND_BUF occupies ~4 × 1.5KB. 40KB covers
+    # several concurrent senders plus receive pbufs, ARP, DHCP and mDNS.
+    # Must stay under 64000 or lwIP widens mem_size_t to u32_t.
+    mem_size = 40960
 
     # Build the lwIP override defines for the Jinja2 template.
     # The template uses #include_next to chain to the framework's original
     # lwipopts.h, then #undef/#define only the values we need to change.
     #
-    # Note: MEMP_MEM_MALLOC stays 0 (framework default). While the memp
-    # allocations use the dedicated lwIP heap (IRQ-safe), the 16KB MEM_SIZE
-    # is too small to hold all pools dynamically under stress. The PBUF_POOL
-    # alone needs ~24KB (16 × 1524 bytes). Increasing MEM_SIZE would negate
-    # the BSS savings.
-    #
     # MEM_LIBC_MALLOC stays 0 (framework default): arduino-pico uses
     # PICO_CYW43_ARCH_THREADSAFE_BACKGROUND which runs lwIP callbacks from
     # a low-priority pendsv IRQ where libc malloc (mutex-based) is unsafe.
+    # MEMP_MEM_MALLOC has no such problem — see the docstring.
     lwip_defines: dict[str, str] = {
         "TCP_SND_BUF": tcp_snd_buf,
         "TCP_WND": tcp_wnd,
         "TCP_SND_QUEUELEN": str(tcp_snd_queuelen),
+        "MEMP_MEM_MALLOC": "1",
+        "MEM_SIZE": str(mem_size),
         "MEMP_NUM_TCP_SEG": str(memp_num_tcp_seg),
         "PBUF_POOL_SIZE": str(pbuf_pool_size),
         "MEMP_NUM_TCP_PCB": str(tcp_sockets),
@@ -495,7 +510,9 @@ def _configure_lwip() -> None:
     udp_min = " (min)" if udp_sockets > sc.udp else ""
     listen_min = " (min)" if listening_tcp > sc.tcp_listen else ""
     _LOGGER.info(
-        "Configuring lwIP: TCP=%d%s [%s], UDP=%d%s [%s], TCP_LISTEN=%d%s [%s]",
+        "Configuring lwIP: %d byte shared heap; expected sockets "
+        "TCP=%d%s [%s], UDP=%d%s [%s], TCP_LISTEN=%d%s [%s]",
+        mem_size,
         tcp_sockets,
         tcp_min,
         sc.tcp_details,

--- a/esphome/components/rp2/lwipopts.h.jinja
+++ b/esphome/components/rp2/lwipopts.h.jinja
@@ -20,9 +20,22 @@
 #undef TCP_WND
 #define TCP_WND                       {{ TCP_WND }}
 
-// Queued segment limits: derived from 4xMSS buffer size, matching ESP32
+// Per-PCB send queue: derived from 4xMSS buffer size, matching ESP32
 #undef TCP_SND_QUEUELEN
 #define TCP_SND_QUEUELEN              {{ TCP_SND_QUEUELEN }}
+
+// Allocate every pool entry from the lwIP heap on demand instead of from
+// fixed-count static arrays, as ESP32 and ESP8266 do. This makes all the
+// MEMP_NUM_* / PBUF_POOL_SIZE values below advisory rather than hard caps.
+// Safe here because lwIP's mem_malloc() is guarded by SYS_ARCH_PROTECT
+// (noInterrupts()), unlike the libc malloc that MEM_LIBC_MALLOC would use.
+#undef MEMP_MEM_MALLOC
+#define MEMP_MEM_MALLOC               {{ MEMP_MEM_MALLOC }}
+
+// The single lwIP heap: now backs the pools above as well as the PBUF_RAM
+// chunks tcp_write() copies into, so it absorbs the static pools it replaces.
+#undef MEM_SIZE
+#define MEM_SIZE                      {{ MEM_SIZE }}
 
 #undef MEMP_NUM_TCP_SEG
 #define MEMP_NUM_TCP_SEG              {{ MEMP_NUM_TCP_SEG }}


### PR DESCRIPTION
# What does this implement/fix?

rp2 sized its lwIP pools to ESP32's numeric values, but ESP-IDF ships `MEM_LIBC_MALLOC=1` and `MEMP_MEM_MALLOC=1`, so on ESP32 those numbers are labels rather than caps. On rp2 they were fixed static arrays plus a 16 KB heap, which creates two failure modes that cannot happen on ESP32:

* `MEMP_NUM_TCP_SEG` was a global pool sized to the per-PCB `TCP_SND_QUEUELEN` (17), so one busy connection could drain it for every other PCB, including the other API connections, mDNS and `web_server`.
* `TCP_OVERSIZE` defaults to `TCP_MSS`, so a connection holding a full `TCP_SND_BUF` occupies roughly 6 KB of the 16 KB heap; two connections exhausted it, while `max_connections` on rp2 is 4.

Either one surfaces as `ERR_MEM` from `tcp_write()`, then `EWOULDBLOCK`, then a refused `send_message()`. Meanwhile the 24 KB receive pbuf pool sat idle and could not lend a byte to the send path.

This sets `MEMP_MEM_MALLOC=1`, which deletes the static pools, and grows `MEM_SIZE` to 40 KB to absorb them. `MEM_LIBC_MALLOC` has to stay 0 because the pico-sdk blocks it under `PICO_CYW43_ARCH_THREADSAFE_BACKGROUND`, but `MEMP_MEM_MALLOC` routes through lwIP's own `mem_malloc()`, which is guarded by `SYS_ARCH_PROTECT` and is safe from the pendsv IRQ. LibreTiny got the same fix in e463dc331e and 30d694e62e; rp2 never got the follow-up.

`TCP_SND_BUF` and `TCP_WND` stay at 4xMSS.

Clean builds of `tests/components/bluetooth_proxy/test.rp2040-ard.yaml`:

| | dev | this PR |
| --- | --- | --- |
| RAM | 83,072 | 80,192 |
| Flash | 616,140 | 616,100 |

2,880 bytes smaller, and the remaining memory is shared instead of rationed per pool. Confirmed in the ELF: `memp_memory_*_base` arrays are gone and `ram_heap` is 40,979 bytes.

`script/stress_test_connect.py` passes with no crash on a W5100 Ethernet board. That covers the fragmentation question, since lwIP's `mem.c` is a first fit allocator and one shared heap can fragment where the fixed pools could not.

Still to do before this leaves draft: the same stress test on a Pico W, and the Eve Flare repro from the issue. Ethernet does not exercise the CYW43 path, which is the one that runs lwIP callbacks from the pendsv IRQ, so it is the case that actually depends on `mem_malloc()` being safe under `SYS_ARCH_PROTECT`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/issues/18249 (does not close it; this removes a trigger, but the log spam itself still needs a retry latch)
- https://github.com/esphome/esphome/issues/18221

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed; the lwIP tuning is applied automatically.
esphome:
  name: my-pico-w

rp2:
  board: rpipicow

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

api:

bluetooth_proxy:
  active: true
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
