### PR TITLE
[debug] Remove Arduino core dependency from RP2 platform code

### DIFF
--- a/esphome/components/debug/debug_rp2.cpp
+++ b/esphome/components/debug/debug_rp2.cpp
@@ -1,8 +1,9 @@
 #include "debug_component.h"
 #ifdef USE_RP2
 #include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include <Arduino.h>
+#include <hardware/clocks.h>
 #include <hardware/watchdog.h>
 #if defined(PICO_RP2350)
 #include <hardware/structs/powman.h>
@@ -68,13 +69,14 @@ const char *DebugComponent::get_reset_reason_(std::span<char, RESET_REASON_BUFFE
 
 const char *DebugComponent::get_wakeup_cause_(std::span<char, WAKEUP_CAUSE_BUFFER_SIZE> buffer) { return ""; }
 
-uint32_t DebugComponent::get_free_heap_() { return ::rp2040.getFreeHeap(); }
+// RAMAllocator already implements the free-heap calculation for this platform, so it is not duplicated here.
+uint32_t DebugComponent::get_free_heap_() { return RAMAllocator<uint8_t>().get_free_heap_size(); }
 
 size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE> buffer, size_t pos) {
   constexpr size_t size = DEVICE_INFO_BUFFER_SIZE;
   char *buf = buffer.data();
 
-  uint32_t cpu_freq = RP2040::f_cpu();
+  uint32_t cpu_freq = clock_get_hz(clk_sys);
   ESP_LOGD(TAG, "CPU Frequency: %" PRIu32, cpu_freq);
   pos = buf_append_printf(buf, size, pos, "|CPU Frequency: %" PRIu32, cpu_freq);
 


### PR DESCRIPTION
# What does this implement/fix?

The RP2 platform file in the `debug` component reached into the Arduino core for two values that are already available directly.

`get_free_heap_()` called `rp2040.getFreeHeap()`. `RAMAllocator::get_free_heap_size()` in `esphome/core/helpers.h` already has an RP2 branch that makes exactly that call, so the component now goes through the allocator and the free-heap calculation lives in one place.

`get_device_info_()` called `RP2040::f_cpu()`. That method is a one-line wrapper whose entire body is `return clock_get_hz(clk_sys)`, so the component now calls the SDK function directly.

With both uses gone, `<Arduino.h>` is no longer needed in this file and is replaced by the headers that provide what the file actually uses: `esphome/core/helpers.h` for `RAMAllocator` and `<hardware/clocks.h>` for `clock_get_hz`.

Behaviour is unchanged. Both replacements resolve to the same underlying calls the Arduino wrappers were making.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
debug:

text_sensor:
  - platform: debug
    device:
      name: "Device Info"
    reset_reason:
      name: "Reset Reason"

sensor:
  - platform: debug
    free:
      name: "Heap Free"
    block:
      name: "Heap Block"
    loop_time:
      name: "Loop Time"
    cpu_frequency:
      name: "CPU Frequency"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
