### PR TITLE
[bluetooth_proxy] Retry dropped GATT acks and stop the retry log spam

### DIFF
--- a/esphome/components/bluetooth_connection/bluetooth_connection.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.h
@@ -92,9 +92,10 @@ static_assert(DONE_SENDING_SERVICES != GATT_NOT_CONNECTED && INIT_SENDING_SERVIC
 // delivered near the client's 30 s timeout could land on a fresh request's
 // empty accumulator and cache as an empty database.
 static constexpr uint8_t SERVICES_DONE_RETRY_LIMIT = 30;
-// Owed-ack retries stop here (~25 s at the 100 ms drain cadence): just under
-// the client's 30 s GATT timeout, so a reply is abandoned before a re-ask.
-static constexpr uint8_t PENDING_ACK_RETRY_LIMIT = 250;
+// Owed-ack retries stop after ~25 s of subscribed drain time from the first
+// refusal, keeping most of the client's 30 s GATT window for congestion to
+// clear while still bounding how stale a delivered reply can be.
+static constexpr uint16_t PENDING_ACK_RETRY_LIMIT = 250;
 
 // ---- Service-streaming size budget, shared by every platform's streamer ----
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.h
@@ -92,13 +92,8 @@ static_assert(DONE_SENDING_SERVICES != GATT_NOT_CONNECTED && INIT_SENDING_SERVIC
 // delivered near the client's 30 s timeout could land on a fresh request's
 // empty accumulator and cache as an empty database.
 static constexpr uint8_t SERVICES_DONE_RETRY_LIMIT = 30;
-// Owed-ack retries stop here (~25 s at the 100 ms drain cadence). The bound
-// comes from the client, not the link: congestion can take tens of seconds to
-// clear, and bleak-esphome's GATT operation timeout is 30 s, so nothing can
-// re-ask before then. Stopping just under it keeps the whole window available
-// for delivery while still closing the stale-reply race that
-// supersede_pending_ack_() alone cannot (a drain that beats the re-request's
-// processing would answer the new request with the old reply).
+// Owed-ack retries stop here (~25 s at the 100 ms drain cadence): just under
+// the client's 30 s GATT timeout, so a reply is abandoned before a re-ask.
 static constexpr uint8_t PENDING_ACK_RETRY_LIMIT = 250;
 
 // ---- Service-streaming size budget, shared by every platform's streamer ----

--- a/esphome/components/bluetooth_connection/bluetooth_connection.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.h
@@ -92,11 +92,14 @@ static_assert(DONE_SENDING_SERVICES != GATT_NOT_CONNECTED && INIT_SENDING_SERVIC
 // delivered near the client's 30 s timeout could land on a fresh request's
 // empty accumulator and cache as an empty database.
 static constexpr uint8_t SERVICES_DONE_RETRY_LIMIT = 30;
-// Owed-ack retries stop on the same reasoning and cadence. supersede only
-// fires once the proxy processes the client's re-request, so a drain that
-// beats that processing could resolve the new request with the old reply;
-// an age bound is what closes that, not the supersede.
-static constexpr uint8_t PENDING_ACK_RETRY_LIMIT = 30;
+// Owed-ack retries stop here (~25 s at the 100 ms drain cadence). The bound
+// comes from the client, not the link: congestion can take tens of seconds to
+// clear, and bleak-esphome's GATT operation timeout is 30 s, so nothing can
+// re-ask before then. Stopping just under it keeps the whole window available
+// for delivery while still closing the stale-reply race that
+// supersede_pending_ack_() alone cannot (a drain that beats the re-request's
+// processing would answer the new request with the old reply).
+static constexpr uint8_t PENDING_ACK_RETRY_LIMIT = 250;
 
 // ---- Service-streaming size budget, shared by every platform's streamer ----
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.h
@@ -92,6 +92,11 @@ static_assert(DONE_SENDING_SERVICES != GATT_NOT_CONNECTED && INIT_SENDING_SERVIC
 // delivered near the client's 30 s timeout could land on a fresh request's
 // empty accumulator and cache as an empty database.
 static constexpr uint8_t SERVICES_DONE_RETRY_LIMIT = 30;
+// Owed-ack retries stop on the same reasoning and cadence. supersede only
+// fires once the proxy processes the client's re-request, so a drain that
+// beats that processing could resolve the new request with the old reply;
+// an age bound is what closes that, not the supersede.
+static constexpr uint8_t PENDING_ACK_RETRY_LIMIT = 30;
 
 // ---- Service-streaming size budget, shared by every platform's streamer ----
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
@@ -397,6 +397,8 @@ void BluedroidGattClient::deliver_pending_search_() {
 // which proxy builds compile without a materializer.
 static_assert(requires(BluedroidGattClient c, BluetoothConnection &conn) { c.stream_service_batch(conn); });
 
+// Bound by the SERVICE STREAMING HAZARD note at the top of
+// bluetooth_connection_hub.cpp: never skip a batch, never send done early.
 void BluedroidGattClient::stream_service_batch(BluetoothConnection &conn) {
   if (this->services_released_) {
     // Released under the stream: park without services-done so a partial

--- a/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
@@ -527,9 +527,11 @@ void BluedroidGattClient::stream_service_batch(BluetoothConnection &conn) {
   // On a failed send, rewind the cursor so the batch is retried instead of
   // silently skipped.
   if (!api_conn->send_message(resp)) {
-    ESP_LOGW(TAG, "[%d] [%s] Failed to send service batch, retrying", conn.connection_index_, conn.address_str_);
+    conn.note_batch_stalled_();
     conn.send_service_ = batch_start;
+    return;
   }
+  conn.batch_stalled_ = false;
 }
 #endif  // USE_BLUETOOTH_PROXY
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -230,8 +230,15 @@ void BluetoothConnection::flush_pending_ack_() {
     return;
   if (this->try_send_ack_(this->pending_ack_, this->pending_ack_handle_, this->pending_ack_error_)) {
     this->clear_pending_ack_();
+    return;
   }
-  // Still refused: stays owed for the next paced drain.
+  if (++this->pending_ack_retries_ >= PENDING_ACK_RETRY_LIMIT) {
+    // Undeliverable: past here the client has given up and may have re-asked,
+    // and a late reply would answer the new request instead of this one.
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X undeliverable, abandoning", this->connection_index_,
+             this->address_str_, this->pending_ack_handle_);
+    this->clear_pending_ack_();
+  }
 }
 
 void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, uint16_t len, int error) {

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -16,9 +16,8 @@ static const char *const TAG = "bluetooth_connection";
 void BluetoothConnection::set_address(uint64_t address) {
   // Keep the proxy's pre-allocated connections-free message in step
   this->proxy_->update_address_slot_(this->address_, address);
-  // The slot is changing hands, so anything owed belonged to the old address.
-  // reset_connection_() already clears on the ordinary teardown path; this is
-  // the choke point that covers every other way a slot is reassigned or freed.
+  // Slot changing hands: anything owed belonged to the old address. The
+  // choke point for every reassignment, not just reset_connection_()'s path.
   this->clear_pending_ack_();
   this->address_ = address;
   if (address == 0) {
@@ -77,9 +76,7 @@ void BluetoothConnection::reset_connection_(conn_err_t reason) {
   this->state_ = ClientState::IDLE;
   this->services_discovered_ = false;
   this->paired_ = false;
-  // The link is gone: an owed reply for it would arrive addressed to a
-  // connection the client has already been told about, and the slot may be
-  // reserved for a different device by the time the drain runs.
+  // Link gone: the slot may hold a different device before the drain runs.
   this->clear_pending_ack_();
   this->batch_stalled_ = false;
   this->backend_->release_services();
@@ -180,61 +177,56 @@ void BluetoothConnection::note_batch_stalled_() {
            this->address_str_);
 }
 
-/// Build and send one payload-free GATT reply. The only construction site
-/// for these messages: first attempt and retry both come through here, so a
-/// re-offer cannot drift from the original.
+/// Both payload-free acks are just (address, handle); only the type differs.
+template<typename Response>
+static bool send_handle_reply_(api::APIConnection *api_connection, uint64_t address, uint16_t handle) {
+  Response resp;
+  resp.address = address;
+  resp.handle = handle;
+  return api_connection->send_message(resp);
+}
+
+/// Sole construction site, so a re-offer cannot drift from the original.
 bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
   if (kind == PendingAck::PENDING_ACK_ERROR) {
-    // The proxy owns the error reply; it reports a refusal the same way.
+    // Proxy owns the error reply and reports a refusal the same way.
     return this->proxy_->send_gatt_error(this->address_, handle, error);
   }
   auto *api_connection = this->proxy_->get_api_connection();
   if (api_connection == nullptr)
     return true;  // Nobody subscribed: nothing is owed
   switch (kind) {
-    case PendingAck::PENDING_ACK_WRITE: {
-      api::BluetoothGATTWriteResponse resp;
-      resp.address = this->address_;
-      resp.handle = handle;
-      return api_connection->send_message(resp);
-    }
-    case PendingAck::PENDING_ACK_NOTIFY: {
-      api::BluetoothGATTNotifyResponse resp;
-      resp.address = this->address_;
-      resp.handle = handle;
-      return api_connection->send_message(resp);
-    }
+    case PendingAck::PENDING_ACK_WRITE:
+      return send_handle_reply_<api::BluetoothGATTWriteResponse>(api_connection, this->address_, handle);
+    case PendingAck::PENDING_ACK_NOTIFY:
+      return send_handle_reply_<api::BluetoothGATTNotifyResponse>(api_connection, this->address_, handle);
     case PendingAck::PENDING_ACK_NONE:
     case PendingAck::PENDING_ACK_ERROR:  // returned above
       return true;
   }
-  // Every enumerator is listed and there is no default label, so adding one
-  // without a branch is a -Wswitch warning rather than a silent notify reply.
-  // This return only satisfies -Wreturn-type.
+  // No default label above, so a new enumerator is a -Wswitch warning rather
+  // than a silent notify reply. This return only satisfies -Wreturn-type.
   return true;
 }
 
 void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
   if (this->try_send_ack_(kind, handle, error))
     return;
-  // V, not W: the reply is owed rather than lost, and a warning here would
-  // ride the same connection that just refused a frame. Matches how the
-  // proxy logs a deferred connections-free update.
+  // V, not W: the reply is owed rather than lost, and a warning would ride
+  // the connection that just refused it (as for connections-free).
   ESP_LOGV(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
            this->address_str_, handle);
   this->latch_pending_ack_(kind, handle, error);
 }
 
 void BluetoothConnection::flush_pending_ack_() {
-  // Local guard: the proxy drain pre-checks, but this must be a no-op on its
-  // own rather than relying on a caller in another file.
+  // No-op on its own rather than relying on the proxy drain's pre-check.
   if (!this->has_pending_ack_())
     return;
   if (this->try_send_ack_(this->pending_ack_, this->pending_ack_handle_, this->pending_ack_error_)) {
     this->clear_pending_ack_();
   }
-  // Still refused: stays owed, re-offered on the next paced drain. The
-  // client's operation timeout remains the outer bound.
+  // Still refused: stays owed for the next paced drain.
 }
 
 void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, uint16_t len, int error) {
@@ -254,8 +246,8 @@ void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, u
   resp.handle = handle;
   resp.set_data(data, len);
   if (!api_connection->send_message(resp)) {
-    // Not latched: the payload would have to be held on the heap through the
-    // congestion that refused it. The client's read timeout arbitrates.
+    // Not latched: would mean holding the payload through the congestion
+    // that refused it. The client's read timeout arbitrates.
     ESP_LOGW(TAG, "[%d] [%s] Failed to send read response", this->connection_index_, this->address_str_);
   }
 }
@@ -295,9 +287,8 @@ void BluetoothConnection::on_notify_data(uint16_t handle, const uint8_t *data, u
   resp.handle = handle;
   resp.set_data(data, len);
   if (!api_connection->send_message(resp)) {
-    // Not latched, same reason as the read reply: the payload cannot be held
-    // through congestion. Notify data is genuinely lossy; the peripheral will
-    // not resend it.
+    // Not latched, same reason as the read reply. Notify data is lossy: the
+    // peripheral will not resend it.
     ESP_LOGW(TAG, "[%d] [%s] Failed to send notify data response", this->connection_index_, this->address_str_);
   }
 }

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -212,10 +212,13 @@ bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_e
 void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
   if (this->try_send_ack_(kind, handle, error))
     return;
-  // V, not W: the reply is owed rather than lost, and a warning would ride
-  // the connection that just refused it (as for connections-free).
-  ESP_LOGV(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
-           this->address_str_, handle);
+  // Warn on the leading edge only, like a stalled service batch: a refused
+  // reply must not be silent, but repeating it every attempt would add traffic
+  // to the connection that just refused one.
+  if (!this->has_pending_ack_()) {
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
+             this->address_str_, handle);
+  }
   this->latch_pending_ack_(kind, handle, error);
 }
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -215,10 +215,10 @@ void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t
   // Report a newly owed reply and a displaced one; displacing is the case
   // that loses a reply. Re-refusing the same one stays quiet.
   if (!this->has_pending_ack_()) {
-    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%04X deferred, TCP buffer full", this->connection_index_,
              this->address_str_, handle);
   } else if (this->pending_ack_handle_ != handle || this->pending_ack_ != kind) {
-    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X dropped for handle 0x%2X", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%04X dropped for handle 0x%04X", this->connection_index_,
              this->address_str_, this->pending_ack_handle_, handle);
   }
   this->latch_pending_ack_(kind, handle, error);
@@ -235,7 +235,7 @@ void BluetoothConnection::flush_pending_ack_() {
   if (++this->pending_ack_retries_ >= PENDING_ACK_RETRY_LIMIT) {
     // Undeliverable: past here the client has given up and may have re-asked,
     // and a late reply would answer the new request instead of this one.
-    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X undeliverable, abandoning", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%04X undeliverable, abandoning", this->connection_index_,
              this->address_str_, this->pending_ack_handle_);
     this->clear_pending_ack_();
   }
@@ -317,7 +317,7 @@ conn_err_t BluetoothConnection::check_connected_op_(const char *action, const ch
 }
 
 conn_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
-  this->supersede_pending_ack_(handle);
+  this->supersede_pending_ack_(handle, PendingAck::PENDING_ACK_NONE);
   if (conn_err_t err = this->check_connected_op_("read", "characteristic"); err != CONN_OK)
     return err;
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
@@ -326,7 +326,7 @@ conn_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
 
 conn_err_t BluetoothConnection::write_characteristic(uint16_t handle, const uint8_t *data, size_t length,
                                                      bool response) {
-  this->supersede_pending_ack_(handle);
+  this->supersede_pending_ack_(handle, PendingAck::PENDING_ACK_WRITE);
   if (conn_err_t err = this->check_connected_op_("write", "characteristic"); err != CONN_OK)
     return err;
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
@@ -334,7 +334,7 @@ conn_err_t BluetoothConnection::write_characteristic(uint16_t handle, const uint
 }
 
 conn_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
-  this->supersede_pending_ack_(handle);
+  this->supersede_pending_ack_(handle, PendingAck::PENDING_ACK_NONE);
   if (conn_err_t err = this->check_connected_op_("read", "descriptor"); err != CONN_OK)
     return err;
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
@@ -345,7 +345,7 @@ conn_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
 // the response flag is intentionally ignored (esp32 maps it to RSP/NO_RSP).
 conn_err_t BluetoothConnection::write_descriptor(uint16_t handle, const uint8_t *data, size_t length,
                                                  bool /*response*/) {
-  this->supersede_pending_ack_(handle);
+  this->supersede_pending_ack_(handle, PendingAck::PENDING_ACK_WRITE);
   if (conn_err_t err = this->check_connected_op_("write", "descriptor"); err != CONN_OK)
     return err;
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
@@ -353,7 +353,7 @@ conn_err_t BluetoothConnection::write_descriptor(uint16_t handle, const uint8_t 
 }
 
 conn_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enable) {
-  this->supersede_pending_ack_(handle);
+  this->supersede_pending_ack_(handle, PendingAck::PENDING_ACK_NOTIFY);
   if (conn_err_t err = this->check_connected_op_("notify", "characteristic"); err != CONN_OK)
     return err;
   ESP_LOGV(TAG, "[%d] [%s] %s GATT characteristic notifications handle %d", this->connection_index_, this->address_str_,

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -235,7 +235,7 @@ void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, u
     return;
   if (error != 0) {
     this->log_gatt_operation_error_("reading char/descriptor", handle, error);
-    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
+    this->send_gatt_error_(handle, error);
     return;
   }
   auto *api_connection = this->proxy_->get_api_connection();
@@ -257,7 +257,7 @@ void BluetoothConnection::on_write_result(uint16_t handle, int error) {
     return;
   if (error != 0) {
     this->log_gatt_operation_error_("writing char/descriptor", handle, error);
-    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
+    this->send_gatt_error_(handle, error);
     return;
   }
   this->send_ack_(PendingAck::PENDING_ACK_WRITE, handle);
@@ -269,7 +269,7 @@ void BluetoothConnection::on_notify_state(uint16_t handle, bool enabled, int err
   if (error != 0) {
     this->log_gatt_operation_error_(enabled ? "registering notifications" : "unregistering notifications", handle,
                                     error);
-    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
+    this->send_gatt_error_(handle, error);
     return;
   }
   this->send_ack_(PendingAck::PENDING_ACK_NOTIFY, handle);
@@ -305,26 +305,26 @@ conn_err_t BluetoothConnection::check_connected_op_(const char *action, const ch
 }
 
 conn_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
+  this->supersede_pending_ack_(handle);
   if (conn_err_t err = this->check_connected_op_("read", "characteristic"); err != CONN_OK)
     return err;
-  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->read_characteristic(handle);
 }
 
 conn_err_t BluetoothConnection::write_characteristic(uint16_t handle, const uint8_t *data, size_t length,
                                                      bool response) {
+  this->supersede_pending_ack_(handle);
   if (conn_err_t err = this->check_connected_op_("write", "characteristic"); err != CONN_OK)
     return err;
-  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->write_characteristic(handle, data, static_cast<uint16_t>(length), response);
 }
 
 conn_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
+  this->supersede_pending_ack_(handle);
   if (conn_err_t err = this->check_connected_op_("read", "descriptor"); err != CONN_OK)
     return err;
-  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->read_descriptor(handle);
 }
@@ -333,17 +333,17 @@ conn_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
 // the response flag is intentionally ignored (esp32 maps it to RSP/NO_RSP).
 conn_err_t BluetoothConnection::write_descriptor(uint16_t handle, const uint8_t *data, size_t length,
                                                  bool /*response*/) {
+  this->supersede_pending_ack_(handle);
   if (conn_err_t err = this->check_connected_op_("write", "descriptor"); err != CONN_OK)
     return err;
-  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->write_descriptor(handle, data, static_cast<uint16_t>(length));
 }
 
 conn_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enable) {
+  this->supersede_pending_ack_(handle);
   if (conn_err_t err = this->check_connected_op_("notify", "characteristic"); err != CONN_OK)
     return err;
-  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] %s GATT characteristic notifications handle %d", this->connection_index_, this->address_str_,
            enable ? "Registering for" : "Unregistering for", handle);
   return this->backend_->notify_characteristic(handle, enable);

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -1,4 +1,24 @@
 // The proxy's per-slot connection wrapper, shared by every platform.
+//
+// SERVICE STREAMING HAZARD - read before touching the streaming code here or
+// in the platform streamers (bluetooth_connection_bluedroid.cpp).
+//
+// A V3 client caches the service list it receives as the device's complete,
+// permanent database. Nothing on the wire marks a list as partial, so a
+// stream that is truncated, has a skipped batch, or is terminated early
+// would be cached whole and poison every later session with the device.
+//
+// The rule: it is always better to send nothing and let the client time out
+// than to let services-done follow an incomplete stream. Concretely:
+//   - a refused batch rewinds the cursor and is retried, never skipped;
+//   - services-done is sent only after every batch was accepted;
+//   - every interruption (subscriber lost or swapped, backend abort,
+//     bounds-check failure) parks or aborts WITHOUT services-done and drops
+//     any owed done;
+//   - a new GetServices supersedes an owed done, so a stale done can never
+//     land on a fresh request's empty accumulator and cache it as empty.
+// The client only caches a list terminated by services-done within the same
+// request; timeouts, disconnects and errors raise instead of caching.
 #include "bluetooth_connection_hub.h"
 
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -73,6 +73,11 @@ void BluetoothConnection::reset_connection_(conn_err_t reason) {
   this->state_ = ClientState::IDLE;
   this->services_discovered_ = false;
   this->paired_ = false;
+  // The link is gone: an owed reply for it would arrive addressed to a
+  // connection the client has already been told about, and the slot may be
+  // reserved for a different device by the time the drain runs.
+  this->clear_pending_ack_();
+  this->batch_stalled_ = false;
   this->backend_->release_services();
   this->proxy_->reset_connection_slot_(this, reason);
 }
@@ -163,13 +168,63 @@ void BluetoothConnection::log_gatt_operation_error_(const char *operation, uint1
            operation, handle, status);
 }
 
+void BluetoothConnection::note_batch_stalled_() {
+  if (this->batch_stalled_)
+    return;
+  this->batch_stalled_ = true;
+  ESP_LOGW(TAG, "[%d] [%s] Service batch deferred, TCP buffer full; retrying", this->connection_index_,
+           this->address_str_);
+}
+
+/// Build and send one payload-free GATT reply. The only construction site
+/// for these messages: first attempt and retry both come through here, so a
+/// re-offer cannot drift from the original.
+bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
+  if (kind == PendingAck::PENDING_ACK_ERROR) {
+    // The proxy owns the error reply; it reports a refusal the same way.
+    return this->proxy_->send_gatt_error(this->address_, handle, error);
+  }
+  auto *api_connection = this->proxy_->get_api_connection();
+  if (api_connection == nullptr)
+    return true;  // Nobody subscribed: nothing is owed
+  if (kind == PendingAck::PENDING_ACK_WRITE) {
+    api::BluetoothGATTWriteResponse resp;
+    resp.address = this->address_;
+    resp.handle = handle;
+    return api_connection->send_message(resp);
+  }
+  api::BluetoothGATTNotifyResponse resp;
+  resp.address = this->address_;
+  resp.handle = handle;
+  return api_connection->send_message(resp);
+}
+
+void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
+  if (this->try_send_ack_(kind, handle, error))
+    return;
+  // V, not W: the reply is owed rather than lost, and a warning here would
+  // ride the same connection that just refused a frame. Matches how the
+  // proxy logs a deferred connections-free update.
+  ESP_LOGV(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
+           this->address_str_, handle);
+  this->latch_pending_ack_(kind, handle, error);
+}
+
+void BluetoothConnection::flush_pending_ack_() {
+  if (this->try_send_ack_(this->pending_ack_, this->pending_ack_handle_, this->pending_ack_error_)) {
+    this->clear_pending_ack_();
+  }
+  // Still refused: stays owed, re-offered on the next paced drain. The
+  // client's operation timeout remains the outer bound.
+}
+
 void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, uint16_t len, int error) {
   // Late completion for a freed slot; nothing to report.
   if (this->address_ == 0)
     return;
   if (error != 0) {
     this->log_gatt_operation_error_("reading char/descriptor", handle, error);
-    this->proxy_->send_gatt_error(this->address_, handle, error);
+    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
     return;
   }
   auto *api_connection = this->proxy_->get_api_connection();
@@ -180,6 +235,8 @@ void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, u
   resp.handle = handle;
   resp.set_data(data, len);
   if (!api_connection->send_message(resp)) {
+    // Not latched: the payload would have to be held on the heap through the
+    // congestion that refused it. The client's read timeout arbitrates.
     ESP_LOGW(TAG, "[%d] [%s] Failed to send read response", this->connection_index_, this->address_str_);
   }
 }
