### PR TITLE
[core] Stop dropping complete lines behind an unfinished one

### DIFF
--- a/esphome/espidf/runner.py
+++ b/esphome/espidf/runner.py
@@ -149,8 +149,9 @@ def main() -> int:
           other control characters count too. Any piece whose
           ANSI-stripped, right-stripped form matches one of
           ``filter_lines`` is dropped.
-        * Only the final piece can be an unfinished line. It is held in a
-          buffer until a ``\\n`` or ``\\r`` arrives.
+        * Only the final piece can still be waiting for more text, so
+          that one is held until a ``\\n`` or ``\\r`` arrives. A piece
+          that ended on one of the other breaks goes out as it is.
 
         Mirrors the matching semantics of ``esphome.util.RedirectText``
         so filter patterns behave identically in both the PlatformIO
@@ -230,13 +231,16 @@ def main() -> int:
                 self._emit(data)
             else:
                 lines = (self._line_buffer + data).splitlines(keepends=True)
-                # Only the last piece can be an unfinished line, so hold
-                # that one and write out the rest.
+                # Every piece but the last ends with something
+                # ``str.splitlines`` treats as a break, so only the last one
+                # can still be waiting for more text. Hold that one, write
+                # out the rest.
                 #
-                # ``str.splitlines`` also breaks on characters we do not
-                # treat as line endings, such as a form feed. Checking every
-                # piece used to stop at the first of those and drop every
-                # complete line behind it.
+                # Some of those breaks are not line endings to us, a form
+                # feed for one, so a piece can go out without ending in a
+                # newline. That beats what we did before, which was to stop
+                # at the first such piece and drop every complete line
+                # behind it.
                 if lines and not lines[-1].endswith(("\n", "\r")):
                     self._line_buffer = lines.pop()
                 else:

--- a/esphome/espidf/runner.py
+++ b/esphome/espidf/runner.py
@@ -228,13 +228,17 @@ def main() -> int:
                 # Nothing to match against, so no need to wait for a full line.
                 self._emit(data)
             else:
-                self._line_buffer += data
-                for line in self._line_buffer.splitlines(keepends=True):
-                    if "\n" not in line and "\r" not in line:
-                        # Incomplete — hold until we see a terminator.
-                        self._line_buffer = line
-                        break
+                lines = (self._line_buffer + data).splitlines(keepends=True)
+                # Only the last piece can be unfinished; hold that one and
+                # write out the rest. Checking every piece instead used to
+                # stop at the first one that ended on a character
+                # ``str.splitlines`` counts as a break but we do not, such as
+                # a form feed, and throw away every complete line behind it.
+                if lines and not lines[-1].endswith(("\n", "\r")):
+                    self._line_buffer = lines.pop()
+                else:
                     self._line_buffer = ""
+                for line in lines:
                     self._emit(line)
 
             # We tell idf.py it is talking to a terminal, so it sends progress

--- a/esphome/espidf/runner.py
+++ b/esphome/espidf/runner.py
@@ -144,12 +144,13 @@ def main() -> int:
 
         * ``isatty()`` unconditionally returns True, tricking downstream
           code into emitting TTY-format output.
-        * Input is split on ``\\n`` / ``\\r`` via
-          ``str.splitlines(keepends=True)`` and any complete line whose
+        * Input is split with ``str.splitlines(keepends=True)``, which
+          breaks on more than ``\\n`` and ``\\r``; form feed and a few
+          other control characters count too. Any piece whose
           ANSI-stripped, right-stripped form matches one of
           ``filter_lines`` is dropped.
-        * Incomplete trailing chunks are held in a buffer until a
-          terminator arrives.
+        * Only the final piece can be an unfinished line. It is held in a
+          buffer until a ``\\n`` or ``\\r`` arrives.
 
         Mirrors the matching semantics of ``esphome.util.RedirectText``
         so filter patterns behave identically in both the PlatformIO
@@ -229,11 +230,13 @@ def main() -> int:
                 self._emit(data)
             else:
                 lines = (self._line_buffer + data).splitlines(keepends=True)
