### PR TITLE
[bluetooth_proxy] Reset every owed reply in one place

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -704,6 +704,25 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
 
 #endif  // !BLUETOOTH_CONNECTION_HAS_GATT
 
+void BluetoothProxy::reset_owed_replies_() {
+  this->connections_free_pending_ = false;
+#ifdef USE_BLE_SCANNER_STATE_CALLBACK
+  // subscribe_api_connection() re-drives this from the hub immediately after,
+  // so clearing it here costs nothing and keeps the list exhaustive.
+  this->scanner_state_pending_ = false;
+#endif
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+  this->pending_unpairing_.clear();
+  this->pending_disconnections_.fill({});
+  for (uint8_t i = 0; i < this->connection_count_; i++) {
+    // Neither a partial stream's tail nor an owed done belongs to the next
+    // session; silence (the client's timeout) arbitrates.
+    this->connections_[i]->park_service_stream_();
+    this->connections_[i]->clear_pending_ack_();
+  }
+#endif
+}
+
 void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection, uint32_t flags) {
   if (api_connection != this->api_connection_) {
     if (this->api_connection_ != nullptr) {
@@ -720,18 +739,7 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
     }
     // Stale retry latches belong to the previous subscriber's session; a
     // re-subscribe by the current one keeps what it is still owed.
-    this->connections_free_pending_ = false;
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-    this->pending_unpairing_.clear();
-    for (uint8_t i = 0; i < this->connection_count_; i++) {
-      // Neither a partial stream's tail nor an owed done belongs to the new
-      // session; silence (the client's timeout) arbitrates.
-      this->connections_[i]->park_service_stream_();
-      // An ack owed to the previous subscriber means nothing to the new one.
-      this->connections_[i]->clear_pending_ack_();
-    }
-    this->pending_disconnections_.fill({});
-#endif
+    this->reset_owed_replies_();
   }
   this->api_connection_ = api_connection;
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
@@ -748,13 +756,7 @@ void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *api_connecti
     return;
   }
   this->api_connection_ = nullptr;
-  this->connections_free_pending_ = false;
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  this->pending_unpairing_.clear();
-#endif
-#ifdef USE_BLE_SCANNER_STATE_CALLBACK
-  this->scanner_state_pending_ = false;
-#endif
+  this->reset_owed_replies_();
 }
 
 void BluetoothProxy::send_connections_free() {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -707,9 +707,13 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
 void BluetoothProxy::reset_owed_replies_() {
   this->connections_free_pending_ = false;
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
-  // subscribe_api_connection() re-drives this from the hub immediately after,
-  // so clearing it here costs nothing and keeps the list exhaustive.
+  // Owed on unsubscribe; on subscribe the trailing send_scanner_state_()
+  // re-drives it from the hub, so clearing it there is free.
   this->scanner_state_pending_ = false;
+#else
+  // Force a poll-arm mismatch: a frame refused at subscribe time could
+  // otherwise match the stale detector and never be retried.
+  this->last_scan_running_ = !this->hub_->scan_running();
 #endif
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
   this->pending_unpairing_.clear();

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -712,7 +712,9 @@ void BluetoothProxy::reset_owed_replies_() {
   this->scanner_state_pending_ = false;
 #else
   // Force a poll-arm mismatch: a frame refused at subscribe time could
-  // otherwise match the stale detector and never be retried.
+  // otherwise match the stale detector and never be retried. Inert on
+  // unsubscribe: loop() returns at the no-subscriber gate before the
+  // detector runs, and a re-subscribe re-arms this anyway.
   this->last_scan_running_ = !this->hub_->scan_running();
 #endif
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -288,6 +288,8 @@ class BluetoothProxy final : public Component {
 
   /// Drop everything the ending session was owed. One list, so a new latch is
   /// one edit rather than two call sites where an omission looks deliberate.
+  /// Drops state only, never sends: api_connection_ is the departing
+  /// subscriber on subscribe and nullptr on unsubscribe.
   void reset_owed_replies_();
 
   // Memory optimized layout for 32-bit systems

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -286,6 +286,15 @@ class BluetoothProxy final : public Component {
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
 #endif
 
+  /// Drop everything the ending session was owed.
+  ///
+  /// Every retry latch belongs to exactly one subscriber, so a subscriber
+  /// change invalidates all of them. Keeping the list in one place makes
+  /// adding a latch a single edit: the two callers previously reset five and
+  /// three separate things, and the two sets were not subsets of each other
+  /// in either direction, so an omission read the same as a decision.
+  void reset_owed_replies_();
+
   // Memory optimized layout for 32-bit systems
   // Group 1: Pointers (4 bytes each, naturally aligned)
   api::APIConnection *api_connection_{nullptr};

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -286,13 +286,8 @@ class BluetoothProxy final : public Component {
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
 #endif
 
-  /// Drop everything the ending session was owed.
-  ///
-  /// Every retry latch belongs to exactly one subscriber, so a subscriber
-  /// change invalidates all of them. Keeping the list in one place makes
-  /// adding a latch a single edit: the two callers previously reset five and
-  /// three separate things, and the two sets were not subsets of each other
-  /// in either direction, so an omission read the same as a decision.
+  /// Drop everything the ending session was owed. One list, so a new latch is
+  /// one edit rather than two call sites where an omission looks deliberate.
   void reset_owed_replies_();
 
   // Memory optimized layout for 32-bit systems


### PR DESCRIPTION
# What does this implement/fix?

Chained on #18274. Cleanup only.

`subscribe_api_connection()` reset five separate pieces of retry state and `unsubscribe_api_connection()` reset three, and the two sets were not subsets of each other either way. Every omission was individually defensible, which is what made the next one hard to spot: a forgotten latch reads like a deliberate one.

Both now call `reset_owed_replies_()`, which drops everything a subscriber could be owed, so adding a latch is one edit rather than two call sites.

Two behaviour changes, both dropping more stale state: `unsubscribe` now also parks service streams, clears per-connection acks and empties `pending_disconnections_`, all of which belonged to the subscriber that left; and `subscribe` clears `scanner_state_pending_`, which the trailing `send_scanner_state_()` re-drives two lines later. On polled-scanner hubs the reset also forces a change-detector mismatch: a scanner-state frame refused at subscribe time could otherwise match the stale detector and never be retried, stranding the new subscriber without a state report.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/issues/18221

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed.
esphome:
  name: my-proxy

api:

bluetooth_proxy:
  active: true
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).