@@ -189,18 +246,10 @@ void BluetoothConnection::on_write_result(uint16_t handle, int error) {
     return;
   if (error != 0) {
     this->log_gatt_operation_error_("writing char/descriptor", handle, error);
-    this->proxy_->send_gatt_error(this->address_, handle, error);
+    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
     return;
   }
-  auto *api_connection = this->proxy_->get_api_connection();
-  if (api_connection == nullptr)
-    return;
-  api::BluetoothGATTWriteResponse resp;
-  resp.address = this->address_;
-  resp.handle = handle;
-  if (!api_connection->send_message(resp)) {
-    ESP_LOGW(TAG, "[%d] [%s] Failed to send write response", this->connection_index_, this->address_str_);
-  }
+  this->send_ack_(PendingAck::PENDING_ACK_WRITE, handle);
 }
 
 void BluetoothConnection::on_notify_state(uint16_t handle, bool enabled, int error) {
@@ -209,18 +258,10 @@ void BluetoothConnection::on_notify_state(uint16_t handle, bool enabled, int err
   if (error != 0) {
     this->log_gatt_operation_error_(enabled ? "registering notifications" : "unregistering notifications", handle,
                                     error);
-    this->proxy_->send_gatt_error(this->address_, handle, error);
+    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
     return;
   }
-  auto *api_connection = this->proxy_->get_api_connection();
-  if (api_connection == nullptr)
-    return;
-  api::BluetoothGATTNotifyResponse resp;
-  resp.address = this->address_;
-  resp.handle = handle;
-  if (!api_connection->send_message(resp)) {
-    ESP_LOGW(TAG, "[%d] [%s] Failed to send notify state response", this->connection_index_, this->address_str_);
-  }
+  this->send_ack_(PendingAck::PENDING_ACK_NOTIFY, handle);
 }
 
 void BluetoothConnection::on_notify_data(uint16_t handle, const uint8_t *data, uint16_t len) {
@@ -235,6 +276,9 @@ void BluetoothConnection::on_notify_data(uint16_t handle, const uint8_t *data, u
   resp.handle = handle;
   resp.set_data(data, len);
   if (!api_connection->send_message(resp)) {
+    // Not latched, same reason as the read reply: the payload cannot be held
+    // through congestion. Notify data is genuinely lossy; the peripheral will
+    // not resend it.
     ESP_LOGW(TAG, "[%d] [%s] Failed to send notify data response", this->connection_index_, this->address_str_);
   }
 }
@@ -413,9 +457,11 @@ void BluetoothConnection::send_service_for_discovery_() {
   // (bounded: a subscriber that stays gone ends streaming via the api-lost
   // rewind above).
   if (!api_conn->send_message(resp)) {
-    ESP_LOGW(TAG, "[%d] [%s] Failed to send service batch, retrying", this->connection_index_, this->address_str_);
+    this->note_batch_stalled_();
     this->send_service_ = batch_start;
+    return;
   }
+  this->batch_stalled_ = false;
 }
 
 }  // namespace esphome::bluetooth_connection

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -212,12 +212,16 @@ bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_e
 void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
   if (this->try_send_ack_(kind, handle, error))
     return;
-  // Warn on the leading edge only, like a stalled service batch: a refused
-  // reply must not be silent, but repeating it every attempt would add traffic
-  // to the connection that just refused one.
+  // Report anything the client will not otherwise learn about: a newly owed
+  // reply, or one being displaced, which is the case that actually loses a
+  // reply for good. Re-refusing the same reply is the only quiet path, since
+  // it is already owed and the drain keeps trying.
   if (!this->has_pending_ack_()) {
     ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
              this->address_str_, handle);
+  } else if (this->pending_ack_handle_ != handle || this->pending_ack_ != kind) {
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X dropped for handle 0x%2X", this->connection_index_,
+             this->address_str_, this->pending_ack_handle_, handle);
   }
   this->latch_pending_ack_(kind, handle, error);
 }

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -212,10 +212,8 @@ bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_e
 void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
   if (this->try_send_ack_(kind, handle, error))
     return;
