### PR TITLE
[audio] Bump microDecoder to v0.4.0

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -371,7 +371,7 @@ async def to_code(config):
             data.wav_support = True
 
     if data.micro_decoder_support:
-        add_idf_component(name="esphome/micro-decoder", ref="0.2.0")
+        add_idf_component(name="esphome/micro-decoder", ref="0.4.0")
 
         # All codecs are enabled by default in micro-decoder, so disable the ones that aren't requested to save flash
         if not data.flac_support:
@@ -380,6 +380,8 @@ async def to_code(config):
             add_idf_sdkconfig_option("CONFIG_MICRO_DECODER_CODEC_MP3", False)
         if not data.opus_support:
             add_idf_sdkconfig_option("CONFIG_MICRO_DECODER_CODEC_OPUS", False)
+        # Vorbis is unsupported in ESPHome, so always disable it
+        add_idf_sdkconfig_option("CONFIG_MICRO_DECODER_CODEC_VORBIS", False)
         if not data.wav_support:
             add_idf_sdkconfig_option("CONFIG_MICRO_DECODER_CODEC_WAV", False)
 

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -8,7 +8,7 @@ dependencies:
   esphome/esp-micro-speech-features:
     version: 1.2.3
   esphome/micro-decoder:
-    version: 0.2.0
+    version: 0.4.0
   esphome/micro-flac:
     version: 0.2.0
   esphome/micro-mp3:


### PR DESCRIPTION
# What does this implement/fix?

Bumps the microDecoder library ([GitHub](https://github.com/esphome-libs/micro-decoder)/[Espressif Registry](https://components.espressif.com/components/esphome/micro-decoder/versions/0.4.0/readme)) to v0.4.0 ([changelog](https://github.com/esphome-libs/micro-decoder/compare/v0.2.0...v0.4.0)).

- Fixes several bugs and makes other easier to diagnose
- v0.4.0 includes Ogg Vorbis suport enabled by default, so until ESPHome supports it properly it is always disabled in the codegen stage
- v0.3.0 added support for external https certificate bundles, so a future ESPHome PR could utilize that for custom certificates.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18271
- may fix (at the very least, will make it easier to diagnose) https://github.com/esphome/home-assistant-voice-pe/issues/613

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):** not applicable

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
media_player:
  - platform: speaker_source
    id: external_media_player
    name: Media Player
    announcement_pipeline:
      format: FLAC
      num_channels: 1
      sample_rate: 48000
      speaker: box_speaker
      sources:
        - http_announcement_source
    
media_source:
  - platform: audio_http
    id: http_announcement_source

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
