### PR TITLE
[tests] Fix flaky modbus server/controller integration tests

### DIFF
--- a/tests/integration/state_utils.py
+++ b/tests/integration/state_utils.py
@@ -475,8 +475,8 @@ class SensorTracker:
             await self.await_change(future, name, timeout=timeout)
 
     async def setup_and_start_scenario(
-        self, client, match_initial_states: bool = False
-    ) -> list:
+        self, client: APIClient, match_initial_states: bool = False
+    ) -> list[EntityInfo]:
         """Wire up subscriptions, wait for initial states, press Start Scenario.
 
         Args:

--- a/tests/integration/state_utils.py
+++ b/tests/integration/state_utils.py
@@ -420,8 +420,15 @@ class SensorTracker:
         """Call ``expect`` for every entry and return a dict of futures."""
         return {name: self.expect(name, value) for name, value in expected.items()}
 
-    def on_state(self, state: EntityState) -> None:
-        """State callback suitable for ``subscribe_states``."""
+    def on_state(self, state: EntityState, first_pending_only: bool = False) -> None:
+        """State callback suitable for ``subscribe_states``.
+
+        Args:
+            state: The state update to record
+            first_pending_only: Only allow the first pending expectation for this
+                sensor to match, instead of the first matching one. Used for
+                connect-time states so they cannot satisfy a later phase.
+        """
         if (
             not isinstance(state, (SensorState, BinarySensorState))
             or state.missing_state
@@ -432,10 +439,12 @@ class SensorTracker:
             return
         self.sensor_states[sensor_name].append(state.state)
         for expected_value, future in self._expectations.get(sensor_name, []):
-            if not future.done() and (
-                expected_value is self._ANY or state.state == expected_value
-            ):
+            if future.done():
+                continue
+            if expected_value is self._ANY or state.state == expected_value:
                 future.set_result(True)
+                break
+            if first_pending_only:
                 break
 
     async def await_change(
@@ -482,10 +491,13 @@ class SensorTracker:
         Args:
             client: The connected API client
             match_initial_states: Also match expectations against the states the
-                device sends when the client connects. Needed when the device can
-                publish a value before the client subscribes: that value arrives in
-                the initial dump, and since equal states are not sent again, no
-                later update would ever match.
+                device sends when the client connects, so a value published before
+                the client subscribed still counts. Binary sensors need this: they
+                drop repeats, so a value that lands in the connect-time dump is
+                never sent again. Plain sensors publish on every poll, so there it
+                only saves waiting for the next one. Only the first pending
+                expectation per sensor can match, so a connect-time value cannot
+                satisfy a later phase.
         """
         entities, _ = await client.list_entities_services()
         self.key_to_sensor.update(
@@ -501,7 +513,7 @@ class SensorTracker:
             pytest.fail("Timeout waiting for initial states")
         if match_initial_states:
             for state in initial_state_helper.initial_states.values():
-                self.on_state(state)
+                self.on_state(state, first_pending_only=True)
         start_btn = find_entity(entities, "start_scenario", ButtonInfo)
         assert start_btn is not None, "Start Scenario button not found"
         client.button_command(start_btn.key)

--- a/tests/integration/state_utils.py
+++ b/tests/integration/state_utils.py
@@ -474,8 +474,19 @@ class SensorTracker:
         for name, future in futures.items():
             await self.await_change(future, name, timeout=timeout)
 
-    async def setup_and_start_scenario(self, client) -> list:
-        """Wire up subscriptions, wait for initial states, press Start Scenario."""
+    async def setup_and_start_scenario(
+        self, client, match_initial_states: bool = False
+    ) -> list:
+        """Wire up subscriptions, wait for initial states, press Start Scenario.
+
+        Args:
+            client: The connected API client
+            match_initial_states: Also match expectations against the states the
+                device sends when the client connects. Needed when the device can
+                publish a value before the client subscribes: that value arrives in
+                the initial dump, and since equal states are not sent again, no
+                later update would ever match.
+        """
         entities, _ = await client.list_entities_services()
         self.key_to_sensor.update(
             build_key_to_entity_mapping(entities, list(self.sensor_states.keys()))
@@ -488,6 +499,9 @@ class SensorTracker:
             import pytest
 
             pytest.fail("Timeout waiting for initial states")
+        if match_initial_states:
+            for state in initial_state_helper.initial_states.values():
+                self.on_state(state)
         start_btn = find_entity(entities, "start_scenario", ButtonInfo)
         assert start_btn is not None, "Start Scenario button not found"
         client.button_command(start_btn.key)

--- a/tests/integration/test_uart_mock_modbus.py
+++ b/tests/integration/test_uart_mock_modbus.py
@@ -330,7 +330,9 @@ async def test_uart_mock_modbus_server_controller(
         run_compiled(yaml_config, line_callback=line_callback),
         api_client_connected() as client,
     ):
-        await tracker.setup_and_start_scenario(client)
+        # The controller polls from boot, so the values can already be in the
+        # states the device sends on connect
+        await tracker.setup_and_start_scenario(client, match_initial_states=True)
         await tracker.await_all(futures)
         _assert_no_modbus_errors(error_log_lines, warning_log_lines)
 
@@ -392,7 +394,11 @@ async def test_uart_mock_modbus_server_controller_write(
         run_compiled(yaml_config, line_callback=line_callback),
         api_client_connected() as client,
     ):
-        entities = await tracker.setup_and_start_scenario(client)
+        # The controller polls from boot, so the baseline can already be in the
+        # states the device sends on connect
+        entities = await tracker.setup_and_start_scenario(
+            client, match_initial_states=True
+        )
 
         # Wait for initial baseline values to confirm the controller <-> server
         # connection is working before issuing writes
@@ -456,7 +462,11 @@ async def test_uart_mock_modbus_server_controller_bits(
         run_compiled(yaml_config, line_callback=line_callback),
         api_client_connected() as client,
     ):
-        entities = await tracker.setup_and_start_scenario(client)
+        # The controller polls from boot, so the baseline can already be in the
+        # states the device sends on connect
+        entities = await tracker.setup_and_start_scenario(
+            client, match_initial_states=True
+        )
 
         # Wait for initial baseline values to confirm the controller <-> server
         # connection is working before issuing writes
@@ -491,7 +501,9 @@ async def test_uart_mock_modbus_server_controller_multiple(
         run_compiled(yaml_config, line_callback=line_callback),
         api_client_connected() as client,
     ):
-        await tracker.setup_and_start_scenario(client)
+        # The controller polls from boot, so the values can already be in the
+        # states the device sends on connect
+        await tracker.setup_and_start_scenario(client, match_initial_states=True)
         await tracker.await_all(futures)
         _assert_no_modbus_errors(error_log_lines, warning_log_lines)
 

--- a/tests/integration/test_uart_mock_modbus.py
+++ b/tests/integration/test_uart_mock_modbus.py
@@ -330,8 +330,9 @@ async def test_uart_mock_modbus_server_controller(
         run_compiled(yaml_config, line_callback=line_callback),
         api_client_connected() as client,
     ):
-        # The controller polls from boot, so the values can already be in the
-        # states the device sends on connect
+        # The controller polls from boot, so the first values can already be in
+        # the states the device sends on connect; matching them there saves
+        # waiting for the next poll
         await tracker.setup_and_start_scenario(client, match_initial_states=True)
         await tracker.await_all(futures)
         _assert_no_modbus_errors(error_log_lines, warning_log_lines)
@@ -395,7 +396,8 @@ async def test_uart_mock_modbus_server_controller_write(
         api_client_connected() as client,
     ):
         # The controller polls from boot, so the baseline can already be in the
-        # states the device sends on connect
+        # states the device sends on connect; matching it there saves waiting for
+        # the next poll
         entities = await tracker.setup_and_start_scenario(
             client, match_initial_states=True
         )
@@ -462,8 +464,8 @@ async def test_uart_mock_modbus_server_controller_bits(
         run_compiled(yaml_config, line_callback=line_callback),
         api_client_connected() as client,
     ):
-        # The controller polls from boot, so the baseline can already be in the
-        # states the device sends on connect
+        # The controller polls from boot and binary sensors drop repeats, so the
+        # baseline can arrive only in the states the device sends on connect
         entities = await tracker.setup_and_start_scenario(
             client, match_initial_states=True
         )
@@ -501,8 +503,9 @@ async def test_uart_mock_modbus_server_controller_multiple(
         run_compiled(yaml_config, line_callback=line_callback),
         api_client_connected() as client,
     ):
-        # The controller polls from boot, so the values can already be in the
-        # states the device sends on connect
+        # The controller polls from boot, so the first values can already be in
+        # the states the device sends on connect; matching them there saves
+        # waiting for the next poll
         await tracker.setup_and_start_scenario(client, match_initial_states=True)
         await tracker.await_all(futures)
         _assert_no_modbus_errors(error_log_lines, warning_log_lines)


### PR DESCRIPTION
# What does this implement/fix?

`test_uart_mock_modbus_server_controller_bits` fails often in CI with `Timeout waiting for bit_coil_0 change`.

The four loopback fixtures start their uart mocks at boot, so the modbus controller can finish its first poll before the test client subscribes to states. Those values then arrive in the state dump the device sends on connect, which the test helper swallows so tests only see changes; because equal states are never sent again, the expected values never show up and phase 1 times out.

`SensorTracker.setup_and_start_scenario` now takes `match_initial_states`, which also matches expectations against the connect time states, and the four server/controller tests opt in. The default keeps today's behaviour for every other caller, including the checks that assert a sensor must not change.

Verified by holding the client back for three seconds after the device boots; that reproduces the CI failure exactly on `dev` and passes with this change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