-  // Report anything the client will not otherwise learn about: a newly owed
-  // reply, or one being displaced, which is the case that actually loses a
-  // reply for good. Re-refusing the same reply is the only quiet path, since
-  // it is already owed and the drain keeps trying.
+  // Report a newly owed reply and a displaced one; displacing is the case
+  // that loses a reply. Re-refusing the same one stays quiet.
   if (!this->has_pending_ack_()) {
     ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
              this->address_str_, handle);

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -179,7 +179,7 @@ void BluetoothConnection::note_batch_stalled_() {
 
 /// Both payload-free acks are just (address, handle); only the type differs.
 template<typename Response>
-static bool send_handle_reply_(api::APIConnection *api_connection, uint64_t address, uint16_t handle) {
+static bool send_handle_reply(api::APIConnection *api_connection, uint64_t address, uint16_t handle) {
   Response resp;
   resp.address = address;
   resp.handle = handle;
@@ -197,9 +197,9 @@ bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_e
     return true;  // Nobody subscribed: nothing is owed
   switch (kind) {
     case PendingAck::PENDING_ACK_WRITE:
-      return send_handle_reply_<api::BluetoothGATTWriteResponse>(api_connection, this->address_, handle);
+      return send_handle_reply<api::BluetoothGATTWriteResponse>(api_connection, this->address_, handle);
     case PendingAck::PENDING_ACK_NOTIFY:
-      return send_handle_reply_<api::BluetoothGATTNotifyResponse>(api_connection, this->address_, handle);
+      return send_handle_reply<api::BluetoothGATTNotifyResponse>(api_connection, this->address_, handle);
     case PendingAck::PENDING_ACK_NONE:
     case PendingAck::PENDING_ACK_ERROR:  // returned above
       return true;

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -16,6 +16,10 @@ static const char *const TAG = "bluetooth_connection";
 void BluetoothConnection::set_address(uint64_t address) {
   // Keep the proxy's pre-allocated connections-free message in step
   this->proxy_->update_address_slot_(this->address_, address);
+  // The slot is changing hands, so anything owed belonged to the old address.
+  // reset_connection_() already clears on the ordinary teardown path; this is
+  // the choke point that covers every other way a slot is reassigned or freed.
+  this->clear_pending_ack_();
   this->address_ = address;
   if (address == 0) {
     this->address_str_[0] = '\0';
@@ -187,16 +191,27 @@ bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_e
   auto *api_connection = this->proxy_->get_api_connection();
   if (api_connection == nullptr)
     return true;  // Nobody subscribed: nothing is owed
-  if (kind == PendingAck::PENDING_ACK_WRITE) {
-    api::BluetoothGATTWriteResponse resp;
-    resp.address = this->address_;
-    resp.handle = handle;
-    return api_connection->send_message(resp);
+  switch (kind) {
+    case PendingAck::PENDING_ACK_WRITE: {
+      api::BluetoothGATTWriteResponse resp;
+      resp.address = this->address_;
+      resp.handle = handle;
+      return api_connection->send_message(resp);
+    }
+    case PendingAck::PENDING_ACK_NOTIFY: {
+      api::BluetoothGATTNotifyResponse resp;
+      resp.address = this->address_;
+      resp.handle = handle;
+      return api_connection->send_message(resp);
+    }
+    case PendingAck::PENDING_ACK_NONE:
+    case PendingAck::PENDING_ACK_ERROR:  // returned above
+      return true;
   }
-  api::BluetoothGATTNotifyResponse resp;
-  resp.address = this->address_;
-  resp.handle = handle;
-  return api_connection->send_message(resp);
+  // Every enumerator is listed and there is no default label, so adding one
+  // without a branch is a -Wswitch warning rather than a silent notify reply.
+  // This return only satisfies -Wreturn-type.
+  return true;
 }
 
 void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
@@ -211,6 +226,10 @@ void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t
 }
 
 void BluetoothConnection::flush_pending_ack_() {
+  // Local guard: the proxy drain pre-checks, but this must be a no-op on its
+  // own rather than relying on a caller in another file.
+  if (!this->has_pending_ack_())
+    return;
   if (this->try_send_ack_(this->pending_ack_, this->pending_ack_handle_, this->pending_ack_error_)) {
     this->clear_pending_ack_();
   }
@@ -297,6 +316,7 @@ conn_err_t BluetoothConnection::check_connected_op_(const char *action, const ch
 conn_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
   if (conn_err_t err = this->check_connected_op_("read", "characteristic"); err != CONN_OK)
     return err;
+  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->read_characteristic(handle);
 }
@@ -305,6 +325,7 @@ conn_err_t BluetoothConnection::write_characteristic(uint16_t handle, const uint
                                                      bool response) {
   if (conn_err_t err = this->check_connected_op_("write", "characteristic"); err != CONN_OK)
     return err;
+  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->write_characteristic(handle, data, static_cast<uint16_t>(length), response);
 }
@@ -312,6 +333,7 @@ conn_err_t BluetoothConnection::write_characteristic(uint16_t handle, const uint
 conn_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
   if (conn_err_t err = this->check_connected_op_("read", "descriptor"); err != CONN_OK)
     return err;
+  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->read_descriptor(handle);
 }
@@ -322,6 +344,7 @@ conn_err_t BluetoothConnection::write_descriptor(uint16_t handle, const uint8_t 
                                                  bool /*response*/) {
   if (conn_err_t err = this->check_connected_op_("write", "descriptor"); err != CONN_OK)
     return err;
+  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->write_descriptor(handle, data, static_cast<uint16_t>(length));
 }
@@ -329,6 +352,7 @@ conn_err_t BluetoothConnection::write_descriptor(uint16_t handle, const uint8_t 
 conn_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enable) {
   if (conn_err_t err = this->check_connected_op_("notify", "characteristic"); err != CONN_OK)
     return err;
+  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] %s GATT characteristic notifications handle %d", this->connection_index_, this->address_str_,
            enable ? "Registering for" : "Unregistering for", handle);
   return this->backend_->notify_characteristic(handle, enable);

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -236,9 +236,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   PendingAck pending_ack_ : 2 {PendingAck::PENDING_ACK_NONE};
   /// Set while a refused batch is retrying, so only the first one warns.
   bool batch_stalled_ : 1 {false};
-  // Plain byte, ordered after the bitfields: an 8-bit field cannot share
-  // pending_ack_'s storage unit, so anywhere earlier it would straddle and
-  // push the tail into a new 8-byte row. Here it takes the one padding byte.
+  // Plain byte after the bitfields: takes the padding byte instead of
+  // straddling pending_ack_'s storage unit and growing the object.
   uint8_t pending_ack_retries_{0};
 };
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -137,10 +137,12 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
     this->pending_ack_error_ = error;
   }
   void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
-  /// Drop an owed reply when the client re-asks about that handle: clients
-  /// match on (address, handle), so a stale one would resolve the new request.
-  void supersede_pending_ack_(uint16_t handle) {
-    if (this->has_pending_ack_() && this->pending_ack_handle_ == handle) {
+  /// Drop an owed reply this re-ask makes stale. Clients match futures on
+  /// response type as well as handle, so an owed error (which resolves any op
+  /// on the handle) is cleared by any re-ask, other kinds only by their own.
+  void supersede_pending_ack_(uint16_t handle, PendingAck kind) {
+    if (this->has_pending_ack_() && this->pending_ack_handle_ == handle &&
+        (this->pending_ack_ == PendingAck::PENDING_ACK_ERROR || this->pending_ack_ == kind)) {
       this->clear_pending_ack_();
     }
   }
@@ -238,6 +240,7 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool batch_stalled_ : 1 {false};
   // Plain byte after the bitfields: takes the padding byte instead of
   // straddling pending_ack_'s storage unit and growing the object.
+  static_assert(PENDING_ACK_RETRY_LIMIT <= 0xFF, "retry counter too narrow");
   uint8_t pending_ack_retries_{0};
 };
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -131,6 +131,7 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   /// newest wins: a GATT client works one request at a time, and a discarded
   /// reply falls back to the timeout it would have hit anyway.
   void latch_pending_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0) {
+    this->pending_ack_retries_ = 0;
     this->pending_ack_ = kind;
     this->pending_ack_handle_ = handle;
     this->pending_ack_error_ = error;
@@ -233,6 +234,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool services_discovered_ : 1 {false};
   static_assert(static_cast<uint8_t>(PendingAck::PENDING_ACK_ERROR) < (1 << 2), "pending_ack_ bitfield too narrow");
   PendingAck pending_ack_ : 2 {PendingAck::PENDING_ACK_NONE};
+  static_assert(PENDING_ACK_RETRY_LIMIT < (1 << 5), "ack retry counter too narrow");
+  uint8_t pending_ack_retries_ : 5 {0};
   /// Set while a refused batch is retrying, so only the first one warns.
   bool batch_stalled_ : 1 {false};
 };

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -177,6 +177,9 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   /// interrupted stream must never be declared complete (the client's
   /// timeout arbitrates), and an owed done is dropped with it.
   void park_service_stream_() {
+    // Agree with reset_connection_(): a stall flag left set would swallow the
+    // next session's leading-edge warning.
+    this->batch_stalled_ = false;
     if (this->send_service_ >= 0) {
       this->backend_->release_services();
       this->send_service_ = DONE_SENDING_SERVICES;
@@ -199,10 +202,10 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bluetooth_proxy::BluetoothProxy *proxy_{nullptr};
   ble_device_base::BLEGattConnection *backend_{nullptr};
 
-  // Group 2: 2-byte types (pending_ack_handle_ lands in existing padding)
+  // Group 2: 2-byte types. Exactly 4 bytes, so address_ below stays
+  // 8-aligned with no padding (the vptr makes Group 1 12 bytes, not 8).
   int16_t send_service_{INIT_SENDING_SERVICES};
   uint16_t mtu_{ble_device_base::DEFAULT_ATT_MTU};
-  uint16_t pending_ack_handle_{0};
 
   // Group 3: 8-byte and 4-byte types
   uint64_t address_{0};
@@ -213,8 +216,11 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
 
   // Group 4: Arrays
   char address_str_[MAC_ADDRESS_PRETTY_BUFFER_SIZE]{};
+  // Parked here rather than in Group 2: address_str_ ends 2-aligned, so this
+  // uses tail slack instead of pushing address_ out by 6 bytes of padding.
+  uint16_t pending_ack_handle_{0};
 
-  // Group 5: bit-packed tail. pending_ack_error_ already took the object
+  // Group 5: bit-packed tail. pending_ack_error_ takes the 8-aligned object
   // from 48 to 56, so the third tail byte is free; first two stay packed.
   static_assert(static_cast<uint8_t>(ClientState::ESTABLISHED) < (1 << 3), "state_ bitfield too narrow");
   static_assert(static_cast<uint8_t>(ConnectionType::V3_WITHOUT_CACHE) < (1 << 2),
@@ -233,6 +239,11 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   /// Set while a refused batch is retrying, so only the first one warns.
   bool batch_stalled_ : 1 {false};
 };
+
+// Pins the layout the field grouping above is arranged for: putting
+// pending_ack_handle_ in Group 2 instead pushes address_ out by 6 bytes of
+// padding and takes this to 64 (the vptr makes Group 1 12 bytes, not 8).
+static_assert(sizeof(BluetoothConnection) <= 56, "BluetoothConnection layout regressed");
 
 }  // namespace esphome::bluetooth_connection
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -136,12 +136,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
     this->pending_ack_error_ = error;
   }
   void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
-  /// Drop an owed reply when the client re-asks about that handle. Clients
-  /// match replies by (address, handle), so a stale one would otherwise
-  /// resolve the retried request before the peripheral has answered. Called
-  /// before the connected check, so a request rejected on a dead link still
-  /// invalidates it, and matched on handle alone: a read superseding an owed
-  /// write reply costs a timeout, which is the safe direction.
+  /// Drop an owed reply when the client re-asks about that handle: clients
+  /// match on (address, handle), so a stale one would resolve the new request.
   void supersede_pending_ack_(uint16_t handle) {
     if (this->has_pending_ack_() && this->pending_ack_handle_ == handle) {
       this->clear_pending_ack_();

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -25,12 +25,9 @@ namespace esphome::bluetooth_connection {
 using ClientState = ble_device_base::ClientState;
 using ConnectionType = ble_device_base::ConnectionType;
 
-/// A GATT acknowledgement the API refused, owed to the current subscriber.
-/// Only payload-free replies appear here: each one is rebuilt from the
-/// address plus the fields below, so a retry is idempotent and costs no
-/// buffered data. Read and notify-data replies carry payloads and are
-/// deliberately absent - retrying those would mean holding data on the heap
-/// through exactly the congestion that refused them.
+/// A refused GATT reply owed to the current subscriber. Payload-free only:
+/// these rebuild from address + handle + error, so a retry costs no buffered
+/// data. Read and notify-data carry payloads and are deliberately absent.
 enum class PendingAck : uint8_t {
   PENDING_ACK_NONE = 0,
   PENDING_ACK_WRITE,
@@ -129,47 +126,33 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
     }
   }
 
-  /// Remember a refused acknowledgement so the proxy drain can re-offer it.
-  /// Newest wins: one slot per connection, sized for the sequential
-  /// request/reply pattern a GATT client uses. If a second reply is refused
-  /// while one is owed, the older one is discarded and that operation falls
-  /// back to the client's timeout, which is what happened to both before
-  /// this latch existed.
+  /// Latch a refused reply for the proxy drain. One slot per connection,
+  /// newest wins: a GATT client works one request at a time, and a discarded
+  /// reply falls back to the timeout it would have hit anyway.
   void latch_pending_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0) {
     this->pending_ack_ = kind;
     this->pending_ack_handle_ = handle;
     this->pending_ack_error_ = error;
   }
   void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
-  /// Drop an owed reply once the client asks again about the same handle.
-  ///
-  /// Without this the retry is unbounded in a way that can do real harm: a
-  /// client whose write times out re-issues it, and the drain could then
-  /// deliver the *old* reply against the *new* request. API clients match a
-  /// reply by (address, handle), so the retried operation would be reported
-  /// as complete before the peripheral has answered it. Dropping the stale
-  /// reply restores the pre-latch outcome for that case, a timeout, which is
-  /// wrong but honest.
+  /// Drop an owed reply when the client re-asks about that handle. Clients
+  /// match replies by (address, handle), so a stale one would otherwise
+  /// resolve the retried request before the peripheral has answered.
   void supersede_pending_ack_(uint16_t handle) {
     if (this->has_pending_ack_() && this->pending_ack_handle_ == handle) {
       this->clear_pending_ack_();
     }
   }
   bool has_pending_ack_() const { return this->pending_ack_ != PendingAck::PENDING_ACK_NONE; }
-  /// Report a refused service batch on the stall's leading edge only. The
-  /// batch itself is never lost - the caller rewinds the cursor and the next
-  /// loop iteration re-sends it - so warning on every attempt says nothing
-  /// new while adding traffic to the connection that is already refusing
-  /// frames. Both streamers route their refusal here, so both report it
-  /// identically.
+  /// Warn on the stall's leading edge only. The batch is never lost (the
+  /// caller rewinds the cursor), and a warning per attempt would add traffic
+  /// to the connection already refusing frames. Both streamers route here.
   void note_batch_stalled_();
-  /// Build and send one payload-free GATT reply. The single construction
-  /// site for these messages, shared by the first attempt and the retry.
+  /// Sole construction site for these replies, shared by send and retry.
   bool try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error);
   /// First attempt: send, and latch it for the drain if the API refuses.
   void send_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0);
-  /// Re-send the owed acknowledgement, rebuilt from the latch. Clears on
-  /// success or when nobody is subscribed; keeps it owed on a refusal.
+  /// Re-offer the owed reply; clears on success, stays owed on a refusal.
   void flush_pending_ack_();
   // A backend providing its own streamer (see the contract doc) builds the
   // response in place from its stack cache; the rest use the table streamer.
@@ -208,8 +191,7 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bluetooth_proxy::BluetoothProxy *proxy_{nullptr};
   ble_device_base::BLEGattConnection *backend_{nullptr};
 
-  // Group 2: 2-byte types (pending_ack_handle_ lands in padding that was
-  // already there, so it is free)
+  // Group 2: 2-byte types (pending_ack_handle_ lands in existing padding)
   int16_t send_service_{INIT_SENDING_SERVICES};
   uint16_t mtu_{ble_device_base::DEFAULT_ATT_MTU};
   uint16_t pending_ack_handle_{0};
@@ -217,17 +199,15 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   // Group 3: 8-byte and 4-byte types
   uint64_t address_{0};
   conn_err_t pending_error_{0};
-  // Full width on purpose: the GATT error domain is open-ended (see
-  // ble_gatt_client.h) and the value is forwarded to the API untranslated,
-  // so narrowing it here would corrupt platform status codes.
+  // Full width: the GATT error domain is open-ended (ble_gatt_client.h) and
+  // forwarded untranslated, so narrowing would corrupt platform codes.
   conn_err_t pending_ack_error_{0};
 
   // Group 4: Arrays
   char address_str_[MAC_ADDRESS_PRETTY_BUFFER_SIZE]{};
 
-  // Group 5: bit-packed tail. pending_ack_error_ already pushed the
-  // 8-aligned object from 48 to 56, so the third tail byte the ack fields
-  // need is free; keep the first two packed exactly as before.
+  // Group 5: bit-packed tail. pending_ack_error_ already took the object
+  // from 48 to 56, so the third tail byte is free; first two stay packed.
   static_assert(static_cast<uint8_t>(ClientState::ESTABLISHED) < (1 << 3), "state_ bitfield too narrow");
   static_assert(static_cast<uint8_t>(ConnectionType::V3_WITHOUT_CACHE) < (1 << 2),
                 "connection_type_ bitfield too narrow");
@@ -242,9 +222,7 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool services_discovered_ : 1 {false};
   static_assert(static_cast<uint8_t>(PendingAck::PENDING_ACK_ERROR) < (1 << 2), "pending_ack_ bitfield too narrow");
   PendingAck pending_ack_ : 2 {PendingAck::PENDING_ACK_NONE};
-  /// True while a refused service batch is being retried. Exists only so the
-  /// warning fires on the stall's leading edge: the retry itself is silent,
-  /// because the log rides the same connection that refused the batch.
+  /// Set while a refused batch is retrying, so only the first one warns.
   bool batch_stalled_ : 1 {false};
 };
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -241,11 +241,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool batch_stalled_ : 1 {false};
 };
 
