### PR TITLE
[core] Show the out-of-flash tip instead of crashing the build

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -887,13 +887,7 @@ class EsphomeCore:
 
     @property
     def is_configured(self) -> bool:
-        """Whether anything has set this CORE up for a target.
-
-        Our runner subprocesses get a fresh CORE that nobody configures, so
-        code that also runs there has to be able to tell. This reports only
-        whether setup happened at all; a CORE that was set up but left half
-        filled in is a bug, and reading from it should still raise.
-        """
+        """Whether anything has set this CORE up for a target."""
         return KEY_CORE in self.data
 
     @property

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -886,6 +886,17 @@ class EsphomeCore:
         return self.relative_pioenvs_path(self.name, "bootloader.bin")
 
     @property
+    def is_configured(self) -> bool:
+        """Whether anything has set this CORE up for a target.
+
+        Our runner subprocesses get a fresh CORE that nobody configures, so
+        code that also runs there has to be able to tell. This reports only
+        whether setup happened at all; a CORE that was set up but left half
+        filled in is a bug, and reading from it should still raise.
+        """
+        return KEY_CORE in self.data
+
+    @property
     def target_platform(self):
         return self.data[KEY_CORE][KEY_TARGET_PLATFORM]
 

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -352,6 +352,10 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     # CORE to ask which platform this is, so tell it.
     if is_esp32_arduino_build():
         env[ESP32_ARDUINO_ENV] = "1"
+    else:
+        # Clear an inherited one, so a stray value in our own environment
+        # cannot make the runner offer the tip for a build it does not suit.
+        env.pop(ESP32_ARDUINO_ENV, None)
 
     return run_external_process(*cmd, env=env, **kwargs)
 

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -19,12 +19,7 @@ from esphome.helpers import (
     rmtree,
     write_file,
 )
-from esphome.util import (
-    ESP32_ARDUINO_ENV,
-    FlashImage,
-    is_esp32_arduino_build,
-    run_external_process,
-)
+from esphome.util import ESP32_ARDUINO_ENV, FlashImage, run_external_process
 
 if TYPE_CHECKING:
     from platformio.project.config import ProjectConfig
@@ -350,11 +345,13 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     # The runner filters PlatformIO's output in the subprocess, so the
     # out-of-flash tip is offered from there. That process has no configured
     # CORE to ask which platform this is, so tell it.
-    if is_esp32_arduino_build():
+    # Ask CORE directly rather than through is_esp32_arduino_build(), which
+    # falls back to this same variable. Reading what we are about to write
+    # would let a stray value in our own environment answer for us. Clear an
+    # inherited one so it cannot reach a build it does not suit.
+    if KEY_CORE in CORE.data and CORE.is_esp32 and CORE.using_arduino:
         env[ESP32_ARDUINO_ENV] = "1"
     else:
-        # Clear an inherited one, so a stray value in our own environment
-        # cannot make the runner offer the tip for a build it does not suit.
         env.pop(ESP32_ARDUINO_ENV, None)
 
     return run_external_process(*cmd, env=env, **kwargs)

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -345,8 +345,9 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     # The runner filters PlatformIO's output in the subprocess, so the
     # out-of-flash tip is offered from there. That process has no configured
     # CORE to ask which platform this is, so tell it.
+    #
     # Ask CORE directly rather than through is_esp32_arduino_build(), which
-    # falls back to this same variable. Reading what we are about to write
+    # falls back to this same variable; reading what we are about to write
     # would let a stray value in our own environment answer for us. Clear an
     # inherited one so it cannot reach a build it does not suit.
     if KEY_CORE in CORE.data and CORE.is_esp32 and CORE.using_arduino:

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -342,14 +342,9 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     base_env = kwargs.pop("env", None)
     env = dict(os.environ if base_env is None else base_env)
     env.update(_ccache_env())
