### PR TITLE
[bluetooth_proxy] Latch the unpair reply

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -828,7 +828,13 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   // retry state, so only the latch is conditional, not the send.
   [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  if (!sent) {
+  if (sent) {
+    // A later unpair landing for an address that still has one owed would
+    // otherwise have the drain repeat it.
+    if (this->pending_unpairing_.matches(address)) {
+      this->pending_unpairing_.clear();
+    }
+  } else {
     // Warn on the leading edge only: a refused reply must not be silent, but
     // repeating it would add traffic to the connection that just refused one.
     if (this->pending_unpairing_.empty()) {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -606,14 +606,11 @@ void BluetoothProxy::loop() {
     }
   }
 
-  // An owed unpair reply. Cleared first, so another refusal re-latches through
-  // the sender; the success flag is recomputed as (error == 0), which is what
-  // every caller passed.
+  // An owed unpair reply. Not pre-cleared: the sender clears on success and
+  // re-latches on refusal, keeping its leading-edge warn guard honest.
   if (!this->pending_unpairing_.empty()) {
-    uint64_t address = this->pending_unpairing_.address();
     conn_err_t error = this->pending_unpairing_.error();
-    this->pending_unpairing_.clear();
-    this->send_device_unpairing(address, error == CONN_OK, error);
+    this->send_device_unpairing(this->pending_unpairing_.address(), error == CONN_OK, error);
   }
 #endif
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -839,6 +839,10 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
     } else if (!this->pending_unpairing_.matches(address)) {
       ESP_LOGW(TAG, "Owed unpair reply for %012" PRIX64 " dropped, displaced by %012" PRIX64,
                this->pending_unpairing_.address(), address);
+    } else if (this->pending_unpairing_.error() == CONN_OK) {
+      // A retry against the already-removed bond reports failure; the owed
+      // success is the answer the client needs, so keep it.
+      return;
     }
     this->pending_unpairing_.set(address, error);
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -606,19 +606,14 @@ void BluetoothProxy::loop() {
     }
   }
 
-  // Owed device-maintenance replies. take_owed_reply_() clears first, so a
-  // repeat refusal re-latches through the sender; the success flag is
-  // recomputed as (error == 0), which is what every caller passed.
-  uint64_t owed_address;
-  conn_err_t owed_error;
-  if (take_owed_reply_(this->pending_pairing_, owed_address, owed_error)) {
-    this->send_device_pairing(owed_address, owed_error == CONN_OK, owed_error);
-  }
-  if (take_owed_reply_(this->pending_unpairing_, owed_address, owed_error)) {
-    this->send_device_unpairing(owed_address, owed_error == CONN_OK, owed_error);
-  }
-  if (take_owed_reply_(this->pending_clear_cache_, owed_address, owed_error)) {
-    this->send_device_clear_cache(owed_address, owed_error == CONN_OK, owed_error);
+  // An owed unpair reply. Cleared first, so another refusal re-latches through
+  // the sender; the success flag is recomputed as (error == 0), which is what
+  // every caller passed.
+  if (!this->pending_unpairing_.empty()) {
+    uint64_t address = this->pending_unpairing_.address();
+    conn_err_t error = this->pending_unpairing_.error();
+    this->pending_unpairing_.clear();
+    this->send_device_unpairing(address, error == CONN_OK, error);
   }
 #endif
 
@@ -730,7 +725,7 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
     // re-subscribe by the current one keeps what it is still owed.
     this->connections_free_pending_ = false;
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
-    this->clear_pending_device_replies_();
+    this->pending_unpairing_.clear();
     for (uint8_t i = 0; i < this->connection_count_; i++) {
       // Neither a partial stream's tail nor an owed done belongs to the new
       // session; silence (the client's timeout) arbitrates.
@@ -758,7 +753,7 @@ void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *api_connecti
   this->api_connection_ = nullptr;
   this->connections_free_pending_ = false;
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  this->clear_pending_device_replies_();
+  this->pending_unpairing_.clear();
 #endif
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
   this->scanner_state_pending_ = false;
@@ -818,17 +813,7 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err
   call.paired = paired;
   call.error = error;
 
-  // Advertisement-only builds answer these with a canned reply and keep no
-  // retry state, so only the latch is conditional, not the send.
-  [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  if (!sent) {
-    // V, not W: the reply is owed rather than lost, and a warning would ride
-    // the connection that just refused it.
-    ESP_LOGV(TAG, "Pairing reply for %012" PRIX64 " deferred, TCP buffer full", address);
-    this->pending_pairing_.set(address, error);
-  }
-#endif
+  this->api_connection_->send_message(call);
 }
 
 void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_err_t error) {
@@ -839,7 +824,7 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   call.success = success;
   call.error = error;
 
-  // Advertisement-only builds answer these with a canned reply and keep no
+  // Advertisement-only builds answer this with a canned reply and keep no
   // retry state, so only the latch is conditional, not the send.
   [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
@@ -862,17 +847,7 @@ void BluetoothProxy::send_device_clear_cache(uint64_t address, bool success, con
   call.success = success;
   call.error = error;
 
-  // Advertisement-only builds answer these with a canned reply and keep no
-  // retry state, so only the latch is conditional, not the send.
-  [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  if (!sent) {
-    // V, not W: the reply is owed rather than lost, and a warning would ride
-    // the connection that just refused it.
-    ESP_LOGV(TAG, "Clear-cache reply for %012" PRIX64 " deferred, TCP buffer full", address);
-    this->pending_clear_cache_.set(address, error);
-  }
-#endif
+  this->api_connection_->send_message(call);
 }
 
 BluetoothProxy *global_bluetooth_proxy = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -829,9 +829,11 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
   if (!sent) {
-    // V, not W: the reply is owed rather than lost, and a warning would ride
-    // the connection that just refused it.
-    ESP_LOGV(TAG, "Unpairing reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    // Warn on the leading edge only: a refused reply must not be silent, but
+    // repeating it would add traffic to the connection that just refused one.
+    if (this->pending_unpairing_.empty()) {
+      ESP_LOGW(TAG, "Unpair reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    }
     this->pending_unpairing_.set(address, error);
   }
 #endif

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -197,7 +197,7 @@ void BluetoothProxy::replace_allocated_slot_(uint64_t find_value, uint64_t set_v
 
 void BluetoothProxy::latch_pending_disconnection_(uint64_t address, conn_err_t error) {
   // Match before free entry so one address never occupies two pool slots.
-  PendingDisconnect *free_entry = nullptr;
+  PendingReply *free_entry = nullptr;
   for (uint8_t i = 0; i < this->connection_count_; i++) {
     auto &owed = this->pending_disconnections_[i];
     if (owed.matches(address)) {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -832,10 +832,13 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
       this->pending_unpairing_.clear();
     }
   } else {
-    // Warn on the leading edge only: a refused reply must not be silent, but
-    // repeating it would add traffic to the connection that just refused one.
+    // Warn on the leading edge and on displacement (that one loses a reply);
+    // the drain's re-refusals of the same reply stay quiet.
     if (this->pending_unpairing_.empty()) {
       ESP_LOGW(TAG, "Unpair reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    } else if (!this->pending_unpairing_.matches(address)) {
+      ESP_LOGW(TAG, "Owed unpair reply for %012" PRIX64 " dropped, displaced by %012" PRIX64,
+               this->pending_unpairing_.address(), address);
     }
     this->pending_unpairing_.set(address, error);
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -566,16 +566,6 @@ void BluetoothProxy::loop() {
     return;
   this->last_advertisement_flush_time_ = now;
 
-  // Owed device-maintenance replies. Cleared before re-sending so a refusal
-  // re-latches through the sender itself, as the connections-free drain does.
-  // The success flag is recomputed as (error == 0), which is what every
-  // caller passed in the first place.
-  if (this->api_connection_ != nullptr) {
-    this->drain_pending_device_reply_(this->pending_pairing_, &BluetoothProxy::send_device_pairing);
-    this->drain_pending_device_reply_(this->pending_unpairing_, &BluetoothProxy::send_device_unpairing);
-    this->drain_pending_device_reply_(this->pending_clear_cache_, &BluetoothProxy::send_device_clear_cache);
-  }
-
   if (this->connections_free_pending_ && this->api_connection_ != nullptr) {
     // Resend a dropped slot-state update, paced by the 100 ms gate so the
     // retry does not hammer the congestion it exists to survive; the
@@ -614,6 +604,21 @@ void BluetoothProxy::loop() {
     if (!owed.empty() && this->send_device_connection(owed.address(), false, 0, owed.error())) {
       owed.clear();
     }
+  }
+
+  // Owed device-maintenance replies. take_owed_reply_() clears first, so a
+  // repeat refusal re-latches through the sender; the success flag is
+  // recomputed as (error == 0), which is what every caller passed.
+  uint64_t owed_address;
+  conn_err_t owed_error;
+  if (take_owed_reply_(this->pending_pairing_, owed_address, owed_error)) {
+    this->send_device_pairing(owed_address, owed_error == CONN_OK, owed_error);
+  }
+  if (take_owed_reply_(this->pending_unpairing_, owed_address, owed_error)) {
+    this->send_device_unpairing(owed_address, owed_error == CONN_OK, owed_error);
+  }
+  if (take_owed_reply_(this->pending_clear_cache_, owed_address, owed_error)) {
+    this->send_device_clear_cache(owed_address, owed_error == CONN_OK, owed_error);
   }
 #endif
 
@@ -724,8 +729,8 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
     // Stale retry latches belong to the previous subscriber's session; a
     // re-subscribe by the current one keeps what it is still owed.
     this->connections_free_pending_ = false;
-    this->clear_pending_device_replies_();
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
+    this->clear_pending_device_replies_();
     for (uint8_t i = 0; i < this->connection_count_; i++) {
       // Neither a partial stream's tail nor an owed done belongs to the new
       // session; silence (the client's timeout) arbitrates.
@@ -752,7 +757,9 @@ void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *api_connecti
   }
   this->api_connection_ = nullptr;
   this->connections_free_pending_ = false;
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
   this->clear_pending_device_replies_();
+#endif
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
   this->scanner_state_pending_ = false;
 #endif
@@ -803,23 +810,6 @@ bool BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, conn_err
   return this->api_connection_->send_message(call);
 }
 
-void BluetoothProxy::defer_device_reply_(PendingDisconnect &owed, uint64_t address, conn_err_t error) {
-  // V, not W: the reply is owed rather than lost, and a warning would ride the
-  // connection that just refused it.
-  ESP_LOGV(TAG, "Device reply for %012" PRIX64 " deferred, TCP buffer full", address);
-  owed.set(address, error);
-}
-
-void BluetoothProxy::drain_pending_device_reply_(PendingDisconnect &owed, DeviceReplySender sender) {
-  if (owed.empty())
-    return;
-  uint64_t address = owed.address();
-  conn_err_t error = owed.error();
-  // Clear first: the sender re-latches if the API refuses it again.
-  owed.clear();
-  (this->*sender)(address, error == CONN_OK, error);
-}
-
 void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err_t error) {
   if (this->api_connection_ == nullptr)
     return;
@@ -828,9 +818,17 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err
   call.paired = paired;
   call.error = error;
 
-  if (!this->api_connection_->send_message(call)) {
-    this->defer_device_reply_(this->pending_pairing_, address, error);
+  // Advertisement-only builds answer these with a canned reply and keep no
+  // retry state, so only the latch is conditional, not the send.
+  [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+  if (!sent) {
+    // V, not W: the reply is owed rather than lost, and a warning would ride
+    // the connection that just refused it.
+    ESP_LOGV(TAG, "Pairing reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    this->pending_pairing_.set(address, error);
   }
+#endif
 }
 
 void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_err_t error) {
@@ -841,9 +839,17 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   call.success = success;
   call.error = error;
 
-  if (!this->api_connection_->send_message(call)) {
-    this->defer_device_reply_(this->pending_unpairing_, address, error);
+  // Advertisement-only builds answer these with a canned reply and keep no
+  // retry state, so only the latch is conditional, not the send.
+  [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+  if (!sent) {
+    // V, not W: the reply is owed rather than lost, and a warning would ride
+    // the connection that just refused it.
+    ESP_LOGV(TAG, "Unpairing reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    this->pending_unpairing_.set(address, error);
   }
+#endif
 }
 
 // Shared by both platform paths: the neutral bluetooth_device_request() uses it to
@@ -856,9 +862,17 @@ void BluetoothProxy::send_device_clear_cache(uint64_t address, bool success, con
   call.success = success;
   call.error = error;
 
-  if (!this->api_connection_->send_message(call)) {
-    this->defer_device_reply_(this->pending_clear_cache_, address, error);
+  // Advertisement-only builds answer these with a canned reply and keep no
+  // retry state, so only the latch is conditional, not the send.
+  [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+  if (!sent) {
+    // V, not W: the reply is owed rather than lost, and a warning would ride
+    // the connection that just refused it.
+    ESP_LOGV(TAG, "Clear-cache reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    this->pending_clear_cache_.set(address, error);
   }
+#endif
 }
 
 BluetoothProxy *global_bluetooth_proxy = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -566,6 +566,16 @@ void BluetoothProxy::loop() {
     return;
   this->last_advertisement_flush_time_ = now;
 
+  // Owed device-maintenance replies. Cleared before re-sending so a refusal
+  // re-latches through the sender itself, as the connections-free drain does.
+  // The success flag is recomputed as (error == 0), which is what every
+  // caller passed in the first place.
+  if (this->api_connection_ != nullptr) {
+    this->drain_pending_device_reply_(this->pending_pairing_, &BluetoothProxy::send_device_pairing);
+    this->drain_pending_device_reply_(this->pending_unpairing_, &BluetoothProxy::send_device_unpairing);
+    this->drain_pending_device_reply_(this->pending_clear_cache_, &BluetoothProxy::send_device_clear_cache);
+  }
+
   if (this->connections_free_pending_ && this->api_connection_ != nullptr) {
     // Resend a dropped slot-state update, paced by the 100 ms gate so the
     // retry does not hammer the congestion it exists to survive; the
@@ -714,6 +724,7 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
     // Stale retry latches belong to the previous subscriber's session; a
     // re-subscribe by the current one keeps what it is still owed.
     this->connections_free_pending_ = false;
+    this->clear_pending_device_replies_();
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
     for (uint8_t i = 0; i < this->connection_count_; i++) {
       // Neither a partial stream's tail nor an owed done belongs to the new
@@ -741,6 +752,7 @@ void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *api_connecti
   }
   this->api_connection_ = nullptr;
   this->connections_free_pending_ = false;
+  this->clear_pending_device_replies_();
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
   this->scanner_state_pending_ = false;
 #endif
@@ -791,6 +803,23 @@ bool BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, conn_err
   return this->api_connection_->send_message(call);
 }
 
+void BluetoothProxy::defer_device_reply_(PendingDisconnect &owed, uint64_t address, conn_err_t error) {
+  // V, not W: the reply is owed rather than lost, and a warning would ride the
+  // connection that just refused it.
+  ESP_LOGV(TAG, "Device reply for %012" PRIX64 " deferred, TCP buffer full", address);
+  owed.set(address, error);
+}
+
+void BluetoothProxy::drain_pending_device_reply_(PendingDisconnect &owed, DeviceReplySender sender) {
+  if (owed.empty())
+    return;
+  uint64_t address = owed.address();
+  conn_err_t error = owed.error();
+  // Clear first: the sender re-latches if the API refuses it again.
+  owed.clear();
+  (this->*sender)(address, error == CONN_OK, error);
+}
+
 void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err_t error) {
   if (this->api_connection_ == nullptr)
     return;
@@ -799,7 +828,9 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err
   call.paired = paired;
   call.error = error;
 
-  this->api_connection_->send_message(call);
+  if (!this->api_connection_->send_message(call)) {
+    this->defer_device_reply_(this->pending_pairing_, address, error);
+  }
 }
 
 void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_err_t error) {
@@ -810,7 +841,9 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   call.success = success;
   call.error = error;
 
-  this->api_connection_->send_message(call);
+  if (!this->api_connection_->send_message(call)) {
+    this->defer_device_reply_(this->pending_unpairing_, address, error);
+  }
 }
 
 // Shared by both platform paths: the neutral bluetooth_device_request() uses it to
@@ -823,7 +856,9 @@ void BluetoothProxy::send_device_clear_cache(uint64_t address, bool success, con
   call.success = success;
   call.error = error;
 
-  this->api_connection_->send_message(call);
+  if (!this->api_connection_->send_message(call)) {
+    this->defer_device_reply_(this->pending_clear_cache_, address, error);
+  }
 }
 
 BluetoothProxy *global_bluetooth_proxy = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -816,6 +816,15 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err
 void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_err_t error) {
   if (this->api_connection_ == nullptr)
     return;
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+  // An owed success is the authoritative answer: a later attempt for the
+  // same address fails only because the first already removed the bond.
+  if (!this->pending_unpairing_.empty() && this->pending_unpairing_.matches(address) &&
+      this->pending_unpairing_.error() == CONN_OK) {
+    success = true;
+    error = CONN_OK;
+  }
+#endif
   api::BluetoothDeviceUnpairingResponse call;
   call.address = address;
   call.success = success;
@@ -839,10 +848,6 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
     } else if (!this->pending_unpairing_.matches(address)) {
       ESP_LOGW(TAG, "Owed unpair reply for %012" PRIX64 " dropped, displaced by %012" PRIX64,
                this->pending_unpairing_.address(), address);
-    } else if (this->pending_unpairing_.error() == CONN_OK) {
-      // A retry against the already-removed bond reports failure; the owed
-      // success is the answer the client needs, so keep it.
-      return;
     }
     this->pending_unpairing_.set(address, error);
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -149,7 +149,9 @@ class BluetoothProxy final : public Component {
   /// False only when the API refused the frame, so the reply is still owed.
   bool send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error);
   void send_device_pairing(uint64_t address, bool paired, conn_err_t error = CONN_OK);
-  void send_device_unpairing(uint64_t address, bool success, conn_err_t error = CONN_OK);
+  /// No default error: the drain rebuilds success as (error == CONN_OK), so a
+  /// caller that omitted it would have a reported failure resent as a success.
+  void send_device_unpairing(uint64_t address, bool success, conn_err_t error);
   void send_device_clear_cache(uint64_t address, bool success, conn_err_t error = CONN_OK);
 
   void bluetooth_scanner_set_mode(bool active);
@@ -303,7 +305,9 @@ class BluetoothProxy final : public Component {
   // needs no equivalent (a retried PAIR is answered from is_paired()) and
   // clear-cache is idempotent. Address-keyed, since unpair acts on an address
   // with no connection slot at all; the success flag is not stored because
-  // every caller passes exactly (error == 0).
+  // every caller passes exactly (error == 0). One slot: two unpairs refused in
+  // the same drain window displace the older reply, which is what happened to
+  // both before this existed. Home Assistant unpairs one device at a time.
   PendingDisconnect pending_unpairing_{};
 #endif
   ble_device_base::BLEHub *hub_{nullptr};

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -63,7 +63,7 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
 /// One owed address-keyed reply in a single word: the 48-bit address in the
 /// low bits, the sign-extending 16-bit error on top. Backs the freed-slot
-/// notifications and the device-maintenance replies. Every error that reaches
+/// notifications and the owed unpair reply. Every error that reaches
 /// it (esp_gatt_status_t, esp_gatt_conn_reason_t, generic ESP_ERR_*, -1) fits
 /// int16_t.
 class PendingDisconnect {
@@ -283,23 +283,6 @@ class BluetoothProxy final : public Component {
   void clear_pending_disconnection_(uint64_t address);
   /// Pool a refused freed-slot notification for the paced drain.
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
-  /// Take an owed reply and clear the slot, so a repeat refusal re-latches
-  /// through the sender itself. False when nothing is owed. Inline so the
-  /// idle path is a load and a branch rather than a call.
-  static bool take_owed_reply_(PendingDisconnect &owed, uint64_t &address, conn_err_t &error) {
-    if (owed.empty())
-      return false;
-    address = owed.address();
-    error = owed.error();
-    owed.clear();
-    return true;
-  }
-  /// A reply owed to the previous subscriber means nothing to the next one.
-  void clear_pending_device_replies_() {
-    this->pending_pairing_.clear();
-    this->pending_unpairing_.clear();
-    this->pending_clear_cache_.clear();
-  }
 #endif
 
   // Memory optimized layout for 32-bit systems
@@ -313,13 +296,15 @@ class BluetoothProxy final : public Component {
   // Proxy-only state, kept off BluetoothConnection; entries are not tied to
   // slot indices.
   std::array<PendingDisconnect, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
-  // Owed device-maintenance replies, one slot per operation so a pair cannot
-  // evict an owed unpair. Address-keyed rather than slot-keyed: unpair and
-  // clear-cache act on an address with no connection at all. The success flag
-  // is not stored because every caller passes exactly (error == 0).
-  PendingDisconnect pending_pairing_{};
+  // An owed unpair reply. Unpair is the one device-maintenance reply worth
+  // retrying: the bond is already gone when the send is refused, so a client
+  // that times out and retries re-runs unpair_device() against a bond that no
+  // longer exists and is told the unpair failed when it succeeded. Pairing
+  // needs no equivalent (a retried PAIR is answered from is_paired()) and
+  // clear-cache is idempotent. Address-keyed, since unpair acts on an address
+  // with no connection slot at all; the success flag is not stored because
+  // every caller passes exactly (error == 0).
   PendingDisconnect pending_unpairing_{};
-  PendingDisconnect pending_clear_cache_{};
 #endif
   ble_device_base::BLEHub *hub_{nullptr};
   // Group 3: 4-byte types; paired with hub_ so the 8-aligned messages below

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -61,11 +61,8 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
 };
 
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
-/// One owed address-keyed reply in a single word: the 48-bit address in the
-/// low bits, the sign-extending 16-bit error on top. Backs the freed-slot
-/// notifications and the owed unpair reply. Every error that reaches
-/// it (esp_gatt_status_t, esp_gatt_conn_reason_t, generic ESP_ERR_*, -1) fits
-/// int16_t.
+/// One owed address-keyed reply in a single word: 48-bit address low, 16-bit
+/// error on top. Every error that reaches it fits int16_t.
 class PendingDisconnect {
  public:
   constexpr void set(uint64_t address, conn_err_t error) {
@@ -298,16 +295,9 @@ class BluetoothProxy final : public Component {
   // Proxy-only state, kept off BluetoothConnection; entries are not tied to
   // slot indices.
   std::array<PendingDisconnect, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
-  // An owed unpair reply. Unpair is the one device-maintenance reply worth
-  // retrying: the bond is already gone when the send is refused, so a client
-  // that times out and retries re-runs unpair_device() against a bond that no
-  // longer exists and is told the unpair failed when it succeeded. Pairing
-  // needs no equivalent (a retried PAIR is answered from is_paired()) and
-  // clear-cache is idempotent. Address-keyed, since unpair acts on an address
-  // with no connection slot at all; the success flag is not stored because
-  // every caller passes exactly (error == 0). One slot: two unpairs refused in
-  // the same drain window displace the older reply, which is what happened to
-  // both before this existed. Home Assistant unpairs one device at a time.
+  // Owed unpair reply. The bond is already gone when the send is refused, so
+  // a retry is told the unpair failed when it succeeded. One slot: a second
+  // refused unpair displaces the first, as happened to both before this.
   PendingDisconnect pending_unpairing_{};
 #endif
   ble_device_base::BLEHub *hub_{nullptr};

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -63,7 +63,7 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
 /// One owed address-keyed reply in a single word: 48-bit address low, 16-bit
 /// error on top. Every error that reaches it fits int16_t.
-class PendingDisconnect {
+class PendingReply {
  public:
   constexpr void set(uint64_t address, conn_err_t error) {
     // Mask: the address originates from the client, and a stray high bit
@@ -71,7 +71,8 @@ class PendingDisconnect {
     this->word_ = (address & ADDRESS_MASK) | (static_cast<uint64_t>(static_cast<uint16_t>(error)) << 48);
   }
   constexpr void clear() { this->word_ = 0; }
-  // Whole-word test: set() is only ever given a live (nonzero) address.
+  // Whole-word test. Slot-sourced addresses are always nonzero; the unpair
+  // caller's is client-supplied, so a zero address reads back as nothing owed.
   constexpr bool empty() const { return this->word_ == 0; }
   // Masked like set(), so a stray high bit cannot defeat the pool lookups.
   constexpr bool matches(uint64_t address) const { return this->address() == (address & ADDRESS_MASK); }
@@ -84,15 +85,15 @@ class PendingDisconnect {
 };
 // Pin the packing at compile time: mask and sign round-trip for every
 // reachable shape (negative, GATT status, ESP_ERR_* range, stray high bit).
-constexpr bool pending_disconnect_round_trips(uint64_t address, uint64_t expected_address, conn_err_t error) {
-  PendingDisconnect p;
+constexpr bool pending_reply_round_trips(uint64_t address, uint64_t expected_address, conn_err_t error) {
+  PendingReply p;
   p.set(address, error);
   return p.address() == expected_address && p.error() == error && !p.empty() && p.matches(address);
 }
-static_assert(pending_disconnect_round_trips(0x0000112233445566ULL, 0x0000112233445566ULL, -1));
-static_assert(pending_disconnect_round_trips(0x0000FFFFFFFFFFFFULL, 0x0000FFFFFFFFFFFFULL, 0x8F));
-static_assert(pending_disconnect_round_trips(0xABCD112233445566ULL, 0x0000112233445566ULL, 0x110));
-static_assert(PendingDisconnect{}.empty());
+static_assert(pending_reply_round_trips(0x0000112233445566ULL, 0x0000112233445566ULL, -1));
+static_assert(pending_reply_round_trips(0x0000FFFFFFFFFFFFULL, 0x0000FFFFFFFFFFFFULL, 0x8F));
+static_assert(pending_reply_round_trips(0xABCD112233445566ULL, 0x0000112233445566ULL, 0x110));
+static_assert(PendingReply{}.empty());
 #endif
 
 class BluetoothProxy final : public Component {
@@ -294,11 +295,11 @@ class BluetoothProxy final : public Component {
   // Address-keyed pool of owed freed-slot notifications; loop() resends.
   // Proxy-only state, kept off BluetoothConnection; entries are not tied to
   // slot indices.
-  std::array<PendingDisconnect, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
+  std::array<PendingReply, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
   // Owed unpair reply. The bond is already gone when the send is refused, so
   // a retry is told the unpair failed when it succeeded. One slot: a second
   // refused unpair displaces the first, as happened to both before this.
-  PendingDisconnect pending_unpairing_{};
+  PendingReply pending_unpairing_{};
 #endif
   ble_device_base::BLEHub *hub_{nullptr};
   // Group 3: 4-byte types; paired with hub_ so the 8-aligned messages below

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -71,8 +71,9 @@ class PendingReply {
     this->word_ = (address & ADDRESS_MASK) | (static_cast<uint64_t>(static_cast<uint16_t>(error)) << 48);
   }
   constexpr void clear() { this->word_ = 0; }
-  // Whole-word test. Slot-sourced addresses are always nonzero; the unpair
-  // caller's is client-supplied, so a zero address reads back as nothing owed.
+  // Whole-word test: only (address 0, error 0) reads back as nothing owed.
+  // A zero-address failure still latches, which is correct - that reply is
+  // owed too. Neither backend can unpair address 0 successfully.
   constexpr bool empty() const { return this->word_ == 0; }
   // Masked like set(), so a stray high bit cannot defeat the pool lookups.
   constexpr bool matches(uint64_t address) const { return this->address() == (address & ADDRESS_MASK); }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -60,8 +60,7 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
   SUBSCRIPTION_RAW_ADVERTISEMENTS = 1 << 0,
 };
 
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-/// One owed freed-slot connected=false notification in a single word: the
+/// One owed address-keyed reply in a single word: the
 /// 48-bit address in the low bits, the sign-extending 16-bit reason on top.
 /// Every reason that reaches the pool (esp_gatt_status_t,
 /// esp_gatt_conn_reason_t, generic ESP_ERR_*, -1) fits int16_t.
@@ -95,7 +94,6 @@ static_assert(pending_disconnect_round_trips(0x0000112233445566ULL, 0x0000112233
 static_assert(pending_disconnect_round_trips(0x0000FFFFFFFFFFFFULL, 0x0000FFFFFFFFFFFFULL, 0x8F));
 static_assert(pending_disconnect_round_trips(0xABCD112233445566ULL, 0x0000112233445566ULL, 0x110));
 static_assert(PendingDisconnect{}.empty());
-#endif
 
 class BluetoothProxy final : public Component {
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
@@ -296,6 +294,27 @@ class BluetoothProxy final : public Component {
   // slot indices.
   std::array<PendingDisconnect, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
 #endif
+  // Owed device-maintenance replies, one slot per operation so a pair cannot
+  // evict an owed unpair. Address-keyed rather than slot-keyed: unpair and
+  // clear-cache act on an address with no connection at all. The success flag
+  // is not stored because every caller passes exactly (error == 0). Built on
+  // every proxy variant: the advertisement-only arm answers these too.
+  /// The three device-reply senders share a signature, so one drain covers
+  /// them all.
+  using DeviceReplySender = void (BluetoothProxy::*)(uint64_t, bool, conn_err_t);
+  void drain_pending_device_reply_(PendingDisconnect &owed, DeviceReplySender sender);
+  /// Log the deferral and latch it, so all three senders report identically.
+  void defer_device_reply_(PendingDisconnect &owed, uint64_t address, conn_err_t error);
+  /// A reply owed to the previous subscriber means nothing to the next one.
+  void clear_pending_device_replies_() {
+    this->pending_pairing_.clear();
+    this->pending_unpairing_.clear();
+    this->pending_clear_cache_.clear();
+  }
+
+  PendingDisconnect pending_pairing_{};
+  PendingDisconnect pending_unpairing_{};
+  PendingDisconnect pending_clear_cache_{};
   ble_device_base::BLEHub *hub_{nullptr};
   // Group 3: 4-byte types; paired with hub_ so the 8-aligned messages below
   // start on an even word, closing two alignment holes.

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -60,10 +60,12 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
   SUBSCRIPTION_RAW_ADVERTISEMENTS = 1 << 0,
 };
 
-/// One owed address-keyed reply in a single word: the
-/// 48-bit address in the low bits, the sign-extending 16-bit reason on top.
-/// Every reason that reaches the pool (esp_gatt_status_t,
-/// esp_gatt_conn_reason_t, generic ESP_ERR_*, -1) fits int16_t.
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+/// One owed address-keyed reply in a single word: the 48-bit address in the
+/// low bits, the sign-extending 16-bit error on top. Backs the freed-slot
+/// notifications and the device-maintenance replies. Every error that reaches
+/// it (esp_gatt_status_t, esp_gatt_conn_reason_t, generic ESP_ERR_*, -1) fits
+/// int16_t.
 class PendingDisconnect {
  public:
   constexpr void set(uint64_t address, conn_err_t error) {
@@ -94,6 +96,7 @@ static_assert(pending_disconnect_round_trips(0x0000112233445566ULL, 0x0000112233
 static_assert(pending_disconnect_round_trips(0x0000FFFFFFFFFFFFULL, 0x0000FFFFFFFFFFFFULL, 0x8F));
 static_assert(pending_disconnect_round_trips(0xABCD112233445566ULL, 0x0000112233445566ULL, 0x110));
 static_assert(PendingDisconnect{}.empty());
+#endif
 
 class BluetoothProxy final : public Component {
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
@@ -280,6 +283,23 @@ class BluetoothProxy final : public Component {
   void clear_pending_disconnection_(uint64_t address);
   /// Pool a refused freed-slot notification for the paced drain.
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
+  /// Take an owed reply and clear the slot, so a repeat refusal re-latches
+  /// through the sender itself. False when nothing is owed. Inline so the
+  /// idle path is a load and a branch rather than a call.
+  static bool take_owed_reply_(PendingDisconnect &owed, uint64_t &address, conn_err_t &error) {
+    if (owed.empty())
+      return false;
+    address = owed.address();
+    error = owed.error();
+    owed.clear();
+    return true;
+  }
+  /// A reply owed to the previous subscriber means nothing to the next one.
+  void clear_pending_device_replies_() {
+    this->pending_pairing_.clear();
+    this->pending_unpairing_.clear();
+    this->pending_clear_cache_.clear();
+  }
 #endif
 
   // Memory optimized layout for 32-bit systems
@@ -293,28 +313,14 @@ class BluetoothProxy final : public Component {
   // Proxy-only state, kept off BluetoothConnection; entries are not tied to
   // slot indices.
   std::array<PendingDisconnect, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
-#endif
   // Owed device-maintenance replies, one slot per operation so a pair cannot
   // evict an owed unpair. Address-keyed rather than slot-keyed: unpair and
   // clear-cache act on an address with no connection at all. The success flag
-  // is not stored because every caller passes exactly (error == 0). Built on
-  // every proxy variant: the advertisement-only arm answers these too.
-  /// The three device-reply senders share a signature, so one drain covers
-  /// them all.
-  using DeviceReplySender = void (BluetoothProxy::*)(uint64_t, bool, conn_err_t);
-  void drain_pending_device_reply_(PendingDisconnect &owed, DeviceReplySender sender);
-  /// Log the deferral and latch it, so all three senders report identically.
-  void defer_device_reply_(PendingDisconnect &owed, uint64_t address, conn_err_t error);
-  /// A reply owed to the previous subscriber means nothing to the next one.
-  void clear_pending_device_replies_() {
-    this->pending_pairing_.clear();
-    this->pending_unpairing_.clear();
-    this->pending_clear_cache_.clear();
-  }
-
+  // is not stored because every caller passes exactly (error == 0).
   PendingDisconnect pending_pairing_{};
   PendingDisconnect pending_unpairing_{};
   PendingDisconnect pending_clear_cache_{};
+#endif
   ble_device_base::BLEHub *hub_{nullptr};
   // Group 3: 4-byte types; paired with hub_ so the 8-aligned messages below
   // start on an even word, closing two alignment holes.


### PR DESCRIPTION
# What does this implement/fix?

Chained on #18259. Reads can be read again, so they need no protection against a refused frame; writes do, but only where a retry gives a *different* answer. Of the device-maintenance replies only unpair fails that test.

**Unpair mutates and is not safely retryable.** The bond is already gone when `send_message()` refuses the reply, so a client that times out and retries re-runs `unpair_device()` against a bond that no longer exists and is told the unpair failed when it succeeded. One `PendingReply` word holds it and the existing 100 ms drain re-offers it.

Pairing and clear-cache are writes too, but a retried `PAIR` is answered from `is_paired()` and clear-cache is idempotent, so neither can leave the client with a wrong result. `set_connection_params` is idempotent and keeps its stated esp32 parity.

The packed one-word latch class needs no structural changes: it already packs a 48-bit address and 16-bit error with a constexpr round-trip proof covering this error domain. It is renamed `PendingDisconnect` to `PendingReply`, since it now holds an unpairing response too. The success flag is not stored, since every caller passes exactly `error == 0`; `send_device_unpairing` has no default error argument so the compiler holds that. A landed unpair clears an owed one, so the drain cannot repeat a reply the client has. One slot, so two unpairs refused in the same window displace the older reply, which is what happened to both before this existed. A refused reply warns once on the stall's leading edge; the drain does not pre-clear the latch, so the retry path stays silent until the reply lands or is displaced. A same-address retry cannot downgrade an owed success: its reply is rewritten from the latched CONN_OK before sending, since the retry only fails because the first attempt already removed the bond; this covers both a refused and an accepted retry.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/issues/18221

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed.
esphome:
  name: my-proxy

api:

bluetooth_proxy:
  active: true
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).