-// Pins the layout the field grouping above is arranged for: putting
-// pending_ack_handle_ in Group 2 instead pushes address_ out by 6 bytes of
-// padding and takes this to 64 (the vptr makes Group 1 12 bytes, not 8).
-// Only meaningful on the 32-bit targets that grouping is for; the host unit
-// tests build 64-bit, where every pointer and the vptr double.
+// Pins the grouping above: pending_ack_handle_ in Group 2 instead would pad
+// address_ out and reach 64. 32-bit only; the host unit tests build 64-bit.
 static_assert(sizeof(void *) != 4 || sizeof(BluetoothConnection) <= 56,
               "BluetoothConnection layout regressed on a 32-bit target");
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -141,6 +141,20 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
     this->pending_ack_error_ = error;
   }
   void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
+  /// Drop an owed reply once the client asks again about the same handle.
+  ///
+  /// Without this the retry is unbounded in a way that can do real harm: a
+  /// client whose write times out re-issues it, and the drain could then
+  /// deliver the *old* reply against the *new* request. API clients match a
+  /// reply by (address, handle), so the retried operation would be reported
+  /// as complete before the peripheral has answered it. Dropping the stale
+  /// reply restores the pre-latch outcome for that case, a timeout, which is
+  /// wrong but honest.
+  void supersede_pending_ack_(uint16_t handle) {
+    if (this->has_pending_ack_() && this->pending_ack_handle_ == handle) {
+      this->clear_pending_ack_();
+    }
+  }
   bool has_pending_ack_() const { return this->pending_ack_ != PendingAck::PENDING_ACK_NONE; }
   /// Report a refused service batch on the stall's leading edge only. The
   /// batch itself is never lost - the caller rewinds the cursor and the next

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -137,7 +137,10 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
   /// Drop an owed reply when the client re-asks about that handle. Clients
   /// match replies by (address, handle), so a stale one would otherwise
