### PR TITLE
[core] Flush stdout in safe_print so logs stream live

### DIFF
--- a/esphome/util.py
+++ b/esphome/util.py
@@ -216,6 +216,11 @@ class RedirectText:
         else:
             self._write_color_replace(s)
 
+        # Same reason as safe_print: the dashboard gives us a pipe, which is
+        # block buffered, so in-process esptool progress would not show up
+        # until the buffer filled.
+        self._out.flush()
+
         # write() returns the number of characters written
         # Let's print the number of characters of the original string in order to not confuse
         # any caller.

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -87,8 +87,11 @@ def safe_print(message="", end="\n"):
         except UnicodeEncodeError:
             pass
 
+    # Always flush: stdout is block buffered when it is a pipe (the dashboard
+    # runs us that way), so live log lines would otherwise sit in the buffer
+    # for a long time instead of streaming out.
     try:
-        print(message, end=end)
+        print(message, end=end, flush=True)
         return
     except UnicodeEncodeError:
         pass
@@ -104,6 +107,7 @@ def safe_print(message="", end="\n"):
         print(
             message.encode(encoding, "backslashreplace").decode(encoding),
             end=end,
+            flush=True,
         )
         return
     except UnicodeEncodeError:
@@ -113,9 +117,10 @@ def safe_print(message="", end="\n"):
         print(
             message.encode("ascii", "backslashreplace").decode("ascii"),
             end=end,
+            flush=True,
         )
     except UnicodeEncodeError:
-        print("Cannot print line because of invalid locale!")
+        print("Cannot print line because of invalid locale!", flush=True)
 
 
 def safe_input(prompt=""):

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -758,7 +758,11 @@ class TestSafePrint:
         enough output piled up to fill it.
         """
         buf = io.BytesIO()
-        piped_stream = io.TextIOWrapper(buf, encoding="utf-8", line_buffering=False)
+        # newline="\n" keeps Windows from rewriting the terminator to "\r\n";
+        # this test is about flushing, not about line endings.
+        piped_stream = io.TextIOWrapper(
+            buf, encoding="utf-8", newline="\n", line_buffering=False
+        )
         monkeypatch.setattr(sys, "stdout", piped_stream)
 
         util.safe_print("live log line")

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -422,6 +422,26 @@ def _make_redirect(
     return redirect, buf
 
 
+def test_redirect_text_flushes_so_piped_output_streams() -> None:
+    """Regression: in-process esptool progress must reach the pipe right away.
+
+    ``run_external_command`` runs esptool inside our own process, so its
+    progress output goes through ``RedirectText.write``. That used to be
+    flushed only because ``colorama.init()`` wrapped stdout in a stream that
+    flushed after every write.
+    """
+    buf = io.BytesIO()
+    piped_stream = io.TextIOWrapper(
+        buf, encoding="utf-8", newline="\n", line_buffering=False
+    )
+    redirect = util.RedirectText(piped_stream)
+
+    redirect.write("Writing at 0x00010000 (50%)\r")
+
+    # No explicit flush here on purpose: RedirectText has to do it.
+    assert buf.getvalue() == b"Writing at 0x00010000 (50%)\r"
+
+
 def test_redirect_text_callback_called_on_matching_line() -> None:
     """Test that a line callback is called and its output is written."""
     results: list[str] = []
@@ -789,7 +809,7 @@ class TestSafePrint:
         monkeypatch.setattr(sys, "stdout", cp1252_stream)
 
         util.safe_print("bars: \u2582\u2584\u2586\u2588 done")
-        cp1252_stream.flush()
+        # No explicit flush: the fallback path has to flush too.
         output = buf.getvalue().decode("cp1252")
 
         # Output is a clean line, not the bytes repr.
@@ -814,7 +834,7 @@ class TestSafePrint:
         monkeypatch.setattr(sys, "stdout", cp1252_stream)
 
         util.safe_print("\033[0;32m\u2582\u2584\u2586\u2588\033[0m")
-        cp1252_stream.flush()
+        # No explicit flush: the fallback path has to flush too.
         output = buf.getvalue().decode("cp1252")
 
         # Dashboard escaping turned ESC into literal "\033" (5 chars), which

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -745,6 +745,27 @@ class TestSafePrint:
         util.safe_print("\033[0;32mhi\033[0m")
         assert capsys.readouterr().out == "\\033[0;32mhi\\033[0m\n"
 
+    def test_flushes_so_piped_output_streams(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: each line must reach the OS pipe right away.
+
+        The dashboard runs ``esphome logs`` with stdout as a pipe, which
+        Python block buffers at 8 KiB. Log lines used to be flushed only
+        because ``colorama.init()`` wrapped stdout in a stream that flushed
+        after every write; once that wrapping was skipped for dashboard runs
+        the lines sat in the buffer and the log view stayed empty until
+        enough output piled up to fill it.
+        """
+        buf = io.BytesIO()
+        piped_stream = io.TextIOWrapper(buf, encoding="utf-8", line_buffering=False)
+        monkeypatch.setattr(sys, "stdout", piped_stream)
+
+        util.safe_print("live log line")
+
+        # No explicit flush here on purpose: safe_print has to do it.
+        assert buf.getvalue() == b"live log line\n"
+
     def test_fallback_writes_string_not_bytes_repr(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

`safe_print` writes log lines with a plain `print()` and no flush. Until #18224 that was fine, because `setup_log()` always called `colorama.init()`, which wrapped `sys.stdout` in a stream that flushed after every write. #18224 skips colorama for dashboard runs, so stdout is left block buffered; when the dashboard runs `esphome logs` with stdout on a pipe, lines now sit in the 8 KiB buffer instead of streaming out. The log view looks dead until enough output piles up to fill the buffer.

The `INFO` lines still show up because they go through `logging` to stderr, which flushes on every record; that is why only the device log lines went missing.

This passes `flush=True` on the `print()` calls in `safe_print`, which restores the old behaviour for every caller, including the serial log path and plain `esphome logs | tee`.

Before, piped, nothing after the handshake for 15s:

```
$ python3 -m esphome --dashboard logs device.yaml --device 192.168.212.41 | head -c 4000
INFO ESPHome 2026.8.0-dev
INFO Starting log output from 192.168.212.41 using esphome API
INFO Successfully connected to device @ 192.168.212.41 in 0.009s
INFO Successful handshake with device @ 192.168.212.41 in 0.016s
```

After, same command, device lines arrive immediately:

```
INFO Successful handshake with device @ 192.168.212.41 in 0.015s
[23:19:47.211][I][app:151]: ESPHome version 2026.8.0-dev compiled on 2026-07-31 15:53:20 -0500
[23:19:47.217][I][app:153]: Project ApolloAutomation.R-PRO-1-ETH version 26.3.2.1
[23:19:47.226][I][app:158]: ESP32 Chip: ESP32-S3 rev0.2, 2 core(s)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes a regression from #18224

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