-    # The runner filters PlatformIO's output in the subprocess, so the
-    # out-of-flash tip is offered from there. That process has no configured
-    # CORE to ask which platform this is, so tell it.
-    #
-    # Ask CORE directly rather than through is_esp32_arduino_build(), which
-    # falls back to this same variable; reading what we are about to write
-    # would let a stray value in our own environment answer for us. Clear an
-    # inherited one so it cannot reach a build it does not suit.
+    # The runner offers the out-of-flash tip but has no configured CORE, so
+    # tell it. Ask CORE, not is_esp32_arduino_build(), which reads this same
+    # variable; clear an inherited one so it cannot reach the wrong build.
     if CORE.is_configured and CORE.is_esp32 and CORE.using_arduino:
         env[ESP32_ARDUINO_ENV] = "1"
     else:

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -19,7 +19,12 @@ from esphome.helpers import (
     rmtree,
     write_file,
 )
-from esphome.util import FlashImage, run_external_process
+from esphome.util import (
+    ESP32_ARDUINO_ENV,
+    FlashImage,
+    is_esp32_arduino_build,
+    run_external_process,
+)
 
 if TYPE_CHECKING:
     from platformio.project.config import ProjectConfig
@@ -342,6 +347,11 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     base_env = kwargs.pop("env", None)
     env = dict(os.environ if base_env is None else base_env)
     env.update(_ccache_env())
+    # The runner filters PlatformIO's output in the subprocess, so the
+    # out-of-flash tip is offered from there. That process has no configured
+    # CORE to ask which platform this is, so tell it.
+    if is_esp32_arduino_build():
+        env[ESP32_ARDUINO_ENV] = "1"
 
     return run_external_process(*cmd, env=env, **kwargs)
 

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -350,7 +350,7 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     # falls back to this same variable; reading what we are about to write
     # would let a stray value in our own environment answer for us. Clear an
     # inherited one so it cannot reach a build it does not suit.
-    if KEY_CORE in CORE.data and CORE.is_esp32 and CORE.using_arduino:
+    if CORE.is_configured and CORE.is_esp32 and CORE.using_arduino:
         env[ESP32_ARDUINO_ENV] = "1"
     else:
         env.pop(ESP32_ARDUINO_ENV, None)

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -142,8 +142,8 @@ def shlex_quote(s: str | Path) -> str:
     return "'" + s.replace("'", "'\"'\"'") + "'"
 
 
-# Set by the parent when it spawns the PlatformIO runner, so the out-of-flash
-# tip can still be offered from a process that has no configured ``CORE``.
+# Tells the PlatformIO runner subprocess, which has no configured CORE, that
+# this is an ESP32 Arduino build.
 ESP32_ARDUINO_ENV = "ESPHOME_ESP32_ARDUINO_BUILD"
 
 ANSI_ESCAPE = re.compile(r"\033[@-_][0-?]*[ -/]*[@-~]")
@@ -526,20 +526,16 @@ def detect_rp2040_bootsel(picotool_path: str | Path) -> BootselResult:
 
 
 def is_esp32_arduino_build() -> bool:
-    """Whether the build in progress targets ESP32 with the Arduino framework.
+    """Whether the build targets ESP32 with the Arduino framework.
 
-    ``RedirectText`` asks this from the PlatformIO runner subprocess as well,
-    and that process gets a fresh ``CORE`` that was never configured, so
-    reading the platform from it raises. The parent passes the answer through
-    the environment instead.
+    The PlatformIO runner subprocess has no configured CORE, so the parent
+    passes the answer in the environment.
     """
     from esphome.core import CORE
 
     if not CORE.is_configured:
-        # Nothing set this CORE up, so we are in the runner subprocess. Note
-        # that a CORE which was set up but left half filled in still counts
-        # as configured, so reading from it raises rather than quietly
-        # falling back to what the environment claims.
+        # The runner subprocess. A half filled in CORE still counts as
+        # configured, so reading from it raises instead of landing here.
         return os.environ.get(ESP32_ARDUINO_ENV) == "1"
     return CORE.is_esp32 and CORE.using_arduino
 

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -535,11 +535,11 @@ def is_esp32_arduino_build() -> bool:
     """
     from esphome.core import CORE
 