-  /// resolve the retried request before the peripheral has answered.
+  /// resolve the retried request before the peripheral has answered. Called
+  /// before the connected check, so a request rejected on a dead link still
+  /// invalidates it, and matched on handle alone: a read superseding an owed
+  /// write reply costs a timeout, which is the safe direction.
   void supersede_pending_ack_(uint16_t handle) {
     if (this->has_pending_ack_() && this->pending_ack_handle_ == handle) {
       this->clear_pending_ack_();
@@ -152,6 +155,11 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error);
   /// First attempt: send, and latch it for the drain if the API refuses.
   void send_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0);
+  /// Report a rejected request. Latched like a completion reply, so a
+  /// refused frame does not strand the client for its whole timeout.
+  void send_gatt_error_(uint16_t handle, conn_err_t error) {
+    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
+  }
   /// Re-offer the owed reply; clears on success, stays owed on a refusal.
   void flush_pending_ack_();
   // A backend providing its own streamer (see the contract doc) builds the

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -234,10 +234,12 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool services_discovered_ : 1 {false};
   static_assert(static_cast<uint8_t>(PendingAck::PENDING_ACK_ERROR) < (1 << 2), "pending_ack_ bitfield too narrow");
   PendingAck pending_ack_ : 2 {PendingAck::PENDING_ACK_NONE};