-                # Only the last piece can be unfinished; hold that one and
-                # write out the rest. Checking every piece instead used to
-                # stop at the first one that ended on a character
-                # ``str.splitlines`` counts as a break but we do not, such as
-                # a form feed, and throw away every complete line behind it.
+                # Only the last piece can be an unfinished line, so hold
+                # that one and write out the rest.
+                #
+                # ``str.splitlines`` also breaks on characters we do not
+                # treat as line endings, such as a form feed. Checking every
+                # piece used to stop at the first of those and drop every
+                # complete line behind it.
                 if lines and not lines[-1].endswith(("\n", "\r")):
                     self._line_buffer = lines.pop()
                 else:

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -230,13 +230,15 @@ class RedirectText:
 
         if self._filter_pattern is not None or self._line_callbacks:
             lines = (self._line_buffer + s).splitlines(True)
-            # Only the last piece can be an unfinished line, so hold that
-            # one and write out the rest.
+            # Every piece but the last ends with something
+            # ``str.splitlines`` treats as a break, so only the last one can
+            # still be waiting for more text. Hold that one, write out the
+            # rest.
             #
-            # ``str.splitlines`` also breaks on characters we do not treat as
-            # line endings, such as a form feed. Checking every piece used to
-            # stop at the first of those and drop every complete line behind
-            # it.
+            # Some of those breaks are not line endings to us, a form feed
+            # for one, so a piece can go out without ending in a newline.
+            # That beats what we did before, which was to stop at the first
+            # such piece and drop every complete line behind it.
             if lines and not lines[-1].endswith(("\n", "\r")):
                 self._line_buffer = lines.pop()
             else:

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -230,11 +230,13 @@ class RedirectText:
 
         if self._filter_pattern is not None or self._line_callbacks:
             lines = (self._line_buffer + s).splitlines(True)
-            # Only the last piece can be an unfinished line; hold that one and
-            # write out the rest. Checking every piece instead used to stop at
-            # the first one that ended on a character ``str.splitlines`` counts
-            # as a break but we do not, such as a form feed, and throw away
-            # every complete line behind it.
+            # Only the last piece can be an unfinished line, so hold that
+            # one and write out the rest.
+            #
+            # ``str.splitlines`` also breaks on characters we do not treat as
+            # line endings, such as a form feed. Checking every piece used to
+            # stop at the first of those and drop every complete line behind
+            # it.
             if lines and not lines[-1].endswith(("\n", "\r")):
                 self._line_buffer = lines.pop()
             else:

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -229,14 +229,17 @@ class RedirectText:
             s = s.decode()
 
         if self._filter_pattern is not None or self._line_callbacks:
-            self._line_buffer += s
-            lines = self._line_buffer.splitlines(True)
-            for line in lines:
-                if "\n" not in line and "\r" not in line:
-                    # Not a complete line, set line buffer
-                    self._line_buffer = line
-                    break
+            lines = (self._line_buffer + s).splitlines(True)
+            # Only the last piece can be an unfinished line; hold that one and
+            # write out the rest. Checking every piece instead used to stop at
+            # the first one that ended on a character ``str.splitlines`` counts
+            # as a break but we do not, such as a form feed, and throw away
+            # every complete line behind it.
+            if lines and not lines[-1].endswith(("\n", "\r")):
+                self._line_buffer = lines.pop()
+            else:
                 self._line_buffer = ""
+            for line in lines:
                 self._emit_line(line)
         else:
             self._write_color_replace(s)

--- a/tests/unit_tests/fixtures/espidf/formfeed_probe.py
+++ b/tests/unit_tests/fixtures/espidf/formfeed_probe.py
@@ -1,0 +1,12 @@
+"""Write a form feed part way through the output, as some toolchains do.
+
+Run through ``esphome/espidf/runner.py`` by test_espidf_runner.py. A form
+feed is not a line terminator here, so everything written must still come
+out, including the complete lines that follow it.
+"""
+
+import sys
+
+sys.stdout.write("Compiling main.cpp\n")
+sys.stdout.write("page one\x0cpage two\n")
+sys.stdout.write("[2/9] Building C object\n")

--- a/tests/unit_tests/fixtures/espidf/formfeed_probe.py
+++ b/tests/unit_tests/fixtures/espidf/formfeed_probe.py
@@ -1,4 +1,4 @@
-"""Write a form feed part way through the output, as some toolchains do.
+"""Write a form feed part way through the output.
 
 Run through ``esphome/espidf/runner.py`` by test_espidf_runner.py. A form
 feed is not a line terminator here, so everything written must still come