-    if const.KEY_CORE not in CORE.data:
-        # Nothing configured this CORE, so we are in the runner subprocess.
-        # Test only for the section, not the keys inside it: a CORE that was
-        # set up but left half filled in is a bug, and should say so rather
-        # than quietly fall back to what the environment claims.
+    if not CORE.is_configured:
+        # Nothing set this CORE up, so we are in the runner subprocess. Note
+        # that a CORE which was set up but left half filled in still counts
+        # as configured, so reading from it raises rather than quietly
+        # falling back to what the environment claims.
         return os.environ.get(ESP32_ARDUINO_ENV) == "1"
     return CORE.is_esp32 and CORE.using_arduino
 

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -535,9 +535,11 @@ def is_esp32_arduino_build() -> bool:
     """
     from esphome.core import CORE
 
-    if CORE.data.get(const.KEY_CORE, {}).get(const.KEY_TARGET_PLATFORM) is None:
+    try:
+        return CORE.is_esp32 and CORE.using_arduino
+    except KeyError:
+        # Nothing configured this CORE, so we are in the runner subprocess.
         return os.environ.get(ESP32_ARDUINO_ENV) == "1"
-    return CORE.is_esp32 and CORE.using_arduino
 
 
 def get_esp32_arduino_flash_error_help() -> str | None:

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -535,11 +535,13 @@ def is_esp32_arduino_build() -> bool:
     """
     from esphome.core import CORE
 
-    try:
-        return CORE.is_esp32 and CORE.using_arduino
-    except KeyError:
+    if const.KEY_CORE not in CORE.data:
         # Nothing configured this CORE, so we are in the runner subprocess.
+        # Test only for the section, not the keys inside it: a CORE that was
+        # set up but left half filled in is a bug, and should say so rather
+        # than quietly fall back to what the environment claims.
         return os.environ.get(ESP32_ARDUINO_ENV) == "1"
+    return CORE.is_esp32 and CORE.using_arduino
 
 
 def get_esp32_arduino_flash_error_help() -> str | None:

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -3,6 +3,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 import io
 import logging
+import os
 from pathlib import Path
 import re
 import sys
@@ -140,6 +141,10 @@ def shlex_quote(s: str | Path) -> str:
 
     return "'" + s.replace("'", "'\"'\"'") + "'"
 
+
+# Set by the parent when it spawns the PlatformIO runner, so the out-of-flash
+# tip can still be offered from a process that has no configured ``CORE``.
+ESP32_ARDUINO_ENV = "ESPHOME_ESP32_ARDUINO_BUILD"
 
 ANSI_ESCAPE = re.compile(r"\033[@-_][0-?]*[ -/]*[@-~]")
 
@@ -520,11 +525,24 @@ def detect_rp2040_bootsel(picotool_path: str | Path) -> BootselResult:
         return BootselResult(0)
 
 
-def get_esp32_arduino_flash_error_help() -> str | None:
-    """Returns helpful message when ESP32 with Arduino runs out of flash space."""
+def is_esp32_arduino_build() -> bool:
+    """Whether the build in progress targets ESP32 with the Arduino framework.
+
+    ``RedirectText`` asks this from the PlatformIO runner subprocess as well,
+    and that process gets a fresh ``CORE`` that was never configured, so
+    reading the platform from it raises. The parent passes the answer through
+    the environment instead.
+    """
     from esphome.core import CORE
 