-  static_assert(PENDING_ACK_RETRY_LIMIT < (1 << 5), "ack retry counter too narrow");
-  uint8_t pending_ack_retries_ : 5 {0};
   /// Set while a refused batch is retrying, so only the first one warns.
   bool batch_stalled_ : 1 {false};
+  // Plain byte, ordered after the bitfields: an 8-bit field cannot share
+  // pending_ack_'s storage unit, so anywhere earlier it would straddle and
+  // push the tail into a new 8-byte row. Here it takes the one padding byte.
+  uint8_t pending_ack_retries_{0};
 };
 
 // Pins the grouping above: pending_ack_handle_ in Group 2 instead would pad

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -25,6 +25,19 @@ namespace esphome::bluetooth_connection {
 using ClientState = ble_device_base::ClientState;
 using ConnectionType = ble_device_base::ConnectionType;
 
+/// A GATT acknowledgement the API refused, owed to the current subscriber.
+/// Only payload-free replies appear here: each one is rebuilt from the
+/// address plus the fields below, so a retry is idempotent and costs no
+/// buffered data. Read and notify-data replies carry payloads and are
+/// deliberately absent - retrying those would mean holding data on the heap
+/// through exactly the congestion that refused them.
+enum class PendingAck : uint8_t {
+  PENDING_ACK_NONE = 0,
+  PENDING_ACK_WRITE,
+  PENDING_ACK_NOTIFY,
+  PENDING_ACK_ERROR,
+};
+
 class BluetoothConnection final : public ble_device_base::GattClientListener {
  public:
   /// Wire the platform backend. Called from codegen before setup.
@@ -115,6 +128,35 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
       this->pending_error_ = err;
     }
   }
