### PR TITLE
[rp2] Fix %f formatting in logs

### DIFF
--- a/esphome/components/rp2/__init__.py
+++ b/esphome/components/rp2/__init__.py
@@ -351,6 +351,11 @@ async def to_code(config):
         ],
     )
 
+    # newlib-nano is the default libc for the arduino-pico toolchain and its
+    # printf silently drops %f unless _printf_float is force-linked. Components
+    # use %f widely in logging, so pull it in.
+    cg.add_build_flag("-Wl,-u,_printf_float")
+
     # Wrap FILE*-based printf functions to eliminate newlib's _vfprintf_r
     # (~9.2 KB). See printf_stubs.cpp for implementation.
     if config.get(CONF_ENABLE_FULL_PRINTF):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This fixes a regression from #18101, which bumped arduino-pico to 6.0.0. That bump brought in Newlib 4.6.0 with nano-printf, and nano-printf is where float support stops being automatic. The regression is only on `dev`, it has not shipped in a release yet.

Every `%f` in a log message renders as an empty string on RP2040 and RP2350. OTA shows it best:

```
[D][esphome.ota:468]: Progress: %
```

The number is gone; the trailing `%%` still prints. The same device also logs `Scan Window:  ms (48 BLE units)` from `rp2_ble_tracker`, so this is not an OTA problem, it affects roughly 600 float conversions across the components.

The arduino-pico toolchain ships newlib-nano as its default libc. There, `_svfprintf_r` is an alias of the integer only `_svfiprintf_r` and it reaches the float formatter through a weak reference to `_printf_float`. Nothing pulls that object into the link, so the weak reference stays null and newlib skips the conversion silently. Neither the framework nor the PlatformIO builder passes `-u _printf_float`, and pico-sdk's float capable printf never takes over `vsnprintf` either because no printf wraps are applied.

This adds `-Wl,-u,_printf_float` for the rp2 platform, which is what ESP8266 already relies on (see the comment in `remove_float_scanf.py.script`, which strips `_scanf_float` but deliberately keeps `_printf_float`) and what nRF52 does with `NEWLIB_LIBC_FLOAT_PRINTF`. The flag is added unconditionally; `enable_full_printf` only controls whether the `FILE*` printf family is wrapped, so both settings need this.

There is a flash cost, since the float formatter and the `dtoa` support code get linked again. The memory impact run on the `rp2` test config reports +12,784 bytes of flash and +364 bytes of RAM. Almost all of it is `_dtoa_r` at 4,724 bytes, `_printf_float` at 1,468 bytes, and the newlib multiprecision helpers behind them.

That cost is really part of #18101 being reported as cheaper than it was. Its memory run showed `_svfprintf_r` shrinking from 8,600 bytes to 652 bytes and `libc` dropping 17,203 bytes, which is float formatting being dropped rather than optimized away. Putting the two runs side by side on the same test config:

| | Flash |
|---|---|
| before #18101 | 110,036 bytes |
| after #18101 | 87,636 bytes |
| with this PR | 100,420 bytes |

So we keep about 9.6 KB of the framework bump's savings, and we get correct log output back.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes a regression from #18101

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
rp2:
  variant: rp2040

logger:
  level: DEBUG

esphome:
  name: rp2float
  on_boot:
    - lambda: |-
        ESP_LOGD("t", "Progress: %0.1f%%", 12.5f);
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