-    if not (CORE.is_esp32 and CORE.using_arduino):
+    if CORE.data.get(const.KEY_CORE, {}).get(const.KEY_TARGET_PLATFORM) is None:
+        return os.environ.get(ESP32_ARDUINO_ENV) == "1"
+    return CORE.is_esp32 and CORE.using_arduino
+
+
+def get_esp32_arduino_flash_error_help() -> str | None:
+    """Returns helpful message when ESP32 with Arduino runs out of flash space."""
+    if not is_esp32_arduino_build():
         return None
 
     from esphome.log import AnsiFore, color

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -387,6 +387,19 @@ def test_run_platformio_cli_ignores_an_inherited_flag_without_core(
         assert ESP32_ARDUINO_ENV not in env
 
 
+def test_run_platformio_cli_raises_on_a_half_filled_core(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """A CORE set up but left incomplete must surface, not fall back."""
+    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data[KEY_CORE] = {}
+
+    with patch.dict(os.environ, {}, clear=False):
+        mock_run_external_process.return_value = 0
+        with pytest.raises(KeyError):
+            toolchain.run_platformio_cli("test", "arg")
+
+
 def test_run_platformio_cli_sets_environment_variables(
     setup_core: Path, mock_run_external_process: Mock
 ) -> None:

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -16,9 +16,10 @@ from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 
+from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 from esphome.core import CORE, EsphomeError
 from esphome.platformio import runner, toolchain
-from esphome.util import FlashImage
+from esphome.util import ESP32_ARDUINO_ENV, FlashImage
 
 
 def test_idedata_firmware_elf_path(setup_core: Path) -> None:
@@ -326,6 +327,43 @@ def test_idedata_null_section_raises_esphome_error(setup_core: Path) -> None:
     """
     with pytest.raises(EsphomeError):
         _ = toolchain.IDEData({"extra": None}).extra_flash_images
+
+
+@pytest.mark.parametrize(
+    ("platform", "framework", "expected"),
+    [
+        ("esp32", "arduino", "1"),
+        ("esp32", "esp-idf", None),
+        ("esp8266", "arduino", None),
+    ],
+)
+def test_run_platformio_cli_flags_an_esp32_arduino_build(
+    setup_core: Path,
+    mock_run_external_process: Mock,
+    platform: str,
+    framework: str,
+    expected: str | None,
+) -> None:
+    """The runner filters output in a subprocess with no configured CORE.
+
+    It offers the out-of-flash tip from there, so it needs to be told which
+    platform this is; anything else must not be flagged.
+    """
+    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: platform,
+        KEY_TARGET_FRAMEWORK: framework,
+    }
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop(ESP32_ARDUINO_ENV, None)
+        mock_run_external_process.return_value = 0
+        toolchain.run_platformio_cli("test", "arg")
+
+        env = mock_run_external_process.call_args[1]["env"]
+        assert env.get(ESP32_ARDUINO_ENV) == expected
+        # Never leaks into our own environment.
+        assert ESP32_ARDUINO_ENV not in os.environ
 
 
 def test_run_platformio_cli_sets_environment_variables(

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -344,13 +344,7 @@ def test_run_platformio_cli_flags_an_esp32_arduino_build(
     framework: str,
     expected: str | None,
 ) -> None:
-    """The runner filters output in a subprocess with no configured CORE.
-
-    It offers the out-of-flash tip from there, so it needs to be told which
-    platform this is; anything else must not be flagged. The variable is
-    seeded first, so an inherited one has to be cleared rather than passed
-    through to a build it does not suit.
-    """
+    """Only an ESP32 Arduino build is flagged, and an inherited one is cleared."""
     CORE.build_path = str(setup_core / "build" / "test")
     CORE.data[KEY_CORE] = {
         KEY_TARGET_PLATFORM: platform,
@@ -370,12 +364,7 @@ def test_run_platformio_cli_flags_an_esp32_arduino_build(
 def test_run_platformio_cli_ignores_an_inherited_flag_without_core(
     setup_core: Path, mock_run_external_process: Mock
 ) -> None:
-    """An inherited flag must not end up answering for CORE.
-
-    ``is_esp32_arduino_build`` falls back to this same variable, so deciding
-    with it here would let a stray value in our own environment decide what
-    we pass on.
-    """
+    """An inherited flag must not end up answering for CORE."""
     CORE.build_path = str(setup_core / "build" / "test")
     CORE.data.pop(KEY_CORE, None)
 

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -347,7 +347,9 @@ def test_run_platformio_cli_flags_an_esp32_arduino_build(
     """The runner filters output in a subprocess with no configured CORE.
 
     It offers the out-of-flash tip from there, so it needs to be told which
-    platform this is; anything else must not be flagged.
+    platform this is; anything else must not be flagged. The variable is
+    seeded first, so an inherited one has to be cleared rather than passed
+    through to a build it does not suit.
     """
     CORE.build_path = str(setup_core / "build" / "test")
     CORE.data[KEY_CORE] = {
@@ -355,15 +357,14 @@ def test_run_platformio_cli_flags_an_esp32_arduino_build(
         KEY_TARGET_FRAMEWORK: framework,
     }
 
-    with patch.dict(os.environ, {}, clear=False):
-        os.environ.pop(ESP32_ARDUINO_ENV, None)
+    with patch.dict(os.environ, {ESP32_ARDUINO_ENV: "1"}, clear=False):
         mock_run_external_process.return_value = 0
         toolchain.run_platformio_cli("test", "arg")
 
         env = mock_run_external_process.call_args[1]["env"]
         assert env.get(ESP32_ARDUINO_ENV) == expected
-        # Never leaks into our own environment.
-        assert ESP32_ARDUINO_ENV not in os.environ
+        # Only the subprocess env is touched; ours is left as it was.
+        assert os.environ[ESP32_ARDUINO_ENV] == "1"
 
 
 def test_run_platformio_cli_sets_environment_variables(

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -367,6 +367,26 @@ def test_run_platformio_cli_flags_an_esp32_arduino_build(
         assert os.environ[ESP32_ARDUINO_ENV] == "1"
 
 
+def test_run_platformio_cli_ignores_an_inherited_flag_without_core(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """An inherited flag must not end up answering for CORE.
+
+    ``is_esp32_arduino_build`` falls back to this same variable, so deciding
+    with it here would let a stray value in our own environment decide what
+    we pass on.
+    """
+    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data.pop(KEY_CORE, None)
+
+    with patch.dict(os.environ, {ESP32_ARDUINO_ENV: "1"}, clear=False):
+        mock_run_external_process.return_value = 0
+        toolchain.run_platformio_cli("test", "arg")
+
+        env = mock_run_external_process.call_args[1]["env"]
+        assert ESP32_ARDUINO_ENV not in env
+
+
 def test_run_platformio_cli_sets_environment_variables(
     setup_core: Path, mock_run_external_process: Mock
 ) -> None:

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -550,6 +550,25 @@ def test_flash_error_help_reads_the_env_var_when_core_is_unconfigured(
     assert "esp-idf" in help_msg
 
 
+def test_is_esp32_arduino_build_raises_on_a_half_filled_core(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CORE that was set up but left incomplete is a bug, so it must raise.
+
+    Only a CORE nobody set up at all means we are in a runner subprocess.
+    Treating a half filled in one the same way would quietly answer a real
+    build from the environment.
+    """
+    from esphome.const import KEY_CORE
+    from esphome.core import CORE
+
+    monkeypatch.setattr(CORE, "data", {KEY_CORE: {}})
+    monkeypatch.setenv(util.ESP32_ARDUINO_ENV, "1")
+
+    with pytest.raises(KeyError):
+        util.is_esp32_arduino_build()
+
+
 @pytest.mark.parametrize(
     ("platform", "framework", "expected"),
     [

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -517,6 +517,79 @@ def test_redirect_text_drain_is_a_no_op_when_nothing_is_held() -> None:
     assert buf.getvalue() == "complete line\n"
 
 
+def test_flash_error_help_is_quiet_when_core_is_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: this used to raise ``KeyError`` in a runner subprocess.
+
+    ``RedirectText`` filters PlatformIO's output from inside the runner, which
+    gets a fresh ``CORE`` that was never set up. Reading the platform there
+    raised, so the flash-overflow line, the very one this tip exists for,
+    crashed the runner instead of getting the tip.
+    """
+    from esphome.core import CORE
+
+    monkeypatch.setattr(CORE, "data", {})
+    monkeypatch.delenv(util.ESP32_ARDUINO_ENV, raising=False)
+
+    assert util.get_esp32_arduino_flash_error_help() is None
+
+
+def test_flash_error_help_reads_the_env_var_when_core_is_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The parent tells the subprocess what it cannot work out for itself."""
+    from esphome.core import CORE
+
+    monkeypatch.setattr(CORE, "data", {})
+    monkeypatch.setenv(util.ESP32_ARDUINO_ENV, "1")
+
+    help_msg = util.get_esp32_arduino_flash_error_help()
+
+    assert help_msg is not None
+    assert "esp-idf" in help_msg
+
+
+@pytest.mark.parametrize(
+    ("platform", "framework", "expected"),
+    [
+        ("esp32", "arduino", True),
+        ("esp32", "esp-idf", False),
+        ("esp8266", "arduino", False),
+    ],
+)
+def test_is_esp32_arduino_build_from_a_configured_core(
+    monkeypatch: pytest.MonkeyPatch, platform: str, framework: str, expected: bool
+) -> None:
+    """With CORE set up, it is the source of truth and the env var is ignored."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+    from esphome.core import CORE
+
+    monkeypatch.setattr(
+        CORE,
+        "data",
+        {KEY_CORE: {KEY_TARGET_PLATFORM: platform, KEY_TARGET_FRAMEWORK: framework}},
+    )
+    monkeypatch.delenv(util.ESP32_ARDUINO_ENV, raising=False)
+
+    assert util.is_esp32_arduino_build() is expected
+
+
+def test_redirect_text_survives_a_flash_error_without_core(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The overflow line goes through even from a process with no CORE."""
+    from esphome.core import CORE
+
+    monkeypatch.setattr(CORE, "data", {})
+    monkeypatch.delenv(util.ESP32_ARDUINO_ENV, raising=False)
+    redirect, buf = _make_redirect(filter_lines=["ignore me"])
+
+    redirect.write("Error: The program size is greater than maximum allowed\n")
+
+    assert buf.getvalue() == "Error: The program size is greater than maximum allowed\n"
+
+
 def test_redirect_text_adds_flash_size_help(monkeypatch: pytest.MonkeyPatch) -> None:
     """An out-of-flash error gets the how-to-fix note appended."""
     monkeypatch.setattr(

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -14,6 +14,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from esphome import util
+from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+from esphome.core import CORE
 
 
 def test_list_yaml_files_with_files_and_directories(tmp_path: Path) -> None:
@@ -520,14 +522,7 @@ def test_redirect_text_drain_is_a_no_op_when_nothing_is_held() -> None:
 def test_flash_error_help_is_quiet_when_core_is_unconfigured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression: this used to raise ``KeyError`` in a runner subprocess.
-
-    ``RedirectText`` filters PlatformIO's output from inside the runner, which
-    gets a fresh ``CORE`` that was never set up. Reading the platform there
-    raised, so the flash-overflow line, the very one this tip exists for,
-    crashed the runner instead of getting the tip.
-    """
-    from esphome.core import CORE
+    """Regression: reading the platform used to raise in the runner."""
 
     monkeypatch.setattr(CORE, "data", {})
     monkeypatch.delenv(util.ESP32_ARDUINO_ENV, raising=False)
@@ -539,7 +534,6 @@ def test_flash_error_help_reads_the_env_var_when_core_is_unconfigured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The parent tells the subprocess what it cannot work out for itself."""
-    from esphome.core import CORE
 
     monkeypatch.setattr(CORE, "data", {})
     monkeypatch.setenv(util.ESP32_ARDUINO_ENV, "1")
@@ -553,14 +547,7 @@ def test_flash_error_help_reads_the_env_var_when_core_is_unconfigured(
 def test_is_esp32_arduino_build_raises_on_a_half_filled_core(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A CORE that was set up but left incomplete is a bug, so it must raise.
-
-    Only a CORE nobody set up at all means we are in a runner subprocess.
-    Treating a half filled in one the same way would quietly answer a real
-    build from the environment.
-    """
-    from esphome.const import KEY_CORE
-    from esphome.core import CORE
+    """A half filled in CORE is a bug, so it must raise, not fall back."""
 
     monkeypatch.setattr(CORE, "data", {KEY_CORE: {}})
     monkeypatch.setenv(util.ESP32_ARDUINO_ENV, "1")
@@ -581,8 +568,6 @@ def test_is_esp32_arduino_build_from_a_configured_core(
     monkeypatch: pytest.MonkeyPatch, platform: str, framework: str, expected: bool
 ) -> None:
     """With CORE set up, it is the source of truth and the env var is ignored."""
-    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
-    from esphome.core import CORE
 
     monkeypatch.setattr(
         CORE,
@@ -598,7 +583,6 @@ def test_redirect_text_survives_a_flash_error_without_core(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The overflow line goes through even from a process with no CORE."""
-    from esphome.core import CORE
 
     monkeypatch.setattr(CORE, "data", {})
     monkeypatch.delenv(util.ESP32_ARDUINO_ENV, raising=False)
@@ -1063,7 +1047,6 @@ class TestSafePrint:
     @pytest.fixture(autouse=True)
     def _no_dashboard(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Default ``CORE.dashboard`` to False so each test starts hermetic."""
-        from esphome.core import CORE
 
         monkeypatch.setattr(CORE, "dashboard", False)
 
@@ -1085,7 +1068,6 @@ class TestSafePrint:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         r"""Dashboard mode escapes raw ``\033`` ESC bytes to literal ``\\033``."""
-        from esphome.core import CORE
 
         monkeypatch.setattr(CORE, "dashboard", True)
         util.safe_print("\033[0;32mhi\033[0m")
@@ -1152,7 +1134,6 @@ class TestSafePrint:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Dashboard ESC escaping + cp1252 fallback compose correctly."""
-        from esphome.core import CORE
 
         monkeypatch.setattr(CORE, "dashboard", True)
         buf = io.BytesIO()


### PR DESCRIPTION
# What does this implement/fix?

`RedirectText` offers a tip when an ESP32 Arduino build runs out of flash. Deciding whether to show it asks `CORE` which platform this is, and `CORE.target_platform` reads `self.data[KEY_CORE][KEY_TARGET_PLATFORM]` with no `.get()`.

PlatformIO runs in a subprocess, and `esphome/platformio/runner.py` wraps that process's stdout in `RedirectText` to filter the output. The parent's own wrapper is bypassed, because `subprocess.run` takes its `fileno()` and never calls `write()`, so the tip only ever runs in the runner. That process gets a fresh `CORE` which was never set up, so the lookup raises:

```
File "esphome/util.py", line 519, in get_esp32_arduino_flash_error_help
  if not (CORE.is_esp32 and CORE.using_arduino):
File "esphome/core/__init__.py", line 890, in target_platform
  return self.data[KEY_CORE][KEY_TARGET_PLATFORM]
KeyError: 'core'
```

The line that trips it is `Error: The program size ... is greater than maximum allowed`, which is exactly the case the tip exists for. So an ESP32 Arduino build that overflows flash gets a traceback out of the runner instead of the advice, and the tip has never once fired from there.

The subprocess cannot work out the platform for itself, so the parent tells it in `run_platformio_cli`. `CORE` stays the source of truth: the flag is read only when nothing has configured `CORE` at all.

Two details worth calling out:

- The parent decides from `CORE` directly rather than through `is_esp32_arduino_build()`, which falls back to the same variable. Reading what it is about to write would let a stray value in the operator's environment answer for it. An inherited one is cleared, so it cannot reach a build it does not suit.
- Detecting the unconfigured case tests for the `core` section only, not the keys inside it. A `CORE` that was set up but left half filled in is a bug, and should raise rather than quietly fall back to what the environment claims.

Before, from a process with no configured `CORE`:

```
RAISED: KeyError 'core'
```

After, the same process returns `None`, and with the flag set it prints the tip for the first time.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