+
+  /// Remember a refused acknowledgement so the proxy drain can re-offer it.
+  /// Newest wins: one slot per connection, sized for the sequential
+  /// request/reply pattern a GATT client uses. If a second reply is refused
+  /// while one is owed, the older one is discarded and that operation falls
+  /// back to the client's timeout, which is what happened to both before
+  /// this latch existed.
+  void latch_pending_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0) {
+    this->pending_ack_ = kind;
+    this->pending_ack_handle_ = handle;
+    this->pending_ack_error_ = error;
+  }
+  void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
+  bool has_pending_ack_() const { return this->pending_ack_ != PendingAck::PENDING_ACK_NONE; }
+  /// Report a refused service batch on the stall's leading edge only. The
+  /// batch itself is never lost - the caller rewinds the cursor and the next
+  /// loop iteration re-sends it - so warning on every attempt says nothing
+  /// new while adding traffic to the connection that is already refusing
+  /// frames. Both streamers route their refusal here, so both report it
+  /// identically.
+  void note_batch_stalled_();
+  /// Build and send one payload-free GATT reply. The single construction
+  /// site for these messages, shared by the first attempt and the retry.
+  bool try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error);
+  /// First attempt: send, and latch it for the drain if the API refuses.
+  void send_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0);
+  /// Re-send the owed acknowledgement, rebuilt from the latch. Clears on
+  /// success or when nobody is subscribed; keeps it owed on a refusal.
+  void flush_pending_ack_();
   // A backend providing its own streamer (see the contract doc) builds the
   // response in place from its stack cache; the rest use the table streamer.
   // Template so the discarded branch is not odr-checked against backends
@@ -152,23 +194,31 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bluetooth_proxy::BluetoothProxy *proxy_{nullptr};
   ble_device_base::BLEGattConnection *backend_{nullptr};
 
-  // Group 2: 2-byte types
+  // Group 2: 2-byte types (pending_ack_handle_ lands in padding that was
+  // already there, so it is free)
   int16_t send_service_{INIT_SENDING_SERVICES};
   uint16_t mtu_{ble_device_base::DEFAULT_ATT_MTU};
+  uint16_t pending_ack_handle_{0};
 
   // Group 3: 8-byte and 4-byte types
   uint64_t address_{0};
   conn_err_t pending_error_{0};
+  // Full width on purpose: the GATT error domain is open-ended (see
+  // ble_gatt_client.h) and the value is forwarded to the API untranslated,
+  // so narrowing it here would corrupt platform status codes.
+  conn_err_t pending_ack_error_{0};
 
   // Group 4: Arrays
   char address_str_[MAC_ADDRESS_PRETTY_BUFFER_SIZE]{};
 
-  // Group 5: bit-packed tail; within 2 bytes the 8-aligned object stays 48.
+  // Group 5: bit-packed tail. pending_ack_error_ already pushed the
+  // 8-aligned object from 48 to 56, so the third tail byte the ack fields
+  // need is free; keep the first two packed exactly as before.
   static_assert(static_cast<uint8_t>(ClientState::ESTABLISHED) < (1 << 3), "state_ bitfield too narrow");
   static_assert(static_cast<uint8_t>(ConnectionType::V3_WITHOUT_CACHE) < (1 << 2),
                 "connection_type_ bitfield too narrow");
   // Ordered so neither byte's fields straddle a storage unit: 3+5 and
-  // 4+2+1+1 fill the two tail bytes exactly.
+  // 4+2+1+1 fill the first two tail bytes exactly.
   ClientState state_ : 3 {ClientState::IDLE};
   static_assert(SERVICES_DONE_RETRY_LIMIT < (1 << 5), "counter bitfield too narrow");
   uint8_t services_done_retries_ : 5 {0};
@@ -176,6 +226,12 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   ConnectionType connection_type_ : 2 {ConnectionType::V1};
   bool paired_ : 1 {false};
   bool services_discovered_ : 1 {false};
