### PR TITLE
[rp2] Use SDK clock query directly in arch_get_cpu_freq_hz

### DIFF
--- a/esphome/components/rp2/hal.cpp
+++ b/esphome/components/rp2/hal.cpp
@@ -7,6 +7,7 @@
 #include "crash_handler.h"
 #endif
 
+#include "hardware/clocks.h"
 #include "hardware/watchdog.h"
 
 // Empty rp2 namespace block to satisfy ci-custom's lint_namespace check.
@@ -33,7 +34,8 @@ void arch_init() {
 #endif
 }
 
-uint32_t arch_get_cpu_freq_hz() { return RP2040::f_cpu(); }
+// clock_get_hz(clk_sys) is the SDK query for the current system clock frequency in Hz.
+uint32_t arch_get_cpu_freq_hz() { return clock_get_hz(clk_sys); }
 
 }  // namespace esphome
 


### PR DESCRIPTION
# What does this implement/fix?

`arch_get_cpu_freq_hz()` called `RP2040::f_cpu()`, which is a one-line wrapper in the Arduino core that returns `clock_get_hz(clk_sys)`. The SDK query is available directly via `hardware/clocks.h`, so this calls it without going through the Arduino core class. Behaviour is unchanged. As a minor side effect the implicit `int` to `uint32_t` conversion goes away, since `clock_get_hz()` already returns `uint32_t` while `f_cpu()` returns `int`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).