--- a/tests/unit_tests/test_espidf_runner.py
+++ b/tests/unit_tests/test_espidf_runner.py
@@ -71,6 +71,17 @@ def test_main_filters_noise_and_flushes_each_write(
     assert output.endswith("still going\n")
 
 
+def test_main_keeps_output_after_a_form_feed(
+    monkeypatch: pytest.MonkeyPatch, fixture_path: Path
+) -> None:
+    """A form feed is text, not a line break, so nothing after it is lost."""
+    buf, _stream = _run_main(monkeypatch, fixture_path / "espidf" / "formfeed_probe.py")
+
+    assert buf.getvalue().decode("utf-8") == (
+        "Compiling main.cpp\npage one\x0cpage two\n[2/9] Building C object\n"
+    )
+
+
 def test_main_drains_a_partial_line_when_the_build_dies(
     monkeypatch: pytest.MonkeyPatch, fixture_path: Path
 ) -> None:

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -445,7 +445,7 @@ def test_redirect_text_flushes_so_piped_output_streams() -> None:
 
 @pytest.mark.parametrize(
     "break_char",
-    ["\x0c", "\x0b", "\x1c", "\x1d", "\x1e", "\x85", " ", " "],
+    ["\x0c", "\x0b", "\x1c", "\x1d", "\x1e", "\x85", "\u2028", "\u2029"],
     ids=["formfeed", "vtab", "fs", "gs", "rs", "nel", "lsep", "psep"],
 )
 def test_redirect_text_keeps_output_after_an_exotic_break_character(

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -443,6 +443,42 @@ def test_redirect_text_flushes_so_piped_output_streams() -> None:
     assert buf.getvalue() == b"Writing at 0x00010000 (50%)\r"
 
 
+@pytest.mark.parametrize(
+    "break_char",
+    ["\x0c", "\x0b", "\x1c", "\x1d", "\x1e", "\x85", " ", " "],
+    ids=["formfeed", "vtab", "fs", "gs", "rs", "nel", "lsep", "psep"],
+)
+def test_redirect_text_keeps_output_after_an_exotic_break_character(
+    break_char: str,
+) -> None:
+    r"""Only ``\n`` and ``\r`` end a line; the rest is ordinary text.
+
+    ``str.splitlines`` treats all of these as line breaks. Splitting on them
+    used to strand the fragment in the buffer and drop every complete line
+    that came after it, which for a form feed in toolchain output meant
+    losing the rest of the build log.
+    """
+    redirect, buf = _make_redirect(filter_lines=["ignore me"])
+
+    redirect.write(f"first{break_char}second\nthird\n")
+
+    assert buf.getvalue() == f"first{break_char}second\nthird\n"
+
+
+def test_redirect_text_treats_crlf_as_one_terminator() -> None:
+    r"""``\r\n``, a lone ``\r`` and a lone ``\n`` each end exactly one line."""
+    redirect, buf = _make_redirect(filter_lines=["ignore me"])
+
+    redirect.write("one\r\ntwo\rthree\nfour")
+
+    # "four" has no terminator yet, so it is held back.
+    assert buf.getvalue() == "one\r\ntwo\rthree\n"
+
+    redirect.drain()
+
+    assert buf.getvalue() == "one\r\ntwo\rthree\nfour\n"
+
+
 def test_redirect_text_drain_releases_held_partial_line() -> None:
     """A last line with no terminator must still reach the user.
 


### PR DESCRIPTION
# What does this implement/fix?

Both output wrappers walk every piece from `str.splitlines(keepends=True)` and stop at the first one holding neither `\n` nor `\r`, treating it as an unfinished line. `str.splitlines` breaks on more than those two, though: form feed, vertical tab, the file/group/record separators, NEL, and the Unicode line and paragraph separators. A piece ending on one of those looks unfinished, so the loop stops there and every complete line behind it in the same chunk is thrown away.

```python
>>> r.write("first\x0csecond\nthird\n")
>>> r._out.getvalue()
''
```

`second` and `third` are gone for good, even though both were properly terminated.

Only the last piece can ever be an unfinished line, so hold that one and write out the rest. That keeps `str.splitlines` doing the splitting, so there is no cost: measured over a real 191 KB install log, 0.13 ms per pass versus 0.15 ms today.

Honest scope note: I could not find any of these characters in real output. Scanning every `.log` and `.txt` under my esphome and device-builder checkouts, 41.7M characters including full IDF and PlatformIO build and install logs, turned up 26 form feeds and all of them were inside LGPL license text. So this is closing a silent-loss path rather than fixing something users are hitting today.

Follow-up to #18265, and stacked on it since it touches the same loop; the base will retarget to dev once that merges.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