+  static_assert(static_cast<uint8_t>(PendingAck::PENDING_ACK_ERROR) < (1 << 2), "pending_ack_ bitfield too narrow");
+  PendingAck pending_ack_ : 2 {PendingAck::PENDING_ACK_NONE};
+  /// True while a refused service batch is being retried. Exists only so the
+  /// warning fires on the stall's leading edge: the retry itself is silent,
+  /// because the log rides the same connection that refused the batch.
+  bool batch_stalled_ : 1 {false};
 };
 
 }  // namespace esphome::bluetooth_connection

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -243,7 +243,10 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
 // Pins the layout the field grouping above is arranged for: putting
 // pending_ack_handle_ in Group 2 instead pushes address_ out by 6 bytes of
 // padding and takes this to 64 (the vptr makes Group 1 12 bytes, not 8).
-static_assert(sizeof(BluetoothConnection) <= 56, "BluetoothConnection layout regressed");
+// Only meaningful on the 32-bit targets that grouping is for; the host unit
+// tests build 64-bit, where every pointer and the vptr double.
+static_assert(sizeof(void *) != 4 || sizeof(BluetoothConnection) <= 56,
+              "BluetoothConnection layout regressed on a 32-bit target");
 
 }  // namespace esphome::bluetooth_connection
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -597,6 +597,9 @@ void BluetoothProxy::loop() {
     if (connection->send_service_ == SERVICES_DONE_PENDING) {
       connection->send_services_done_();
     }
+    if (connection->has_pending_ack_()) {
+      connection->flush_pending_ack_();
+    }
     auto &owed = this->pending_disconnections_[i];
     if (!owed.empty() && this->send_device_connection(owed.address(), false, 0, owed.error())) {
       owed.clear();
@@ -716,6 +719,8 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
       // Neither a partial stream's tail nor an owed done belongs to the new
       // session; silence (the client's timeout) arbitrates.
       this->connections_[i]->park_service_stream_();
+      // An ack owed to the previous subscriber means nothing to the new one.
+      this->connections_[i]->clear_pending_ack_();
     }
     this->pending_disconnections_.fill({});
 #endif
@@ -776,14 +781,14 @@ bool BluetoothProxy::send_gatt_services_done(uint64_t address) {
   return this->api_connection_->send_message(call);
 }
 
-void BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error) {
+bool BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error) {
   if (this->api_connection_ == nullptr)
-    return;
+    return true;  // Nobody subscribed: nothing is owed, only a refused frame reports false
   api::BluetoothGATTErrorResponse call;
   call.address = address;
   call.handle = handle;
   call.error = error;
-  this->api_connection_->send_message(call);
+  return this->api_connection_->send_message(call);
 }
 
 void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err_t error) {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -387,7 +387,7 @@ void BluetoothProxy::bluetooth_gatt_read(const api::BluetoothGATTReadRequest &ms
 
   auto err = connection->read_characteristic(msg.handle);
   if (err != CONN_OK) {
-    this->send_gatt_error(msg.address, msg.handle, err);
+    connection->send_gatt_error_(msg.handle, err);
   }
 }
 
@@ -400,7 +400,7 @@ void BluetoothProxy::bluetooth_gatt_write(const api::BluetoothGATTWriteRequest &
 
   auto err = connection->write_characteristic(msg.handle, msg.data, msg.data_len, msg.response);
   if (err != CONN_OK) {
-    this->send_gatt_error(msg.address, msg.handle, err);
+    connection->send_gatt_error_(msg.handle, err);
   }
 }
 
@@ -413,7 +413,7 @@ void BluetoothProxy::bluetooth_gatt_read_descriptor(const api::BluetoothGATTRead
 
   auto err = connection->read_descriptor(msg.handle);
   if (err != CONN_OK) {
-    this->send_gatt_error(msg.address, msg.handle, err);
+    connection->send_gatt_error_(msg.handle, err);
   }
 }
 
@@ -426,7 +426,7 @@ void BluetoothProxy::bluetooth_gatt_write_descriptor(const api::BluetoothGATTWri
 
   auto err = connection->write_descriptor(msg.handle, msg.data, msg.data_len, true);
   if (err != CONN_OK) {
-    this->send_gatt_error(msg.address, msg.handle, err);
+    connection->send_gatt_error_(msg.handle, err);
   }
 }
 
@@ -477,7 +477,7 @@ void BluetoothProxy::bluetooth_gatt_notify(const api::BluetoothGATTNotifyRequest
 
   auto err = connection->notify_characteristic(msg.handle, msg.enable);
   if (err != CONN_OK) {
-    this->send_gatt_error(msg.address, msg.handle, err);
+    connection->send_gatt_error_(msg.handle, err);
   }
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -145,8 +145,7 @@ class BluetoothProxy final : public Component {
   void send_connections_free(api::APIConnection *api_connection);
   /// Same convention as send_device_connection: false only on a refused frame.
   bool send_gatt_services_done(uint64_t address);
-  /// Returns false only when the API refused the frame, so a caller that
-  /// can re-offer it knows the reply is still owed.
+  /// False only when the API refused the frame, so the reply is still owed.
   bool send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error);
   void send_device_pairing(uint64_t address, bool paired, conn_err_t error = CONN_OK);
   void send_device_unpairing(uint64_t address, bool success, conn_err_t error = CONN_OK);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -145,7 +145,9 @@ class BluetoothProxy final : public Component {
   void send_connections_free(api::APIConnection *api_connection);
   /// Same convention as send_device_connection: false only on a refused frame.
   bool send_gatt_services_done(uint64_t address);
-  void send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error);
+  /// Returns false only when the API refused the frame, so a caller that
+  /// can re-offer it knows the reply is still owed.
+  bool send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error);
   void send_device_pairing(uint64_t address, bool paired, conn_err_t error = CONN_OK);
   void send_device_unpairing(uint64_t address, bool success, conn_err_t error = CONN_OK);
   void send_device_clear_cache(uint64_t address, bool success, conn_err_t error = CONN_OK);


### PR DESCRIPTION
# What does this implement/fix?

**The log spam made the problem worse, not just noisier.** The service-batch retry warned on every refused attempt, over the same connection whose buffer was already at high water, so the logging consumed the headroom needed to clear the batch. It now warns on the stall's leading edge only. That is the wall of identical lines in #18249.

**Refused GATT acks were dropped outright.** A write, notify-state or error reply that `send_message()` refuses is lost and the operation stalls until the client times out. These are payload-free, so each connection latches one and the existing 100 ms drain re-offers it. Read and notify-data stay unlatched: retrying those means holding payloads through the congestion that refused them. Phase 4 of #18221.

An owed reply is dropped on link reset, on subscriber change, when the client re-asks on that handle (any re-ask clears an owed error; write and notify acks only clear on their own kind, since clients match futures on response type too), and after 250 drains (about 25 s); congestion can take tens of seconds to clear, and the client cannot re-ask before its 30 s GATT timeout, so the bound stops just under it. Clients match on (address, handle), so a stale reply could otherwise resolve a request the client re-issued after timing out. The supersede alone only narrows that: it fires when the proxy *processes* the re-request, and a drain can beat that processing. The age bound is what closes it, the same mechanism the owed-done latch next door already uses. The supersede check runs before the connected test, so a request rejected on a dead link still invalidates what is owed.

Deferrals report at `W`, not `V`, so a drop is never silent, and both the newly-owed and the displaced case report — displacing is the one that actually loses a reply. Only re-refusing a reply that is still owed stays quiet.

`BluetoothConnection` goes from 48 to 56 bytes, measured with a `static_assert` probe rather than counted by hand: the vptr means Group 1 is 12 bytes and `dev` had no padding there, so the handle rides in the tail slack after `address_str_`. A `static_assert`, scoped to 32-bit targets, pins it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18249
- https://github.com/esphome/esphome/issues/18221 (Phase 4; the earlier phases are already on dev)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed.
esphome:
  name: my-proxy

api:

bluetooth_proxy:
  active: true
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).










