### PR TITLE
[adc] Fix RP2350B internal temperature reading wrong ADC channel

### DIFF
--- a/esphome/components/adc/adc_sensor_rp2.cpp
+++ b/esphome/components/adc/adc_sensor_rp2.cpp
@@ -52,7 +52,11 @@ float ADCSensor::sample() {
   if (this->is_temperature_) {
     adc_set_temp_sensor_enabled(true);
     delay(1);
-    adc_select_input(4);
+    // The on-die temperature sensor sits on the last ADC channel, and which one
+    // that is depends on the chip: input 4 on RP2040 and RP2350A, but input 8 on
+    // RP2350B, which has eight external channels instead of four. The SDK
+    // resolves it for the target being built, so do not hardcode it.
+    adc_select_input(ADC_TEMPERATURE_CHANNEL_NUM);
 
     for (uint8_t sample = 0; sample < this->sample_count_; sample++) {
       raw = adc_read();


### PR DESCRIPTION
# What does this implement/fix?

The RP2 ADC sensor hardcoded the on-die temperature sensor's ADC channel as input 4. That is only correct on RP2040 and RP2350A. RP2350B has eight external ADC channels instead of four, so its temperature sensor is on input 8 and input 4 is GPIO44. On RP2350B boards this produced a silently wrong temperature reading rather than an error.

This replaces the literal with the pico-sdk's `ADC_TEMPERATURE_CHANNEL_NUM`, which is defined as `NUM_ADC_CHANNELS - 1`. `hardware/platform_defs.h` sets `NUM_ADC_CHANNELS` to 5 for RP2040 and RP2350A and 9 for RP2350B, so the channel now resolves correctly for whichever target is being built. A comment explains why it must not be a literal.

This is the same fix applied to the `internal_temperature` component in #18262.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: adc
    pin: TEMPERATURE
    name: Internal Temperature
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).